### PR TITLE
Bump next version in test fixture

### DIFF
--- a/packages/@sanity/original-cli/test/__fixtures__/remote-template/package.json
+++ b/packages/@sanity/original-cli/test/__fixtures__/remote-template/package.json
@@ -6,7 +6,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "next": "15.5.7",
+    "next": "15.5.9",
     "next-sanity": "^9",
     "sanity": "^4.21.0"
   }


### PR DESCRIPTION
### Description

Bumps Next.js from `15.5.7` to `15.5.9` in response to CVE-2025-55184 and CVE-2025-55183.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
