### PR TITLE
feat(manifest): make extractManifestSafe safe

### DIFF
--- a/packages/@sanity/cli/src/actions/manifest/extractManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractManifest.ts
@@ -51,7 +51,7 @@ export async function extractManifestSafe(
     if (EXTRACT_MANIFEST_LOG_ERRORS) {
       options.output.error(err)
     }
-    throw err
+    return err
   }
 }
 

--- a/packages/@sanity/cli/src/commands/manifest/extract.ts
+++ b/packages/@sanity/cli/src/commands/manifest/extract.ts
@@ -34,14 +34,14 @@ export class ExtractManifestCommand extends SanityCommand<typeof ExtractManifest
     const {flags} = await this.parse(ExtractManifestCommand)
     const workDir = (await this.getProjectRoot()).directory
 
-    try {
-      await extractManifestSafe({
-        flags,
-        output: this.output,
-        workDir,
-      })
-    } catch (error) {
-      this.error(`Failed to extract manifest:\n${error}`, {exit: 1})
+    const error = await extractManifestSafe({
+      flags,
+      output: this.output,
+      workDir,
+    })
+
+    if (error) {
+      this.error(`Failed to extract manifest:\n${error.message}`, {exit: 1})
     }
   }
 }


### PR DESCRIPTION
### Description
In working on app manifests, I noticed that `extractManifestSafe` wasn't safe (because it threw an error). This might have been intentional, since `packages/@sanity/cli/src/commands/manifest/extract.ts` catches the error, but this might present an issue for ensureManifestExtractSatisfied, which expects an error to be returned: https://github.com/sanity-io/cli/blob/4a79f5b2ea31b90efe99cd06f898a42755f97777/packages/%40sanity/cli/src/actions/schema/utils/manifestExtractor.ts#L21

I don't have strong opinions either way; this change makes the function truer to its name, but if we're fine with throwing the error then we should remove it (or not call it safe).

### Testing
Tests still seem to be passing but we can add some if needed. 