### PR TITLE
chore(ci): publish create-sanity without prerelease

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,10 +54,15 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
-      - name: Publish packages
+      - name: Publish packages except create-sanity
         if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
         # TODO: Remove the tag once we have a proper release
-        run: pnpm publish -r --filter="@sanity/cli" --filter="@sanity/cli*" --filter="@sanity/eslint-config-cli" --filter="create-sanity" --tag alpha
+        run: pnpm publish -r --filter="@sanity/cli" --filter="@sanity/cli*" --filter="@sanity/eslint-config-cli" --tag alpha
+
+      - name: Publish create-sanity
+        if: ${{ steps.release.outputs['packages/create-sanity--release_created'] == 'true' || github.event.inputs.publish == 'true' }}
+        # We are publishing create-sanity separately because it needs to be published without a prerelease tag
+        run: pnpm publish --filter="create-sanity"
 
       - name: Summary
         if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
@@ -66,8 +71,8 @@ jobs:
           echo "All CLI packages published:" >> $GITHUB_STEP_SUMMARY
           echo "| Package | Version |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|---------|" >> $GITHUB_STEP_SUMMARY
-          echo "| @sanity/cli-core | ${{ steps.release.outputs['cli-core--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| @sanity/cli-test | ${{ steps.release.outputs['cli-test--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| @sanity/cli | ${{ steps.release.outputs['cli--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| @sanity/eslint-config-cli | ${{ steps.release.outputs['eslint-config-cli--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| create-sanity | ${{ steps.release.outputs['create-sanity--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| @sanity/cli-core | ${{ steps.release.outputs['packages/@sanity/cli-core--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| @sanity/cli-test | ${{ steps.release.outputs['packages/@sanity/cli-test--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| @sanity/cli | ${{ steps.release.outputs['packages/@sanity/cli--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| @sanity/eslint-config-cli | ${{ steps.release.outputs['packages/@sanity/eslint-config-cli--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| create-sanity | ${{ steps.release.outputs['packages/create-sanity--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,5 @@
   "packages/@sanity/cli-test": "0.0.2-alpha.5",
   "packages/@sanity/cli": "6.0.0-alpha.6",
   "packages/@sanity/eslint-config-cli": "0.0.0-alpha.1",
-  "packages/create-sanity": "6.0.0-alpha.2"
+  "packages/create-sanity": "5.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -93,10 +93,7 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "component": "create-sanity",
-      "prerelease": true,
-      "prerelease-type": "alpha",
-      "release-type": "node",
-      "versioning": "prerelease"
+      "release-type": "node"
     }
   },
   "plugins": [


### PR DESCRIPTION
This should allow publishing a real version of create-sanity to npm 