### PR TITLE
test: use `pnpx` instead of `npx` in test fixture setup

### DIFF
--- a/packages/@sanity/cli/test/testFixtures.ts
+++ b/packages/@sanity/cli/test/testFixtures.ts
@@ -56,7 +56,7 @@ export async function setup() {
     }
 
     buildPromises.push(
-      exec('npx sanity build --yes', {
+      exec('pnpx sanity build --yes', {
         cwd: toPath,
       }),
     )


### PR DESCRIPTION
### Description

I am having trouble running tests locally, and switching from npx to pnpx seems to do the trick. It _kind of_ makes more sense anyway, since we are using pnpm to install dependencies in the same file, and pnpm might have slightly different binary resolving logic.

### What to review

Ensure tests still work

### Testing

Relying on existing tests here.
