### PR TITLE
feat(cors): add cors delete command

### DIFF
--- a/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
@@ -1,0 +1,239 @@
+import {runCommand} from '@oclif/test'
+import {mockApi, testCommand} from '@sanity/cli-test'
+import nock from 'nock'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {CORS_API_VERSION} from '../../../actions/cors/constants.js'
+import {type CorsOrigin} from '../../../actions/cors/types.js'
+import {NO_PROJECT_ID} from '../../../util/errorMessages.js'
+import {Delete} from '../delete.js'
+
+// Test fixtures
+const createCorsOrigin = (
+  overrides: Partial<CorsOrigin> & {id: number; origin: string},
+): CorsOrigin => ({
+  allowCredentials: true,
+  createdAt: '2023-01-01T00:00:00Z',
+  deletedAt: null,
+  projectId: 'test-project',
+  updatedAt: null,
+  ...overrides,
+})
+
+const TEST_ORIGINS = {
+  APP_EXAMPLE: createCorsOrigin({
+    allowCredentials: false,
+    id: 2,
+    origin: 'https://app.example.com',
+  }),
+  CASE_MIXED: createCorsOrigin({id: 1, origin: 'https://Example.Com'}),
+  EXAMPLE: createCorsOrigin({id: 1, origin: 'https://example.com'}),
+  LOCALHOST: createCorsOrigin({id: 1, origin: 'http://localhost:3000'}),
+  SPECIAL_CHARS: createCorsOrigin({id: 1, origin: 'https://café.example.com'}),
+} as const
+
+// Mock the config functions with relative paths
+vi.mock('../../../../../cli-core/src/config/findProjectRoot.js', () => ({
+  findProjectRoot: vi.fn().mockResolvedValue({
+    directory: '/test/path',
+    root: '/test/path',
+    type: 'studio',
+  }),
+}))
+
+vi.mock('../../../../../cli-core/src/config/cli/getCliConfig.js', () => ({
+  getCliConfig: vi.fn().mockResolvedValue({
+    api: {
+      projectId: 'test-project',
+    },
+  }),
+}))
+
+vi.mock('../../../../../cli-core/src/services/getCliToken.js', () => ({
+  getCliToken: vi.fn().mockResolvedValue('test-token'),
+}))
+
+// Mock inquirer prompts
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn(),
+}))
+
+describe('#cors:delete', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    const pending = nock.pendingMocks()
+    nock.cleanAll()
+    expect(pending, 'pending mocks').toEqual([])
+  })
+
+  test('--help works', async () => {
+    const {stdout} = await runCommand(['cors delete', '--help'])
+    expect(stdout).toContain('Delete an existing CORS origin from your project')
+  })
+
+  test('deletes a specific CORS origin', async () => {
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: '/projects/test-project/cors',
+    }).reply(200, [TEST_ORIGINS.EXAMPLE, TEST_ORIGINS.APP_EXAMPLE])
+
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      method: 'delete',
+      uri: '/projects/test-project/cors/1',
+    }).reply(204)
+
+    const {stdout} = await testCommand(Delete, ['https://example.com'])
+    expect(stdout).toBe('Origin deleted\n')
+  })
+
+  test('prompts user to select origin when none specified', async () => {
+    const {select} = await import('@inquirer/prompts')
+    vi.mocked(select).mockResolvedValue(2)
+
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: '/projects/test-project/cors',
+    }).reply(200, [TEST_ORIGINS.EXAMPLE, TEST_ORIGINS.APP_EXAMPLE])
+
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      method: 'delete',
+      uri: '/projects/test-project/cors/2',
+    }).reply(204)
+
+    const {stdout} = await testCommand(Delete)
+    expect(stdout).toBe('Origin deleted\n')
+    expect(select).toHaveBeenCalledWith({
+      choices: [
+        {name: 'https://example.com', value: 1},
+        {name: 'https://app.example.com', value: 2},
+      ],
+      message: 'Select origin to delete',
+    })
+  })
+
+  test('handles case-insensitive origin matching', async () => {
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: '/projects/test-project/cors',
+    }).reply(200, [TEST_ORIGINS.CASE_MIXED])
+
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      method: 'delete',
+      uri: '/projects/test-project/cors/1',
+    }).reply(204)
+
+    const {stdout} = await testCommand(Delete, ['https://example.com'])
+    expect(stdout).toBe('Origin deleted\n')
+  })
+
+  test('throws error when specified origin is not found', async () => {
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: '/projects/test-project/cors',
+    }).reply(200, [TEST_ORIGINS.EXAMPLE])
+
+    const {error} = await testCommand(Delete, ['https://nonexistent.com'])
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toEqual('Origin "https://nonexistent.com" not found')
+    expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test('throws error when no CORS origins exist', async () => {
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: '/projects/test-project/cors',
+    }).reply(200, [])
+
+    const {error} = await testCommand(Delete, ['https://example.com'])
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toEqual('No CORS origins configured for this project.')
+    expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test.each([
+    {desc: 'when fetching origins', message: 'Internal Server Error', statusCode: 500},
+    {desc: 'with 404 error when fetching origins', message: 'Project not found', statusCode: 404},
+  ])('handles API error $desc', async ({message, statusCode}) => {
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: '/projects/test-project/cors',
+    }).reply(statusCode, {message})
+
+    const {error} = await testCommand(Delete, ['https://example.com'])
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Failed to fetch CORS origins')
+    expect(error?.message).toContain(message)
+    expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test.each([
+    {desc: 'when deleting origin', message: 'Failed to delete', statusCode: 500},
+    {desc: 'with 404 error when deleting origin', message: 'Origin not found', statusCode: 404},
+  ])('handles API error $desc', async ({message, statusCode}) => {
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: '/projects/test-project/cors',
+    }).reply(200, [TEST_ORIGINS.EXAMPLE])
+
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      method: 'delete',
+      uri: '/projects/test-project/cors/1',
+    }).reply(statusCode, {message})
+
+    const {error} = await testCommand(Delete, ['https://example.com'])
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Origin deletion failed')
+    expect(error?.message).toContain(message)
+    expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test.each([
+    {desc: 'no project ID is found', projectId: undefined},
+    {desc: 'project ID is empty string', projectId: ''},
+  ])('throws error when $desc', async ({projectId}) => {
+    const {getCliConfig} = await import('../../../../../cli-core/src/config/cli/getCliConfig.js')
+    vi.mocked(getCliConfig).mockResolvedValueOnce({
+      api: {projectId},
+    })
+
+    const {error} = await testCommand(Delete, ['https://example.com'])
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toEqual(NO_PROJECT_ID)
+    expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test('handles network errors when fetching origins', async () => {
+    // Don't set up any mock to simulate network failure
+    const {error} = await testCommand(Delete, ['https://example.com'])
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Failed to fetch CORS origins')
+    expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test.each([
+    {
+      desc: 'special characters',
+      input: 'https://café.example.com',
+      origin: TEST_ORIGINS.SPECIAL_CHARS,
+    },
+    {desc: 'ports', input: 'http://localhost:3000', origin: TEST_ORIGINS.LOCALHOST},
+  ])('handles $desc in origin names', async ({input, origin}) => {
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: '/projects/test-project/cors',
+    }).reply(200, [origin])
+
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      method: 'delete',
+      uri: '/projects/test-project/cors/1',
+    }).reply(204)
+
+    const {stdout} = await testCommand(Delete, [input])
+    expect(stdout).toBe('Origin deleted\n')
+  })
+})

--- a/packages/@sanity/cli/src/commands/cors/delete.ts
+++ b/packages/@sanity/cli/src/commands/cors/delete.ts
@@ -1,0 +1,110 @@
+import {select} from '@inquirer/prompts'
+import {Args} from '@oclif/core'
+import {SanityCommand, subdebug} from '@sanity/cli-core'
+
+import {CORS_API_VERSION} from '../../actions/cors/constants.js'
+import {type CorsOrigin} from '../../actions/cors/types.js'
+import {NO_PROJECT_ID} from '../../util/errorMessages.js'
+
+const deleteCorsDebug = subdebug('cors:delete')
+
+export class Delete extends SanityCommand<typeof Delete> {
+  static override args = {
+    origin: Args.string({
+      description: 'Origin to delete (will prompt if not provided)',
+      required: false,
+    }),
+  }
+
+  static override description = 'Delete an existing CORS origin from your project'
+
+  static override examples = [
+    {
+      command: '<%= config.bin %> <%= command.id %>',
+      description: 'Interactively select and delete a CORS origin',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> https://example.com',
+      description: 'Delete a specific CORS origin',
+    },
+  ]
+
+  public async run(): Promise<void> {
+    const {args} = await this.parse(Delete)
+
+    const client = await this.getGlobalApiClient({
+      apiVersion: CORS_API_VERSION,
+      requireUser: true,
+    })
+
+    // Ensure we have project context
+    const projectId = await this.getProjectId()
+    if (!projectId) {
+      this.error(NO_PROJECT_ID, {exit: 1})
+    }
+
+    // Get the origin ID to delete
+    const originId = await this.promptForOrigin(args.origin, client, projectId)
+
+    // Delete the origin
+    try {
+      await client.request({
+        method: 'DELETE',
+        uri: `/projects/${projectId}/cors/${originId}`,
+      })
+
+      this.log('Origin deleted')
+    } catch (error) {
+      const err = error as Error
+      deleteCorsDebug(`Error deleting CORS origin ${originId} for project ${projectId}`, err)
+      this.error(`Origin deletion failed:\n${err.message}`, {exit: 1})
+    }
+  }
+
+  private async promptForOrigin(
+    specifiedOrigin: string | undefined,
+    client: Awaited<ReturnType<typeof this.getGlobalApiClient>>,
+    projectId: string,
+  ): Promise<number> {
+    // Fetch all CORS origins
+    let origins: CorsOrigin[]
+    try {
+      origins = await client.request<CorsOrigin[]>({uri: `/projects/${projectId}/cors`})
+    } catch (error) {
+      const err = error as Error
+      deleteCorsDebug(`Error fetching CORS origins for project ${projectId}`, err)
+      this.error(`Failed to fetch CORS origins:\n${err.message}`, {exit: 1})
+    }
+
+    if (origins.length === 0) {
+      this.error('No CORS origins configured for this project.', {exit: 1})
+    }
+
+    // If origin is specified, find it in the list
+    if (specifiedOrigin) {
+      const specifiedOriginLower = specifiedOrigin.toLowerCase()
+      const selectedOrigin = origins.find(
+        (origin) => origin.origin.toLowerCase() === specifiedOriginLower,
+      )
+
+      if (!selectedOrigin) {
+        this.error(`Origin "${specifiedOrigin}" not found`, {exit: 1})
+      }
+
+      return selectedOrigin.id
+    }
+
+    // If no origin specified, prompt user to select one
+    const choices = origins.map((origin) => ({
+      name: origin.origin,
+      value: origin.id,
+    }))
+
+    const selectedId = await select({
+      choices,
+      message: 'Select origin to delete',
+    })
+
+    return selectedId
+  }
+}


### PR DESCRIPTION
### TL;DR

Add a new `cors delete` command to the Sanity CLI to allow users to delete CORS origins from their projects.

### What changed?

- Added a new `Delete` command class in `packages/@sanity/cli/src/commands/cors/delete.ts`
- Implemented functionality to delete CORS origins either by specifying the origin directly or through an interactive prompt
- Added comprehensive test coverage in `packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts` covering various scenarios:
  - Deleting a specific origin
  - Interactive selection when no origin is specified
  - Case-insensitive matching
  - Error handling for various conditions
  - Support for special characters and ports in origin URLs

### How to test?

1. Run `sanity cors delete` to interactively select and delete a CORS origin
2. Run `sanity cors delete https://example.com` to delete a specific CORS origin
3. Verify error handling by attempting to delete non-existent origins

### Why make this change?

This command completes the CORS management functionality in the Sanity CLI, allowing users to not only add and list CORS origins but also delete them when they're no longer needed. This provides a complete set of tools for managing CORS configurations directly from the command line.