### PR TITLE
chore: ignore string.raw for snapshots

### DIFF
--- a/packages/@sanity/cli/eslint.config.mjs
+++ b/packages/@sanity/cli/eslint.config.mjs
@@ -16,4 +16,10 @@ export default [
       'import/no-unresolved': 'off',
     },
   },
+  {
+    files: ['**/*.test.ts'],
+    rules: {
+      'unicorn/prefer-string-raw': 'off',
+    },
+  },
 ]

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -50,85 +50,85 @@ describe('#init: oclif command setup', () => {
     const {stdout} = await runCommand('init --help')
 
     expect(stdout).toMatchInlineSnapshot(String.raw`
-            "Initialize a new Sanity Studio, project and/or app
+      "Initialize a new Sanity Studio, project and/or app
 
-            USAGE
-              $ sanity init [--json] [--auto-updates | --bare] [--coupon
-                <code> | --project-plan <name>] [--dataset <name> | --dataset-default]
-                [--env <filename> | ] [--git <message> | ] [--mcp]
-                [--nextjs-add-config-files] [--nextjs-append-env] [--nextjs-embed-studio]
-                [--organization <id>] [--output-path <path> | ] [--overwrite-files]
-                [--package-manager <manager> | ] [--project <id> | --create-project <name>]
-                [--provider <provider>] [--template <template> | ] [--typescript | ]
-                [--visibility <mode>] [-y]
+      USAGE
+        $ sanity init [--json] [--auto-updates | --bare] [--coupon
+          <code> | --project-plan <name>] [--dataset <name> | --dataset-default]
+          [--env <filename> | ] [--git <message> | ] [--mcp]
+          [--nextjs-add-config-files] [--nextjs-append-env] [--nextjs-embed-studio]
+          [--organization <id>] [--output-path <path> | ] [--overwrite-files]
+          [--package-manager <manager> | ] [--project <id> | --create-project <name>]
+          [--provider <provider>] [--template <template> | ] [--typescript | ]
+          [--visibility <mode>] [-y]
 
-            FLAGS
-              -y, --yes                        Unattended mode, answers "yes" to any
-                                               "yes/no" prompt and otherwise uses defaults
-                  --[no-]auto-updates          Enable auto updates of studio versions
-                  --bare                       Skip the Studio initialization and only print
-                                               the selected project ID and dataset name to
-                                               stdout
-                  --coupon=<code>              Optionally select a coupon for a new project
-                                               (cannot be used with --project-plan)
-                  --create-project=<name>      Create a new project with the given name
-                  --dataset=<name>             Dataset name for the studio
-                  --dataset-default            Set up a project with a public dataset named
-                                               "production"
-                  --env=<filename>             Write environment variables to file
-                  --[no-]git=<message>         Specify a commit message for initial commit,
-                                               or disable git init
-                  --[no-]mcp                   Enable AI editor integration (MCP) setup
-                  --organization=<id>          Organization ID to use for the project
-                  --output-path=<path>         Path to write studio project to
-                  --overwrite-files            Overwrite existing files
-                  --package-manager=<manager>  Specify which package manager to use
-                                               [allowed: npm, yarn, pnpm]
-                  --project=<id>               Project ID to use for the studio
-                  --project-plan=<name>        Optionally select a plan for a new project
-                  --provider=<provider>        Login provider to use
-                  --template=<template>        [default: clean] Project template to use
-                                               [default: "clean"]
-                  --[no-]typescript            Enable TypeScript support
-                  --visibility=<mode>          Visibility mode for dataset
+      FLAGS
+        -y, --yes                        Unattended mode, answers "yes" to any
+                                         "yes/no" prompt and otherwise uses defaults
+            --[no-]auto-updates          Enable auto updates of studio versions
+            --bare                       Skip the Studio initialization and only print
+                                         the selected project ID and dataset name to
+                                         stdout
+            --coupon=<code>              Optionally select a coupon for a new project
+                                         (cannot be used with --project-plan)
+            --create-project=<name>      Create a new project with the given name
+            --dataset=<name>             Dataset name for the studio
+            --dataset-default            Set up a project with a public dataset named
+                                         "production"
+            --env=<filename>             Write environment variables to file
+            --[no-]git=<message>         Specify a commit message for initial commit,
+                                         or disable git init
+            --[no-]mcp                   Enable AI editor integration (MCP) setup
+            --organization=<id>          Organization ID to use for the project
+            --output-path=<path>         Path to write studio project to
+            --overwrite-files            Overwrite existing files
+            --package-manager=<manager>  Specify which package manager to use
+                                         [allowed: npm, yarn, pnpm]
+            --project=<id>               Project ID to use for the studio
+            --project-plan=<name>        Optionally select a plan for a new project
+            --provider=<provider>        Login provider to use
+            --template=<template>        [default: clean] Project template to use
+                                         [default: "clean"]
+            --[no-]typescript            Enable TypeScript support
+            --visibility=<mode>          Visibility mode for dataset
 
-            GLOBAL FLAGS
-              --json  Format output as json.
+      GLOBAL FLAGS
+        --json  Format output as json.
 
-            NEXT.JS FLAGS
-              --[no-]nextjs-add-config-files  Add config files to Next.js project
-              --[no-]nextjs-append-env        Append project ID and dataset to .env file
-              --[no-]nextjs-embed-studio      Embed the Studio in Next.js application
+      NEXT.JS FLAGS
+        --[no-]nextjs-add-config-files  Add config files to Next.js project
+        --[no-]nextjs-append-env        Append project ID and dataset to .env file
+        --[no-]nextjs-embed-studio      Embed the Studio in Next.js application
 
-            DESCRIPTION
-              Initialize a new Sanity Studio, project and/or app
+      DESCRIPTION
+        Initialize a new Sanity Studio, project and/or app
 
-            EXAMPLES
-              $ sanity init
+      EXAMPLES
+        $ sanity init
 
-              Initialize a new project with a public dataset named "production"
+        Initialize a new project with a public dataset named "production"
 
-                $ sanity init --dataset-default
+          $ sanity init --dataset-default
 
-              Initialize a project with the given project ID and dataset to the given path
+        Initialize a project with the given project ID and dataset to the given path
 
-                $ sanity init -y --project abc123 --dataset production --output-path \
-                  ~/myproj
+          $ sanity init -y --project abc123 --dataset production --output-path \
+            ~/myproj
 
-              Initialize a project with the given project ID and dataset using the moviedb
-              template to the given path
+        Initialize a project with the given project ID and dataset using the moviedb
+        template to the given path
 
-                $ sanity init -y --project abc123 --dataset staging --template moviedb \
-                  --output-path .
+          $ sanity init -y --project abc123 --dataset staging --template moviedb \
+            --output-path .
 
-              Create a brand new project with name "Movies Unlimited"
+        Create a brand new project with name "Movies Unlimited"
 
-                $ sanity init -y --create-project "Movies Unlimited" --dataset moviedb \
-                  --visibility private --template moviedb --output-path \
-                  /Users/espenh/movies-unlimited
+          $ sanity init -y --create-project "Movies Unlimited" --dataset moviedb \
+            --visibility private --template moviedb --output-path \
+            /Users/espenh/movies-unlimited
 
-            "
-          `)
+      "
+    `)
   })
 
   test.each([


### PR DESCRIPTION
Having `String.raw` although autofixable by eslint makes it so that `vitest watch` does not update the snapshot which is not convenient 