### PR TITLE
feat: add defineCliConfig function

### DIFF
--- a/examples/basic-studio/sanity.cli.ts
+++ b/examples/basic-studio/sanity.cli.ts
@@ -1,4 +1,4 @@
-import {defineCliConfig} from 'sanity/cli'
+import {defineCliConfig} from '@sanity/cli'
 
 export default defineCliConfig({
   api: {

--- a/examples/multi-workspace-studio/sanity.cli.ts
+++ b/examples/multi-workspace-studio/sanity.cli.ts
@@ -1,4 +1,4 @@
-import {defineCliConfig} from 'sanity/cli'
+import {defineCliConfig} from '@sanity/cli'
 
 export default defineCliConfig({
   api: {

--- a/examples/worst-case-studio/sanity.cli.ts
+++ b/examples/worst-case-studio/sanity.cli.ts
@@ -1,5 +1,5 @@
 import {defines} from '@/defines'
-import {defineCliConfig} from 'sanity/cli'
+import {defineCliConfig} from '@sanity/cli'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineCliConfig({

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "type": "module",
   "scripts": {
     "build": "turbo run build",
+    "build:cli": "turbo run build --filter=@sanity/cli",
     "check": "npm run check:lint && npm run check:types",
     "check:lint": "turbo run lint",
     "check:types": "tsc --noEmit",

--- a/packages/@sanity/cli/src/config/cli/createCliConfig.ts
+++ b/packages/@sanity/cli/src/config/cli/createCliConfig.ts
@@ -1,0 +1,8 @@
+import type {CliConfig} from './types.js'
+
+/**
+ * @deprecated Use `defineCliConfig` instead
+ */
+export function createCliConfig(config: CliConfig): CliConfig {
+  return config
+}

--- a/packages/@sanity/cli/src/config/cli/defineCliConfig.ts
+++ b/packages/@sanity/cli/src/config/cli/defineCliConfig.ts
@@ -1,0 +1,6 @@
+import type {CliConfig} from './types.js'
+
+/** @beta */
+export function defineCliConfig(config: CliConfig): CliConfig {
+  return config
+}

--- a/packages/@sanity/cli/src/index.ts
+++ b/packages/@sanity/cli/src/index.ts
@@ -4,21 +4,6 @@
  */
 
 // @todo implement
-export function getCliClient(_options: any): any {
-  throw new Error('@todo not implemented yet')
-}
-
-// @todo implement typings
-export function defineCliConfig(config: any) {
-  return config
-}
-
-// @todo implement typings
-export function createCliConfig(config: any) {
-  return config
-}
-
-// @todo implement
 export function loadEnv(
   mode: string,
   envDir: string,
@@ -26,3 +11,7 @@ export function loadEnv(
 ): Record<string, string> {
   return {}
 }
+
+export {createCliConfig} from './config/cli/createCliConfig.js'
+export {defineCliConfig} from './config/cli/defineCliConfig.js'
+export {getCliConfig} from './config/cli/getCliConfig.js'

--- a/packages/@sanity/original-cli/src/actions/init-project/createCliConfig.ts
+++ b/packages/@sanity/original-cli/src/actions/init-project/createCliConfig.ts
@@ -3,7 +3,7 @@ import {parse, print} from 'recast'
 import * as parser from 'recast/parsers/typescript'
 
 const defaultTemplate = `
-import {defineCliConfig} from 'sanity/cli'
+import {defineCliConfig} from '@sanity/cli'
 
 export default defineCliConfig({
   api: {

--- a/packages/@sanity/original-cli/test/__fixtures__/remote-template/sanity.cli.ts
+++ b/packages/@sanity/original-cli/test/__fixtures__/remote-template/sanity.cli.ts
@@ -1,4 +1,4 @@
-import {defineCliConfig} from 'sanity/cli'
+import {defineCliConfig} from '@sanity/cli'
 
 export default defineCliConfig({
   api: {

--- a/packages/@sanity/original-cli/test/__fixtures__/v3/sanity.cli.ts
+++ b/packages/@sanity/original-cli/test/__fixtures__/v3/sanity.cli.ts
@@ -1,4 +1,4 @@
-import {defineCliConfig} from 'sanity/cli'
+import {defineCliConfig} from '@sanity/cli'
 
 export default defineCliConfig({
   api: {


### PR DESCRIPTION
Adds `defineCliConfig` function. For now the examples config are using import from `@sanity/cli` due to some issues with imports. This might change in the future but for now it gets things moving