### PR TITLE
feat(create-sanity): spawn new `@sanity/cli` from `create-sanity`

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -23,7 +23,8 @@
       "source": "./src/index.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create-sanity/.depcheckrc.json
+++ b/packages/create-sanity/.depcheckrc.json
@@ -1,3 +1,0 @@
-{
-  "ignores": ["@sanity/cli"]
-}

--- a/packages/create-sanity/index.js
+++ b/packages/create-sanity/index.js
@@ -1,9 +1,18 @@
 #!/usr/bin/env node
-const childProcess = require('node:child_process')
-const path = require('node:path')
-const resolvePkg = require('resolve-pkg')
+import {spawn} from 'node:child_process'
+import {join} from 'node:path'
+
+import {moduleResolve} from 'import-meta-resolve'
 
 const args = process.argv.slice(2)
-const cliDir = resolvePkg('@sanity/cli', {cwd: __dirname})
-const cli = path.join(cliDir, 'bin', 'sanity')
-childProcess.spawn('node', [cli, 'init', '', ...args.concat('--from-create')], {stdio: 'inherit'})
+
+let cliBin
+try {
+  const cliPkgDir = await moduleResolve('@sanity/cli/package.json', import.meta.url)
+  const cliDir = join(cliPkgDir.pathname, '..')
+  cliBin = join(cliDir, 'bin', 'run.js')
+} catch (err) {
+  throw new Error('Failed to resolve `@sanity/cli` package', {cause: err})
+}
+
+spawn('node', [cliBin, 'init', ...args, '--from-create'], {stdio: 'inherit'})

--- a/packages/create-sanity/package.json
+++ b/packages/create-sanity/package.json
@@ -21,18 +21,16 @@
   },
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",
+  "type": "module",
   "bin": "./index.js",
   "files": [
     "index.js"
   ],
   "dependencies": {
     "@sanity/cli": "workspace:*",
-    "resolve-pkg": "^2.0.0"
-  },
-  "devDependencies": {
-    "@types/react": "^19.0.10"
+    "import-meta-resolve": "^4.1.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,13 +542,9 @@ importers:
       '@sanity/cli':
         specifier: workspace:*
         version: link:../@sanity/cli
-      resolve-pkg:
-        specifier: ^2.0.0
-        version: 2.0.0
-    devDependencies:
-      '@types/react':
-        specifier: ^19.0.10
-        version: 19.0.12
+      import-meta-resolve:
+        specifier: ^4.1.0
+        version: 4.1.0
 
 packages:
 
@@ -6289,10 +6285,6 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
-  resolve-pkg@2.0.0:
-    resolution: {integrity: sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==}
-    engines: {node: '>=8'}
 
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
@@ -14624,10 +14616,6 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
-
-  resolve-pkg@2.0.0:
-    dependencies:
-      resolve-from: 5.0.0
 
   resolve.exports@2.0.3: {}
 


### PR DESCRIPTION
### Description

Updates the `create-sanity` module to be ESM, require node 20 and spawn the new CLI (init command doesn't exist yet, but that will follow)

### What to review

Changes make sense and work
