### PR TITLE
chore(ci): add workflow for types and build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Check Types and Build
+
+on:
+  # Build on pushes to branches that have a PR (including drafts)
+  pull_request:
+  # Build on pushes to the main branch
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          node-version: 20
+
+      - name: Typecheck
+        run: pnpm check:types
+
+      - name: Build CLI
+        run: pnpm build:cli

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:cli": "turbo run build --filter=@sanity/cli",
     "check": "npm run check:lint && npm run check:types",
     "check:lint": "turbo run lint -- --fix",
-    "check:types": "tsc --noEmit",
+    "check:types": "turbo run check:types --filter=@sanity/cli",
     "clean": "rimraf packages/@sanity/*/lib packages/*/lib packages/@sanity/*/dist packages/*/dist",
     "clean:deps": "rimraf packages/*/node_modules examples/*/node_modules node_modules",
     "depcheck": "knip",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -42,7 +42,7 @@
     "check:types": "tsc --noEmit",
     "lint": "eslint .",
     "make:devfile": "nodetouch isDev",
-    "manifest:generate": "oclif manifest && oclif readme",
+    "manifest:generate": "oclif manifest",
     "prepack": "pnpm run manifest:generate",
     "postpack": "rimraf oclif.manifest.json",
     "test": "vitest run",

--- a/packages/@sanity/cli/src/actions/versions/buildPackageArray.ts
+++ b/packages/@sanity/cli/src/actions/versions/buildPackageArray.ts
@@ -9,8 +9,8 @@ import {tryFindLatestVersion} from './tryFindLatestVersion.js'
  *
  * @internal
  */
-function isPinnedVersion(version) {
-  return semver.valid(version)
+function isPinnedVersion(version: string): boolean {
+  return !!semver.valid(version)
 }
 
 /**

--- a/packages/@sanity/cli/src/config/cli/getCliConfig.ts
+++ b/packages/@sanity/cli/src/config/cli/getCliConfig.ts
@@ -34,13 +34,16 @@ export async function getCliConfig(rootPath: string): Promise<CliConfig> {
     throw new NotFoundError(`No CLI config found at ${rootPath}/sanity.cli.(ts|js)`)
   }
 
-  let cliConfig: unknown
+  let cliConfig: CliConfig | undefined
   try {
-    cliConfig = await tsxWorkerTask(new URL('getCliConfig.worker.js', import.meta.url), {
-      name: 'cliConfig',
-      rootPath,
-      workerData: {configPath},
-    })
+    cliConfig = await tsxWorkerTask<CliConfig | undefined>(
+      new URL('getCliConfig.worker.js', import.meta.url),
+      {
+        name: 'cliConfig',
+        rootPath,
+        workerData: {configPath},
+      },
+    )
   } catch (err) {
     debug('Failed to load CLI config in worker thread: %s', err)
 
@@ -54,7 +57,9 @@ export async function getCliConfig(rootPath: string): Promise<CliConfig> {
 
     // Ensure we get the default export (sometimes we get a bit of a mixed bag)
     cliConfig = await tsx.import(configPath, import.meta.url)
-    cliConfig = isRecord(cliConfig) && 'default' in cliConfig ? cliConfig.default : cliConfig
+    cliConfig = (isRecord(cliConfig) && 'default' in cliConfig ? cliConfig.default : cliConfig) as
+      | CliConfig
+      | undefined
 
     tsx.unregister()
   }

--- a/packages/@sanity/cli/src/core/apiClient.ts
+++ b/packages/@sanity/cli/src/core/apiClient.ts
@@ -18,7 +18,7 @@ const apiHosts: Record<string, string | undefined> = {
 /**
  * @internal
  */
-interface GlobalCliClientOptions {
+export interface GlobalCliClientOptions {
   /**
    * The API version to use for this client.
    */

--- a/packages/@sanity/cli/src/loaders/studio/studioWorkerLoader.worker.ts
+++ b/packages/@sanity/cli/src/loaders/studio/studioWorkerLoader.worker.ts
@@ -76,11 +76,11 @@ try {
 
 let viteConfig = defaultViteConfig
 if (typeof cliConfig?.vite === 'function') {
-  viteConfig = await cliConfig.vite(viteConfig, {
+  viteConfig = (await cliConfig.vite(viteConfig, {
     command: 'build',
     isSsrBuild: true,
     mode: 'production',
-  })
+  })) as InlineConfig
 } else if (isRecord(cliConfig?.vite)) {
   viteConfig = mergeConfig(viteConfig, cliConfig.vite)
 }

--- a/packages/@sanity/cli/src/loaders/tsx/tsxWorkerTask.ts
+++ b/packages/@sanity/cli/src/loaders/tsx/tsxWorkerTask.ts
@@ -30,10 +30,10 @@ interface TsxWorkerTaskOptions extends RequireProps<WorkerOptions, 'name'> {
  * @throws If the worker exits with a non-zero code
  * @internal
  */
-export function tsxWorkerTask(
+export function tsxWorkerTask<T = unknown>(
   filePath: string | URL,
   options: TsxWorkerTaskOptions,
-): Promise<unknown> {
+): Promise<T> {
   const tsconfig = getTsconfig(options.rootPath)
 
   const env = {

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,7 @@
       "cache": false,
       "persistent": true
     },
+    "check:types": {},
     "watch": {},
     "test": {},
     "test:coverage": {},


### PR DESCRIPTION
### TL;DR

Added GitHub Actions workflow for type checking and building the CLI, along with necessary TypeScript improvements.

### What changed?

- Added a new GitHub Actions workflow file (`.github/workflows/build.yml`) that runs type checking and builds the CLI on PRs and pushes to main
- Updated the `check:types` script in the root `package.json` to only check types for the CLI package
- Modified the CLI package's `manifest:generate` script to only generate the manifest without readme
- Fixed TypeScript issues in several files:
  - Added proper type annotations in `buildPackageArray.ts`
  - Improved type safety in `getCliConfig.ts` with generic type parameters
  - Added explicit type casting in `studioWorkerLoader.worker.ts`
  - Added generic type parameter to `tsxWorkerTask` function
  - Exported `GlobalCliClientOptions` interface from `apiClient.ts`
- Updated `turbo.json` to include the `check:types` task

### How to test?

1. Create a PR to verify the GitHub Actions workflow runs correctly
2. Run `pnpm check:types` locally to ensure type checking passes
3. Run `pnpm build:cli` to verify the CLI builds successfully

### Why make this change?

This change improves the development workflow by automatically checking types and building the CLI on PRs and pushes to main, catching potential issues earlier. The TypeScript improvements enhance type safety and developer experience by providing better type checking and autocompletion.