### PR TITLE
chore(ci): use node version as turbo cache input

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,6 +14,10 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    - name: Set NODE_VERSION for Turbo cache
+      run: echo "NODE_VERSION=${{ inputs.node-version }}" >> $GITHUB_ENV
+      shell: bash
+
     - name: Install pnpm
       uses: pnpm/action-setup@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           node-version: 20
 
+      - name: Set Turbo cache bypass on rerun
+        if: github.run_attempt > 1
+        run: echo "TURBO_FORCE=true" >> $GITHUB_ENV
+
       - name: Typecheck
         run: pnpm check:types
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,5 +26,9 @@ jobs:
         with:
           node-version: 20
 
+      - name: Set Turbo cache bypass on rerun
+        if: github.run_attempt > 1
+        run: echo "TURBO_FORCE=true" >> $GITHUB_ENV
+
       - name: Lint
         run: pnpm check:lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Set Turbo cache bypass on rerun
+        if: github.run_attempt > 1
+        run: echo "TURBO_FORCE=true" >> $GITHUB_ENV
+
       - name: Test
         env:
           SANITY_AUTH_TOKEN: 'test-token'

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
-  "globalEnv": ["SANITY_API_TOKEN"],
+  "globalEnv": ["SANITY_API_TOKEN", "NODE_VERSION"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
See https://github.com/sanity-io/cli/actions/runs/20603662409/job/59174923755?pr=239 to see cache force in action 