### PR TITLE
chore(release): fixes versioning to be pre-release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -59,7 +59,8 @@
       "component": "cli-core",
       "prerelease": true,
       "prerelease-type": "alpha",
-      "release-type": "node"
+      "release-type": "node",
+      "versioning": "prerelease"
     },
     "packages/@sanity/cli-test": {
       "bump-minor-pre-major": true,
@@ -67,7 +68,8 @@
       "component": "cli-test",
       "prerelease": true,
       "prerelease-type": "alpha",
-      "release-type": "node"
+      "release-type": "node",
+      "versioning": "prerelease"
     }
   },
   "plugins": [
@@ -76,6 +78,5 @@
       "updateAllPackages": false
     }
   ],
-  "prerelease": true,
   "release-type": "node"
 }


### PR DESCRIPTION
I think ™️ this should do it. Using https://github.com/sanity-io/sdk/blob/9f62205b5ce8fbc18af69ba27b347a24da7b4bbc/release-please-config.json as a reference