### PR TITLE
chore: don't ignore examples folder

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   "prConcurrentLimit": 3,
   "automerge": true,
   "dependencyDashboardApproval": false,
+  "ignorePaths": ["**/node_modules/**", "**/bower_components/**", "**/tests/**", "**/fixtures/**"],
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
Turns out by default renovate ignore examples folder https://arc.net/l/quote/cwcupjyl