### PR TITLE
refactor: stricter type checks for expiring config utility

### DIFF
--- a/packages/@sanity/cli-core/src/util/__tests__/createExpiringConfig.test.ts
+++ b/packages/@sanity/cli-core/src/util/__tests__/createExpiringConfig.test.ts
@@ -366,4 +366,110 @@ describe('createExpiringConfig', () => {
     expect(onFetch).toHaveBeenCalledOnce()
     expect(onCacheHit).toHaveBeenCalledOnce()
   })
+
+  test('throws when cached value fails validateValue', async () => {
+    const invalidCached = 123
+    const ttl = 10_000
+
+    const validateValue = vi.fn((v: unknown): v is string => typeof v === 'string')
+
+    const config = createExpiringConfig<string>({
+      fetchValue,
+      key: 'test-key',
+      onCacheHit,
+      onFetch,
+      onRevalidate,
+      store: mockStore,
+      ttl,
+      // @ts-expect-error vitest mocks don't jive with assertions
+      validateValue,
+    })
+
+    // Cached entry that is not expired but invalid per validateValue
+    vi.mocked(mockStore.get).mockReturnValue({
+      updatedAt: Date.now(),
+      value: invalidCached,
+    })
+
+    await expect(config.get()).rejects.toThrow('Stored value is invalid')
+    expect(validateValue).toHaveBeenCalledOnce()
+    expect(onCacheHit).not.toHaveBeenCalled()
+    expect(onFetch).not.toHaveBeenCalled()
+    expect(onRevalidate).not.toHaveBeenCalled()
+    expect(mockStore.set).not.toHaveBeenCalled()
+  })
+
+  test('throws when fetched value fails validateValue (cache miss)', async () => {
+    const validateValue = vi.fn((v: unknown): v is string => typeof v === 'string')
+    const config = createExpiringConfig<string>({
+      fetchValue: fetchValue.mockResolvedValue(42 as unknown as string),
+      key: 'test-key',
+      onFetch,
+      store: mockStore,
+      ttl: 5000,
+      // @ts-expect-error vitest mocks don't jive with assertions
+      validateValue,
+    })
+
+    // Empty cache
+    vi.mocked(mockStore.get).mockReturnValue(undefined)
+
+    await expect(config.get()).rejects.toThrow('Fetched value is invalid')
+    expect(onFetch).toHaveBeenCalledOnce()
+    expect(validateValue).toHaveBeenCalledOnce()
+    expect(mockStore.set).not.toHaveBeenCalled()
+  })
+
+  test('returns cached value when validateValue accepts it', async () => {
+    const cachedValue = 'ok'
+    const validateValue = vi.fn((v: unknown): v is string => typeof v === 'string')
+    const config = createExpiringConfig<string>({
+      fetchValue,
+      key: 'test-key',
+      onCacheHit,
+      store: mockStore,
+      ttl: 5000,
+      // @ts-expect-error vitest mocks don't jive with assertions
+      validateValue,
+    })
+
+    vi.mocked(mockStore.get).mockReturnValue({
+      updatedAt: Date.now(),
+      value: cachedValue,
+    })
+
+    const result = await config.get()
+
+    expect(result).toBe(cachedValue)
+    expect(validateValue).toHaveBeenCalledOnce()
+    expect(onCacheHit).toHaveBeenCalledOnce()
+    expect(fetchValue).not.toHaveBeenCalled()
+  })
+
+  test('revalidation path validates fetched value and throws if invalid', async () => {
+    const validateValue = vi.fn((v: unknown): v is string => typeof v === 'string')
+    const config = createExpiringConfig<string>({
+      fetchValue: fetchValue.mockResolvedValue(99 as unknown as string),
+      key: 'test-key',
+      onFetch,
+      onRevalidate,
+      store: mockStore,
+      ttl: 1, // ensure expiration
+      // @ts-expect-error vitest mocks don't jive with assertions
+      validateValue,
+    })
+
+    // Cached value that has expired but is otherwise valid in shape and passes validate
+    vi.mocked(mockStore.get).mockReturnValue({
+      updatedAt: Date.now() - 10,
+      value: 'stale',
+    })
+
+    await expect(config.get()).rejects.toThrow('Fetched value is invalid')
+    expect(onRevalidate).toHaveBeenCalledOnce()
+    expect(onFetch).toHaveBeenCalledOnce()
+    // validateValue called for stored value and fetched value
+    expect(validateValue).toHaveBeenCalledTimes(2)
+    expect(mockStore.set).not.toHaveBeenCalled()
+  })
 })

--- a/packages/@sanity/cli-core/src/util/createExpiringConfig.ts
+++ b/packages/@sanity/cli-core/src/util/createExpiringConfig.ts
@@ -1,5 +1,10 @@
 import type ConfigStore from 'configstore'
 
+interface ExpiringConfigValue {
+  updatedAt: number
+  value: unknown
+}
+
 export interface ExpiringConfigOptions<Type> {
   /** Fetch value */
   fetchValue: () => Promise<Type> | Type
@@ -16,6 +21,12 @@ export interface ExpiringConfigOptions<Type> {
   onFetch?: () => void
   /** Subscribe to revalidate event */
   onRevalidate?: () => void
+
+  /**
+   * Assert the fetched value is valid, or throw if invalid.
+   * If none is provided, it will always accept the fetched value.
+   */
+  validateValue?: (value: unknown) => value is Type
 }
 
 export interface ExpiringConfigApi<Type> {
@@ -41,16 +52,22 @@ export function createExpiringConfig<Type>({
   onRevalidate = () => null,
   store,
   ttl,
+  validateValue = (value: unknown): value is Type => true,
 }: ExpiringConfigOptions<Type>): ExpiringConfigApi<Type> {
   let currentFetch: Promise<Type> | null = null
   return {
     delete() {
       store.delete(key)
     },
-    async get() {
-      const {updatedAt, value} = store.get(key) ?? {}
+    async get(): Promise<Type> {
+      const stored = store.get(key)
 
-      if (value && updatedAt) {
+      if (isExpiringValue(stored)) {
+        const {updatedAt, value} = stored
+        if (!validateValue(value)) {
+          throw new Error('Stored value is invalid')
+        }
+
         const hasExpired = Date.now() - updatedAt > ttl
 
         if (!hasExpired) {
@@ -68,6 +85,10 @@ export function createExpiringConfig<Type>({
 
       currentFetch = Promise.resolve(fetchValue())
       const nextValue = await currentFetch
+      if (!validateValue(nextValue)) {
+        throw new Error('Fetched value is invalid')
+      }
+
       currentFetch = null
 
       store.set(key, {
@@ -78,4 +99,27 @@ export function createExpiringConfig<Type>({
       return nextValue
     },
   }
+}
+
+/**
+ * Checks if the given stored value is valid (does not check if expired, only verified shape)
+ *
+ * @param stored - The stored value to check
+ * @returns True if the stored value is valid
+ * @internal
+ */
+function isExpiringValue(stored: unknown): stored is ExpiringConfigValue {
+  if (typeof stored !== 'object' || stored === null || Array.isArray(stored)) {
+    return false
+  }
+
+  if (!('updatedAt' in stored) || typeof stored.updatedAt !== 'number') {
+    return false
+  }
+
+  if (!('value' in stored)) {
+    return false
+  }
+
+  return true
 }

--- a/packages/@sanity/cli/src/actions/telemetry/fetchTelemetryConsent.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/fetchTelemetryConsent.ts
@@ -1,6 +1,6 @@
 import {createExpiringConfig, getGlobalCliClient, getUserConfig} from '@sanity/cli-core'
 
-import {type ValidApiConsentStatus} from './isValidApiConsentStatus.js'
+import {isValidApiConsentResponse, type ValidApiConsentStatus} from './isValidApiConsentStatus.js'
 import {telemetryDebug} from './telemetryDebug.js'
 
 export const TELEMETRY_CONSENT_CONFIG_KEY = 'telemetryConsent'
@@ -37,6 +37,7 @@ export async function fetchTelemetryConsent(): Promise<{
     },
     store: getUserConfig(),
     ttl: FIVE_MINUTES,
+    validateValue: isValidApiConsentResponse,
   })
 
   return telemetryConsentConfig.get()

--- a/packages/@sanity/cli/src/actions/telemetry/isValidApiConsentStatus.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/isValidApiConsentStatus.ts
@@ -2,11 +2,31 @@ export const VALID_API_STATUSES = ['granted', 'denied', 'unset'] as const
 export type ValidApiConsentStatus = (typeof VALID_API_STATUSES)[number]
 
 /**
+ * Check if the given status is a valid consent status
+ *
  * @param status - The status to check
  * @returns True if the status is valid, false otherwise
- *
  * @internal
  */
 export function isValidApiConsentStatus(status: string): status is ValidApiConsentStatus {
   return VALID_API_STATUSES.includes(status as ValidApiConsentStatus)
+}
+
+/**
+ * Check if the given response is a valid API consent response
+ *
+ * @param response - The response to check
+ * @returns True if the response is valid, false otherwise
+ * @internal
+ */
+export function isValidApiConsentResponse(
+  response: unknown,
+): response is {status: ValidApiConsentStatus} {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    'status' in response &&
+    typeof response.status === 'string' &&
+    isValidApiConsentStatus(response.status)
+  )
 }


### PR DESCRIPTION
### Description

The expiringConfig utility was somewhat loose on checking that the fetched value actually matches the expected value shape. This PR makes it stricter, allowing you do pass a custom `validateValue` option to verify. If none is passed, it'll just accept anything that is there (same as current behavior).

This also fixes a case where an upcoming typescript upgrade will start complaining about the returned value.

### What to review

Type check (`isValidApiConsentResponse`) looks correct?
…anything else?

### Testing

Added tests for the validateValue api