### PR TITLE
test: use explicit argument passing syntax instead of string-based

### DIFF
--- a/packages/@sanity/cli/src/commands/__tests__/blueprints.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/blueprints.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, it} from 'vitest'
 
 describe('#blueprints', () => {
   it('should print blueprints help', async () => {
-    const {stdout} = await runCommand('blueprints --help')
+    const {stdout} = await runCommand(['blueprints', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Local Blueprint and remote Stack management commands
 
@@ -35,7 +35,7 @@ describe('#blueprints', () => {
 
 describe('#functions', () => {
   it('should print function help', async () => {
-    const {stdout} = await runCommand('functions --help')
+    const {stdout} = await runCommand(['functions', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Sanity Function development and management commands
 

--- a/packages/@sanity/cli/src/commands/__tests__/build.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/build.test.ts
@@ -13,7 +13,7 @@ describe(
   {concurrent: false},
   () => {
     test('help text is correct', async () => {
-      const {stdout} = await runCommand('build --help')
+      const {stdout} = await runCommand(['build', '--help'])
       expect(stdout).toMatchInlineSnapshot(`
         "Builds the Sanity Studio configuration into a static bundle
 

--- a/packages/@sanity/cli/src/commands/__tests__/codemod.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/codemod.test.ts
@@ -58,7 +58,7 @@ describe('#codemod', () => {
   })
 
   test('outputs empty string for help command', async () => {
-    const {stdout} = await runCommand('codemod --help')
+    const {stdout} = await runCommand(['codemod', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Updates Sanity Studio codebase with a code modification script

--- a/packages/@sanity/cli/src/commands/__tests__/debug.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/debug.test.ts
@@ -49,7 +49,7 @@ afterEach(() => {
 
 describe('#debug', () => {
   test('help text is correct', async () => {
-    const {stdout} = await runCommand('debug --help')
+    const {stdout} = await runCommand(['debug', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Provides diagnostic info for Sanity Studio troubleshooting
 

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.test.ts
@@ -1,6 +1,6 @@
 import {runCommand} from '@oclif/test'
 import {confirm, input, select} from '@sanity/cli-core/ux'
-import {mockApi, testCommand,testExample} from '@sanity/cli-test'
+import {mockApi, testCommand, testExample} from '@sanity/cli-test'
 import nock from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -101,7 +101,7 @@ describe('#deploy', () => {
   })
 
   test('help text is correct', async () => {
-    const {stdout} = await runCommand('deploy --help')
+    const {stdout} = await runCommand(['deploy', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Builds and deploys Sanity Studio or application to Sanity hosting
 

--- a/packages/@sanity/cli/src/commands/__tests__/exec.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/exec.test.ts
@@ -84,7 +84,7 @@ describe('#exec', {timeout: 15 * 1000}, () => {
   })
 
   test('help text is correct', async () => {
-    const {stdout} = await runCommand('exec --help')
+    const {stdout} = await runCommand(['exec', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Executes a script within the Sanity Studio context
 

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -56,7 +56,7 @@ describe('#init: oclif command setup', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand('init --help')
+    const {stdout} = await runCommand(['init', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Initialize a new Sanity Studio, project and/or app

--- a/packages/@sanity/cli/src/commands/__tests__/install.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/install.test.ts
@@ -36,7 +36,7 @@ afterEach(() => {
 
 describe('#install', () => {
   test('help text is correct', async () => {
-    const {stdout} = await runCommand('install --help')
+    const {stdout} = await runCommand(['install', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Installs dependencies for Sanity Studio project
 

--- a/packages/@sanity/cli/src/commands/__tests__/learn.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/learn.test.ts
@@ -15,7 +15,7 @@ describe('#learn', () => {
   })
 
   test('help text is correct', async () => {
-    const {stdout} = await runCommand('learn --help')
+    const {stdout} = await runCommand(['learn', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Opens Sanity Learn in your web browser
 

--- a/packages/@sanity/cli/src/commands/__tests__/migration.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/migration.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, test} from 'vitest'
 
 describe('#migration', () => {
   test('should print migrations help', async () => {
-    const {stdout} = await runCommand('migration --help')
+    const {stdout} = await runCommand(['migration', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Create a new migration within your project
 
@@ -20,7 +20,7 @@ describe('#migration', () => {
   })
 
   test('should print migration create help', async () => {
-    const {stdout} = await runCommand('migration create --help')
+    const {stdout} = await runCommand(['migration', 'create', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Create a new migration within your project
 
@@ -47,7 +47,7 @@ describe('#migration', () => {
   })
 
   test('should print migration list help', async () => {
-    const {stdout} = await runCommand('migration list --help')
+    const {stdout} = await runCommand(['migration', 'list', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "List available migrations
 
@@ -67,7 +67,7 @@ describe('#migration', () => {
   })
 
   test('should print migration run help', async () => {
-    const {stdout} = await runCommand('migration run --help')
+    const {stdout} = await runCommand(['migration', 'run', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Run a migration against a dataset
 

--- a/packages/@sanity/cli/src/commands/__tests__/typegen.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/typegen.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, it} from 'vitest'
 
 describe('#typegen', () => {
   it('should print typegen help', async () => {
-    const {stdout} = await runCommand('typegen --help')
+    const {stdout} = await runCommand(['typegen', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Beta: Generate TypeScript types for schema and GROQ
 
@@ -18,7 +18,7 @@ describe('#typegen', () => {
   })
 
   it('should print typegen generate help', async () => {
-    const {stdout} = await runCommand('typegen generate --help')
+    const {stdout} = await runCommand(['typegen', 'generate', '--help'])
 
     expect(stdout).toContain('Sanity TypeGen')
   })

--- a/packages/@sanity/cli/src/commands/backup/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/backup/__tests__/disable.test.ts
@@ -53,7 +53,7 @@ describe('#backup:disable', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['backup disable', '--help'])
+    const {stdout} = await runCommand(['backup', 'disable', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Disable backup for a dataset.
 

--- a/packages/@sanity/cli/src/commands/backup/__tests__/download.test.ts
+++ b/packages/@sanity/cli/src/commands/backup/__tests__/download.test.ts
@@ -113,7 +113,7 @@ describe('#backup:download', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['backup download', '--help'])
+    const {stdout} = await runCommand(['backup', 'download', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Download a dataset backup to a local file.

--- a/packages/@sanity/cli/src/commands/backup/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/backup/__tests__/enable.test.ts
@@ -58,7 +58,7 @@ describe('#backup:enable', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['backup enable', '--help'])
+    const {stdout} = await runCommand(['backup', 'enable', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Enable backup for a dataset.
 

--- a/packages/@sanity/cli/src/commands/backup/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/backup/__tests__/list.test.ts
@@ -66,7 +66,7 @@ describe('#backup:list', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['backup:list', '--help'])
+    const {stdout} = await runCommand(['backup', 'list', '--help'])
     expect(stdout).toContain('List available backups for a dataset')
     expect(stdout).toContain('USAGE')
     expect(stdout).toContain('EXAMPLES')

--- a/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
@@ -59,7 +59,7 @@ describe('#cors:delete', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['cors delete', '--help'])
+    const {stdout} = await runCommand(['cors', 'delete', '--help'])
     expect(stdout).toContain('Delete an existing CORS origin from your project')
   })
 

--- a/packages/@sanity/cli/src/commands/cors/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/list.test.ts
@@ -28,7 +28,7 @@ describe('#list', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['cors list', '--help'])
+    const {stdout} = await runCommand(['cors', 'list', '--help'])
 
     expect(stdout).toContain('List all origins allowed to access the API for this project')
   })

--- a/packages/@sanity/cli/src/commands/dataset/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/__tests__/copy.test.ts
@@ -84,7 +84,7 @@ describe('#dataset:copy', () => {
   })
 
   test('help works', async () => {
-    const {stdout} = await runCommand(['dataset copy', '--help'])
+    const {stdout} = await runCommand(['dataset', 'copy', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Manages dataset copying, including starting a new copy job, listing copy jobs and following the progress of a running copy job

--- a/packages/@sanity/cli/src/commands/dataset/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/__tests__/create.test.ts
@@ -64,7 +64,7 @@ describe('#dataset:create', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['dataset create', '--help'])
+    const {stdout} = await runCommand(['dataset', 'create', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Create a new dataset within your project

--- a/packages/@sanity/cli/src/commands/dataset/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/__tests__/delete.test.ts
@@ -54,7 +54,7 @@ describe('#dataset:delete', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['dataset delete', '--help'])
+    const {stdout} = await runCommand(['dataset', 'delete', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Delete a dataset within your project
 

--- a/packages/@sanity/cli/src/commands/dataset/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/__tests__/export.test.ts
@@ -135,7 +135,7 @@ describe('#dataset:export', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['dataset:export', '--help'])
+    const {stdout} = await runCommand(['dataset', 'export', '--help'])
 
     expect(stdout).toContain('Export dataset to local filesystem as a gzipped tarball')
     expect(stdout).toContain('ARGUMENTS')

--- a/packages/@sanity/cli/src/commands/dataset/__tests__/import.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/__tests__/import.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, test} from 'vitest'
 
 describe('#dataset:import', () => {
   test('should print datasets:import help', async () => {
-    const {stdout} = await runCommand('dataset import --help')
+    const {stdout} = await runCommand(['dataset', 'import', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Import documents to a Sanity dataset

--- a/packages/@sanity/cli/src/commands/dataset/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/__tests__/list.test.ts
@@ -50,7 +50,7 @@ describe('#dataset:list', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['dataset list', '--help'])
+    const {stdout} = await runCommand(['dataset', 'list', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "List datasets of your project
 

--- a/packages/@sanity/cli/src/commands/dataset/alias/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/alias/__tests__/create.test.ts
@@ -50,7 +50,7 @@ describe('#dataset:alias:create', () => {
   })
 
   test('help works correctly', async () => {
-    const {stdout} = await runCommand(['dataset alias create', '--help'])
+    const {stdout} = await runCommand(['dataset', 'alias', 'create', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Create a dataset alias within your project
 

--- a/packages/@sanity/cli/src/commands/dataset/alias/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/alias/__tests__/delete.test.ts
@@ -39,7 +39,7 @@ describe('#dataset:alias:delete', () => {
   })
 
   test('help works correctly', async () => {
-    const {stdout} = await runCommand(['dataset alias delete', '--help'])
+    const {stdout} = await runCommand(['dataset', 'alias', 'delete', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Delete a dataset alias within your project
 

--- a/packages/@sanity/cli/src/commands/dataset/alias/__tests__/link.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/alias/__tests__/link.test.ts
@@ -49,7 +49,7 @@ describe('#dataset:alias:link', () => {
   })
 
   test('help works correctly', async () => {
-    const {stdout} = await runCommand(['dataset alias link', '--help'])
+    const {stdout} = await runCommand(['dataset', 'alias', 'link', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Link a dataset alias to a dataset within your project
 

--- a/packages/@sanity/cli/src/commands/dataset/alias/__tests__/unlink.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/alias/__tests__/unlink.test.ts
@@ -39,7 +39,7 @@ describe('#dataset:alias:unlink', () => {
   })
 
   test('help works correctly', async () => {
-    const {stdout} = await runCommand(['dataset alias unlink', '--help'])
+    const {stdout} = await runCommand(['dataset', 'alias', 'unlink', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Unlink a dataset alias from its dataset within your project
 

--- a/packages/@sanity/cli/src/commands/dataset/visibility/__tests__/get.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/visibility/__tests__/get.test.ts
@@ -37,7 +37,7 @@ describe('#dataset:visibility:get', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['dataset visibility get', '--help'])
+    const {stdout} = await runCommand(['dataset', 'visibility', 'get', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Get the visibility of a dataset

--- a/packages/@sanity/cli/src/commands/dataset/visibility/__tests__/set.test.ts
+++ b/packages/@sanity/cli/src/commands/dataset/visibility/__tests__/set.test.ts
@@ -39,7 +39,7 @@ describe('#dataset:visibility:set', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['dataset visibility set', '--help'])
+    const {stdout} = await runCommand(['dataset', 'visibility', 'set', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Set the visibility of a dataset

--- a/packages/@sanity/cli/src/commands/docs/__tests__/browse.test.ts
+++ b/packages/@sanity/cli/src/commands/docs/__tests__/browse.test.ts
@@ -15,7 +15,7 @@ describe('#docs:browse', () => {
   })
 
   test('help text is correct', async () => {
-    const {stdout} = await runCommand('docs browse --help')
+    const {stdout} = await runCommand(['docs', 'browse', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Open Sanity docs in a web browser
 

--- a/packages/@sanity/cli/src/commands/docs/__tests__/read.test.ts
+++ b/packages/@sanity/cli/src/commands/docs/__tests__/read.test.ts
@@ -77,7 +77,7 @@ describe('#docs:read', () => {
   })
 
   test('help text is correct', async () => {
-    const {stdout} = await runCommand('docs read --help')
+    const {stdout} = await runCommand(['docs', 'read', '--help'])
     expect(stdout).toContain('Read an article in terminal')
     expect(stdout).toContain('ARGUMENTS')
     expect(stdout).toContain('FLAGS')

--- a/packages/@sanity/cli/src/commands/docs/__tests__/search.test.ts
+++ b/packages/@sanity/cli/src/commands/docs/__tests__/search.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 
 describe('#docs:search', () => {
   test('--help works', async () => {
-    const {stdout} = await runCommand('docs search --help')
+    const {stdout} = await runCommand(['docs', 'search', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Search Sanity docs
 

--- a/packages/@sanity/cli/src/commands/documents/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/create.test.ts
@@ -125,7 +125,7 @@ describe('#documents:create', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['documents create', '--help'])
+    const {stdout} = await runCommand(['documents', 'create', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Create one or more documents

--- a/packages/@sanity/cli/src/commands/documents/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/delete.test.ts
@@ -39,7 +39,7 @@ describe('#documents:delete', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['documents delete', '--help'])
+    const {stdout} = await runCommand(['documents', 'delete', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Delete one or more documents from the projects configured dataset

--- a/packages/@sanity/cli/src/commands/documents/__tests__/get.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/get.test.ts
@@ -37,7 +37,7 @@ describe('#documents:get', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['documents get', '--help'])
+    const {stdout} = await runCommand(['documents', 'get', '--help'])
 
     expect(stdout).toContain('Get and print a document by ID')
     expect(stdout).toContain('ARGUMENTS')

--- a/packages/@sanity/cli/src/commands/documents/__tests__/query.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/query.test.ts
@@ -36,7 +36,7 @@ describe('#documents:query', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['documents query', '--help'])
+    const {stdout} = await runCommand(['documents', 'query', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Query for documents

--- a/packages/@sanity/cli/src/commands/documents/__tests__/validate.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/validate.test.ts
@@ -66,7 +66,7 @@ describe('#documents:validate', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['documents validate', '--help'])
+    const {stdout} = await runCommand(['documents', 'validate', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Validate documents in a dataset against the studio schema

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/list.test.ts
@@ -28,7 +28,7 @@ describe('#list', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['graphql list', '--help'])
+    const {stdout} = await runCommand(['graphql', 'list', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "List all GraphQL endpoints deployed for this project

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
@@ -50,7 +50,7 @@ describe('graphql undeploy', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['graphql undeploy', '--help'])
+    const {stdout} = await runCommand(['graphql', 'undeploy', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Remove a deployed GraphQL API
@@ -160,7 +160,9 @@ describe('graphql undeploy', () => {
       uri: '/apis/graphql/production/default',
     }).reply(204)
 
-    const {stdout} = await testCommand(Undeploy, ['--project', 'custom-project', '--force'], {mocks: defaultMocks})
+    const {stdout} = await testCommand(Undeploy, ['--project', 'custom-project', '--force'], {
+      mocks: defaultMocks,
+    })
 
     expect(stdout).toBe('GraphQL API deleted\n')
   })
@@ -175,14 +177,11 @@ describe('graphql undeploy', () => {
       uri: '/apis/graphql/staging/experimental',
     }).reply(204)
 
-    const {stdout} = await testCommand(Undeploy, [
-      '--project',
-      'custom-project',
-      '--dataset',
-      'staging',
-      '--tag',
-      'experimental',
-    ], {mocks: defaultMocks})
+    const {stdout} = await testCommand(
+      Undeploy,
+      ['--project', 'custom-project', '--dataset', 'staging', '--tag', 'experimental'],
+      {mocks: defaultMocks},
+    )
 
     expect(stdout).toBe('GraphQL API deleted\n')
     expect(mockConfirm).toHaveBeenCalledWith({
@@ -277,7 +276,9 @@ describe('graphql undeploy', () => {
       uri: '/apis/graphql/staging/default',
     }).reply(204)
 
-    const {stderr, stdout} = await testCommand(Undeploy, ['--api', 'ios', '--dataset', 'staging'], {mocks: defaultMocks})
+    const {stderr, stdout} = await testCommand(Undeploy, ['--api', 'ios', '--dataset', 'staging'], {
+      mocks: defaultMocks,
+    })
 
     expect(stdout).toBe('GraphQL API deleted\n')
     expect(stderr).toContain('Both --api and --dataset specified, using --dataset staging')
@@ -303,12 +304,11 @@ describe('graphql undeploy', () => {
       uri: '/apis/graphql/production/default',
     }).reply(204)
 
-    const {stderr, stdout} = await testCommand(Undeploy, [
-      '--api',
-      'ios',
-      '--project',
-      'test-project',
-    ], {mocks: defaultMocks})
+    const {stderr, stdout} = await testCommand(
+      Undeploy,
+      ['--api', 'ios', '--project', 'test-project'],
+      {mocks: defaultMocks},
+    )
 
     expect(stdout).toBe('GraphQL API deleted\n')
     expect(stderr).toContain('Both --api and --project specified, using --project test-project')
@@ -334,7 +334,9 @@ describe('graphql undeploy', () => {
       uri: '/apis/graphql/production/beta',
     }).reply(204)
 
-    const {stderr, stdout} = await testCommand(Undeploy, ['--api', 'ios', '--tag', 'beta'], {mocks: defaultMocks})
+    const {stderr, stdout} = await testCommand(Undeploy, ['--api', 'ios', '--tag', 'beta'], {
+      mocks: defaultMocks,
+    })
 
     expect(stdout).toBe('GraphQL API deleted\n')
     expect(stderr).toContain('Both --api and --tag specified, using --tag beta')

--- a/packages/@sanity/cli/src/commands/hook/__tests__/attempt.test.ts
+++ b/packages/@sanity/cli/src/commands/hook/__tests__/attempt.test.ts
@@ -29,7 +29,7 @@ describe('#attempt', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['hook attempt', '--help'])
+    const {stdout} = await runCommand(['hook', 'attempt', '--help'])
 
     expect(stdout).toContain('Print details of a given webhook delivery attempt')
     expect(stdout).toMatchInlineSnapshot(`

--- a/packages/@sanity/cli/src/commands/hook/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/hook/__tests__/create.test.ts
@@ -42,7 +42,7 @@ describe('#hook:create', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['hook create', '--help'])
+    const {stdout} = await runCommand(['hook', 'create', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Create a new webhook for the current project

--- a/packages/@sanity/cli/src/commands/hook/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/hook/__tests__/delete.test.ts
@@ -38,7 +38,7 @@ describe('#delete', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['hook delete', '--help'])
+    const {stdout} = await runCommand(['hook', 'delete', '--help'])
 
     expect(stdout).toContain('Delete a hook within your project')
   })

--- a/packages/@sanity/cli/src/commands/hook/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/hook/__tests__/list.test.ts
@@ -28,7 +28,7 @@ describe('#list', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['hook list', '--help'])
+    const {stdout} = await runCommand(['hook', 'list', '--help'])
 
     expect(stdout).toContain('List hooks for a given project')
   })

--- a/packages/@sanity/cli/src/commands/hook/__tests__/logs.test.ts
+++ b/packages/@sanity/cli/src/commands/hook/__tests__/logs.test.ts
@@ -39,7 +39,7 @@ describe('#hook:logs', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['hook logs', '--help'])
+    const {stdout} = await runCommand(['hook', 'logs', '--help'])
 
     expect(stdout).toContain('List latest log entries for a given hook')
   })

--- a/packages/@sanity/cli/src/commands/manifest/__tests__/extract.test.ts
+++ b/packages/@sanity/cli/src/commands/manifest/__tests__/extract.test.ts
@@ -60,7 +60,7 @@ describe('#manifest:extract', () => {
   })
 
   test('should show --help text', async () => {
-    const {error = NO_ERROR, stdout} = await runCommand('manifest extract --help')
+    const {error = NO_ERROR, stdout} = await runCommand(['manifest', 'extract', '--help'])
 
     expect(error, 'should not error').toStrictEqual(NO_ERROR)
     expect(stdout).toMatchInlineSnapshot(`
@@ -110,10 +110,9 @@ describe('#manifest:extract', () => {
     expect(stderr).toContain('Extracting manifest')
     expect(stderr).toContain('Extracted manifest')
 
-    expect(mockMkdir).toHaveBeenCalledWith(
-      convertToSystemPath('/test/path/dist/static'),
-      {recursive: true},
-    )
+    expect(mockMkdir).toHaveBeenCalledWith(convertToSystemPath('/test/path/dist/static'), {
+      recursive: true,
+    })
 
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining('create-schema.json'),
@@ -152,10 +151,9 @@ describe('#manifest:extract', () => {
     expect(stderr).toContain('Extracting manifest')
     expect(stderr).toContain('Extracted manifest')
 
-    expect(mockMkdir).toHaveBeenCalledWith(
-      convertToSystemPath('/test/path/test/static'),
-      {recursive: true},
-    )
+    expect(mockMkdir).toHaveBeenCalledWith(convertToSystemPath('/test/path/test/static'), {
+      recursive: true,
+    })
 
     expect(mockWriteFile).toHaveBeenCalledWith(
       convertToSystemPath('/test/path/test/static/create-manifest.json'),

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -61,7 +61,7 @@ describe('#mcp:configure', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['mcp configure', '--help'])
+    const {stdout} = await runCommand(['mcp', 'configure', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Configure Sanity MCP server for AI editors (Cursor, VS Code, Claude Code)

--- a/packages/@sanity/cli/src/commands/media/__tests__/create-aspect.test.ts
+++ b/packages/@sanity/cli/src/commands/media/__tests__/create-aspect.test.ts
@@ -41,7 +41,7 @@ describe('#media:create-aspect', () => {
   })
 
   test('should show help text correctly', async () => {
-    const {stdout} = await runCommand(['media create-aspect --help'])
+    const {stdout} = await runCommand(['media', 'create-aspect', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Create a new aspect definition file
@@ -78,10 +78,9 @@ describe('#media:create-aspect', () => {
     expect(stdout).toContain('Next steps:')
     expect(stdout).toContain('sanity media deploy-aspect myTestAspect')
 
-    expect(mockMkdir).toHaveBeenCalledWith(
-      convertToSystemPath('/test/project/aspects'),
-      {recursive: true},
-    )
+    expect(mockMkdir).toHaveBeenCalledWith(convertToSystemPath('/test/project/aspects'), {
+      recursive: true,
+    })
     expect(mockAccess).toHaveBeenCalledWith(
       convertToSystemPath('/test/project/aspects/myTestAspect.ts'),
     )
@@ -161,10 +160,9 @@ describe('#media:create-aspect', () => {
       },
     })
 
-    expect(mockMkdir).toHaveBeenCalledWith(
-      convertToSystemPath('/new/aspects/path'),
-      {recursive: true},
-    )
+    expect(mockMkdir).toHaveBeenCalledWith(convertToSystemPath('/new/aspects/path'), {
+      recursive: true,
+    })
   })
 
   test('should generate correct template content', async () => {

--- a/packages/@sanity/cli/src/commands/media/__tests__/delete-aspect.test.ts
+++ b/packages/@sanity/cli/src/commands/media/__tests__/delete-aspect.test.ts
@@ -44,7 +44,7 @@ describe('#media:delete-aspect', () => {
   })
 
   test('should show help text correctly', async () => {
-    const {stdout} = await runCommand(['media delete-aspect --help'])
+    const {stdout} = await runCommand(['media', 'delete-aspect', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Undeploy an aspect

--- a/packages/@sanity/cli/src/commands/media/__tests__/deploy-aspect.test.ts
+++ b/packages/@sanity/cli/src/commands/media/__tests__/deploy-aspect.test.ts
@@ -178,7 +178,7 @@ describe('#media:deploy-aspect', () => {
   })
 
   test('should show help text correctly', async () => {
-    const {stdout} = await runCommand(['media deploy-aspect --help'])
+    const {stdout} = await runCommand(['media', 'deploy-aspect', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Deploy an aspect

--- a/packages/@sanity/cli/src/commands/media/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/media/__tests__/export.test.ts
@@ -131,7 +131,7 @@ describe('#media:export', () => {
   })
 
   test('should show help text correctly', async () => {
-    const {stdout} = await runCommand(['media export --help'])
+    const {stdout} = await runCommand(['media', 'export', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Export an archive of all file and image assets including their aspect data from the target media library. Video assets are excluded from the export.

--- a/packages/@sanity/cli/src/commands/openapi/__tests__/get.test.ts
+++ b/packages/@sanity/cli/src/commands/openapi/__tests__/get.test.ts
@@ -41,7 +41,7 @@ describe('#openapi:get', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['openapi get', '--help'])
+    const {stdout} = await runCommand(['openapi', 'get', '--help'])
 
     expect(stdout).toContain('Get an OpenAPI specification by slug')
   })

--- a/packages/@sanity/cli/src/commands/openapi/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/openapi/__tests__/list.test.ts
@@ -28,7 +28,7 @@ describe('#openapi:list', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['openapi list', '--help'])
+    const {stdout} = await runCommand(['openapi', 'list', '--help'])
 
     expect(stdout).toContain('List all available OpenAPI specifications')
   })

--- a/packages/@sanity/cli/src/commands/projects/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/list.test.ts
@@ -14,7 +14,7 @@ describe('#list', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['projects list', '--help'])
+    const {stdout} = await runCommand(['projects', 'list', '--help'])
 
     expect(stdout).toContain('Lists projects connected to your user')
   })

--- a/packages/@sanity/cli/src/commands/schema/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/schema/__tests__/delete.test.ts
@@ -81,7 +81,7 @@ describe('#schema:delete', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['schema delete', '--help'])
+    const {stdout} = await runCommand(['schema', 'delete', '--help'])
 
     expect(stdout).toContain('Delete schema documents by id')
     expect(stdout).toContain('--ids')

--- a/packages/@sanity/cli/src/commands/schema/__tests__/deploy.test.ts
+++ b/packages/@sanity/cli/src/commands/schema/__tests__/deploy.test.ts
@@ -74,7 +74,7 @@ describe('#schema:deploy', () => {
   })
 
   test('should show --help text', async () => {
-    const {stdout} = await runCommand('schema deploy --help')
+    const {stdout} = await runCommand(['schema', 'deploy', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Deploy schema documents into workspace datasets.

--- a/packages/@sanity/cli/src/commands/schema/__tests__/extract.test.ts
+++ b/packages/@sanity/cli/src/commands/schema/__tests__/extract.test.ts
@@ -48,7 +48,7 @@ describe('#schema:extract', () => {
   })
 
   test('should show --help text', async () => {
-    const {stdout} = await runCommand('schema extract --help')
+    const {stdout} = await runCommand(['schema', 'extract', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Extracts a JSON representation of a Sanity schema within a Studio context.
@@ -117,10 +117,9 @@ describe('#schema:extract', () => {
     expect(stderr).toContain('Extracting schema')
     expect(stderr).toContain('Extracted schema')
 
-    expect(mockMkdir).toHaveBeenCalledWith(
-      convertToSystemPath('/test/project/test'),
-      {recursive: true},
-    )
+    expect(mockMkdir).toHaveBeenCalledWith(convertToSystemPath('/test/project/test'), {
+      recursive: true,
+    })
 
     expect(mockWriteFile).toHaveBeenCalledWith(
       convertToSystemPath('/test/project/test/schema.json'),

--- a/packages/@sanity/cli/src/commands/schema/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/schema/__tests__/list.test.ts
@@ -69,7 +69,7 @@ describe('#schema:list', () => {
   })
 
   test('should show --help text', async () => {
-    const {stdout} = await runCommand('schema list --help')
+    const {stdout} = await runCommand(['schema', 'list', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "Lists all schemas in the current dataset.

--- a/packages/@sanity/cli/src/commands/schema/__tests__/validate.test.ts
+++ b/packages/@sanity/cli/src/commands/schema/__tests__/validate.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../../actions/schema/validateAction.js', () => ({
 
 describe('#schema:validate', () => {
   test('--help works', async () => {
-    const {stdout} = await runCommand(['schema:validate', '--help'])
+    const {stdout} = await runCommand(['schema', 'validate', '--help'])
     expect(stdout).toMatchInlineSnapshot(`
       "Validates all schema types specified in a workspace
 

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
@@ -42,7 +42,7 @@ describe('#tokens:add', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['tokens add', '--help'])
+    const {stdout} = await runCommand(['tokens', 'add', '--help'])
 
     expect(stdout).toContain('Create a new API token for this project')
   })

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
@@ -69,7 +69,7 @@ describe('#tokens:delete', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['tokens delete', '--help'])
+    const {stdout} = await runCommand(['tokens', 'delete', '--help'])
     expect(stdout).toContain('Delete an API token from this project')
   })
 
@@ -83,7 +83,9 @@ describe('#tokens:delete', () => {
       uri: '/projects/test-project/tokens/token-api-123',
     }).reply(204)
 
-    const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123'], {mocks: defaultMocks})
+    const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123'], {
+      mocks: defaultMocks,
+    })
     expect(stdout).toBe('Token deleted successfully\n')
     expect(confirm).toHaveBeenCalledWith({
       default: false,
@@ -98,7 +100,9 @@ describe('#tokens:delete', () => {
       uri: '/projects/test-project/tokens/token-api-123',
     }).reply(204)
 
-    const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {mocks: defaultMocks})
+    const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {
+      mocks: defaultMocks,
+    })
     expect(stdout).toBe('Token deleted successfully\n')
   })
 
@@ -109,7 +113,9 @@ describe('#tokens:delete', () => {
       uri: '/projects/test-project/tokens/token-api-123',
     }).reply(204)
 
-    const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123', '-y'], {mocks: defaultMocks})
+    const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123', '-y'], {
+      mocks: defaultMocks,
+    })
     expect(stdout).toBe('Token deleted successfully\n')
   })
 
@@ -218,7 +224,9 @@ describe('#tokens:delete', () => {
       uri: '/projects/test-project/tokens/nonexistent-token',
     }).reply(404, {message: 'Token not found'})
 
-    const {error} = await testCommand(DeleteTokensCommand, ['nonexistent-token', '--yes'], {mocks: defaultMocks})
+    const {error} = await testCommand(DeleteTokensCommand, ['nonexistent-token', '--yes'], {
+      mocks: defaultMocks,
+    })
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Token with ID "nonexistent-token" not found')
     expect(error?.oclif?.exit).toBe(1)
@@ -247,7 +255,9 @@ describe('#tokens:delete', () => {
       uri: '/projects/test-project/tokens/token-api-123',
     }).reply(statusCode, {message})
 
-    const {error} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {mocks: defaultMocks})
+    const {error} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {
+      mocks: defaultMocks,
+    })
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Token deletion failed')
     expect(error?.message).toContain(message)
@@ -304,7 +314,9 @@ describe('#tokens:delete', () => {
 
   test('handles network errors when deleting token', async () => {
     // Don't set up any mock to simulate network failure
-    const {error} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {mocks: defaultMocks})
+    const {error} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {
+      mocks: defaultMocks,
+    })
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Token deletion failed')
     expect(error?.oclif?.exit).toBe(1)

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/list.test.ts
@@ -67,7 +67,7 @@ describe('#tokens:list', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['tokens list', '--help'])
+    const {stdout} = await runCommand(['tokens', 'list', '--help'])
 
     expect(stdout).toMatchInlineSnapshot(`
       "List API tokens for the current project

--- a/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
@@ -81,7 +81,7 @@ describe('#invite', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['users invite', '--help'])
+    const {stdout} = await runCommand(['users', 'invite', '--help'])
 
     expect(stdout).toContain('Invite a new user to the project')
     expect(stdout).toContain('--role')

--- a/packages/@sanity/cli/src/commands/users/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/list.test.ts
@@ -40,7 +40,7 @@ describe('#list', () => {
   })
 
   test('--help works', async () => {
-    const {stdout} = await runCommand(['users list', '--help'])
+    const {stdout} = await runCommand(['users', 'list', '--help'])
 
     expect(stdout).toContain('List all users of the project')
   })


### PR DESCRIPTION
### Description

There are a bunch of different conventions floating around in the codebase - but the most explicit (and correct) way to test commands is to pass arguments as an array. This simplifies things when you get to "escaping" arguments across platforms etc. 

This normalizes to use an array of args when testing commands, and also removes some oclif colon-based subcommand conventions (eg `backups:list` instead of `backups list`).

### What to review

Shouldn't be any major differences here, but let me know if I missed anything.

### Testing

No new tests, only modified existing ones