### PR TITLE
chore(ci): use commit sha for preview versions

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -59,7 +59,7 @@ jobs:
             const output = JSON.parse(fs.readFileSync('pkg-pr-new-output.json', 'utf8'));
 
             const sha = context.payload.pull_request?.head?.sha;
-            const BOT_COMMENT_IDENTIFIER = `<!-- pkg-pr-new-commit-${sha} -->`;
+            const BOT_COMMENT_IDENTIFIER = '<!-- pkg.pr.new -->'
             const BACKTICKS = '```';
 
             function renderPackages(pkgs) {


### PR DESCRIPTION
### TL;DR

Enhanced the PR preview package workflow to provide a more informative and interactive comment on pull requests.

### What changed?

- Removed the manual extraction of PR number and commit info as these are now handled by the GitHub script
- Changed the `pkg-pr-new` command to output JSON and disable its built-in commenting feature
- Added a new GitHub script action that:
  - Creates a formatted comment with package installation instructions
  - Includes a direct npx command to run the CLI from the PR
  - Provides links to the commit
  - Updates the comment if it already exists instead of creating duplicates

### How to test?

1. Create a PR that affects any of the CLI packages
2. Verify that the workflow runs successfully
3. Check that a nicely formatted comment appears on the PR with:
   - An npx command to run the CLI directly
   - Installation instructions for each preview package
   - A link to the commit

### Why make this change?

The previous implementation provided minimal information in PR comments. This enhancement makes it easier for reviewers and developers to test changes by providing clear instructions on how to use the preview packages, improving the PR review experience.