### PR TITLE
chore(ci): skip claude for release PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Claude review for release PRs authored by app/squiggler
+    if: github.event.pull_request.user.login != 'app/squiggler'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
### TL;DR

Skip Claude code reviews for PRs authored by app/squiggler.

### What changed?

Modified the GitHub workflow for Claude code reviews to skip running on pull requests authored by app/squiggler. Replaced the commented-out author filtering logic with an active condition that explicitly excludes the squiggler app.

### How to test?

1. Create a PR from the app/squiggler account
2. Verify that the Claude code review workflow doesn't trigger
3. Create a PR from any other account
4. Verify that the Claude code review workflow runs normally

### Why make this change?

This change prevents unnecessary Claude code reviews on automated release PRs created by the squiggler app. Since these PRs are automatically generated, they don't require AI code review, which saves on API costs and reduces workflow noise.