### PR TITLE
chore(deps): make better renovate grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,10 +29,27 @@
         "eslint",
         "eslint-plugin-*",
         "eslint-config-*",
-        "typescript-eslint"
+        "typescript-eslint",
+        "@typescript-eslint/*",
+        "eslint-*",
+        "@stylistic/eslint-plugin"
       ],
       "group": {"semanticCommitType": "chore"},
       "semanticCommitType": "chore"
+    },
+    {
+      "description": "Group sanity related deps in a single PR, as they often have to update together",
+      "groupName": "sanity-tooling",
+      "matchPackageNames": ["@sanity/*", "sanity"],
+      "group": {"semanticCommitType": "fix"},
+      "semanticCommitType": "fix"
+    },
+    {
+      "description": "Group oclif related deps in a single PR, as they often have to update together",
+      "groupName": "oclif-tooling",
+      "matchPackageNames": ["@oclif/*", "oclif"],
+      "group": {"semanticCommitType": "fix"},
+      "semanticCommitType": "fix"
     },
     {
       "group": {"semanticCommitType": "chore"},
@@ -48,6 +65,13 @@
       "description": "Group all dependencies from the examples directory",
       "matchFileNames": ["examples/**/package.json"],
       "groupName": "Examples dependencies"
+    },
+    {
+      "description": "Group vitest related deps in a single PR, as they often have to update together",
+      "groupName": "vitest-tooling",
+      "matchPackageNames": ["@vitest/*", "vitest", "vitest-*"],
+      "group": {"semanticCommitType": "chore"},
+      "semanticCommitType": "chore"
     },
     {
       "matchDepTypes": ["dependencies", "peerDependencies"],


### PR DESCRIPTION
### TL;DR

Enhanced Renovate configuration to better group related dependencies.

### What changed?

- Added additional ESLint-related packages to the existing ESLint group, including `@typescript-eslint/*`, `eslint-*`, and `@stylistic/eslint-plugin`
- Created new dependency groups for:
  - Sanity-related packages (`@sanity/*`, `sanity`)
  - Oclif-related packages (`@oclif/*`, `oclif`)
  - Vitest-related packages (`@vitest/*`, `vitest`, `vitest-*`)
- Set appropriate semantic commit types for each group

### How to test?

- Verify that Renovate creates properly grouped PRs for the specified dependencies
- Check that Renovate uses the correct semantic commit types for each group

### Why make this change?

This improves dependency management by grouping related packages that often need to be updated together. This reduces the number of PRs and ensures compatible versions are updated simultaneously, making the review and merge process more efficient.