### PR TITLE
fix(create-sanity): make path lookup more resistent

### DIFF
--- a/packages/create-sanity/index.js
+++ b/packages/create-sanity/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import {spawn} from 'node:child_process'
 import {readFile} from 'node:fs/promises'
-import {join} from 'node:path'
+import {dirname, resolve} from 'node:path'
 import {fileURLToPath} from 'node:url'
 
 import {moduleResolve} from 'import-meta-resolve'
@@ -11,7 +11,7 @@ const args = process.argv.slice(2)
 let cliBin
 try {
   const cliPkgDir = fileURLToPath(await moduleResolve('@sanity/cli/package.json', import.meta.url))
-  const cliDir = join(cliPkgDir, '..')
+  const cliDir = dirname(cliPkgDir)
 
   // Read the package.json file and extract the bin path
   const pJson = await readFile(cliPkgDir, 'utf8')
@@ -21,7 +21,7 @@ try {
     throw new Error('Failed to resolve `@sanity/cli` package')
   }
 
-  cliBin = join(cliDir, binPath)
+  cliBin = resolve(cliDir, binPath)
 } catch (err) {
   throw new Error('Failed to resolve `@sanity/cli` package', {cause: err})
 }


### PR DESCRIPTION
Use built in node primitives to lookup path and resolve the path making it less error prone. Existing tests should suffice 