### PR TITLE
fix(core): fixes issue with resolving plugins in studio config

### DIFF
--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -69,6 +69,7 @@
     "json-lexer": "^1.2.0",
     "log-symbols": "^7.0.1",
     "ora": "catalog:",
+    "rxjs": "catalog:",
     "tsx": "catalog:",
     "vite": "catalog:",
     "zod": "catalog:"

--- a/packages/@sanity/cli-core/src/config/studio/readStudioConfig.worker.ts
+++ b/packages/@sanity/cli-core/src/config/studio/readStudioConfig.worker.ts
@@ -2,6 +2,7 @@ import {pathToFileURL} from 'node:url'
 import {isMainThread, parentPort, workerData} from 'node:worker_threads'
 
 import {moduleResolve} from 'import-meta-resolve'
+import {firstValueFrom, of} from 'rxjs'
 import {z} from 'zod'
 
 import {doImport} from '../../util/doImport.js'
@@ -30,12 +31,6 @@ if (resolvePlugins) {
   if (typeof resolveConfig !== 'function') {
     throw new TypeError('Expected `resolveConfig` from `sanity` to be a function')
   }
-
-  // We'll want to use some observable tooling, but we'd prefer to use something
-  // compatible with what the studio uses internally, thus try to load RxJS from the
-  // sanity module path instead of installing it as a dependency locally.
-  const rxjsPath = (await moduleResolve('rxjs', sanityUrl)).href
-  const {firstValueFrom, of} = await doImport(rxjsPath)
 
   // We will also want to stub out some configuration - we don't need to resolve the
   // users' logged in state, for instance - so let's disable the auth implementation.

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -122,7 +122,7 @@
     "recast": "^0.23.11",
     "resolve-from": "^5.0.0",
     "rimraf": "catalog:",
-    "rxjs": "^7.8.1",
+    "rxjs": "catalog:",
     "sanity": "catalog:",
     "semver": "^7.7.2",
     "semver-compare": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ catalogs:
     rimraf:
       specifier: ^6.0.1
       version: 6.1.2
+    rxjs:
+      specifier: ^7.8.2
+      version: 7.8.2
     sanity:
       specifier: ^5.6.0
       version: 5.6.0
@@ -484,7 +487,7 @@ importers:
         specifier: 'catalog:'
         version: 6.1.2
       rxjs:
-        specifier: ^7.8.1
+        specifier: 'catalog:'
         version: 7.8.2
       sanity:
         specifier: 'catalog:'
@@ -670,6 +673,9 @@ importers:
       ora:
         specifier: 'catalog:'
         version: 9.0.0
+      rxjs:
+        specifier: 'catalog:'
+        version: 7.8.2
       tsx:
         specifier: 'catalog:'
         version: 4.21.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,6 +47,7 @@ catalog:
   'get-tsconfig': ^4.13.0
   execa: ^9.6.0
   ora: ^9.0.0
+  rxjs: ^7.8.2
 
   # Build Tools
   '@swc/core': ^1.15.10


### PR DESCRIPTION
The `node` condition for rxjs is [cjs](https://github.com/ReactiveX/rxjs/blob/master/packages/rxjs/package.json#L19) which is causing issues with importing in ESM. We can add custom conditions but that seems to be brittle if studio changes the version of rxjs and the conditions change in there. 

Any other reason to not add it just add it as a dependency? 


> 1. Duplicate rxjs dependency in @sanity/cli (line 125)

> The PR adds rxjs to @sanity/cli-core but @sanity/cli already has rxjs as a dependency. Since @sanity/cli depends on @sanity/cli-core (line 70 in cli/package.json), this creates a duplicate dependency in the dependency tree. The CLI package should rely on the transitive dependency from cli-core instead.

> Fix: Remove rxjs: "catalog:" from packages/@sanity/cli/package.json:125 and let it be provided by the @sanity/cli-core dependency.

Is this true :notsure: ? 