### PR TITLE
test: add utility to assert on logs

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -73,6 +73,7 @@
     "@types/jsdom": "^21.1.7",
     "@types/node": "^20.17.23",
     "@vitest/coverage-v8": "^3.1.2",
+    "ansis": "^3.17.0",
     "eslint": "^9.22.0",
     "eslint-config-oclif": "^6.0.24",
     "eslint-config-prettier": "^10.1.1",

--- a/packages/@sanity/cli/src/commands/__tests__/build.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/build.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, test} from 'vitest'
+import {testCommand} from '~test/helpers/testCommand.js'
+
+import {BuildCommand} from '../build.js'
+
+describe('#build', () => {
+  test('command runs', async () => {
+    const {stdout} = await testCommand(BuildCommand)
+
+    expect(stdout).toContain(
+      JSON.stringify({
+        minify: true,
+        'source-maps': false,
+        yes: false,
+      }),
+    )
+  })
+
+  test('takes minify flag', async () => {
+    const {stdout} = await testCommand(BuildCommand, ['--no-minify'])
+
+    expect(stdout).toContain(
+      JSON.stringify({
+        minify: false,
+        'source-maps': false,
+        yes: false,
+      }),
+    )
+  })
+
+  test('shows an error for invalid flags', async () => {
+    const {error} = await testCommand(BuildCommand, ['--invalid'])
+
+    expect(error?.message).toContain('Nonexistent flag: --invalid')
+  })
+})

--- a/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, test} from 'vitest'
+import {testCommand} from '~test/helpers/testCommand.js'
+
+import {DevCommand} from '../dev.js'
+
+describe('#dev', () => {
+  test('command runs', async () => {
+    const {stdout} = await testCommand(DevCommand)
+
+    expect(stdout).toContain(
+      JSON.stringify({
+        host: '127.0.0.1',
+        port: 3333,
+      }),
+    )
+  })
+
+  test('takes port and host flags', async () => {
+    const {stdout} = await testCommand(DevCommand, ['--host', '0.0.0.0', '--port', '3000'])
+
+    expect(stdout).toContain(
+      JSON.stringify({
+        host: '0.0.0.0',
+        port: 3000,
+      }),
+    )
+  })
+
+  test('shows an error for invalid flags', async () => {
+    const {error} = await testCommand(DevCommand, ['--invalid'])
+
+    expect(error?.message).toContain('Nonexistent flag: --invalid')
+  })
+})

--- a/packages/@sanity/cli/src/commands/__tests__/docs.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/docs.test.ts
@@ -7,7 +7,9 @@ import {DocsCommand} from '../docs.js'
 
 describe('#docs', () => {
   test('command runs', async () => {
-    await testCommand(DocsCommand)
+    const {stdout} = await testCommand(DocsCommand)
+
+    expect(stdout).toContain('Opening https://www.sanity.io/docs')
     // Mocked in test setup
     expect(open).toHaveBeenCalledWith('https://www.sanity.io/docs')
   })

--- a/packages/@sanity/cli/src/commands/__tests__/learn.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/learn.test.ts
@@ -7,7 +7,9 @@ import {LearnCommand} from '../learn.js'
 
 describe('#learn', () => {
   test('command runs', async () => {
-    await testCommand(LearnCommand)
+    const {stdout} = await testCommand(LearnCommand)
+
+    expect(stdout).toContain('Opening https://www.sanity.io/learn')
     // Mocked in test setup
     expect(open).toHaveBeenCalledWith('https://www.sanity.io/learn')
   })

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -1,0 +1,50 @@
+import {runCommand} from '@oclif/test'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+import {testCommand} from '~test/helpers/testCommand.js'
+
+import {logout} from '../../actions/auth/logout.js'
+import {getCliToken} from '../../config/cliToken.js'
+import {LogoutCommand} from '../logout.js'
+
+vi.mock('../../actions/auth/logout.js')
+vi.mock('../../config/cliToken.js')
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('#logout', () => {
+  test('--help works', async () => {
+    const {stdout} = await runCommand(['logout', '--help'])
+
+    expect(stdout).toMatchInlineSnapshot(`
+      "Logs out the CLI from the current user session
+
+      USAGE
+        $ sanity logout
+
+      DESCRIPTION
+        Logs out the CLI from the current user session
+
+      "
+    `)
+  })
+
+  test('logs out successfully if a token exists', async () => {
+    vi.mocked(getCliToken).mockResolvedValueOnce('test-token')
+
+    const {stdout} = await testCommand(LogoutCommand)
+
+    expect(logout).toHaveBeenCalledTimes(1)
+    expect(stdout).toContain('Logged out successfully')
+  })
+
+  test('shows an error if no token exists', async () => {
+    vi.mocked(getCliToken).mockResolvedValueOnce('')
+
+    const {stdout} = await testCommand(LogoutCommand)
+
+    expect(logout).not.toHaveBeenCalled()
+    expect(stdout).toContain('No login credentials found')
+  })
+})

--- a/packages/@sanity/cli/src/commands/__tests__/manage.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/manage.test.ts
@@ -63,8 +63,9 @@ describe('#manage', () => {
       },
     })
 
-    await testCommand(ManageCommand)
+    const {stdout} = await testCommand(ManageCommand)
 
+    expect(stdout).toContain('Opening https://www.sanity.io/manage/project/test-project-id')
     // Mocked in test setup
     expect(open).toHaveBeenCalledWith('https://www.sanity.io/manage/project/test-project-id')
   })
@@ -80,8 +81,9 @@ describe('#manage', () => {
       },
     })
 
-    await testCommand(ManageCommand)
+    const {stdout} = await testCommand(ManageCommand)
 
+    expect(stdout).toContain('Opening https://www.sanity.io/manage/project/test-project-id')
     // Mocked in test setup
     expect(open).toHaveBeenCalledWith('https://www.sanity.io/manage/project/test-project-id')
   })
@@ -102,7 +104,9 @@ describe('#manage', () => {
       },
     ])
 
-    await testCommand(ManageCommand)
+    const {stdout} = await testCommand(ManageCommand)
+
+    expect(stdout).toContain('Opening https://www.sanity.io/manage/')
     // Mocked in test setup
     expect(open).toHaveBeenCalledWith('https://www.sanity.io/manage/')
   })
@@ -111,7 +115,9 @@ describe('#manage', () => {
     vi.mocked(getCliConfig).mockResolvedValueOnce({})
     vi.mocked(getStudioConfig).mockResolvedValueOnce({} as never)
 
-    await testCommand(ManageCommand)
+    const {stdout} = await testCommand(ManageCommand)
+
+    expect(stdout).toContain('Opening https://www.sanity.io/manage/')
     // Mocked in test setup
     expect(open).toHaveBeenCalledWith('https://www.sanity.io/manage/')
   })

--- a/packages/@sanity/cli/src/commands/build.ts
+++ b/packages/@sanity/cli/src/commands/build.ts
@@ -40,7 +40,6 @@ export class BuildCommand extends SanityCliCommand<typeof BuildCommand> {
   } satisfies FlagInput
 
   public async run(): Promise<void> {
-    const {flags} = await this.parse(BuildCommand)
-    console.log(flags)
+    this.log(JSON.stringify(this.flags))
   }
 }

--- a/packages/@sanity/cli/src/commands/dev.ts
+++ b/packages/@sanity/cli/src/commands/dev.ts
@@ -26,8 +26,6 @@ export class DevCommand extends SanityCliCommand<typeof DevCommand> {
   } satisfies FlagInput
 
   public async run(): Promise<void> {
-    const {flags} = await this.parse(DevCommand)
-
-    console.log(flags)
+    this.log(JSON.stringify(this.flags))
   }
 }

--- a/packages/@sanity/cli/test/helpers/testCommand.ts
+++ b/packages/@sanity/cli/test/helpers/testCommand.ts
@@ -1,15 +1,133 @@
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 
-import {Command, Config} from '@oclif/core'
+import {Command, Config, Errors} from '@oclif/core'
+import ansis from 'ansis'
 
-export function testCommand(
+type CaptureOptions = {
+  /**
+   * Whether to print the output to the console
+   */
+  print?: boolean
+  /**
+   * Whether to strip ANSI escape codes from the output
+   */
+  stripAnsi?: boolean
+  testNodeEnv?: string
+}
+
+type CaptureResult<T = unknown> = {
+  error?: Error & Partial<Errors.CLIError>
+  result?: T
+  stderr: string
+  stdout: string
+}
+
+/**
+ * Capture the output of a command and return the result
+ *
+ * @param fn - The function to capture the output of
+ * @param opts - The options for the capture
+ * @returns The result of the command
+ * @internal
+ *
+ * Credits to oclif for the original implementation:
+ * https://github.com/oclif/test/blob/2a5407e6fc80d388043d10f6b7b8eaa586483015/src/index.ts
+ *
+ * We are not using the libary directly since it does not support mocking code inside of the command
+ * possibly because the commands run in a different thread
+ */
+async function captureOutput<T>(
+  fn: () => Promise<T>,
+  opts?: CaptureOptions,
+): Promise<CaptureResult<T>> {
+  const print = opts?.print ?? false
+  const stripAnsi = opts?.stripAnsi ?? true
+  const testNodeEnv = opts?.testNodeEnv || 'test'
+
+  const originals = {
+    NODE_ENV: process.env.NODE_ENV,
+    stderrWrite: process.stderr.write,
+    stdoutWrite: process.stdout.write,
+  }
+
+  const output: Record<'stderr' | 'stdout', string[]> = {
+    stderr: [],
+    stdout: [],
+  }
+
+  const toString = (str: string | Uint8Array): string =>
+    stripAnsi ? ansis.strip(str.toString()) : str.toString()
+
+  const getStderr = (): string => output.stderr.map((b) => toString(b)).join('')
+  const getStdout = (): string => output.stdout.map((b) => toString(b)).join('')
+
+  const mockWrite =
+    (std: 'stderr' | 'stdout'): typeof process.stderr.write =>
+    (
+      chunk: string | Uint8Array,
+      encodingOrCb?: ((err?: Error) => void) | BufferEncoding,
+      cb?: (err?: Error) => void,
+    ) => {
+      output[std].push(chunk.toString())
+
+      if (print) {
+        let callback: ((err?: Error) => void) | undefined = cb
+        let encoding: BufferEncoding | undefined
+        if (typeof encodingOrCb === 'function') {
+          callback = encodingOrCb
+        } else {
+          encoding = encodingOrCb
+        }
+        originals[`${std}Write`].apply(process[std], [chunk, encoding, callback])
+      } else if (typeof cb === 'function') {
+        cb()
+      } else if (typeof encodingOrCb === 'function') {
+        encodingOrCb()
+      }
+      return true
+    }
+
+  process.stdout.write = mockWrite('stdout')
+  process.stderr.write = mockWrite('stderr')
+  process.env.NODE_ENV = testNodeEnv
+
+  try {
+    const result = await fn()
+    return {
+      result,
+      stderr: getStderr(),
+      stdout: getStdout(),
+    }
+  } catch (error) {
+    // Check if it's an oclif CLIError or a regular error
+    const processedError =
+      error instanceof Error // Check if it's an Error (this includes CLIError)
+        ? Object.assign(error, {message: toString(error.message)}) // If so, process its message
+        : new Error(toString(String(error))) // Otherwise, create a new Error from string representation
+
+    return {
+      error: processedError,
+      stderr: getStderr(),
+      stdout: getStdout(),
+    }
+  } finally {
+    process.stdout.write = originals.stdoutWrite
+    process.stderr.write = originals.stderrWrite
+    process.env.NODE_ENV = originals.NODE_ENV
+  }
+}
+
+export async function testCommand(
   command: (new (argv: string[], config: Config) => Command) & typeof Command,
   args?: string[],
-  config?: Config,
-) {
-  return command.run(args || [], {
-    root: path.resolve(fileURLToPath(import.meta.url), '../../../'),
-    ...config,
-  })
+  options?: {capture?: CaptureOptions; config?: Partial<Config>},
+): Promise<CaptureResult<unknown>> {
+  const commandInstancePromise = () =>
+    command.run(args || [], {
+      root: path.resolve(fileURLToPath(import.meta.url), '../../../'),
+      ...options?.config,
+    })
+
+  return captureOutput(commandInstancePromise, options?.capture)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.1.2
         version: 3.1.2(vitest@3.1.2(@types/debug@4.1.12)(@types/node@20.17.30)(jsdom@26.0.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1))
+      ansis:
+        specifier: ^3.17.0
+        version: 3.17.0
       eslint:
         specifier: ^9.22.0
         version: 9.23.0


### PR DESCRIPTION
### TL;DR

Added comprehensive test coverage for CLI commands and improved output handling in test helpers.

### Why make this change?

Adds a utility that captures output from all the commands and returns that in the test. This is useful for doing assertion on the stdout. The difference between this and the implementation of `@oclif/test` is that it runs it on the same thread as the test runs which has benefits of allowing you to mock things in tests. It also has a small QOL benefit which is that test:watch works properly