### PR TITLE
chore(deps): dedupe lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "type": "module",
   "scripts": {
     "build": "turbo run build",
-    "build:cli": "turbo run build --filter=@sanity/cli --force && pnpm run build:types",
+    "build:cli": "turbo run build --filter=@sanity/cli && pnpm run build:types",
     "build:types": "turbo run build:types --filter=@sanity/cli --filter=@sanity/cli-core",
     "check": "npm run check:lint && npm run check:types",
     "check:lint": "turbo run lint -- --fix",

--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -77,7 +77,6 @@
     "@repo/tsconfig": "workspace:*",
     "@swc/cli": "^0.7.8",
     "@swc/core": "^1.14.0",
-    "@types/configstore": "^6.0.2",
     "@types/debug": "^4.1.12",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^20.19.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,9 +577,6 @@ importers:
       '@swc/core':
         specifier: ^1.14.0
         version: 1.15.7
-      '@types/configstore':
-        specifier: ^6.0.2
-        version: 6.0.2
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -3334,9 +3331,6 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
-
-  '@types/configstore@6.0.2':
-    resolution: {integrity: sha512-OS//b51j9uyR3zvwD04Kfs5kHpve2qalQ18JhY/ho3voGYUTPLEG90/ocfKPI48hyHH8T04f7KEEbK6Ue60oZQ==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -11288,8 +11282,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
-
-  '@types/configstore@6.0.2': {}
 
   '@types/debug@4.1.12':
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -18,9 +18,7 @@
     },
     "check:types": {},
     "watch": {},
-    "test": {
-      "cache": false
-    },
+    "test": {},
     "test:coverage": {},
     "test:watch": {},
     "extract-commands": {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Dedupes lockfile and regenerates to fix dependency issue causing renovate PRs to fail