### PR TITLE
feat: improve clarity of undeploy output w/ apps

### DIFF
--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -238,6 +238,39 @@ describe('#undeploy', () => {
     )
   })
 
+  test('undeploys app with missing title and reports using fallback value', async () => {
+    vi.mocked(getCliConfig).mockResolvedValueOnce({
+      app: {id: 'core-id'},
+    })
+
+    mockUserApplicationsApi({
+      query: {appType: 'coreApp'},
+      uri: '/user-applications/core-id',
+    }).reply(200, {
+      appHost: 'core-host',
+      id: 'core-id',
+      // title missing
+    })
+
+    mockUserApplicationsApi({
+      method: 'DELETE',
+      query: {appType: 'coreApp'},
+      uri: '/user-applications/core-id',
+    }).reply(200)
+
+    vi.mocked(confirm).mockResolvedValueOnce(true)
+
+    const {stdout} = await testCommand(UndeployCommand, [])
+
+    expect(stdout).toContain('Application undeploy scheduled')
+    expect(stdout).toContain('your application')
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringMatching(/\(untitled application\)/),
+      }),
+    )
+  })
+
   test('handles generic errors', async () => {
     vi.mocked(getCliConfig).mockResolvedValueOnce({
       api: {projectId: 'test'},

--- a/packages/@sanity/cli/src/commands/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/undeploy.ts
@@ -57,7 +57,7 @@ export class UndeployCommand extends SanityCommand<typeof UndeployCommand> {
         if (isApp) {
           message = `This will undeploy the following application:
 
-    Title: ${chalk.yellow(userApplication.title)}
+    Title: ${chalk.yellow(userApplication.title || '(untitled application)')}
     ID:    ${chalk.yellow(userApplication.id)}
 
 The application will no longer be available for any of your users if you proceed.
@@ -85,9 +85,9 @@ Are you ${chalk.red('sure')} you want to undeploy?`
 
       if (isApp) {
         this.log(
-          `\nApplication undeploy scheduled. It might be a few minutes until ${chalk.yellow(
-            userApplication.title,
-          )} is unavailable.`,
+          `\nApplication undeploy scheduled. It might be a few minutes until ${
+            userApplication.title ? chalk.yellow(userApplication.title) : 'your application'
+          } is unavailable.`,
         )
       } else {
         this.log(


### PR DESCRIPTION
### Description

Updates the output of the `undeploy` command when undeploying apps. This change brings the output of this command to parity with the current CLI.

New state:

<img width="772" height="272" alt="Screenshot 2025-11-19 at 14 13 57" src="https://github.com/user-attachments/assets/35b7c95a-e409-4983-8547-9aaed890c6d5" />

### What to review

- Does the new output read well? Is it clear?
- Are the changes to the associated test sufficient?

### Testing

- Verified new output locally (see screenshot above)
- All tests passing locally
