### PR TITLE
chore(deps): adds renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>sanity-io/renovate-config"],
+  "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
+  "schedule": ["before 5am"],
+  "prConcurrentLimit": 3,
+  "automerge": true,
+  "dependencyDashboardApproval": false,
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)",
+      "group": {"semanticCommitType": "chore"},
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "Group TypeScript related deps in a single PR, as they often have to update together",
+      "groupName": "typescript-tooling",
+      "matchPackageNames": ["@sanity/pkg-utils", "typescript"],
+      "group": {"semanticCommitType": "chore"},
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "Group eslint related deps in a single PR, as they often have to update together",
+      "groupName": "eslint-tooling",
+      "matchPackageNames": [
+        "@eslint/*",
+        "eslint",
+        "eslint-plugin-*",
+        "eslint-config-*",
+        "typescript-eslint"
+      ],
+      "group": {"semanticCommitType": "chore"},
+      "semanticCommitType": "chore"
+    },
+    {
+      "group": {"semanticCommitType": "chore"},
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies",
+        "engines",
+        "optionalDependencies",
+        "peerDependencies"
+      ],
+      "matchManagers": ["npm"],
+      "semanticCommitType": "chore",
+      "description": "Group all dependencies from the examples directory",
+      "matchFileNames": ["examples/**/package.json"],
+      "groupName": "Examples dependencies"
+    },
+    {
+      "matchDepTypes": ["dependencies", "peerDependencies"],
+      "rangeStrategy": "bump",
+      "semanticCommitType": "fix"
+    }
+  ]
+}


### PR DESCRIPTION
### TL;DR

Add Renovate configuration for automated dependency updates.

### What changed?

Added a new `.github/renovate.json` file that configures Renovate bot with the following settings:
- Extends the Sanity.io base configuration
- Schedules updates to run before 5am
- Limits concurrent PRs to 3
- Enables automerge for approved updates
- Creates specific grouping rules for:
  - Non-major devDependencies
  - TypeScript-related dependencies
  - ESLint-related dependencies
  - Example directory dependencies
- Sets appropriate semantic commit types for different dependency types

### How to test?

Once merged, observe that Renovate bot creates PRs according to the defined configuration. Verify that dependencies are grouped correctly and that the bot respects the concurrent PR limit.

### Why make this change?

This configuration automates dependency management, reducing manual work while ensuring dependencies stay up-to-date in a controlled manner. The grouping rules help minimize PR noise by bundling related updates together, and the semantic commit types ensure proper versioning when changes are merged.