### PR TITLE
refactor(test): deprecate project client on SanityCommand

### DIFF
--- a/packages/@sanity/cli-core/src/SanityCommand.ts
+++ b/packages/@sanity/cli-core/src/SanityCommand.ts
@@ -36,6 +36,8 @@ export abstract class SanityCommand<T extends typeof Command> extends Command {
    *
    * @param args - The project API client options.
    * @returns The project API client.
+   *
+   * @deprecated use `getProjectCliClient` function directly instead.
    */
   protected getProjectApiClient = (args: ProjectCliClientOptions) => getProjectCliClient(args)
 

--- a/packages/@sanity/cli/src/commands/dataset/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/__tests__/delete.test.ts
@@ -27,9 +27,8 @@ vi.mock('../../../../../cli-core/src/services/getCliToken.js', () => ({
   getCliToken: vi.fn().mockResolvedValue('test-token'),
 }))
 
-vi.mock('../../../../../cli-core/src/services/apiClient.js', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('../../../../../cli-core/src/services/apiClient.js')>()
+vi.mock('@sanity/cli-core', async () => {
+  const actual = await vi.importActual('@sanity/cli-core')
   return {
     ...actual,
     getProjectCliClient: vi.fn(),

--- a/packages/@sanity/cli/src/commands/dataset/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/__tests__/export.test.ts
@@ -39,9 +39,13 @@ vi.mock('../../../../../cli-core/src/services/getCliToken.js', () => ({
   getCliToken: vi.fn().mockResolvedValue('test-token'),
 }))
 
-vi.mock('../../../../../cli-core/src/services/apiClient.js', () => ({
-  getProjectCliClient: vi.fn(),
-}))
+vi.mock('@sanity/cli-core', async () => {
+  const actual = await vi.importActual('@sanity/cli-core')
+  return {
+    ...actual,
+    getProjectCliClient: vi.fn(),
+  }
+})
 
 vi.mock('node:fs/promises', () => ({
   default: {

--- a/packages/@sanity/cli/src/commands/dataset/export.ts
+++ b/packages/@sanity/cli/src/commands/dataset/export.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import {type Writable} from 'node:stream'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input, spinner} from '@sanity/cli-core/ux'
 import {type DatasetsResponse} from '@sanity/client'
 import {exportDataset, type ExportOptions, type ExportProgress} from '@sanity/export'
@@ -12,6 +12,7 @@ import prettyMs from 'pretty-ms'
 
 import {validateDatasetName} from '../../actions/dataset/validateDatasetName.js'
 import {promptForDataset} from '../../prompts/promptForDataset.js'
+import {listDatasets} from '../../services/datasets.js'
 import {absolutify} from '../../util/absolutify.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
@@ -102,8 +103,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
       })
     }
 
-    // Get the project API client
-    const projectClient = await this.getProjectApiClient({
+    const projectClient = await getProjectCliClient({
       apiVersion: '2023-05-26',
       projectId,
       requireUser: true,
@@ -112,7 +112,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
     let datasets: DatasetsResponse
 
     try {
-      datasets = await projectClient.datasets.list()
+      datasets = await listDatasets(projectId)
     } catch (error) {
       exportDebug('Error listing datasets', error)
       this.error(`Failed to list datasets:\n${error instanceof Error ? error.message : error}`, {

--- a/packages/@sanity/cli/src/commands/documents/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/create.test.ts
@@ -44,9 +44,13 @@ vi.mock('../../../../../cli-core/src/services/getCliToken.js', () => ({
   getCliToken: vi.fn().mockResolvedValue('test-token'),
 }))
 
-vi.mock('../../../../../cli-core/src/services/apiClient.js', () => ({
-  getProjectCliClient: vi.fn(),
-}))
+vi.mock('@sanity/cli-core', async () => {
+  const actual = await vi.importActual('@sanity/cli-core')
+  return {
+    ...actual,
+    getProjectCliClient: vi.fn(),
+  }
+})
 
 const mockGetCliConfig = vi.mocked(getCliConfig)
 const mockGetProjectCliClient = vi.mocked(getProjectCliClient)

--- a/packages/@sanity/cli/src/commands/documents/__tests__/get.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/get.test.ts
@@ -24,9 +24,13 @@ vi.mock('../../../../../cli-core/src/services/getCliToken.js', () => ({
   getCliToken: vi.fn().mockResolvedValue('test-token'),
 }))
 
-vi.mock('../../../../../cli-core/src/services/apiClient.js', () => ({
-  getProjectCliClient: vi.fn(),
-}))
+vi.mock('@sanity/cli-core', async () => {
+  const actual = await vi.importActual('@sanity/cli-core')
+  return {
+    ...actual,
+    getProjectCliClient: vi.fn(),
+  }
+})
 
 const mockGetCliConfig = vi.mocked(getCliConfig)
 const mockGetProjectCliClient = vi.mocked(getProjectCliClient)
@@ -61,7 +65,6 @@ describe('#documents:get', () => {
       },
     })
 
-    // Mock the getProjectApiClient to return a mock client with getDocument
     const mockGetDocument = vi.fn().mockResolvedValue(mockDoc)
     mockGetProjectCliClient.mockResolvedValue({
       getDocument: mockGetDocument,
@@ -88,7 +91,6 @@ describe('#documents:get', () => {
       },
     })
 
-    // Mock the getProjectApiClient to return a mock client with getDocument
     const mockGetDocument = vi.fn().mockResolvedValue(mockDoc)
     mockGetProjectCliClient.mockResolvedValue({
       getDocument: mockGetDocument,
@@ -133,7 +135,6 @@ describe('#documents:get', () => {
       },
     })
 
-    // Mock the getProjectApiClient to return a mock client with getDocument
     const mockGetDocument = vi.fn().mockResolvedValue(mockDoc)
     mockGetProjectCliClient.mockResolvedValue({
       getDocument: mockGetDocument,

--- a/packages/@sanity/cli/src/commands/documents/__tests__/query.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/query.test.ts
@@ -23,9 +23,13 @@ vi.mock('../../../../../cli-core/src/services/getCliToken.js', () => ({
   getCliToken: vi.fn().mockResolvedValue('test-token'),
 }))
 
-vi.mock('../../../../../cli-core/src/services/apiClient.js', () => ({
-  getProjectCliClient: vi.fn(),
-}))
+vi.mock('@sanity/cli-core', async () => {
+  const actual = await vi.importActual('@sanity/cli-core')
+  return {
+    ...actual,
+    getProjectCliClient: vi.fn(),
+  }
+})
 
 const mockGetCliConfig = vi.mocked(getCliConfig)
 const mockGetProjectCliClient = vi.mocked(getProjectCliClient)

--- a/packages/@sanity/cli/src/commands/documents/create.ts
+++ b/packages/@sanity/cli/src/commands/documents/create.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 import {type MultipleMutationResult, type Mutation} from '@sanity/client'
 import {watch as chokidarWatch} from 'chokidar'
 import {execa, execaSync} from 'execa'
@@ -75,6 +75,8 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
     }),
   }
 
+  private client!: Awaited<ReturnType<typeof getProjectCliClient>>
+
   public async run(): Promise<void> {
     const {args, flags} = await this.parse(CreateDocumentCommand)
     const {file} = args
@@ -95,7 +97,7 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
 
     const targetDataset = dataset || cliConfig.api?.dataset
 
-    const client = await this.getProjectApiClient({
+    this.client = await getProjectCliClient({
       apiVersion: DOCUMENTS_API_VERSION,
       dataset: targetDataset,
       projectId,
@@ -119,7 +121,7 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
       try {
         const contentPath = path.resolve(process.cwd(), file)
         const content = json5.parse(await fs.readFile(contentPath, 'utf8'))
-        const result = await this.writeDocuments(content, operation, client)
+        const result = await this.writeDocuments(content, operation)
         this.log(this.getResultMessage(result, operation))
         return
       } catch (error) {
@@ -136,7 +138,7 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
       // Add UUID prefix to prevent predictable file names and potential conflicts
       const tmpFile = path.join(os.tmpdir(), 'sanity-cli', `${randomUUID()}-${docId}.${ext}`)
       const stringify = useJson5 ? json5.stringify : JSON.stringify
-      const defaultValue = (id && (await client.getDocument(id))) || {
+      const defaultValue = (id && (await this.client.getDocument(id))) || {
         _id: docId,
         _type: 'specify-me',
       }
@@ -155,11 +157,7 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
       })
 
       const editor = getEditor()
-      const readAndPerformCreatesFromFile = this.readAndPerformCreatesFromFile.bind(
-        this,
-        operation,
-        client,
-      )
+      const readAndPerformCreatesFromFile = this.readAndPerformCreatesFromFile.bind(this, operation)
 
       if (watch) {
         // If we're in watch mode, we want to run the creation on each change (if it validates)
@@ -245,7 +243,6 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
    */
   private async readAndPerformCreatesFromFile(
     operation: MutationOperationName,
-    client: Awaited<ReturnType<typeof this.getProjectApiClient>>,
     filePath: string,
     defaultValue: unknown,
   ): Promise<void> {
@@ -266,7 +263,7 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
     }
 
     try {
-      const writeResult = await this.writeDocuments(content, operation, client)
+      const writeResult = await this.writeDocuments(content, operation)
       this.log(this.getResultMessage(writeResult, operation))
     } catch (err) {
       const error = err as Error
@@ -360,7 +357,6 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
   private async writeDocuments(
     documents: {_id?: string; _type: string} | {_id?: string; _type: string}[],
     operation: MutationOperationName,
-    client: Awaited<ReturnType<typeof this.getProjectApiClient>>,
   ): Promise<MultipleMutationResult> {
     const docs = Array.isArray(documents) ? documents : [documents]
     if (docs.length === 0) {
@@ -392,6 +388,6 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
       throw new Error(`Unsupported operation ${operation}`)
     })
 
-    return client.transaction(mutations).commit()
+    return this.client.transaction(mutations).commit()
   }
 }

--- a/packages/@sanity/cli/src/commands/documents/delete.ts
+++ b/packages/@sanity/cli/src/commands/documents/delete.ts
@@ -1,5 +1,5 @@
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {DOCUMENTS_API_VERSION} from '../../actions/documents/constants.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
@@ -79,8 +79,7 @@ export class DeleteDocumentCommand extends SanityCommand<typeof DeleteDocumentCo
     const targetDataset = dataset || cliConfig.api?.dataset
 
     try {
-      // Get a global client and configure it for the project and dataset
-      const projectClient = await this.getProjectApiClient({
+      const projectClient = await getProjectCliClient({
         apiVersion: DOCUMENTS_API_VERSION,
         dataset: targetDataset,
         projectId,

--- a/packages/@sanity/cli/src/commands/documents/get.ts
+++ b/packages/@sanity/cli/src/commands/documents/get.ts
@@ -1,5 +1,5 @@
 import {Args, Flags} from '@oclif/core'
-import {colorizeJson, SanityCommand, subdebug} from '@sanity/cli-core'
+import {colorizeJson, getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {DOCUMENTS_API_VERSION} from '../../actions/documents/constants.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
@@ -65,8 +65,7 @@ export class GetDocumentCommand extends SanityCommand<typeof GetDocumentCommand>
     const targetDataset = dataset || cliConfig.api?.dataset
 
     try {
-      // Get a global client and configure it for the project and dataset
-      const projectClient = await this.getProjectApiClient({
+      const projectClient = await getProjectCliClient({
         apiVersion: DOCUMENTS_API_VERSION,
         dataset: targetDataset,
         projectId,

--- a/packages/@sanity/cli/src/commands/documents/query.ts
+++ b/packages/@sanity/cli/src/commands/documents/query.ts
@@ -1,5 +1,5 @@
 import {Args, Flags} from '@oclif/core'
-import {colorizeJson, SanityCommand, subdebug} from '@sanity/cli-core'
+import {colorizeJson, getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {DOCUMENTS_API_VERSION} from '../../actions/documents/constants.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
@@ -87,8 +87,7 @@ export class QueryDocumentCommand extends SanityCommand<typeof QueryDocumentComm
     }
 
     try {
-      // Get a project client and configure it for the query
-      const projectClient = await this.getProjectApiClient({
+      const projectClient = await getProjectCliClient({
         apiVersion: targetApiVersion,
         dataset: targetDataset,
         projectId: targetProject,

--- a/packages/@sanity/cli/src/commands/graphql/list.ts
+++ b/packages/@sanity/cli/src/commands/graphql/list.ts
@@ -1,4 +1,4 @@
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 import {chalk} from '@sanity/cli-core/ux'
 
 import {
@@ -42,7 +42,7 @@ export class List extends SanityCommand<typeof List> {
       return
     }
 
-    const client = await this.getProjectApiClient({
+    const client = await getProjectCliClient({
       apiVersion: GRAPHQL_API_VERSION,
       projectId,
     })

--- a/packages/@sanity/cli/src/commands/graphql/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/undeploy.ts
@@ -3,7 +3,7 @@ import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 
 import {getGraphQLAPIs} from '../../actions/graphql/getGraphQLAPIs.js'
-import {GRAPHQL_API_VERSION} from '../../services/graphql.js'
+import {deleteGraphQLAPI} from '../../services/graphql.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
 const undeployGraphqlDebug = subdebug('graphql:undeploy')
@@ -142,17 +142,11 @@ export class Undeploy extends SanityCommand<typeof Undeploy> {
       }
     }
 
-    // Delete the GraphQL API
     try {
-      const client = await this.getProjectApiClient({
-        apiVersion: GRAPHQL_API_VERSION,
+      await deleteGraphQLAPI({
+        dataset,
         projectId,
-        requireUser: true,
-      })
-
-      await client.request({
-        method: 'DELETE',
-        uri: `/apis/graphql/${dataset}/${tag}`,
+        tag,
       })
 
       this.log('GraphQL API deleted')

--- a/packages/@sanity/cli/src/commands/media/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/media/__tests__/export.test.ts
@@ -1,12 +1,14 @@
 import fs from 'node:fs/promises'
 
 import {runCommand} from '@oclif/test'
-import {type CliConfig, getCliConfig, getGlobalCliClient} from '@sanity/cli-core'
+import {type CliConfig, getCliConfig} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
-import {testCommand} from '@sanity/cli-test'
+import {mockApi, testCommand} from '@sanity/cli-test'
 import {exportDataset} from '@sanity/export'
+import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
+import {MEDIA_LIBRARY_API_VERSION} from '../../../services/mediaLibraries.js'
 import {NO_PROJECT_ID} from '../../../util/errorMessages.js'
 import {MediaExportCommand} from '../export.js'
 
@@ -39,11 +41,6 @@ vi.mock('../../../../../cli-core/src/services/getCliToken.js', () => ({
   getCliToken: vi.fn().mockResolvedValue('test-token'),
 }))
 
-vi.mock('../../../../../cli-core/src/services/apiClient.js', () => ({
-  getGlobalCliClient: vi.fn(),
-  getProjectCliClient: vi.fn(),
-}))
-
 vi.mock('node:fs/promises', () => ({
   default: {
     mkdir: vi.fn().mockResolvedValue(undefined),
@@ -55,7 +52,6 @@ const mockExportDataset = vi.mocked(exportDataset)
 const mockInput = vi.mocked(input)
 const mockSelect = vi.mocked(select)
 const mockGetCliConfig = vi.mocked(getCliConfig)
-const mockGetGlobalCliClient = vi.mocked(getGlobalCliClient)
 const mockFs = vi.mocked(fs)
 
 const TEST_CONFIG = {
@@ -100,21 +96,10 @@ const createTestContext = (
 
   const context = {...defaults, ...overrides}
 
-  // Setup CLI config
   const apiConfig: CliConfig['api'] = {projectId: context.projectId}
 
   mockGetCliConfig.mockResolvedValue({api: apiConfig})
 
-  // Setup client mock
-  const mockClient = {
-    config: () => ({projectId: context.projectId}),
-    request: vi.fn().mockResolvedValue({
-      data: context.mediaLibraries,
-    }),
-  }
-  mockGetGlobalCliClient.mockResolvedValue(mockClient as never)
-
-  // Setup fs.stat mock
   if (context.fileExists) {
     mockFs.stat.mockResolvedValue({
       isFile: () => context.isFile,
@@ -136,7 +121,10 @@ const createTestContext = (
 
 describe('#media:export', () => {
   afterEach(() => {
+    const pending = nock.pendingMocks()
+    nock.cleanAll()
     vi.clearAllMocks()
+    expect(pending, 'pending mocks').toEqual([])
   })
 
   test('should show help text correctly', async () => {
@@ -183,6 +171,17 @@ describe('#media:export', () => {
   test('should export with provided destination', async () => {
     createTestContext({selectValue: TEST_CONFIG.MEDIA_LIBRARY_ID})
 
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
+    })
+
     const {stderr, stdout} = await testCommand(MediaExportCommand, [TEST_OUTPUTS.TAR_GZ])
 
     expect(stderr).toBe('')
@@ -204,6 +203,17 @@ describe('#media:export', () => {
   test('should export with media library ID flag', async () => {
     createTestContext()
 
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
+    })
+
     const {stderr, stdout} = await testCommand(MediaExportCommand, [
       TEST_OUTPUTS.TAR_GZ,
       '--media-library-id',
@@ -224,6 +234,17 @@ describe('#media:export', () => {
   test('should prompt for media library when not provided', async () => {
     createTestContext({selectValue: TEST_CONFIG.MEDIA_LIBRARY_ID})
 
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
+    })
+
     await testCommand(MediaExportCommand, [TEST_OUTPUTS.TAR_GZ])
 
     expect(mockSelect).toHaveBeenCalledWith(
@@ -237,6 +258,17 @@ describe('#media:export', () => {
     createTestContext({
       inputValue: TEST_OUTPUTS.TAR_GZ,
       selectValue: TEST_CONFIG.MEDIA_LIBRARY_ID,
+    })
+
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
     })
 
     await testCommand(MediaExportCommand, [])
@@ -254,6 +286,17 @@ describe('#media:export', () => {
       selectValue: TEST_CONFIG.MEDIA_LIBRARY_ID,
     })
 
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
+    })
+
     const {error} = await testCommand(MediaExportCommand, [TEST_OUTPUTS.EXISTING])
 
     expect(error?.message).toContain(ERROR_MESSAGES.ALREADY_EXISTS)
@@ -265,6 +308,17 @@ describe('#media:export', () => {
     createTestContext({
       fileExists: true,
       selectValue: TEST_CONFIG.MEDIA_LIBRARY_ID,
+    })
+
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
     })
 
     const {stderr, stdout} = await testCommand(MediaExportCommand, [
@@ -283,6 +337,17 @@ describe('#media:export', () => {
       selectValue: TEST_CONFIG.MEDIA_LIBRARY_ID,
     })
 
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
+    })
+
     await testCommand(MediaExportCommand, ['some-directory'])
 
     expect(mockExportDataset).toHaveBeenCalledWith(
@@ -294,6 +359,17 @@ describe('#media:export', () => {
 
   test('should export to stdout when destination is -', async () => {
     createTestContext({selectValue: TEST_CONFIG.MEDIA_LIBRARY_ID})
+
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
+    })
 
     await testCommand(MediaExportCommand, [TEST_OUTPUTS.STDOUT])
 
@@ -325,7 +401,18 @@ describe('#media:export', () => {
       setup: {},
     },
   ])('should error when $scenario', async ({additionalCheck, args, errorMessage, setup}) => {
-    createTestContext(setup)
+    const context = createTestContext(setup)
+
+    // Add mockApi for scenarios that have a projectId
+    if (context.projectId) {
+      mockApi({
+        apiVersion: MEDIA_LIBRARY_API_VERSION,
+        query: {projectId: context.projectId},
+        uri: '/media-libraries',
+      }).reply(200, {
+        data: context.mediaLibraries,
+      })
+    }
 
     const {error} = await testCommand(MediaExportCommand, args)
 
@@ -350,6 +437,17 @@ describe('#media:export', () => {
   ])('should pass $description flag correctly', async ({args, expected}) => {
     createTestContext({selectValue: TEST_CONFIG.MEDIA_LIBRARY_ID})
 
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
+    })
+
     await testCommand(MediaExportCommand, [TEST_OUTPUTS.TAR_GZ, ...args])
 
     expect(mockExportDataset).toHaveBeenCalledWith(expect.objectContaining(expected))
@@ -357,6 +455,18 @@ describe('#media:export', () => {
 
   test('should handle export failure', async () => {
     createTestContext({selectValue: TEST_CONFIG.MEDIA_LIBRARY_ID})
+
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
+    })
+
     mockExportDataset.mockRejectedValueOnce(new Error('Export operation failed'))
 
     const {error} = await testCommand(MediaExportCommand, [TEST_OUTPUTS.TAR_GZ])
@@ -368,6 +478,17 @@ describe('#media:export', () => {
 
   test('should create subdirectories if they do not exist', async () => {
     createTestContext({selectValue: TEST_CONFIG.MEDIA_LIBRARY_ID})
+
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'test-media-library', organizationId: 'org-1', status: 'active'},
+        {id: 'another-library', organizationId: 'org-1', status: 'active'},
+      ],
+    })
 
     await testCommand(MediaExportCommand, [TEST_OUTPUTS.SUBDIR])
 
@@ -384,6 +505,17 @@ describe('#media:export', () => {
         {id: 'inactive-library', organizationId: 'org-1', status: 'inactive' as const},
       ],
       selectValue: 'active-library',
+    })
+
+    mockApi({
+      apiVersion: MEDIA_LIBRARY_API_VERSION,
+      query: {projectId: TEST_CONFIG.PROJECT_ID},
+      uri: '/media-libraries',
+    }).reply(200, {
+      data: [
+        {id: 'active-library', organizationId: 'org-1', status: 'active'},
+        {id: 'inactive-library', organizationId: 'org-1', status: 'inactive'},
+      ],
     })
 
     await testCommand(MediaExportCommand, [TEST_OUTPUTS.TAR_GZ])

--- a/packages/@sanity/cli/src/commands/media/__tests__/import.test.ts
+++ b/packages/@sanity/cli/src/commands/media/__tests__/import.test.ts
@@ -41,9 +41,13 @@ vi.mock('../../../../../cli-core/src/config/cli/getCliConfig.js', () => ({
   getCliConfig: mocks.getCliConfig,
 }))
 
-vi.mock('../../../../../cli-core/src/services/apiClient.js', () => ({
-  getProjectCliClient: mocks.getProjectCliClient,
-}))
+vi.mock('@sanity/cli-core', async () => {
+  const actual = await vi.importActual('@sanity/cli-core')
+  return {
+    ...actual,
+    getProjectCliClient: mocks.getProjectCliClient,
+  }
+})
 
 vi.mock('../../../actions/media/importMedia.js', () => ({
   importer: mocks.importer,

--- a/packages/@sanity/cli/src/commands/media/export.ts
+++ b/packages/@sanity/cli/src/commands/media/export.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import {type Writable} from 'node:stream'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input, spinner} from '@sanity/cli-core/ux'
 import {exportDataset, type ExportOptions, type ExportProgress} from '@sanity/export'
 import boxen from 'boxen'
@@ -72,7 +72,7 @@ export class MediaExportCommand extends SanityCommand<typeof MediaExportCommand>
       })
     }
 
-    const projectClient = await this.getProjectApiClient({
+    const projectClient = await getProjectCliClient({
       apiVersion: 'v2025-02-19',
       projectId,
       requireUser: true,

--- a/packages/@sanity/cli/src/commands/media/import.ts
+++ b/packages/@sanity/cli/src/commands/media/import.ts
@@ -1,5 +1,5 @@
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {getProjectCliClient, SanityCommand} from '@sanity/cli-core'
 import {chalk, spinner} from '@sanity/cli-core/ux'
 import {SanityClient} from '@sanity/client'
 import boxen from 'boxen'
@@ -97,7 +97,7 @@ export class MediaImportCommand extends SanityCommand<typeof MediaImportCommand>
       this.error(`Media library with id "${mediaLibraryId}" not found`, {exit: 1})
     }
 
-    const projectClient = await this.getProjectApiClient({
+    const projectClient = await getProjectCliClient({
       apiVersion: 'v2025-02-19',
       dataset,
       perspective: 'drafts',

--- a/packages/@sanity/cli/src/services/graphql.ts
+++ b/packages/@sanity/cli/src/services/graphql.ts
@@ -29,3 +29,22 @@ export async function listGraphQLEndpoints(projectId: string): Promise<GraphQLEn
     uri: '/apis/graphql',
   })
 }
+
+interface DeleteGraphQLAPIOptions {
+  dataset: string
+  projectId: string
+  tag: string
+}
+
+export async function deleteGraphQLAPI({dataset, projectId, tag}: DeleteGraphQLAPIOptions) {
+  const client = await getProjectCliClient({
+    apiVersion: GRAPHQL_API_VERSION,
+    projectId,
+    requireUser: true,
+  })
+
+  return client.request({
+    method: 'DELETE',
+    uri: `/apis/graphql/${dataset}/${tag}`,
+  })
+}


### PR DESCRIPTION
### TL;DR

Refactored API client usage in CLI commands to use direct imports instead of class methods.

### What changed?

- Deprecated `getProjectApiClient` method in `SanityCommand` class
- Updated commands to import and use `getProjectCliClient` directly from `@sanity/cli-core`
- Refactored test mocks to use the proper import paths
- Created dedicated service functions for GraphQL API operations
- Added a new `deleteGraphQLAPI` function to encapsulate GraphQL API deletion logic
- Added a `listDatasets` function for dataset operations
- Fixed test mocks to use `vi.importActual` for more accurate testing

### How to test?

- Run the CLI commands that were modified to ensure they still work correctly
- Verify that dataset operations, document operations, GraphQL operations, and media operations all function as expected
- Run the test suite to ensure all tests pass with the new implementation

### Why make this change?

This change improves code maintainability by:
1. Removing the dependency on class inheritance for API client access
2. Making the code more modular with direct imports
3. Creating dedicated service functions for specific API operations
4. Making testing more straightforward with proper mocking
5. Preparing for future refactoring by deprecating the class method

The change follows better software design principles by favoring composition over inheritance and encapsulating API operations in dedicated service functions.