### PR TITLE
fix(create-sanity): set exit code from spawned process

### DIFF
--- a/packages/create-sanity/index.js
+++ b/packages/create-sanity/index.js
@@ -15,4 +15,7 @@ try {
   throw new Error('Failed to resolve `@sanity/cli` package', {cause: err})
 }
 
-spawn('node', [cliBin, 'init', ...args, '--from-create'], {stdio: 'inherit'})
+const proc = spawn('node', [cliBin, 'init', ...args, '--from-create'], {stdio: 'inherit'})
+proc.on('exit', (code) => {
+  process.exitCode = code
+})


### PR DESCRIPTION
### Description

Small fix: If the `sanity` CLI exits with an error code, `create-sanity` should do the same.

### Testing

Will add some tests for this whole module once some basics for the `init` command is in place.