### PR TITLE
refactor(test): deprecate global client on SanityCommand

### DIFF
--- a/packages/@sanity/cli-core/src/SanityCommand.ts
+++ b/packages/@sanity/cli-core/src/SanityCommand.ts
@@ -28,6 +28,8 @@ export abstract class SanityCommand<T extends typeof Command> extends Command {
    *
    * @param args - The global API client options.
    * @returns The global API client.
+   *
+   * @deprecated use `getGlobalCliClient` function directly instead.
    */
   protected getGlobalApiClient = (args: GlobalCliClientOptions) => getGlobalCliClient(args)
 

--- a/packages/@sanity/cli/src/actions/cors/constants.ts
+++ b/packages/@sanity/cli/src/actions/cors/constants.ts
@@ -1,1 +1,0 @@
-export const CORS_API_VERSION = 'v2025-08-14'

--- a/packages/@sanity/cli/src/actions/cors/types.ts
+++ b/packages/@sanity/cli/src/actions/cors/types.ts
@@ -1,9 +1,0 @@
-export interface CorsOrigin {
-  allowCredentials: boolean
-  createdAt: string
-  deletedAt: string | null
-  id: number
-  origin: string
-  projectId: string
-  updatedAt: string | null
-}

--- a/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
@@ -4,6 +4,7 @@ import semver from 'semver'
 
 import {startDevServer} from '../../server/devServer.js'
 import {gracefulServerDeath} from '../../server/gracefulServerDeath.js'
+import {getProjectById} from '../../services/projects.js'
 import {getAppId} from '../../util/appId.js'
 import {compareDependencyVersions} from '../../util/compareDependencyVersions.js'
 import {getPackageManagerChoice} from '../../util/packageManager/packageManagerChoice.js'
@@ -21,7 +22,7 @@ import {type DevActionOptions} from './types.js'
 export async function startStudioDevServer(
   options: DevActionOptions,
 ): Promise<{close?: () => Promise<void>}> {
-  const {apiClient, cliConfig, flags, output, workDir} = options
+  const {cliConfig, flags, output, workDir} = options
   const projectId = cliConfig?.api?.projectId
   let organizationId: string | undefined
 
@@ -103,16 +104,9 @@ export async function startStudioDevServer(
       output.error('Project Id is required to load in dashboard', {exit: 1})
     }
 
-    const client = await apiClient({
-      apiVersion: '2025-08-25',
-      requireUser: true,
-    })
-
     try {
-      const project = await client.request<{organizationId: string}>({
-        uri: `/projects/${projectId}`,
-      })
-      organizationId = project.organizationId
+      const project = await getProjectById(projectId!)
+      organizationId = project.organizationId!
     } catch (error) {
       devDebug('Error getting organization id from project id', error)
       output.error('Failed to get organization id from project id', {exit: 1})

--- a/packages/@sanity/cli/src/actions/dev/types.ts
+++ b/packages/@sanity/cli/src/actions/dev/types.ts
@@ -1,12 +1,10 @@
-import {type CliConfig, type GlobalCliClientOptions, type Output} from '@sanity/cli-core'
-import {type SanityClient} from '@sanity/client'
+import {type CliConfig, type Output} from '@sanity/cli-core'
 
 import {type DevCommand} from '../../commands/dev.js'
 
 export type DevFlags = DevCommand['flags']
 
 export interface DevActionOptions {
-  apiClient: (args: GlobalCliClientOptions) => Promise<SanityClient>
   cliConfig: CliConfig
   flags: DevFlags
   isApp: boolean

--- a/packages/@sanity/cli/src/actions/users/apiVersion.ts
+++ b/packages/@sanity/cli/src/actions/users/apiVersion.ts
@@ -1,6 +1,0 @@
-/**
- * The API version to use for the users list command
- *
- * @internal
- */
-export const USERS_API_VERSION = 'v2025-08-30'

--- a/packages/@sanity/cli/src/actions/users/getMembersForProject.ts
+++ b/packages/@sanity/cli/src/actions/users/getMembersForProject.ts
@@ -1,11 +1,10 @@
-import {type SanityClient} from '@sanity/client'
-
+import {getProjectById, getProjectInvites} from '../../services/projects.js'
+import {getMembers} from '../../services/user.js'
 import {getPendingInvitations} from './getPendingInvitations.js'
-import {type Invite, type PartialProjectResponse, type User} from './types.js'
+import {type User} from './types.js'
 import {usersDebug} from './usersDebug.js'
 
 interface GetMembersForProjectOptions {
-  client: SanityClient
   projectId: string
 
   /**
@@ -37,26 +36,14 @@ interface MemberList {
  * @returns A list of all members for a project
  */
 export async function getMembersForProject({
-  client,
   includeInvitations,
   includeRobots,
   projectId,
 }: GetMembersForProjectOptions): Promise<MemberList[]> {
   try {
-    const useGlobalApi = true
     const [pendingInvitations, project] = await Promise.all([
-      includeInvitations
-        ? client
-            .request<Invite[]>({uri: `/invitations/project/${projectId}`, useGlobalApi})
-            .then(getPendingInvitations)
-        : [],
-      client.request<PartialProjectResponse>({
-        query: {
-          includeFeatures: 'false',
-        },
-        uri: `/projects/${projectId}`,
-        useGlobalApi,
-      }),
+      includeInvitations ? getProjectInvites(projectId).then(getPendingInvitations) : [],
+      getProjectById(projectId),
     ])
 
     const memberIds = project.members
@@ -64,9 +51,7 @@ export async function getMembersForProject({
       .filter((member) => !member.isRobot || includeRobots)
       .map((member) => member.id)
 
-    const users = await client
-      .request<User | User[]>({uri: `/users/${memberIds.join(',')}`, useGlobalApi})
-      .then((user) => (Array.isArray(user) ? user : [user]))
+    const users = await getMembers(memberIds).then((user) => (Array.isArray(user) ? user : [user]))
 
     const projectMembers = project.members
       .map((member) => {

--- a/packages/@sanity/cli/src/actions/users/types.ts
+++ b/packages/@sanity/cli/src/actions/users/types.ts
@@ -1,12 +1,3 @@
-interface Member {
-  createdAt: string
-  id: string
-  isCurrentUser: boolean
-  isRobot: boolean
-  role: string
-  updatedAt: string | null
-}
-
 export interface Invite {
   acceptedByUserId: string | null
   createdAt: string
@@ -30,10 +21,6 @@ export interface User {
 
   provider: string
   updatedAt: string | null
-}
-
-export interface PartialProjectResponse {
-  members: Member[]
 }
 
 export interface Role {

--- a/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
@@ -3,9 +3,9 @@ import {createServer} from 'node:http'
 import {join} from 'node:path'
 
 import {runCommand} from '@oclif/test'
+import {getProjectCliClient} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
-import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {testExample} from '~test/helpers/testExample.js'
 
@@ -37,6 +37,14 @@ vi.mock('../../../../cli-core/src/util/isInteractive.js', () => ({
   isInteractive: vi.fn().mockReturnValue(true),
 }))
 
+vi.mock('@sanity/cli-core', async () => {
+  const actual = await vi.importActual('@sanity/cli-core')
+  return {
+    ...actual,
+    getProjectCliClient: vi.fn(),
+  }
+})
+
 vi.mock('../../util/packageManager/upgradePackages.js')
 vi.mock('../../util/packageManager/packageManagerChoice.js')
 
@@ -45,6 +53,7 @@ const mockCompareDependencyVersions = vi.mocked(compareDependencyVersions)
 const mockConfirm = vi.mocked(confirm)
 const mockUpgradePackages = vi.mocked(upgradePackages)
 const mockGetPackageManagerChoice = vi.mocked(getPackageManagerChoice)
+const mockGetProjectCliClient = vi.mocked(getProjectCliClient)
 
 type Result = {
   close?: () => Promise<void>
@@ -52,10 +61,6 @@ type Result = {
 
 describe('#dev', () => {
   afterEach(() => {
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
-    expect(pending, 'pending mocks').toEqual([])
-
     vi.clearAllMocks()
   })
 
@@ -234,10 +239,11 @@ describe('#dev', () => {
 
       await writeFile(configPath, modifiedConfig)
 
-      mockApi({
-        apiVersion: 'v2025-08-25',
-        uri: `/projects/${projectId}`,
-      }).reply(200, {organizationId: 'test-org'})
+      mockGetProjectCliClient.mockResolvedValue({
+        projects: {
+          getById: vi.fn().mockResolvedValue({organizationId: 'test-org'}),
+        },
+      } as never)
 
       const {error, result, stderr, stdout} = await testCommand(
         DevCommand,
@@ -288,10 +294,11 @@ describe('#dev', () => {
       )
       await writeFile(configPath, modifiedConfig)
 
-      mockApi({
-        apiVersion: 'v2025-08-25',
-        uri: `/projects/${projectId}`,
-      }).reply(404, {error: 'Project not found'})
+      mockGetProjectCliClient.mockResolvedValue({
+        projects: {
+          getById: vi.fn().mockRejectedValue(new Error('Project not found')),
+        },
+      } as never)
 
       const {error} = await testCommand(DevCommand, ['--load-in-dashboard', '--port', '5344'], {
         config: {root: cwd},

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -45,7 +45,7 @@ describe('#init: oclif command setup', () => {
   test('--help works', async () => {
     const {stdout} = await runCommand('init --help')
 
-    expect(stdout).toMatchInlineSnapshot(`
+    expect(stdout).toMatchInlineSnapshot(String.raw`
         "Initialize a new Sanity Studio, project and/or app
 
         USAGE
@@ -108,19 +108,19 @@ describe('#init: oclif command setup', () => {
 
           Initialize a project with the given project ID and dataset to the given path
 
-            $ sanity init -y --project abc123 --dataset production --output-path \\
+            $ sanity init -y --project abc123 --dataset production --output-path \
               ~/myproj
 
           Initialize a project with the given project ID and dataset using the moviedb
           template to the given path
 
-            $ sanity init -y --project abc123 --dataset staging --template moviedb \\
+            $ sanity init -y --project abc123 --dataset staging --template moviedb \
               --output-path .
 
           Create a brand new project with name "Movies Unlimited"
 
-            $ sanity init -y --create-project "Movies Unlimited" --dataset moviedb \\
-              --visibility private --template moviedb --output-path \\
+            $ sanity init -y --create-project "Movies Unlimited" --dataset moviedb \
+              --visibility private --template moviedb --output-path \
               /Users/espenh/movies-unlimited
 
         "

--- a/packages/@sanity/cli/src/commands/backup/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/backup/__tests__/disable.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../../../../cli-core/src/services/getCliToken.js', () => ({
   getCliToken: vi.fn().mockResolvedValue('test-token'),
 }))
 
-vi.mock(import('../../../../../cli-core/src/services/apiClient.js'), async (importOriginal) => {
+vi.mock(import('@sanity/cli-core'), async (importOriginal) => {
   const actual = await importOriginal()
   return {
     ...actual,

--- a/packages/@sanity/cli/src/commands/backup/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/backup/__tests__/enable.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../../../../cli-core/src/services/getCliToken.js', () => ({
   getCliToken: vi.fn().mockResolvedValue('test-token'),
 }))
 
-vi.mock(import('../../../../../cli-core/src/services/apiClient.js'), async (importOriginal) => {
+vi.mock(import('@sanity/cli-core'), async (importOriginal) => {
   const actual = await importOriginal()
   return {
     ...actual,

--- a/packages/@sanity/cli/src/commands/backup/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/backup/__tests__/list.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../../../../cli-core/src/services/getCliToken.js', () => ({
   getCliToken: vi.fn().mockResolvedValue('test-token'),
 }))
 
-vi.mock(import('../../../../../cli-core/src/services/apiClient.js'), async (importOriginal) => {
+vi.mock(import('@sanity/cli-core'), async (importOriginal) => {
   const actual = await importOriginal()
   return {
     ...actual,

--- a/packages/@sanity/cli/src/commands/backup/disable.ts
+++ b/packages/@sanity/cli/src/commands/backup/disable.ts
@@ -4,7 +4,7 @@ import {chalk, select} from '@sanity/cli-core/ux'
 import {type DatasetsResponse} from '@sanity/client'
 
 import {assertDatasetExists} from '../../actions/backup/assertDatasetExist.js'
-import {BACKUP_API_VERSION} from '../../actions/backup/constants.js'
+import {setBackup} from '../../services/backup.js'
 import {listDatasets} from '../../services/datasets.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
@@ -40,11 +40,6 @@ export class DisableBackupCommand extends SanityCommand<typeof DisableBackupComm
       this.error(NO_PROJECT_ID, {exit: 1})
     }
 
-    const client = await this.getGlobalApiClient({
-      apiVersion: BACKUP_API_VERSION,
-      requireUser: true,
-    })
-
     let datasets: DatasetsResponse
 
     try {
@@ -66,13 +61,7 @@ export class DisableBackupCommand extends SanityCommand<typeof DisableBackupComm
     }
 
     try {
-      await client.request({
-        body: {
-          enabled: false,
-        },
-        method: 'PUT',
-        uri: `/projects/${projectId}/datasets/${dataset}/settings/backups`,
-      })
+      await setBackup({dataset, projectId, status: false})
 
       this.log(`${chalk.green(`Disabled daily backups for dataset ${dataset}.\n`)}`)
       this.log(

--- a/packages/@sanity/cli/src/commands/backup/enable.ts
+++ b/packages/@sanity/cli/src/commands/backup/enable.ts
@@ -4,9 +4,9 @@ import {chalk} from '@sanity/cli-core/ux'
 import {type DatasetsResponse} from '@sanity/client'
 
 import {assertDatasetExists} from '../../actions/backup/assertDatasetExist.js'
-import {BACKUP_API_VERSION} from '../../actions/backup/constants.js'
 import {NEW_DATASET_VALUE, promptForDataset} from '../../prompts/promptForDataset.js'
 import {promptForDatasetName} from '../../prompts/promptForDatasetName.js'
+import {setBackup} from '../../services/backup.js'
 import {createDataset, listDatasets} from '../../services/datasets.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
@@ -41,11 +41,6 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
     if (!projectId) {
       this.error(NO_PROJECT_ID, {exit: 1})
     }
-
-    const client = await this.getGlobalApiClient({
-      apiVersion: BACKUP_API_VERSION,
-      requireUser: true,
-    })
 
     let datasets: DatasetsResponse
 
@@ -88,13 +83,7 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
     }
 
     try {
-      await client.request({
-        body: {
-          enabled: true,
-        },
-        method: 'PUT',
-        uri: `/projects/${projectId}/datasets/${dataset}/settings/backups`,
-      })
+      await setBackup({dataset, projectId, status: true})
 
       this.log(
         `${chalk.green(

--- a/packages/@sanity/cli/src/commands/backup/list.ts
+++ b/packages/@sanity/cli/src/commands/backup/list.ts
@@ -6,7 +6,7 @@ import {Table} from 'console-table-printer'
 import {isAfter, isValid, lightFormat, parse} from 'date-fns'
 
 import {assertDatasetExists} from '../../actions/backup/assertDatasetExist.js'
-import {BACKUP_API_VERSION} from '../../actions/backup/constants.js'
+import {listBackups} from '../../services/backup.js'
 import {listDatasets} from '../../services/datasets.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
@@ -18,15 +18,6 @@ type ListBackupRequestQueryParams = {
   after?: string
   before?: string
   limit: string
-}
-
-type ListBackupResponse = {
-  backups: ListBackupResponseItem[]
-}
-
-type ListBackupResponseItem = {
-  createdAt: string
-  id: string
 }
 
 export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
@@ -80,11 +71,6 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
     if (!projectId) {
       this.error(NO_PROJECT_ID, {exit: 1})
     }
-
-    const client = await this.getGlobalApiClient({
-      apiVersion: BACKUP_API_VERSION,
-      requireUser: true,
-    })
 
     let datasets: DatasetsResponse
 
@@ -140,9 +126,12 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
     }
 
     try {
-      const response = await client.request<ListBackupResponse>({
-        query,
-        uri: `/projects/${projectId}/datasets/${dataset}/backups`,
+      const response = await listBackups({
+        after: flags.after,
+        before: flags.before,
+        datasetName: dataset,
+        limit: flags.limit,
+        projectId,
       })
 
       if (response.backups.length === 0) {

--- a/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
@@ -6,7 +6,7 @@ import {mockApi, testCommand} from '@sanity/cli-test'
 import nock from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {CORS_API_VERSION} from '../../../actions/cors/constants.js'
+import {CORS_API_VERSION} from '../../../services/cors.js'
 import {NO_PROJECT_ID} from '../../../util/errorMessages.js'
 import {Add} from '../add.js'
 

--- a/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
@@ -3,12 +3,10 @@ import {mockApi, testCommand} from '@sanity/cli-test'
 import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {CORS_API_VERSION} from '../../../actions/cors/constants.js'
-import {type CorsOrigin} from '../../../actions/cors/types.js'
+import {CORS_API_VERSION, type CorsOrigin} from '../../../services/cors.js'
 import {NO_PROJECT_ID} from '../../../util/errorMessages.js'
 import {Delete} from '../delete.js'
 
-// Test fixtures
 const createCorsOrigin = (
   overrides: Partial<CorsOrigin> & {id: number; origin: string},
 ): CorsOrigin => ({
@@ -32,7 +30,6 @@ const TEST_ORIGINS = {
   SPECIAL_CHARS: createCorsOrigin({id: 1, origin: 'https://café.example.com'}),
 } as const
 
-// Mock the config functions with relative paths
 vi.mock('../../../../../cli-core/src/config/findProjectRoot.js', () => ({
   findProjectRoot: vi.fn().mockResolvedValue({
     directory: '/test/path',

--- a/packages/@sanity/cli/src/commands/cors/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/list.test.ts
@@ -3,11 +3,10 @@ import {mockApi, testCommand} from '@sanity/cli-test'
 import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {CORS_API_VERSION} from '../../../actions/cors/constants.js'
+import {CORS_API_VERSION} from '../../../services/cors.js'
 import {NO_PROJECT_ID} from '../../../util/errorMessages.js'
 import {List} from '../list.js'
 
-// Mock the config functions with relative paths
 vi.mock('../../../../../cli-core/src/config/findProjectRoot.js', () => ({
   findProjectRoot: vi.fn().mockResolvedValue({
     directory: '/test/path',

--- a/packages/@sanity/cli/src/commands/cors/add.ts
+++ b/packages/@sanity/cli/src/commands/cors/add.ts
@@ -6,8 +6,8 @@ import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {chalk, confirm, logSymbols} from '@sanity/cli-core/ux'
 import {oneline} from 'oneline'
 
-import {CORS_API_VERSION} from '../../actions/cors/constants.js'
 import {filterAndValidateOrigin} from '../../actions/cors/filterAndValidateOrigin.js'
+import {createCorsOrigin} from '../../services/cors.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
 const addCorsDebug = subdebug('cors:add')
@@ -50,11 +50,6 @@ export class Add extends SanityCommand<typeof Add> {
     const {args, flags} = await this.parse(Add)
     const {origin} = args
 
-    const client = await this.getGlobalApiClient({
-      apiVersion: CORS_API_VERSION,
-      requireUser: true,
-    })
-
     // Ensure we have project context
     const projectId = await this.getProjectId()
     if (!projectId) {
@@ -91,14 +86,10 @@ export class Add extends SanityCommand<typeof Add> {
     }
 
     try {
-      const response = await client.request({
-        body: {
-          allowCredentials,
-          origin: filteredOrigin,
-        },
-        maxRedirects: 0,
-        method: 'POST',
-        uri: `/projects/${projectId}/cors`,
+      const response = await createCorsOrigin({
+        allowCredentials,
+        origin: filteredOrigin,
+        projectId,
       })
 
       addCorsDebug(`CORS origin added successfully`, response)

--- a/packages/@sanity/cli/src/commands/cors/delete.ts
+++ b/packages/@sanity/cli/src/commands/cors/delete.ts
@@ -2,8 +2,7 @@ import {Args} from '@oclif/core'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 
-import {CORS_API_VERSION} from '../../actions/cors/constants.js'
-import {type CorsOrigin} from '../../actions/cors/types.js'
+import {type CorsOrigin, deleteCorsOrigin, listCorsOrigins} from '../../services/cors.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
 const deleteCorsDebug = subdebug('cors:delete')
@@ -32,11 +31,6 @@ export class Delete extends SanityCommand<typeof Delete> {
   public async run(): Promise<void> {
     const {args} = await this.parse(Delete)
 
-    const client = await this.getGlobalApiClient({
-      apiVersion: CORS_API_VERSION,
-      requireUser: true,
-    })
-
     // Ensure we have project context
     const projectId = await this.getProjectId()
     if (!projectId) {
@@ -44,14 +38,10 @@ export class Delete extends SanityCommand<typeof Delete> {
     }
 
     // Get the origin ID to delete
-    const originId = await this.promptForOrigin(args.origin, client, projectId)
+    const originId = await this.promptForOrigin(args.origin, projectId)
 
-    // Delete the origin
     try {
-      await client.request({
-        method: 'DELETE',
-        uri: `/projects/${projectId}/cors/${originId}`,
-      })
+      await deleteCorsOrigin({originId, projectId})
 
       this.log('Origin deleted')
     } catch (error) {
@@ -63,13 +53,11 @@ export class Delete extends SanityCommand<typeof Delete> {
 
   private async promptForOrigin(
     specifiedOrigin: string | undefined,
-    client: Awaited<ReturnType<typeof this.getGlobalApiClient>>,
     projectId: string,
   ): Promise<number> {
-    // Fetch all CORS origins
     let origins: CorsOrigin[]
     try {
-      origins = await client.request<CorsOrigin[]>({uri: `/projects/${projectId}/cors`})
+      origins = await listCorsOrigins(projectId)
     } catch (error) {
       const err = error as Error
       deleteCorsDebug(`Error fetching CORS origins for project ${projectId}`, err)

--- a/packages/@sanity/cli/src/commands/cors/list.ts
+++ b/packages/@sanity/cli/src/commands/cors/list.ts
@@ -1,7 +1,6 @@
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 
-import {CORS_API_VERSION} from '../../actions/cors/constants.js'
-import {type CorsOrigin} from '../../actions/cors/types.js'
+import {type CorsOrigin, listCorsOrigins} from '../../services/cors.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
 const listCorsDebug = subdebug('cors:list')
@@ -16,15 +15,8 @@ export class List extends SanityCommand<typeof List> {
   ]
 
   public async run(): Promise<void> {
-    // Parse to ensure no invalid flags are passed
     await this.parse(List)
 
-    const client = await this.getGlobalApiClient({
-      apiVersion: CORS_API_VERSION,
-      requireUser: true,
-    })
-
-    // Ensure we have project context
     const projectId = await this.getProjectId()
     if (!projectId) {
       this.error(NO_PROJECT_ID, {exit: 1})
@@ -32,7 +24,7 @@ export class List extends SanityCommand<typeof List> {
 
     let origins: CorsOrigin[]
     try {
-      origins = await client.request<CorsOrigin[]>({uri: `/projects/${projectId}/cors`})
+      origins = await listCorsOrigins(projectId)
     } catch (error) {
       const err = error as Error
 

--- a/packages/@sanity/cli/src/commands/dev.ts
+++ b/packages/@sanity/cli/src/commands/dev.ts
@@ -52,7 +52,6 @@ export class DevCommand extends SanityCommand<typeof DevCommand> {
 
     try {
       const result = await devAction({
-        apiClient: this.getGlobalApiClient,
         cliConfig,
         flags,
         isApp,

--- a/packages/@sanity/cli/src/commands/documents/__tests__/validate.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/validate.test.ts
@@ -41,14 +41,18 @@ vi.mock('../../../../../cli-core/src/config/cli/getCliConfig.js', () => ({
   getCliConfig: vi.fn(),
 }))
 
-vi.mock('../../../../../cli-core/src/services/apiClient.js', () => ({
-  getGlobalCliClient: vi.fn().mockResolvedValue({
-    config: vi.fn(() => ({
-      dataset: 'test-dataset',
-      projectId: 'test-project',
-    })),
-  }),
-}))
+vi.mock('@sanity/cli-core', async () => {
+  const actual = await vi.importActual('@sanity/cli-core')
+  return {
+    ...actual,
+    getGlobalCliClient: vi.fn().mockResolvedValue({
+      config: vi.fn(() => ({
+        dataset: 'test-dataset',
+        projectId: 'test-project',
+      })),
+    }),
+  }
+})
 
 vi.mock('../../../actions/documents/validate.js', () => ({
   validateDocuments: mocks.validate,

--- a/packages/@sanity/cli/src/commands/documents/validate.ts
+++ b/packages/@sanity/cli/src/commands/documents/validate.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import {Flags} from '@oclif/core'
-import {Output, SanityCommand} from '@sanity/cli-core'
+import {getGlobalCliClient, Output, SanityCommand} from '@sanity/cli-core'
 import {chalk, confirm, logSymbols} from '@sanity/cli-core/ux'
 import {type ClientConfig} from '@sanity/client'
 
@@ -90,7 +90,7 @@ export class ValidateDocumentsCommand extends SanityCommand<typeof ValidateDocum
     const {flags} = await this.parse(ValidateDocumentsCommand)
     const unattendedMode = Boolean(flags.yes)
 
-    const apiClient = await this.getGlobalApiClient({
+    const apiClient = await getGlobalCliClient({
       apiVersion: DOCUMENTS_API_VERSION,
       requireUser: true,
     })

--- a/packages/@sanity/cli/src/commands/hook/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/hook/__tests__/create.test.ts
@@ -1,10 +1,8 @@
 import {runCommand} from '@oclif/test'
-import {getCliConfig} from '@sanity/cli-core'
-import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {getCliConfig, getProjectCliClient} from '@sanity/cli-core'
+import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {HOOK_API_VERSION} from '../../../actions/hook/constants.js'
 import {NO_PROJECT_ID} from '../../../util/errorMessages.js'
 import {CreateHookCommand} from '../create.js'
 
@@ -32,12 +30,19 @@ vi.mock('../../../../../cli-core/src/config/cli/getCliConfig.js', async () => {
   }
 })
 
+const mockGetProjectCliClient = vi.mocked(getProjectCliClient)
+
+vi.mock('@sanity/cli-core', async () => {
+  const actual = await vi.importActual('@sanity/cli-core')
+  return {
+    ...actual,
+    getProjectCliClient: vi.fn(),
+  }
+})
+
 describe('#hook:create', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
-    expect(pending, 'pending mocks').toEqual([])
   })
 
   test('--help works', async () => {
@@ -64,13 +69,14 @@ describe('#hook:create', () => {
   test('opens webhook creation URL for project with organization', async () => {
     const open = await import('open')
 
-    mockApi({
-      apiVersion: HOOK_API_VERSION,
-      uri: '/projects/test-project',
-    }).reply(200, {
-      id: 'test-project',
-      organizationId: 'test-org',
-    })
+    mockGetProjectCliClient.mockResolvedValueOnce({
+      projects: {
+        getById: vi.fn().mockResolvedValue({
+          id: 'test-project',
+          organizationId: 'test-org',
+        }),
+      },
+    } as never)
 
     const {stdout} = await testCommand(CreateHookCommand)
 
@@ -85,12 +91,13 @@ describe('#hook:create', () => {
   test('opens webhook creation URL for project without organization (personal)', async () => {
     const open = await import('open')
 
-    mockApi({
-      apiVersion: HOOK_API_VERSION,
-      uri: '/projects/test-project',
-    }).reply(200, {
-      id: 'test-project',
-    })
+    mockGetProjectCliClient.mockResolvedValueOnce({
+      projects: {
+        getById: vi.fn().mockResolvedValue({
+          id: 'test-project',
+        }),
+      },
+    } as never)
 
     const {stdout} = await testCommand(CreateHookCommand)
 
@@ -103,10 +110,7 @@ describe('#hook:create', () => {
   })
 
   test('displays an error if the project fetch fails', async () => {
-    mockApi({
-      apiVersion: HOOK_API_VERSION,
-      uri: '/projects/test-project',
-    }).reply(500, {message: 'Internal Server Error'})
+    mockGetProjectCliClient.mockRejectedValueOnce(new Error('Internal Server Error'))
 
     const {error} = await testCommand(CreateHookCommand)
 
@@ -131,13 +135,14 @@ describe('#hook:create', () => {
     const open = await import('open')
     vi.mocked(open.default).mockRejectedValueOnce(new Error('Failed to open browser'))
 
-    mockApi({
-      apiVersion: HOOK_API_VERSION,
-      uri: '/projects/test-project',
-    }).reply(200, {
-      id: 'test-project',
-      organizationId: 'test-org',
-    })
+    mockGetProjectCliClient.mockResolvedValueOnce({
+      projects: {
+        getById: vi.fn().mockResolvedValue({
+          id: 'test-project',
+          organizationId: 'test-org',
+        }),
+      },
+    } as never)
 
     const {error} = await testCommand(CreateHookCommand)
 

--- a/packages/@sanity/cli/src/commands/hook/create.ts
+++ b/packages/@sanity/cli/src/commands/hook/create.ts
@@ -1,7 +1,7 @@
 import {getSanityUrl, SanityCommand, subdebug} from '@sanity/cli-core'
 import open from 'open'
 
-import {HOOK_API_VERSION} from '../../actions/hook/constants.js'
+import {getProjectById} from '../../services/projects.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
 const createHookDebug = subdebug('hook:create')
@@ -16,11 +16,6 @@ export class CreateHookCommand extends SanityCommand<typeof CreateHookCommand> {
   ]
 
   public async run() {
-    const client = await this.getGlobalApiClient({
-      apiVersion: HOOK_API_VERSION,
-      requireUser: true,
-    })
-
     const projectId = await this.getProjectId()
     if (!projectId) {
       this.error(NO_PROJECT_ID, {exit: 1})
@@ -28,7 +23,7 @@ export class CreateHookCommand extends SanityCommand<typeof CreateHookCommand> {
 
     let projectInfo: {organizationId?: string | null}
     try {
-      projectInfo = await client.projects.getById(projectId)
+      projectInfo = await getProjectById(projectId)
     } catch (error) {
       const err = error as Error
       createHookDebug(`Error fetching project info for project ${projectId}`, err)

--- a/packages/@sanity/cli/src/commands/hook/delete.ts
+++ b/packages/@sanity/cli/src/commands/hook/delete.ts
@@ -2,8 +2,8 @@ import {Args} from '@oclif/core'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 
-import {HOOK_API_VERSION} from '../../actions/hook/constants.js'
 import {type Hook} from '../../actions/hook/types'
+import {deleteHookForProject, listHooksForProject} from '../../services/hooks.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
 const deleteHookDebug = subdebug('hook:delete')
@@ -32,26 +32,16 @@ export class Delete extends SanityCommand<typeof Delete> {
   public async run(): Promise<void> {
     const {args} = await this.parse(Delete)
 
-    const client = await this.getGlobalApiClient({
-      apiVersion: HOOK_API_VERSION,
-      requireUser: true,
-    })
-
-    // Ensure we have project context
     const projectId = await this.getProjectId()
     if (!projectId) {
       this.error(NO_PROJECT_ID, {exit: 1})
     }
 
     // Get the hook ID to delete
-    const hookId = await this.promptForHook(args.name, client, projectId)
+    const hookId = await this.promptForHook(args.name, projectId)
 
-    // Delete the hook
     try {
-      await client.request({
-        method: 'DELETE',
-        uri: `/hooks/projects/${projectId}/${hookId}`,
-      })
+      await deleteHookForProject(projectId, hookId)
 
       this.log('Hook deleted')
     } catch (error) {
@@ -63,13 +53,11 @@ export class Delete extends SanityCommand<typeof Delete> {
 
   private async promptForHook(
     specifiedName: string | undefined,
-    client: Awaited<ReturnType<typeof this.getGlobalApiClient>>,
     projectId: string,
   ): Promise<string> {
-    // Fetch all hooks for this project
     let hooks: Hook[]
     try {
-      hooks = await client.request<Hook[]>({uri: `/hooks/projects/${projectId}`})
+      hooks = await listHooksForProject(projectId)
     } catch (error) {
       const err = error as Error
       deleteHookDebug(`Error fetching hooks for project ${projectId}`, err)

--- a/packages/@sanity/cli/src/commands/hook/list.ts
+++ b/packages/@sanity/cli/src/commands/hook/list.ts
@@ -1,7 +1,7 @@
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 
-import {HOOK_API_VERSION} from '../../actions/hook/constants.js'
 import {type Hook} from '../../actions/hook/types'
+import {listHooksForProject} from '../../services/hooks.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
 const listHookDebug = subdebug('hook:list')
@@ -16,11 +16,6 @@ export class List extends SanityCommand<typeof List> {
   ]
 
   public async run() {
-    const client = await this.getGlobalApiClient({
-      apiVersion: HOOK_API_VERSION,
-      requireUser: true,
-    })
-
     // Ensure we have project context
     const projectId = await this.getProjectId()
     if (!projectId) {
@@ -29,7 +24,7 @@ export class List extends SanityCommand<typeof List> {
 
     let hooks: Hook[]
     try {
-      hooks = await client.request<Hook[]>({uri: `/hooks/projects/${projectId}`})
+      hooks = await listHooksForProject(projectId)
     } catch (error) {
       const err = error as Error
 

--- a/packages/@sanity/cli/src/commands/projects/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/list.test.ts
@@ -3,6 +3,7 @@ import {mockApi, testCommand} from '@sanity/cli-test'
 import nock from 'nock'
 import {afterEach, describe, expect, test} from 'vitest'
 
+import {PROJECTS_API_VERSION} from '../../../services/projects.js'
 import {List} from '../list.js'
 
 describe('#list', () => {
@@ -20,7 +21,7 @@ describe('#list', () => {
 
   test('displays projects correctly', async () => {
     mockApi({
-      apiVersion: 'v2025-05-15',
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects',
     }).reply(200, [
       {
@@ -44,7 +45,7 @@ describe('#list', () => {
 
   test('sorts by members when --sort members is specified', async () => {
     mockApi({
-      apiVersion: 'v2025-05-15',
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects',
     }).reply(200, [
       {
@@ -88,7 +89,7 @@ describe('#list', () => {
 
   test('sorts in ascending order when --order asc is specified', async () => {
     mockApi({
-      apiVersion: 'v2025-05-15',
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects',
     }).reply(200, [
       {
@@ -129,7 +130,7 @@ describe('#list', () => {
 
   test('displays an error if the API request fails', async () => {
     mockApi({
-      apiVersion: 'v2025-05-15',
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects',
     }).reply(500, {message: 'Internal Server Error'})
 

--- a/packages/@sanity/cli/src/commands/projects/list.ts
+++ b/packages/@sanity/cli/src/commands/projects/list.ts
@@ -3,9 +3,10 @@ import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {chalk} from '@sanity/cli-core/ux'
 import {size, sortBy} from 'lodash-es'
 
+import {listProjects} from '../../services/projects.js'
+
 const sortFields = ['id', 'members', 'name', 'url', 'created']
 
-const LIST_PROJECTS_API_VERSION = 'v2025-05-15'
 const projectsDebug = subdebug('projects')
 
 export class List extends SanityCommand<typeof List> {
@@ -35,13 +36,8 @@ export class List extends SanityCommand<typeof List> {
   public async run() {
     const {order, sort} = this.flags
 
-    const client = await this.getGlobalApiClient({
-      apiVersion: LIST_PROJECTS_API_VERSION,
-      requireUser: true,
-    })
-
     try {
-      const projects = await client.projects.list()
+      const projects = await listProjects()
       const ordered = sortBy(
         projects.map(({createdAt, displayName, id, members = []}) => {
           const manage = `https://www.sanity.io/manage/project/${id}`

--- a/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
@@ -5,7 +5,7 @@ import {mockApi, testCommand} from '@sanity/cli-test'
 import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {USERS_API_VERSION} from '../../../actions/users/apiVersion.js'
+import {PROJECTS_API_VERSION} from '../../../services/projects.js'
 import {NO_PROJECT_ID} from '../../../util/errorMessages.js'
 import {UsersInviteCommand} from '../invite.js'
 
@@ -98,12 +98,12 @@ describe('#invite', () => {
 
   test('invites user with email and role provided via flags', async () => {
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       method: 'post',
       uri: '/invitations/project/test-project',
     }).reply(200, {})
@@ -119,12 +119,12 @@ describe('#invite', () => {
 
   test('invites user with email provided via args and role as flag', async () => {
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       method: 'post',
       uri: '/invitations/project/test-project',
     }).reply(200, {})
@@ -140,7 +140,7 @@ describe('#invite', () => {
 
   test('exits when role is not found', async () => {
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
@@ -176,12 +176,12 @@ describe('#invite', () => {
 
   test('handles 402 quota error', async () => {
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       method: 'post',
       uri: '/invitations/project/test-project',
     }).reply(402, {message: 'Payment required'})
@@ -201,12 +201,12 @@ describe('#invite', () => {
 
   test('handles API errors during invitation', async () => {
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       method: 'post',
       uri: '/invitations/project/test-project',
     }).reply(500, {message: 'Internal server error'})
@@ -224,7 +224,7 @@ describe('#invite', () => {
 
   test('handles API errors when fetching roles', async () => {
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(500, {message: 'Internal server error'})
 
@@ -241,7 +241,7 @@ describe('#invite', () => {
 
   test('exits when trying to assign role that does not apply to users', async () => {
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
@@ -259,12 +259,12 @@ describe('#invite', () => {
 
   test('role names are case insensitive', async () => {
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       method: 'post',
       uri: '/invitations/project/test-project',
     }).reply(200, {})
@@ -282,12 +282,12 @@ describe('#invite', () => {
     vi.mocked(input).mockResolvedValueOnce('prompted@example.com')
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       method: 'post',
       uri: '/invitations/project/test-project',
     }).reply(200, {})
@@ -306,12 +306,12 @@ describe('#invite', () => {
     vi.mocked(select).mockResolvedValueOnce('administrator')
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       method: 'post',
       uri: '/invitations/project/test-project',
     }).reply(200, {})
@@ -343,12 +343,12 @@ describe('#invite', () => {
     vi.mocked(select).mockResolvedValueOnce('viewer')
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       method: 'post',
       uri: '/invitations/project/test-project',
     }).reply(200, {})

--- a/packages/@sanity/cli/src/commands/users/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/list.test.ts
@@ -1,10 +1,11 @@
 import {runCommand} from '@oclif/test'
-import {getCliConfig} from '@sanity/cli-core'
+import {getCliConfig, getProjectCliClient} from '@sanity/cli-core'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {USERS_API_VERSION} from '../../../actions/users/apiVersion.js'
+import {PROJECTS_API_VERSION} from '../../../services/projects.js'
+import {USERS_API_VERSION} from '../../../services/user.js'
 import {List} from '../list.js'
 
 vi.mock('../../../../../cli-core/src/config/findProjectRoot.js', async () => {
@@ -27,6 +28,16 @@ vi.mock('../../../../../cli-core/src/config/cli/getCliConfig.js', async () => {
   }
 })
 
+vi.mock('@sanity/cli-core', async () => {
+  const actual = await vi.importActual('@sanity/cli-core')
+  return {
+    ...actual,
+    getProjectCliClient: vi.fn(),
+  }
+})
+
+const mockGetProjectCliClient = vi.mocked(getProjectCliClient)
+
 describe('#list', () => {
   afterEach(() => {
     vi.clearAllMocks()
@@ -42,18 +53,18 @@ describe('#list', () => {
   })
 
   test('displays users correctly', async () => {
+    mockGetProjectCliClient.mockResolvedValue({
+      projects: {
+        getById: vi.fn().mockResolvedValue({
+          members: [
+            {id: 'user1', isRobot: false, role: 'developer'},
+            {id: 'user2', isRobot: false, role: 'admin'},
+          ],
+        }),
+      },
+    } as never)
     mockApi({
-      apiVersion: USERS_API_VERSION,
-      query: {includeFeatures: 'false'},
-      uri: '/projects/test-project',
-    }).reply(200, {
-      members: [
-        {id: 'user1', isRobot: false, role: 'developer'},
-        {id: 'user2', isRobot: false, role: 'admin'},
-      ],
-    })
-    mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/invitations/project/test-project',
     }).reply(200, [])
 
@@ -71,18 +82,18 @@ describe('#list', () => {
   })
 
   test('displays pending invitations correctly', async () => {
+    mockGetProjectCliClient.mockResolvedValue({
+      projects: {
+        getById: vi.fn().mockResolvedValue({
+          members: [
+            {id: 'user1', isRobot: false, role: 'developer'},
+            {id: 'user2', isRobot: false, role: 'admin'},
+          ],
+        }),
+      },
+    } as never)
     mockApi({
-      apiVersion: USERS_API_VERSION,
-      query: {includeFeatures: 'false'},
-      uri: '/projects/test-project',
-    }).reply(200, {
-      members: [
-        {id: 'user1', isRobot: false, role: 'developer'},
-        {id: 'user2', isRobot: false, role: 'admin'},
-      ],
-    })
-    mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/invitations/project/test-project',
     }).reply(200, [
       {
@@ -107,14 +118,13 @@ describe('#list', () => {
   })
 
   test('displays an error if the API request fails', async () => {
+    // Wait for 50ms to ensure the Promise.all is called
+    setTimeout(
+      () => mockGetProjectCliClient.mockRejectedValue(new Error('Internal server error')),
+      50,
+    )
     mockApi({
-      apiVersion: USERS_API_VERSION,
-      query: {includeFeatures: 'false'},
-      uri: '/projects/test-project',
-    }).reply(500, {message: 'Internal Server Error'})
-
-    mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/invitations/project/test-project',
     }).reply(200, [])
 
@@ -125,19 +135,19 @@ describe('#list', () => {
   })
 
   test('sorts by role when --sort role is specified', async () => {
+    mockGetProjectCliClient.mockResolvedValue({
+      projects: {
+        getById: vi.fn().mockResolvedValue({
+          members: [
+            {id: 'user1', isRobot: false, role: 'developer'},
+            {id: 'user2', isRobot: false, role: 'admin'},
+            {id: 'user3', isRobot: false, role: 'viewer'},
+          ],
+        }),
+      },
+    } as never)
     mockApi({
-      apiVersion: USERS_API_VERSION,
-      query: {includeFeatures: 'false'},
-      uri: '/projects/test-project',
-    }).reply(200, {
-      members: [
-        {id: 'user1', isRobot: false, role: 'developer'},
-        {id: 'user2', isRobot: false, role: 'admin'},
-        {id: 'user3', isRobot: false, role: 'viewer'},
-      ],
-    })
-    mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/invitations/project/test-project',
     }).reply(200, [])
 
@@ -174,20 +184,20 @@ describe('#list', () => {
   })
 
   test('sorts in descending order when --order desc is specified', async () => {
-    mockApi({
-      apiVersion: USERS_API_VERSION,
-      query: {includeFeatures: 'false'},
-      uri: '/projects/test-project',
-    }).reply(200, {
-      members: [
-        {id: 'user1', isRobot: false, role: 'developer'},
-        {id: 'user2', isRobot: false, role: 'admin'},
-        {id: 'user3', isRobot: false, role: 'viewer'},
-      ],
-    })
+    mockGetProjectCliClient.mockResolvedValue({
+      projects: {
+        getById: vi.fn().mockResolvedValue({
+          members: [
+            {id: 'user1', isRobot: false, role: 'developer'},
+            {id: 'user2', isRobot: false, role: 'admin'},
+            {id: 'user3', isRobot: false, role: 'viewer'},
+          ],
+        }),
+      },
+    } as never)
 
     mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/invitations/project/test-project',
     }).reply(200, [])
 
@@ -224,16 +234,16 @@ describe('#list', () => {
   })
 
   test('excludes invitations when --no-invitations is specified', async () => {
-    mockApi({
-      apiVersion: USERS_API_VERSION,
-      query: {includeFeatures: 'false'},
-      uri: '/projects/test-project',
-    }).reply(200, {
-      members: [
-        {id: 'user1', isRobot: false, role: 'developer'},
-        {id: 'user2', isRobot: false, role: 'admin'},
-      ],
-    })
+    mockGetProjectCliClient.mockResolvedValue({
+      projects: {
+        getById: vi.fn().mockResolvedValue({
+          members: [
+            {id: 'user1', isRobot: false, role: 'developer'},
+            {id: 'user2', isRobot: false, role: 'admin'},
+          ],
+        }),
+      },
+    } as never)
 
     mockApi({
       apiVersion: USERS_API_VERSION,
@@ -251,19 +261,19 @@ describe('#list', () => {
   })
 
   test('excludes robots when --no-robots is specified', async () => {
+    mockGetProjectCliClient.mockResolvedValue({
+      projects: {
+        getById: vi.fn().mockResolvedValue({
+          members: [
+            {id: 'user1', isRobot: false, role: 'developer'},
+            {id: 'user2', isRobot: false, role: 'admin'},
+            {id: 'robot1', isRobot: true, role: 'viewer'},
+          ],
+        }),
+      },
+    } as never)
     mockApi({
-      apiVersion: USERS_API_VERSION,
-      query: {includeFeatures: 'false'},
-      uri: '/projects/test-project',
-    }).reply(200, {
-      members: [
-        {id: 'user1', isRobot: false, role: 'developer'},
-        {id: 'user2', isRobot: false, role: 'admin'},
-        {id: 'robot1', isRobot: true, role: 'viewer'},
-      ],
-    })
-    mockApi({
-      apiVersion: USERS_API_VERSION,
+      apiVersion: PROJECTS_API_VERSION,
       uri: '/invitations/project/test-project',
     }).reply(200, [])
 

--- a/packages/@sanity/cli/src/commands/users/invite.ts
+++ b/packages/@sanity/cli/src/commands/users/invite.ts
@@ -2,9 +2,9 @@ import {Args, Flags} from '@oclif/core'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 
-import {USERS_API_VERSION} from '../../actions/users/apiVersion.js'
 import {type Role} from '../../actions/users/types.js'
 import {validateEmail} from '../../actions/users/validateEmail.js'
+import {getProjectRoles, inviteUser} from '../../services/projects.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
 
 const QUOTA_ERROR_MESSAGE =
@@ -48,11 +48,6 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
     const {email: selectedEmail} = this.args
     const {role: selectedRole} = this.flags
 
-    const client = await this.getGlobalApiClient({
-      apiVersion: USERS_API_VERSION,
-      requireUser: true,
-    })
-
     const projectId = await this.getProjectId()
 
     if (!projectId) {
@@ -61,9 +56,7 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
 
     let roles: Role[]
     try {
-      roles = (await client.request<Role[]>({uri: `/projects/${projectId}/roles`})).filter(
-        (role) => role.appliesToUsers,
-      )
+      roles = (await getProjectRoles(projectId)).filter((role) => role.appliesToUsers)
     } catch (error) {
       usersInviteDebug('Error fetching roles', error)
       this.error('Error fetching roles', {exit: 1})
@@ -81,13 +74,7 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
     }
 
     try {
-      await client.request({
-        body: {email, role: role.name},
-        maxRedirects: 0,
-        method: 'POST',
-        uri: `/invitations/project/${projectId}`,
-        useGlobalApi: true,
-      })
+      await inviteUser({email, projectId, role: role.name})
 
       this.log(`Invitation sent to ${email}`)
     } catch (error) {

--- a/packages/@sanity/cli/src/commands/users/list.ts
+++ b/packages/@sanity/cli/src/commands/users/list.ts
@@ -3,7 +3,6 @@ import {SanityCommand} from '@sanity/cli-core'
 import {chalk} from '@sanity/cli-core/ux'
 import {size, sortBy} from 'lodash-es'
 
-import {USERS_API_VERSION} from '../../actions/users/apiVersion.js'
 import {getMembersForProject} from '../../actions/users/getMembersForProject.js'
 
 export class List extends SanityCommand<typeof List> {
@@ -50,11 +49,6 @@ export class List extends SanityCommand<typeof List> {
   public async run(): Promise<void> {
     const {invitations, order, robots, sort} = this.flags
 
-    const client = await this.getGlobalApiClient({
-      apiVersion: USERS_API_VERSION,
-      requireUser: true,
-    })
-
     const projectId = await this.getProjectId()
 
     if (!projectId) {
@@ -62,7 +56,6 @@ export class List extends SanityCommand<typeof List> {
     }
 
     const members = await getMembersForProject({
-      client,
       includeInvitations: invitations,
       includeRobots: robots,
       projectId,

--- a/packages/@sanity/cli/src/services/backup.ts
+++ b/packages/@sanity/cli/src/services/backup.ts
@@ -24,6 +24,8 @@ interface BackupDetailsResponse {
 }
 
 export async function listBackups(options: {
+  after?: string
+  before?: string
   datasetName: string
   limit?: number
   projectId: string
@@ -36,6 +38,14 @@ export async function listBackups(options: {
   const query: Record<string, string> = {}
   if (options.limit) {
     query.limit = options.limit.toString()
+  }
+
+  if (options.after) {
+    query.after = options.after
+  }
+
+  if (options.before) {
+    query.before = options.before
   }
 
   return client.request({
@@ -63,5 +73,26 @@ export async function getBackupDetails(options: {
   return client.request({
     query,
     uri: `/projects/${options.projectId}/datasets/${options.datasetName}/backups/${options.backupId}`,
+  })
+}
+
+interface SetBackupOptions {
+  dataset: string
+  projectId: string
+  status: boolean
+}
+
+export async function setBackup({dataset, projectId, status}: SetBackupOptions) {
+  const client = await getGlobalCliClient({
+    apiVersion: BACKUP_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.request({
+    body: {
+      enabled: status,
+    },
+    method: 'PUT',
+    uri: `/projects/${projectId}/datasets/${dataset}/settings/backups`,
   })
 }

--- a/packages/@sanity/cli/src/services/cors.ts
+++ b/packages/@sanity/cli/src/services/cors.ts
@@ -1,0 +1,66 @@
+import {getGlobalCliClient} from '@sanity/cli-core'
+
+export const CORS_API_VERSION = 'v2025-08-14'
+
+interface CreateCorsOriginOptions {
+  allowCredentials: boolean
+  origin: string
+  projectId: string
+}
+
+export async function createCorsOrigin({
+  allowCredentials,
+  origin,
+  projectId,
+}: CreateCorsOriginOptions) {
+  const client = await getGlobalCliClient({
+    apiVersion: CORS_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.request({
+    body: {
+      allowCredentials,
+      origin,
+    },
+    maxRedirects: 0,
+    method: 'POST',
+    uri: `/projects/${projectId}/cors`,
+  })
+}
+
+interface DeleteCorsOriginOptions {
+  originId: number
+  projectId: string
+}
+
+export async function deleteCorsOrigin({originId, projectId}: DeleteCorsOriginOptions) {
+  const client = await getGlobalCliClient({
+    apiVersion: CORS_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.request({
+    method: 'DELETE',
+    uri: `/projects/${projectId}/cors/${originId}`,
+  })
+}
+
+export interface CorsOrigin {
+  allowCredentials: boolean
+  createdAt: string
+  deletedAt: string | null
+  id: number
+  origin: string
+  projectId: string
+  updatedAt: string | null
+}
+
+export async function listCorsOrigins(projectId: string) {
+  const client = await getGlobalCliClient({
+    apiVersion: CORS_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.request<CorsOrigin[]>({uri: `/projects/${projectId}/cors`})
+}

--- a/packages/@sanity/cli/src/services/hooks.ts
+++ b/packages/@sanity/cli/src/services/hooks.ts
@@ -62,3 +62,21 @@ export async function getHookAttempt({
     uri: `/hooks/projects/${projectId}/attempts/${attemptId}`,
   })
 }
+
+export async function listHooksForProject(projectId: string): Promise<Hook[]> {
+  const client = await getGlobalCliClient({
+    apiVersion: HOOK_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.request<Hook[]>({uri: `/hooks/projects/${projectId}`})
+}
+
+export async function deleteHookForProject(projectId: string, hookId: string): Promise<void> {
+  const client = await getGlobalCliClient({
+    apiVersion: HOOK_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.request({method: 'DELETE', uri: `/hooks/projects/${projectId}/${hookId}`})
+}

--- a/packages/@sanity/cli/src/services/projects.ts
+++ b/packages/@sanity/cli/src/services/projects.ts
@@ -1,5 +1,7 @@
 import {debug, getGlobalCliClient, getProjectCliClient} from '@sanity/cli-core'
 
+import {type Invite, type Role} from '../actions/users/types.js'
+
 export const PROJECTS_API_VERSION = '2025-09-22'
 
 export const CREATE_PROJECT_API_VERSION = 'v2025-05-14'
@@ -60,4 +62,52 @@ export async function getProjectById(projectId: string) {
   })
 
   return client.projects.getById(projectId)
+}
+
+export async function getProjectRoles(projectId: string) {
+  const client = await getGlobalCliClient({
+    apiVersion: PROJECTS_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.request<Role[]>({uri: `/projects/${projectId}/roles`})
+}
+
+interface InviteUserOptions {
+  email: string
+  projectId: string
+  role: string
+}
+
+export async function inviteUser({email, projectId, role}: InviteUserOptions) {
+  const client = await getGlobalCliClient({
+    apiVersion: PROJECTS_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.request({
+    body: {email, role},
+    maxRedirects: 0,
+    method: 'POST',
+    uri: `/invitations/project/${projectId}`,
+    useGlobalApi: true,
+  })
+}
+
+export async function listProjects() {
+  const client = await getGlobalCliClient({
+    apiVersion: PROJECTS_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.projects.list()
+}
+
+export async function getProjectInvites(projectId: string) {
+  const client = await getGlobalCliClient({
+    apiVersion: PROJECTS_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.request<Invite[]>({uri: `/invitations/project/${projectId}`})
 }

--- a/packages/@sanity/cli/src/services/user.ts
+++ b/packages/@sanity/cli/src/services/user.ts
@@ -1,12 +1,28 @@
 import {getGlobalCliClient, type SanityOrgUser} from '@sanity/cli-core'
 
-import {INIT_API_VERSION} from '../actions/init/constants.js'
+import {type User} from '../actions/users/types.js'
+
+/**
+ * The API version to use for the users list command
+ *
+ * @internal
+ */
+export const USERS_API_VERSION = 'v2025-08-30'
 
 export async function getCliUser() {
   const client = await getGlobalCliClient({
-    apiVersion: INIT_API_VERSION,
+    apiVersion: USERS_API_VERSION,
     requireUser: true,
   })
 
   return client.users.getById('me') as unknown as SanityOrgUser
+}
+
+export async function getMembers(memberIds: string[]) {
+  const client = await getGlobalCliClient({
+    apiVersion: USERS_API_VERSION,
+    requireUser: true,
+  })
+
+  return client.request<User | User[]>({uri: `/users/${memberIds.join(',')}`})
 }


### PR DESCRIPTION
### TL;DR

Refactored API client usage in CLI commands to use dedicated service modules instead of direct client calls.

### What changed?

- Created dedicated service modules for various API operations (cors, hooks, projects, backup, users)
- Removed direct usage of `getGlobalApiClient` in command classes in favor of service functions
- Consolidated API version constants into their respective service modules
- Removed redundant types that are now defined in service modules
- Updated tests to use the new service approach
- Deprecated `getGlobalApiClient` method in `SanityCommand` class

### How to test?

- Run the CLI commands that were modified to ensure they still work correctly
- Verify that commands like `sanity cors list`, `sanity users list`, `sanity hook create`, etc. function as expected
- Run the test suite to ensure all tests pass

### Why make this change?

This refactoring improves code organization by:
- Centralizing API client logic in dedicated service modules
- Reducing duplication of API version constants and request logic
- Making the codebase more maintainable by isolating API-specific code
- Preparing for the deprecation of the `getGlobalApiClient` method in the `SanityCommand` class

The change follows the principle of separation of concerns, making the code more modular and easier to maintain.