### PR TITLE
feat: add plugin for not found commands

### DIFF
--- a/packages/@sanity/cli/oclif.config.js
+++ b/packages/@sanity/cli/oclif.config.js
@@ -31,6 +31,6 @@ export default {
   bin: 'sanity',
   commands: isProduction ? './dist/commands' : './src/commands',
   dirname: 'sanity',
-  plugins: ['@oclif/plugin-help'],
+  plugins: ['@oclif/plugin-help', '@oclif/plugin-not-found'],
   topicSeparator: ' ',
 }

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -45,6 +45,7 @@
     "@inquirer/prompts": "^7.3.2",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
+    "@oclif/plugin-not-found": "^3.2.51",
     "@sanity/client": "^7.0.0",
     "@sanity/telemetry": "^0.7.9",
     "debug": "^4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       '@oclif/plugin-help':
         specifier: ^6.2.28
         version: 6.2.28
+      '@oclif/plugin-not-found':
+        specifier: ^3.2.51
+        version: 3.2.51(@types/node@20.17.30)
       '@sanity/client':
         specifier: ^7.0.0
         version: 7.0.0(debug@4.4.0)
@@ -1763,12 +1766,39 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/checkbox@4.1.6':
+    resolution: {integrity: sha512-62u896rWCtKKE43soodq5e/QcRsA22I+7/4Ov7LESWnKRO6BVo2A1DFLDmXL9e28TB0CfHc3YtkbPm7iwajqkg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/confirm@3.2.0':
     resolution: {integrity: sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==}
     engines: {node: '>=18'}
 
+  '@inquirer/confirm@5.1.10':
+    resolution: {integrity: sha512-FxbQ9giWxUWKUk2O5XZ6PduVnH2CZ/fmMKMBkH71MHJvWr7WL5AHKevhzF1L5uYWB2P548o1RzVxrNd3dpmk6g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/confirm@5.1.8':
     resolution: {integrity: sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.1.11':
+    resolution: {integrity: sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -1789,6 +1819,15 @@ packages:
     resolution: {integrity: sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==}
     engines: {node: '>=18'}
 
+  '@inquirer/editor@4.2.11':
+    resolution: {integrity: sha512-YoZr0lBnnLFPpfPSNsQ8IZyKxU47zPyVi9NLjCWtna52//M/xuL0PGPAxHxxYhdOhnvY2oBafoM+BI5w/JK7jw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/editor@4.2.9':
     resolution: {integrity: sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==}
     engines: {node: '>=18'}
@@ -1807,6 +1846,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/expand@4.0.13':
+    resolution: {integrity: sha512-HgYNWuZLHX6q5y4hqKhwyytqAghmx35xikOGY3TcgNiElqXGPas24+UzNPOwGUZa5Dn32y25xJqVeUcGlTv+QQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/figures@1.0.11':
     resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
     engines: {node: '>=18'}
@@ -1814,6 +1862,15 @@ packages:
   '@inquirer/input@2.3.0':
     resolution: {integrity: sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==}
     engines: {node: '>=18'}
+
+  '@inquirer/input@4.1.10':
+    resolution: {integrity: sha512-kV3BVne3wJ+j6reYQUZi/UN9NZGZLxgc/tfyjeK3mrx1QI7RXPxGp21IUTv+iVHcbP4ytZALF8vCHoxyNSC6qg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/input@4.1.8':
     resolution: {integrity: sha512-WXJI16oOZ3/LiENCAxe8joniNp8MQxF6Wi5V+EBbVA0ZIOpFcL4I9e7f7cXse0HJeIPCWO8Lcgnk98juItCi7Q==}
@@ -1833,8 +1890,26 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/number@3.0.13':
+    resolution: {integrity: sha512-IrLezcg/GWKS8zpKDvnJ/YTflNJdG0qSFlUM/zNFsdi4UKW/CO+gaJpbMgQ20Q58vNKDJbEzC6IebdkprwL6ew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/password@4.0.11':
     resolution: {integrity: sha512-dH6zLdv+HEv1nBs96Case6eppkRggMe8LoOTl30+Gq5Wf27AO/vHFgStTVz4aoevLdNXqwE23++IXGw4eiOXTg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.13':
+    resolution: {integrity: sha512-NN0S/SmdhakqOTJhDwOpeBEEr8VdcYsjmZHDb0rblSh2FcbXQOr+2IApP7JG4WE3sxIdKytDn4ed3XYwtHxmJQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -1851,6 +1926,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/prompts@7.5.1':
+    resolution: {integrity: sha512-5AOrZPf2/GxZ+SDRZ5WFplCA2TAQgK3OYrXCYmJL5NaTu4ECcoWFlfUZuw7Es++6Njv7iu/8vpYJhuzxUH76Vg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/rawlist@4.0.11':
     resolution: {integrity: sha512-uAYtTx0IF/PqUAvsRrF3xvnxJV516wmR6YVONOmCWJbbt87HcDHLfL9wmBQFbNJRv5kCjdYKrZcavDkH3sVJPg==}
     engines: {node: '>=18'}
@@ -1860,8 +1944,26 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/rawlist@4.1.1':
+    resolution: {integrity: sha512-VBUC0jPN2oaOq8+krwpo/mf3n/UryDUkKog3zi+oIi8/e5hykvdntgHUB9nhDM78RubiyR1ldIOfm5ue+2DeaQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/search@3.0.11':
     resolution: {integrity: sha512-9CWQT0ikYcg6Ls3TOa7jljsD7PgjcsYEM0bYE+Gkz+uoW9u8eaJCRHJKkucpRE5+xKtaaDbrND+nPDoxzjYyew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.0.13':
+    resolution: {integrity: sha512-9g89d2c5Izok/Gw/U7KPC3f9kfe5rA1AJ24xxNZG0st+vWekSk7tB9oE+dJv5JXd0ZSijomvW0KPMoBd8qbN4g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -1882,6 +1984,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/select@4.2.1':
+    resolution: {integrity: sha512-gt1Kd5XZm+/ddemcT3m23IP8aD8rC9drRckWoP/1f7OL46Yy2FGi8DSmNjEjQKtPl6SV96Kmjbl6p713KXJ/Jg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/type@1.5.5':
     resolution: {integrity: sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==}
     engines: {node: '>=18'}
@@ -1892,6 +2003,15 @@ packages:
 
   '@inquirer/type@3.0.5':
     resolution: {integrity: sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.6':
+    resolution: {integrity: sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2112,8 +2232,8 @@ packages:
     resolution: {integrity: sha512-eFLP2yjiK+xMRGcv9k9jOWV08HB+/Cgg1ND91zS4Uwgp1krMoL39Is+hIqnZOKkmiEMtiv8k5EDqCVv+DTRywg==}
     engines: {node: '>=18.0.0'}
 
-  '@oclif/plugin-not-found@3.2.48':
-    resolution: {integrity: sha512-H2y3PtiU/MYZXvvWUR0vr4PCoSSsN8inGDlLgLxQ4q+osAlJ256RxKCVMsSJG9fWt+Pg/+wrLzpx0OsbyVOi9g==}
+  '@oclif/plugin-not-found@3.2.51':
+    resolution: {integrity: sha512-hnYH4GS7lYD3Z59LO9RZAIXQPmuW+rNnTjCheSwAzWyoUH1M2Va6dUpamfnMf/GryrFvn1srBDdgKHr5KRf+Qw==}
     engines: {node: '>=18.0.0'}
 
   '@oclif/plugin-warn-if-update-available@3.1.38':
@@ -9235,15 +9355,45 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.30
 
+  '@inquirer/checkbox@4.1.6(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/core': 10.1.11(@types/node@20.17.30)
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.30
+
   '@inquirer/confirm@3.2.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
 
+  '@inquirer/confirm@5.1.10(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/core': 10.1.11(@types/node@20.17.30)
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
+    optionalDependencies:
+      '@types/node': 20.17.30
+
   '@inquirer/confirm@5.1.8(@types/node@20.17.30)':
     dependencies:
       '@inquirer/core': 10.1.9(@types/node@20.17.30)
       '@inquirer/type': 3.0.5(@types/node@20.17.30)
+    optionalDependencies:
+      '@types/node': 20.17.30
+
+  '@inquirer/core@10.1.11(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 20.17.30
 
@@ -9275,6 +9425,14 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
 
+  '@inquirer/editor@4.2.11(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/core': 10.1.11(@types/node@20.17.30)
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
+      external-editor: 3.1.0
+    optionalDependencies:
+      '@types/node': 20.17.30
+
   '@inquirer/editor@4.2.9(@types/node@20.17.30)':
     dependencies:
       '@inquirer/core': 10.1.9(@types/node@20.17.30)
@@ -9291,12 +9449,27 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.30
 
+  '@inquirer/expand@4.0.13(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/core': 10.1.11(@types/node@20.17.30)
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.30
+
   '@inquirer/figures@1.0.11': {}
 
   '@inquirer/input@2.3.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
+
+  '@inquirer/input@4.1.10(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/core': 10.1.11(@types/node@20.17.30)
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
+    optionalDependencies:
+      '@types/node': 20.17.30
 
   '@inquirer/input@4.1.8(@types/node@20.17.30)':
     dependencies:
@@ -9312,10 +9485,25 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.30
 
+  '@inquirer/number@3.0.13(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/core': 10.1.11(@types/node@20.17.30)
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
+    optionalDependencies:
+      '@types/node': 20.17.30
+
   '@inquirer/password@4.0.11(@types/node@20.17.30)':
     dependencies:
       '@inquirer/core': 10.1.9(@types/node@20.17.30)
       '@inquirer/type': 3.0.5(@types/node@20.17.30)
+      ansi-escapes: 4.3.2
+    optionalDependencies:
+      '@types/node': 20.17.30
+
+  '@inquirer/password@4.0.13(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/core': 10.1.11(@types/node@20.17.30)
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
       ansi-escapes: 4.3.2
     optionalDependencies:
       '@types/node': 20.17.30
@@ -9335,10 +9523,33 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.30
 
+  '@inquirer/prompts@7.5.1(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/checkbox': 4.1.6(@types/node@20.17.30)
+      '@inquirer/confirm': 5.1.10(@types/node@20.17.30)
+      '@inquirer/editor': 4.2.11(@types/node@20.17.30)
+      '@inquirer/expand': 4.0.13(@types/node@20.17.30)
+      '@inquirer/input': 4.1.10(@types/node@20.17.30)
+      '@inquirer/number': 3.0.13(@types/node@20.17.30)
+      '@inquirer/password': 4.0.13(@types/node@20.17.30)
+      '@inquirer/rawlist': 4.1.1(@types/node@20.17.30)
+      '@inquirer/search': 3.0.13(@types/node@20.17.30)
+      '@inquirer/select': 4.2.1(@types/node@20.17.30)
+    optionalDependencies:
+      '@types/node': 20.17.30
+
   '@inquirer/rawlist@4.0.11(@types/node@20.17.30)':
     dependencies:
       '@inquirer/core': 10.1.9(@types/node@20.17.30)
       '@inquirer/type': 3.0.5(@types/node@20.17.30)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.30
+
+  '@inquirer/rawlist@4.1.1(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/core': 10.1.11(@types/node@20.17.30)
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 20.17.30
@@ -9348,6 +9559,15 @@ snapshots:
       '@inquirer/core': 10.1.9(@types/node@20.17.30)
       '@inquirer/figures': 1.0.11
       '@inquirer/type': 3.0.5(@types/node@20.17.30)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.30
+
+  '@inquirer/search@3.0.13(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/core': 10.1.11(@types/node@20.17.30)
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 20.17.30
@@ -9370,6 +9590,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.30
 
+  '@inquirer/select@4.2.1(@types/node@20.17.30)':
+    dependencies:
+      '@inquirer/core': 10.1.11(@types/node@20.17.30)
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.6(@types/node@20.17.30)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.30
+
   '@inquirer/type@1.5.5':
     dependencies:
       mute-stream: 1.0.0
@@ -9379,6 +9609,10 @@ snapshots:
       mute-stream: 1.0.0
 
   '@inquirer/type@3.0.5(@types/node@20.17.30)':
+    optionalDependencies:
+      '@types/node': 20.17.30
+
+  '@inquirer/type@3.0.6(@types/node@20.17.30)':
     optionalDependencies:
       '@types/node': 20.17.30
 
@@ -9664,9 +9898,9 @@ snapshots:
     dependencies:
       '@oclif/core': 4.3.0
 
-  '@oclif/plugin-not-found@3.2.48(@types/node@20.17.30)':
+  '@oclif/plugin-not-found@3.2.51(@types/node@20.17.30)':
     dependencies:
-      '@inquirer/prompts': 7.4.0(@types/node@20.17.30)
+      '@inquirer/prompts': 7.5.1(@types/node@20.17.30)
       '@oclif/core': 4.3.0
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
@@ -11250,14 +11484,6 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.2.4(@types/node@20.17.30)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1)
-
-  '@vitest/mocker@3.1.2(vite@6.2.4(@types/node@22.13.17)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1))':
-    dependencies:
-      '@vitest/spy': 3.1.2
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.2.4(@types/node@22.13.17)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1)
 
   '@vitest/pretty-format@3.1.2':
     dependencies:
@@ -14157,7 +14383,7 @@ snapshots:
       '@inquirer/select': 2.5.0
       '@oclif/core': 4.3.0
       '@oclif/plugin-help': 6.2.28
-      '@oclif/plugin-not-found': 3.2.48(@types/node@20.17.30)
+      '@oclif/plugin-not-found': 3.2.51(@types/node@20.17.30)
       '@oclif/plugin-warn-if-update-available': 3.1.38
       async-retry: 1.3.3
       chalk: 4.1.2
@@ -16016,7 +16242,7 @@ snapshots:
   vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.13.17)(jsdom@26.0.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1):
     dependencies:
       '@vitest/expect': 3.1.2
-      '@vitest/mocker': 3.1.2(vite@6.2.4(@types/node@22.13.17)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1))
+      '@vitest/mocker': 3.1.2(vite@6.2.4(@types/node@20.17.30)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1))
       '@vitest/pretty-format': 3.1.2
       '@vitest/runner': 3.1.2
       '@vitest/snapshot': 3.1.2


### PR DESCRIPTION
### TL;DR

Added the `@oclif/plugin-not-found` to the Sanity CLI to improve the user experience when commands are mistyped.

![Screenshot 2025-05-15 at 4.00.44 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/PDkcC35kPWS8bTs7BD65/46d4b524-135e-4b4e-9962-ab5799936b44.png)

### What changed?

- Added `@oclif/plugin-not-found` as a dependency in `package.json`
- Added the plugin to the `plugins` array in `oclif.config.js`
- Updated the pnpm-lock.yaml file with the new dependency

### Why make this change?

The `@oclif/plugin-not-found` enhances the CLI user experience by providing helpful suggestions when users mistype commands. Instead of showing a generic "command not found" error, it will suggest the closest matching command, making the CLI more user-friendly and reducing friction for developers.