### PR TITLE
chore(ci): fix issues with publishing with catalog

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -50,6 +50,7 @@ jobs:
             './packages/@sanity/cli-core' \
             './packages/@sanity/cli-test' \
             './packages/@sanity/eslint-config-cli' \
+            --pnpm \
             --comment=update \
             --compact
         env:


### PR DESCRIPTION
Need `--pnpm` so it converts the `catalog:` deps to real versions before publish