### PR TITLE
chore(deps): don't bump peer deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,11 @@
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
+      "enabled": false,
+      "description": "Exclude peer dependencies from being updated",
+      "matchDepTypes": ["peerDependencies"]
+    },
+    {
       "description": "Exclude sanity & @sanity/* packages from minimumReleaseAge (no delay for internal packages)",
       "matchPackageNames": ["@sanity/*", "@portabletext/*", "react-rx", "groq-js", "sanity"],
       "minimumReleaseAge": "0 days"

--- a/packages/@sanity/cli-test/package.json
+++ b/packages/@sanity/cli-test/package.json
@@ -83,7 +83,7 @@
   "peerDependencies": {
     "@oclif/core": "^4.0.0",
     "@sanity/cli-core": "workspace:*",
-    "@sanity/client": "^7.14.0",
+    "@sanity/client": "^7.0.0",
     "vitest": ">=3.0.0 <4.0.0"
   },
   "engines": {

--- a/packages/@sanity/eslint-config-cli/package.json
+++ b/packages/@sanity/eslint-config-cli/package.json
@@ -54,7 +54,7 @@
     "publint": "catalog:"
   },
   "peerDependencies": {
-    "eslint": "^9.39.2"
+    "eslint": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Stops renovate from using a specific version for peer deps and reverts the changes that already happened