### PR TITLE
chore: add groq to exclude from minimum release

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,6 +60,7 @@ minimumReleaseAgeExclude:
   - '@portabletext/*'
   - '@sanity/*'
   - 'groq-js'
+  - 'groq'
   - 'react-rx'
   - 'sanity'
   - 'use-effect-event'


### PR DESCRIPTION
To fix deps like https://github.com/sanity-io/cli/pull/292 in future