### PR TITLE
fix(ci): allow SANITY_API_TOKEN env var in turbo runs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
+  "globalEnv": ["SANITY_API_TOKEN"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Forgot you have to explicitly allow env vars in turbo so the action was failing. This should fix it