### PR TITLE
chore: remove usage from readme

### DIFF
--- a/packages/@sanity/cli/README.md
+++ b/packages/@sanity/cli/README.md
@@ -5,27 +5,8 @@ Code for sanity cli
 <!-- toc -->
 
 - [@sanity/cli](#sanitycli)
-- [Usage](#usage)
 - [Commands](#commands)
 <!-- tocstop -->
-
-# Usage
-
-  <!-- usage -->
-
-```sh-session
-$ npm install -g @sanity/cli
-$ sanity COMMAND
-running command...
-$ sanity (--version)
-@sanity/cli/6.0.0-alpha.7 darwin-arm64 node-v24.13.0
-$ sanity --help [COMMAND]
-USAGE
-  $ sanity COMMAND
-...
-```
-
-<!-- usagestop -->
 
 # Commands
 
@@ -150,7 +131,7 @@ EXAMPLES
     $ sanity backup disable production
 ```
 
-_See code: [src/commands/backup/disable.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/backup/disable.ts)_
+_See code: [src/commands/backup/disable.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/backup/disable.ts)_
 
 ## `sanity backup download [DATASET]`
 
@@ -190,7 +171,7 @@ EXAMPLES
     $ sanity backup download production --backup-id 2024-01-01-backup-3 --out /path/to/file --overwrite
 ```
 
-_See code: [src/commands/backup/download.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/backup/download.ts)_
+_See code: [src/commands/backup/download.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/backup/download.ts)_
 
 ## `sanity backup enable [DATASET]`
 
@@ -216,7 +197,7 @@ EXAMPLES
     $ sanity backup enable production
 ```
 
-_See code: [src/commands/backup/enable.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/backup/enable.ts)_
+_See code: [src/commands/backup/enable.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/backup/enable.ts)_
 
 ## `sanity backup list [DATASET]`
 
@@ -255,7 +236,7 @@ EXAMPLES
     $ sanity backup list production --after 2024-01-31 --limit 10
 ```
 
-_See code: [src/commands/backup/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/backup/list.ts)_
+_See code: [src/commands/backup/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/backup/list.ts)_
 
 ## `sanity blueprints add TYPE`
 
@@ -619,7 +600,7 @@ EXAMPLES
   $ sanity build --no-minify --source-maps
 ```
 
-_See code: [src/commands/build.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/build.ts)_
+_See code: [src/commands/build.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/build.ts)_
 
 ## `sanity codemod [CODEMODNAME]`
 
@@ -650,7 +631,7 @@ EXAMPLES
     $ sanity codemod reactIconsV3 --dry
 ```
 
-_See code: [src/commands/codemod.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/codemod.ts)_
+_See code: [src/commands/codemod.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/codemod.ts)_
 
 ## `sanity cors add ORIGIN`
 
@@ -683,7 +664,7 @@ EXAMPLES
     $ sanity cors add https://myapp.com --credentials
 ```
 
-_See code: [src/commands/cors/add.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/cors/add.ts)_
+_See code: [src/commands/cors/add.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/cors/add.ts)_
 
 ## `sanity cors delete [ORIGIN]`
 
@@ -709,7 +690,7 @@ EXAMPLES
     $ sanity cors delete https://example.com
 ```
 
-_See code: [src/commands/cors/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/cors/delete.ts)_
+_See code: [src/commands/cors/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/cors/delete.ts)_
 
 ## `sanity cors list`
 
@@ -728,7 +709,7 @@ EXAMPLES
     $ sanity cors list
 ```
 
-_See code: [src/commands/cors/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/cors/list.ts)_
+_See code: [src/commands/cors/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/cors/list.ts)_
 
 ## `sanity dataset alias create [ALIASNAME] [TARGETDATASET]`
 
@@ -763,7 +744,7 @@ EXAMPLES
     $ sanity dataset alias create ~conference conf-2025
 ```
 
-_See code: [src/commands/dataset/alias/create.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/alias/create.ts)_
+_See code: [src/commands/dataset/alias/create.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/alias/create.ts)_
 
 ## `sanity dataset alias delete ALIASNAME`
 
@@ -796,7 +777,7 @@ EXAMPLES
     $ sanity dataset alias delete conference --force
 ```
 
-_See code: [src/commands/dataset/alias/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/alias/delete.ts)_
+_See code: [src/commands/dataset/alias/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/alias/delete.ts)_
 
 ## `sanity dataset alias link [ALIASNAME] [TARGETDATASET]`
 
@@ -838,7 +819,7 @@ EXAMPLES
     $ sanity dataset alias link conference conf-2025 --force
 ```
 
-_See code: [src/commands/dataset/alias/link.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/alias/link.ts)_
+_See code: [src/commands/dataset/alias/link.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/alias/link.ts)_
 
 ## `sanity dataset alias unlink [ALIASNAME]`
 
@@ -875,7 +856,7 @@ EXAMPLES
     $ sanity dataset alias unlink conference --force
 ```
 
-_See code: [src/commands/dataset/alias/unlink.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/alias/unlink.ts)_
+_See code: [src/commands/dataset/alias/unlink.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/alias/unlink.ts)_
 
 ## `sanity dataset copy [SOURCE] [TARGET]`
 
@@ -936,7 +917,7 @@ EXAMPLES
     $ sanity dataset copy --list --offset 2 --limit 10
 ```
 
-_See code: [src/commands/dataset/copy.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/copy.ts)_
+_See code: [src/commands/dataset/copy.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/copy.ts)_
 
 ## `sanity dataset create [NAME]`
 
@@ -970,7 +951,7 @@ EXAMPLES
     $ sanity dataset create my-dataset --visibility private
 ```
 
-_See code: [src/commands/dataset/create.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/create.ts)_
+_See code: [src/commands/dataset/create.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/create.ts)_
 
 ## `sanity dataset delete DATASETNAME`
 
@@ -999,7 +980,7 @@ EXAMPLES
     $ sanity dataset delete my-dataset --force
 ```
 
-_See code: [src/commands/dataset/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/delete.ts)_
+_See code: [src/commands/dataset/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/delete.ts)_
 
 ## `sanity dataset export [NAME] [DESTINATION]`
 
@@ -1049,7 +1030,7 @@ EXAMPLES
     $ sanity dataset export staging staging.tar.gz --types products,shops
 ```
 
-_See code: [src/commands/dataset/export.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/export.ts)_
+_See code: [src/commands/dataset/export.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/export.ts)_
 
 ## `sanity dataset import SOURCE`
 
@@ -1091,7 +1072,7 @@ EXAMPLES
     cat my-dataset.ndjson | sanity dataset import -p myPrOj -d test -
 ```
 
-_See code: [src/commands/dataset/import.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/import.ts)_
+_See code: [src/commands/dataset/import.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/import.ts)_
 
 ## `sanity dataset list`
 
@@ -1110,7 +1091,7 @@ EXAMPLES
     $ sanity dataset list
 ```
 
-_See code: [src/commands/dataset/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/list.ts)_
+_See code: [src/commands/dataset/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/list.ts)_
 
 ## `sanity dataset visibility get DATASET`
 
@@ -1132,7 +1113,7 @@ EXAMPLES
     $ sanity dataset visibility get my-dataset
 ```
 
-_See code: [src/commands/dataset/visibility/get.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/visibility/get.ts)_
+_See code: [src/commands/dataset/visibility/get.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/visibility/get.ts)_
 
 ## `sanity dataset visibility set DATASET MODE`
 
@@ -1159,7 +1140,7 @@ EXAMPLES
     $ sanity dataset visibility set my-dataset public
 ```
 
-_See code: [src/commands/dataset/visibility/set.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dataset/visibility/set.ts)_
+_See code: [src/commands/dataset/visibility/set.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dataset/visibility/set.ts)_
 
 ## `sanity debug`
 
@@ -1181,7 +1162,7 @@ EXAMPLES
   $ sanity debug --secrets
 ```
 
-_See code: [src/commands/debug.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/debug.ts)_
+_See code: [src/commands/debug.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/debug.ts)_
 
 ## `sanity deploy [SOURCEDIR]`
 
@@ -1221,7 +1202,7 @@ EXAMPLES
     $ sanity deploy --schema-required
 ```
 
-_See code: [src/commands/deploy.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/deploy.ts)_
+_See code: [src/commands/deploy.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/deploy.ts)_
 
 ## `sanity dev`
 
@@ -1248,7 +1229,7 @@ EXAMPLES
   $ sanity dev --load-in-dashboard
 ```
 
-_See code: [src/commands/dev.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/dev.ts)_
+_See code: [src/commands/dev.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/dev.ts)_
 
 ## `sanity docs browse`
 
@@ -1262,7 +1243,7 @@ DESCRIPTION
   Open Sanity docs in a web browser
 ```
 
-_See code: [src/commands/docs/browse.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/docs/browse.ts)_
+_See code: [src/commands/docs/browse.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/docs/browse.ts)_
 
 ## `sanity docs read PATH`
 
@@ -1299,7 +1280,7 @@ EXAMPLES
     $ sanity docs read https://www.sanity.io/docs/studio/installation -w
 ```
 
-_See code: [src/commands/docs/read.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/docs/read.ts)_
+_See code: [src/commands/docs/read.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/docs/read.ts)_
 
 ## `sanity docs search QUERY`
 
@@ -1332,7 +1313,7 @@ EXAMPLES
     $ sanity docs search "deployment" --limit=5
 ```
 
-_See code: [src/commands/docs/search.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/docs/search.ts)_
+_See code: [src/commands/docs/search.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/docs/search.ts)_
 
 ## `sanity documents create [FILE]`
 
@@ -1376,7 +1357,7 @@ EXAMPLES
     $ sanity documents create --id myDocId --watch --replace --json5
 ```
 
-_See code: [src/commands/documents/create.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/documents/create.ts)_
+_See code: [src/commands/documents/create.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/documents/create.ts)_
 
 ## `sanity documents delete ID [IDS]`
 
@@ -1414,7 +1395,7 @@ EXAMPLES
     $ sanity documents delete doc1 doc2
 ```
 
-_See code: [src/commands/documents/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/documents/delete.ts)_
+_See code: [src/commands/documents/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/documents/delete.ts)_
 
 ## `sanity documents get DOCUMENTID`
 
@@ -1448,7 +1429,7 @@ EXAMPLES
     $ sanity documents get myDocId --dataset production
 ```
 
-_See code: [src/commands/documents/get.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/documents/get.ts)_
+_See code: [src/commands/documents/get.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/documents/get.ts)_
 
 ## `sanity documents query QUERY`
 
@@ -1485,7 +1466,7 @@ EXAMPLES
     $ sanity documents query '*[_id == "header"] { "headerText": pt::text(body) }' --api-version v2021-06-07
 ```
 
-_See code: [src/commands/documents/query.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/documents/query.ts)_
+_See code: [src/commands/documents/query.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/documents/query.ts)_
 
 ## `sanity documents validate`
 
@@ -1534,7 +1515,7 @@ EXAMPLES
     $ sanity documents validate --level info
 ```
 
-_See code: [src/commands/documents/validate.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/documents/validate.ts)_
+_See code: [src/commands/documents/validate.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/documents/validate.ts)_
 
 ## `sanity exec SCRIPT`
 
@@ -1575,7 +1556,7 @@ EXAMPLES
     $ sanity exec --mock-browser-env myscript.js -- --dry-run positional-argument
 ```
 
-_See code: [src/commands/exec.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/exec.ts)_
+_See code: [src/commands/exec.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/exec.ts)_
 
 ## `sanity functions add`
 
@@ -1847,7 +1828,7 @@ EXAMPLES
     $ sanity graphql list
 ```
 
-_See code: [src/commands/graphql/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/graphql/list.ts)_
+_See code: [src/commands/graphql/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/graphql/list.ts)_
 
 ## `sanity graphql undeploy`
 
@@ -1889,7 +1870,7 @@ EXAMPLES
     $ sanity graphql undeploy --force
 ```
 
-_See code: [src/commands/graphql/undeploy.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/graphql/undeploy.ts)_
+_See code: [src/commands/graphql/undeploy.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/graphql/undeploy.ts)_
 
 ## `sanity help [COMMAND]`
 
@@ -1909,7 +1890,7 @@ DESCRIPTION
   Display help for sanity.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.36/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.37/src/commands/help.ts)_
 
 ## `sanity hook attempt ATTEMPTID`
 
@@ -1931,7 +1912,7 @@ EXAMPLES
     $ sanity hook attempt abc123
 ```
 
-_See code: [src/commands/hook/attempt.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/hook/attempt.ts)_
+_See code: [src/commands/hook/attempt.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/hook/attempt.ts)_
 
 ## `sanity hook create`
 
@@ -1950,7 +1931,7 @@ EXAMPLES
     $ sanity hook create
 ```
 
-_See code: [src/commands/hook/create.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/hook/create.ts)_
+_See code: [src/commands/hook/create.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/hook/create.ts)_
 
 ## `sanity hook delete [NAME]`
 
@@ -1976,7 +1957,7 @@ EXAMPLES
     $ sanity hook delete my-hook
 ```
 
-_See code: [src/commands/hook/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/hook/delete.ts)_
+_See code: [src/commands/hook/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/hook/delete.ts)_
 
 ## `sanity hook list`
 
@@ -1995,7 +1976,7 @@ EXAMPLES
     $ sanity hook list
 ```
 
-_See code: [src/commands/hook/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/hook/list.ts)_
+_See code: [src/commands/hook/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/hook/list.ts)_
 
 ## `sanity hook logs [NAME]`
 
@@ -2024,7 +2005,7 @@ EXAMPLES
     $ sanity hook logs [NAME]
 ```
 
-_See code: [src/commands/hook/logs.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/hook/logs.ts)_
+_See code: [src/commands/hook/logs.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/hook/logs.ts)_
 
 ## `sanity init`
 
@@ -2093,7 +2074,7 @@ EXAMPLES
       --output-path /Users/espenh/movies-unlimited
 ```
 
-_See code: [src/commands/init.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/init.ts)_
 
 ## `sanity install [PACKAGES]`
 
@@ -2117,7 +2098,7 @@ EXAMPLES
   $ sanity install some-package another-package
 ```
 
-_See code: [src/commands/install.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/install.ts)_
+_See code: [src/commands/install.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/install.ts)_
 
 ## `sanity learn`
 
@@ -2131,7 +2112,7 @@ DESCRIPTION
   Opens Sanity Learn in your web browser
 ```
 
-_See code: [src/commands/learn.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/learn.ts)_
+_See code: [src/commands/learn.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/learn.ts)_
 
 ## `sanity login`
 
@@ -2163,7 +2144,7 @@ EXAMPLES
     $ sanity login --provider github --no-open
 ```
 
-_See code: [src/commands/login.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/login.ts)_
 
 ## `sanity logout`
 
@@ -2177,7 +2158,7 @@ DESCRIPTION
   Logs out the CLI from the current user session
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/logout.ts)_
 
 ## `sanity manage`
 
@@ -2191,7 +2172,7 @@ DESCRIPTION
   Opens project management interface in your web browser
 ```
 
-_See code: [src/commands/manage.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/manage.ts)_
+_See code: [src/commands/manage.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/manage.ts)_
 
 ## `sanity manifest extract`
 
@@ -2219,7 +2200,7 @@ EXAMPLES
     $ sanity manifest extract --path /public/static
 ```
 
-_See code: [src/commands/manifest/extract.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/manifest/extract.ts)_
+_See code: [src/commands/manifest/extract.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/manifest/extract.ts)_
 
 ## `sanity mcp configure`
 
@@ -2238,7 +2219,7 @@ EXAMPLES
     $ sanity mcp configure
 ```
 
-_See code: [src/commands/mcp/configure.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/mcp/configure.ts)_
+_See code: [src/commands/mcp/configure.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/mcp/configure.ts)_
 
 ## `sanity media create-aspect`
 
@@ -2257,7 +2238,7 @@ EXAMPLES
     $ sanity media create-aspect
 ```
 
-_See code: [src/commands/media/create-aspect.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/media/create-aspect.ts)_
+_See code: [src/commands/media/create-aspect.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/media/create-aspect.ts)_
 
 ## `sanity media delete-aspect ASPECTNAME`
 
@@ -2283,7 +2264,7 @@ EXAMPLES
     $ sanity media delete-aspect someAspect
 ```
 
-_See code: [src/commands/media/delete-aspect.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/media/delete-aspect.ts)_
+_See code: [src/commands/media/delete-aspect.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/media/delete-aspect.ts)_
 
 ## `sanity media deploy-aspect [ASPECTNAME]`
 
@@ -2313,7 +2294,7 @@ EXAMPLES
     $ sanity media deploy-aspect --all
 ```
 
-_See code: [src/commands/media/deploy-aspect.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/media/deploy-aspect.ts)_
+_See code: [src/commands/media/deploy-aspect.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/media/deploy-aspect.ts)_
 
 ## `sanity media export [DESTINATION]`
 
@@ -2351,7 +2332,7 @@ EXAMPLES
     $ sanity media export --media-library-id my-library-id
 ```
 
-_See code: [src/commands/media/export.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/media/export.ts)_
+_See code: [src/commands/media/export.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/media/export.ts)_
 
 ## `sanity media import SOURCE`
 
@@ -2386,7 +2367,7 @@ EXAMPLES
     $ sanity media import products --replace-aspects
 ```
 
-_See code: [src/commands/media/import.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/media/import.ts)_
+_See code: [src/commands/media/import.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/media/import.ts)_
 
 ## `sanity migration create [TITLE]`
 
@@ -2514,7 +2495,7 @@ EXAMPLES
     $ sanity openapi get query > query-api.yaml
 ```
 
-_See code: [src/commands/openapi/get.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/openapi/get.ts)_
+_See code: [src/commands/openapi/get.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/openapi/get.ts)_
 
 ## `sanity openapi list`
 
@@ -2545,7 +2526,7 @@ EXAMPLES
     $ sanity openapi list --web
 ```
 
-_See code: [src/commands/openapi/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/openapi/list.ts)_
+_See code: [src/commands/openapi/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/openapi/list.ts)_
 
 ## `sanity preview [OUTPUTDIR]`
 
@@ -2576,7 +2557,7 @@ EXAMPLES
   $ sanity preview some/build-output-dir
 ```
 
-_See code: [src/commands/preview.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/preview.ts)_
+_See code: [src/commands/preview.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/preview.ts)_
 
 ## `sanity projects list`
 
@@ -2605,7 +2586,7 @@ EXAMPLES
     $ sanity projects list --sort=members --order=asc
 ```
 
-_See code: [src/commands/projects/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/projects/list.ts)_
+_See code: [src/commands/projects/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/projects/list.ts)_
 
 ## `sanity schema delete`
 
@@ -2639,7 +2620,7 @@ EXAMPLES
     $ sanity schema delete --no-extract-manifest --ids sanity.workspace.schema.workspaceName
 ```
 
-_See code: [src/commands/schema/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/schema/delete.ts)_
+_See code: [src/commands/schema/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/schema/delete.ts)_
 
 ## `sanity schema deploy`
 
@@ -2679,7 +2660,7 @@ EXAMPLES
     $ sanity schema deploy --no-extract-manifest
 ```
 
-_See code: [src/commands/schema/deploy.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/schema/deploy.ts)_
+_See code: [src/commands/schema/deploy.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/schema/deploy.ts)_
 
 ## `sanity schema extract`
 
@@ -2707,7 +2688,7 @@ EXAMPLES
     $ sanity schema extract --workspace default
 ```
 
-_See code: [src/commands/schema/extract.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/schema/extract.ts)_
+_See code: [src/commands/schema/extract.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/schema/extract.ts)_
 
 ## `sanity schema list`
 
@@ -2753,7 +2734,7 @@ EXAMPLES
     $ sanity schema list --no-extract-manifest
 ```
 
-_See code: [src/commands/schema/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/schema/list.ts)_
+_See code: [src/commands/schema/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/schema/list.ts)_
 
 ## `sanity schema validate`
 
@@ -2796,7 +2777,7 @@ EXAMPLES
     $ sanity schema validate --debug-metafile-path metafile.json
 ```
 
-_See code: [src/commands/schema/validate.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/schema/validate.ts)_
+_See code: [src/commands/schema/validate.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/schema/validate.ts)_
 
 ## `sanity start [OUTPUTDIR]`
 
@@ -2844,7 +2825,7 @@ EXAMPLES
     $ sanity telemetry telemetry disable
 ```
 
-_See code: [src/commands/telemetry/disable.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/telemetry/disable.ts)_
+_See code: [src/commands/telemetry/disable.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/telemetry/disable.ts)_
 
 ## `sanity telemetry enable`
 
@@ -2863,7 +2844,7 @@ EXAMPLES
     $ sanity telemetry telemetry enable
 ```
 
-_See code: [src/commands/telemetry/enable.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/telemetry/enable.ts)_
+_See code: [src/commands/telemetry/enable.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/telemetry/enable.ts)_
 
 ## `sanity telemetry status`
 
@@ -2882,7 +2863,7 @@ EXAMPLES
     $ sanity telemetry telemetry status
 ```
 
-_See code: [src/commands/telemetry/status.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/telemetry/status.ts)_
+_See code: [src/commands/telemetry/status.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/telemetry/status.ts)_
 
 ## `sanity tokens add [LABEL]`
 
@@ -2921,7 +2902,7 @@ EXAMPLES
     $ sanity tokens add "API Token" --json
 ```
 
-_See code: [src/commands/tokens/add.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/tokens/add.ts)_
+_See code: [src/commands/tokens/add.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/tokens/add.ts)_
 
 ## `sanity tokens delete [TOKENID]`
 
@@ -2954,7 +2935,7 @@ EXAMPLES
     $ sanity tokens delete silJ2lFmK6dONB --yes
 ```
 
-_See code: [src/commands/tokens/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/tokens/delete.ts)_
+_See code: [src/commands/tokens/delete.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/tokens/delete.ts)_
 
 ## `sanity tokens list`
 
@@ -2980,7 +2961,7 @@ EXAMPLES
     $ sanity tokens list --json
 ```
 
-_See code: [src/commands/tokens/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/tokens/list.ts)_
+_See code: [src/commands/tokens/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/tokens/list.ts)_
 
 ## `sanity undeploy`
 
@@ -2997,7 +2978,7 @@ DESCRIPTION
   Removes the deployed Sanity Studio/App from Sanity hosting
 ```
 
-_See code: [src/commands/undeploy.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/undeploy.ts)_
+_See code: [src/commands/undeploy.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/undeploy.ts)_
 
 ## `sanity users invite [EMAIL]`
 
@@ -3030,7 +3011,7 @@ EXAMPLES
     $ sanity users invite pippi@sanity.io --role administrator
 ```
 
-_See code: [src/commands/users/invite.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/users/invite.ts)_
+_See code: [src/commands/users/invite.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/users/invite.ts)_
 
 ## `sanity users list`
 
@@ -3065,7 +3046,7 @@ EXAMPLES
     $ sanity users list --sort role
 ```
 
-_See code: [src/commands/users/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/users/list.ts)_
+_See code: [src/commands/users/list.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/users/list.ts)_
 
 ## `sanity versions`
 
@@ -3082,6 +3063,6 @@ EXAMPLES
   $ sanity versions
 ```
 
-_See code: [src/commands/versions.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.7/src/commands/versions.ts)_
+_See code: [src/commands/versions.ts](https://github.com/sanity-io/cli/blob/v6.0.0-alpha.8/src/commands/versions.ts)_
 
 <!-- commandsstop -->


### PR DESCRIPTION
The usage is not necessary and incorrect for our use case as well as it creates conflict with different versions