### PR TITLE
feat: add undeploy command

### DIFF
--- a/packages/@sanity/cli/src/actions/undeploy/getStudioOrAppUserApplication.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/getStudioOrAppUserApplication.ts
@@ -19,13 +19,18 @@ export async function getStudioOrAppUserApplication(options: GetStudioOrAppUserA
       throw new Error(NO_APP_ID)
     }
 
-    return getUserApplication({appId: cliConfig.app?.id})
+    return getUserApplication({appId})
   }
 
-  console.log(cliConfig.studioHost)
   if (!cliConfig.studioHost) {
     throw new Error(NO_STUDIO_HOST)
   }
 
-  return getUserApplication({appHost: cliConfig.studioHost})
+  if (!cliConfig.api?.projectId) {
+    throw new Error(
+      `sanity.cli.ts does not contain a project identifier ("api.projectId"), which is required for the Sanity CLI to communicate with the Sanity API`,
+    )
+  }
+
+  return getUserApplication({appHost: cliConfig.studioHost, projectId: cliConfig.api?.projectId})
 }

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -1,14 +1,13 @@
 import {confirm} from '@inquirer/prompts'
 import {runCommand} from '@oclif/test'
+import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {testCommand} from '~test/helpers/testCommand.js'
 
 import {getCliConfig} from '../../config/cli/getCliConfig.js'
-import {deleteUserApplication, getUserApplication} from '../../services/userApplications.js'
 import {UndeployCommand} from '../undeploy.js'
 
 vi.mock('@inquirer/prompts')
-vi.mock('../../services/userApplications.js')
 
 vi.mock(import('../../config/findProjectRoot.js'), async (importOriginal) => {
   const actual = await importOriginal()
@@ -30,8 +29,25 @@ vi.mock(import('../../config/cli/getCliConfig.js'), async (importOriginal) => {
   }
 })
 
+function mockUserApplicationsApi(options: {
+  method?: 'DELETE' | 'GET'
+  query?: Record<string, string>
+  uri: string
+}) {
+  const {method = 'GET', query = {}, uri} = options
+  const apiHost = 'https://api.sanity.io'
+  const apiVersion = 'v2024-08-01'
+
+  return nock(apiHost)
+    [method.toLowerCase() as 'delete' | 'get'](`/${apiVersion}${uri}`)
+    .query({tag: 'sanity.cli', ...query})
+}
+
 afterEach(() => {
   vi.clearAllMocks()
+  const pending = nock.pendingMocks()
+  nock.cleanAll()
+  expect(pending, 'pending mocks').toEqual([])
 })
 
 describe('#undeploy', () => {
@@ -46,16 +62,23 @@ describe('#undeploy', () => {
       api: {projectId: 'test'},
       studioHost: 'my-host',
     })
-    vi.mocked(getUserApplication).mockResolvedValueOnce({
+
+    mockUserApplicationsApi({
+      query: {appHost: 'my-host', appType: 'studio'},
+      uri: '/projects/test/user-applications',
+    }).reply(200, {
       appHost: 'my-host',
       id: 'app-id',
-    } as never)
+    })
+
+    mockUserApplicationsApi({
+      method: 'DELETE',
+      query: {appType: 'studio'},
+      uri: '/user-applications/app-id',
+    }).reply(200)
 
     const {stdout} = await testCommand(UndeployCommand, ['--yes'])
 
-    expect(deleteUserApplication).toHaveBeenCalledWith(
-      expect.objectContaining({applicationId: 'app-id', appType: 'studio'}),
-    )
     expect(stdout).toContain('Studio undeploy scheduled')
   })
 
@@ -63,16 +86,23 @@ describe('#undeploy', () => {
     vi.mocked(getCliConfig).mockResolvedValueOnce({
       app: {id: 'core-id'},
     })
-    vi.mocked(getUserApplication).mockResolvedValueOnce({
+
+    mockUserApplicationsApi({
+      query: {appType: 'coreApp'},
+      uri: '/user-applications/core-id',
+    }).reply(200, {
       appHost: 'core-host',
       id: 'core-id',
-    } as never)
+    })
+
+    mockUserApplicationsApi({
+      method: 'DELETE',
+      query: {appType: 'coreApp'},
+      uri: '/user-applications/core-id',
+    }).reply(200)
 
     const {stdout} = await testCommand(UndeployCommand, ['--yes'])
 
-    expect(deleteUserApplication).toHaveBeenCalledWith(
-      expect.objectContaining({applicationId: 'core-id', appType: 'coreApp'}),
-    )
     expect(stdout).toContain('Application undeploy scheduled')
   })
 
@@ -81,12 +111,31 @@ describe('#undeploy', () => {
       api: {projectId: 'test'},
       studioHost: 'my-host',
     })
-    vi.mocked(getUserApplication).mockResolvedValueOnce(null)
+
+    mockUserApplicationsApi({
+      query: {appHost: 'my-host', appType: 'studio'},
+      uri: '/projects/test/user-applications',
+    }).reply(404)
 
     const {stdout} = await testCommand(UndeployCommand, ['--yes'])
 
-    expect(deleteUserApplication).not.toHaveBeenCalled()
     expect(stdout).toContain('Nothing to undeploy')
+  })
+
+  test('does nothing if no application found (app config)', async () => {
+    vi.mocked(getCliConfig).mockResolvedValueOnce({
+      app: {id: 'core-id'},
+    })
+
+    mockUserApplicationsApi({
+      query: {appType: 'coreApp'},
+      uri: '/user-applications/core-id',
+    }).reply(404)
+
+    const {stdout} = await testCommand(UndeployCommand, ['--yes'])
+
+    expect(stdout).toContain('Application with the given ID does not exist.')
+    expect(stdout).toContain('Nothing to undeploy.')
   })
 
   test('does nothing if studioHost is missing', async () => {
@@ -96,7 +145,6 @@ describe('#undeploy', () => {
 
     const {stdout} = await testCommand(UndeployCommand, ['--yes'])
 
-    expect(deleteUserApplication).not.toHaveBeenCalled()
     expect(stdout).toContain('No studio host provided')
     expect(stdout).toContain('Nothing to undeploy')
   })
@@ -108,7 +156,6 @@ describe('#undeploy', () => {
 
     const {stdout} = await testCommand(UndeployCommand, ['--yes'])
 
-    expect(deleteUserApplication).not.toHaveBeenCalled()
     expect(stdout).toContain('No application ID provided')
     expect(stdout).toContain('Nothing to undeploy')
   })
@@ -118,15 +165,20 @@ describe('#undeploy', () => {
       api: {projectId: 'test'},
       studioHost: 'my-host',
     })
-    vi.mocked(getUserApplication).mockResolvedValueOnce({
+
+    mockUserApplicationsApi({
+      query: {appHost: 'my-host', appType: 'studio'},
+      uri: '/projects/test/user-applications',
+    }).reply(200, {
       appHost: 'my-host',
       id: 'app-id',
-    } as never)
+    })
+
     vi.mocked(confirm).mockResolvedValueOnce(false)
 
     await testCommand(UndeployCommand, [])
 
-    expect(deleteUserApplication).not.toHaveBeenCalled()
+    // No delete call should be made since prompt was rejected
   })
 
   test('undeploys if prompt is accepted', async () => {
@@ -134,18 +186,57 @@ describe('#undeploy', () => {
       api: {projectId: 'test'},
       studioHost: 'my-host',
     })
-    vi.mocked(getUserApplication).mockResolvedValueOnce({
+
+    mockUserApplicationsApi({
+      query: {appHost: 'my-host', appType: 'studio'},
+      uri: '/projects/test/user-applications',
+    }).reply(200, {
       appHost: 'my-host',
       id: 'app-id',
-    } as never)
+    })
+
+    mockUserApplicationsApi({
+      method: 'DELETE',
+      query: {appType: 'studio'},
+      uri: '/user-applications/app-id',
+    }).reply(200)
+
     vi.mocked(confirm).mockResolvedValueOnce(true)
 
     const {stdout} = await testCommand(UndeployCommand, [])
 
-    expect(deleteUserApplication).toHaveBeenCalledWith(
-      expect.objectContaining({applicationId: 'app-id', appType: 'studio'}),
-    )
     expect(stdout).toContain('Studio undeploy scheduled')
+  })
+
+  test('undeploys app if prompt is accepted (app config)', async () => {
+    vi.mocked(getCliConfig).mockResolvedValueOnce({
+      app: {id: 'core-id'},
+    })
+
+    mockUserApplicationsApi({
+      query: {appType: 'coreApp'},
+      uri: '/user-applications/core-id',
+    }).reply(200, {
+      appHost: 'core-host',
+      id: 'core-id',
+    })
+
+    mockUserApplicationsApi({
+      method: 'DELETE',
+      query: {appType: 'coreApp'},
+      uri: '/user-applications/core-id',
+    }).reply(200)
+
+    vi.mocked(confirm).mockResolvedValueOnce(true)
+
+    const {stdout} = await testCommand(UndeployCommand, [])
+
+    expect(stdout).toContain('Application undeploy scheduled')
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('This will undeploy core-id'),
+      }),
+    )
   })
 
   test('handles generic errors', async () => {
@@ -153,7 +244,11 @@ describe('#undeploy', () => {
       api: {projectId: 'test'},
       studioHost: 'my-host',
     })
-    vi.mocked(getUserApplication).mockRejectedValueOnce(new Error('Generic error'))
+
+    mockUserApplicationsApi({
+      query: {appHost: 'my-host', appType: 'studio'},
+      uri: '/projects/test/user-applications',
+    }).reply(500, {message: 'Generic error'})
 
     const {error, stderr} = await testCommand(UndeployCommand, ['--yes'])
 

--- a/packages/@sanity/cli/src/commands/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/undeploy.ts
@@ -33,23 +33,39 @@ export class UndeployCommand extends SanityCliCommand<typeof UndeployCommand> {
     let spin = spinner('Checking application info').start()
     try {
       const userApplication = await getStudioOrAppUserApplication({cliConfig})
-      console.log(userApplication)
       if (!userApplication) {
         spin.fail()
-        this.log('Application with the given ID does not exist.')
-        this.log('Nothing to undeploy.')
+        if (isApp) {
+          this.log('Application with the given ID does not exist.')
+          this.log('Nothing to undeploy.')
+        } else {
+          this.log('Your project has not been assigned a studio hostname')
+          this.log('or the `studioHost` provided does not exist.')
+          this.log('Nothing to undeploy.')
+        }
+
         return
       }
       spin.succeed()
 
+      const url = `https://${chalk.yellow(userApplication.appHost)}.sanity.studio`
+
       if (!flags.yes) {
+        let message = `This will undeploy ${url} and make it unavailable for your users.\nThe hostname will be available for anyone to claim.\nAre you ${chalk.red(
+          'sure',
+        )} you want to undeploy?`
+
+        if (isApp) {
+          message = `This will undeploy ${chalk.yellow(
+            userApplication.id,
+          )} and make it unavailable for your users.\nAre you ${chalk.red(
+            'sure',
+          )} you want to undeploy?`
+        }
+
         const shouldUndeploy = await confirm({
           default: false,
-          message: `This will undeploy ${chalk.yellow(
-            userApplication.id,
-          )} and make it unavailable for your users.\nThe hostname will be available for anyone to claim.\nAre you ${chalk.red(
-            'sure',
-          )} you want to undeploy?`,
+          message,
         })
 
         if (!shouldUndeploy) {
@@ -72,7 +88,6 @@ export class UndeployCommand extends SanityCliCommand<typeof UndeployCommand> {
           )} is unavailable.`,
         )
       } else {
-        const url = `https://${chalk.yellow(userApplication.appHost)}.sanity.studio`
         this.log(
           `Studio undeploy scheduled. It might take a few minutes before ${url} is unavailable.`,
         )

--- a/packages/@sanity/cli/src/services/__tests__/userApplications.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/userApplications.test.ts
@@ -35,11 +35,11 @@ describe('getUserApplication', () => {
     const result = {appHost: 'my-host', id: '123'}
     mockClient.request.mockResolvedValueOnce(result)
 
-    const app = await getUserApplication({appHost: 'my-host'})
+    const app = await getUserApplication({appHost: 'my-host', projectId: '123'})
 
     expect(mockClient.request).toHaveBeenCalledWith({
-      query: {appHost: 'my-host'},
-      uri: '/user-applications',
+      query: {appHost: 'my-host', appType: 'studio'},
+      uri: '/projects/123/user-applications',
     })
     expect(app).toBe(result)
   })
@@ -48,7 +48,7 @@ describe('getUserApplication', () => {
     const result = {appHost: 'my-host', id: '123'}
     mockClient.request.mockResolvedValueOnce(result)
 
-    const app = await getUserApplication({})
+    const app = await getUserApplication()
 
     expect(mockClient.request).toHaveBeenCalledWith({
       query: {default: 'true'},

--- a/packages/@sanity/cli/src/services/userApplications.ts
+++ b/packages/@sanity/cli/src/services/userApplications.ts
@@ -28,27 +28,32 @@ interface UserApplication {
   activeDeployment?: ActiveDeployment | null
 }
 
-interface GetUserApplicationOptions {
-  appHost?: string
-  appId?: string
-}
-
+export async function getUserApplication(options: {appId: string}): Promise<UserApplication | null>
+export async function getUserApplication(options: {
+  appHost: string
+  projectId: string
+}): Promise<UserApplication | null>
+export async function getUserApplication(): Promise<UserApplication | null>
 export async function getUserApplication({
   appHost,
   appId,
-}: GetUserApplicationOptions): Promise<UserApplication | null> {
+  projectId,
+}: {
+  appHost?: string
+  appId?: string
+  projectId?: string
+} = {}): Promise<UserApplication | null> {
   let uri = '/user-applications'
   let query: Record<string, string | string[]>
   if (appId) {
     uri = `/user-applications/${appId}`
     query = {appType: 'coreApp'}
   } else if (appHost) {
+    uri = `/projects/${projectId}/user-applications`
     query = {appHost, appType: 'studio'}
   } else {
     query = {default: 'true'}
   }
-
-  console.log(query, uri)
 
   const client = await getGlobalCliClient({
     apiVersion: USER_APPLICATIONS_API_VERSION,


### PR DESCRIPTION
### TL;DR

Added a new `undeploy` command to the Sanity CLI that allows users to remove deployed Sanity Studios and applications from Sanity hosting.

### What changed?

- Added a new `UndeployCommand` class that handles the undeploy command logic
- Implemented two separate undeploy functions:
  - `undeployStudio` for removing deployed Sanity Studios
  - `undeployApp` for removing deployed Sanity applications
- Created a new `userApplications` service with functions to:
  - Get application information by ID or host
  - Delete applications
- Added a utility function `determineIsApp` to check if the current project is an app
- Added comprehensive test coverage for all new functionality

### How to test?

1. Run `sanity undeploy --help` to see the command documentation
2. To undeploy a studio:
   - Ensure your project has a `studioHost` configured
   - Run `sanity undeploy` and confirm the prompt (or use `--yes` flag)
3. To undeploy an application:
   - Ensure your project has an `app.id` configured
   - Run `sanity undeploy` and confirm the prompt (or use `--yes` flag)

### Why make this change?

This change provides users with a convenient way to remove deployed Sanity Studios and applications directly from the CLI. Previously, users would need to use the Sanity dashboard or API to undeploy their projects. This command simplifies the workflow for developers who prefer working with the CLI and need to manage their deployments.