### PR TITLE
chore: drop npm `build` script for fixtures

### DIFF
--- a/fixtures/basic-app/package.json
+++ b/fixtures/basic-app/package.json
@@ -8,7 +8,6 @@
   "license": "UNLICENSED",
   "main": "package.json",
   "scripts": {
-    "build": "sanity build",
     "dev": "sanity dev",
     "start": "sanity start"
   },

--- a/fixtures/basic-studio/package.json
+++ b/fixtures/basic-studio/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sanity/basic-studio",
+  "name": "basic-studio",
   "version": "1.0.0",
   "private": true,
   "keywords": [
@@ -9,7 +9,6 @@
   "type": "module",
   "main": "package.json",
   "scripts": {
-    "build": "sanity build",
     "deploy": "sanity deploy",
     "deploy-graphql": "sanity graphql deploy",
     "dev": "sanity dev",

--- a/fixtures/multi-workspace-studio/package.json
+++ b/fixtures/multi-workspace-studio/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sanity/multi-workspace-studio",
+  "name": "multi-workspace-studio",
   "version": "1.0.0",
   "private": true,
   "keywords": [
@@ -9,7 +9,6 @@
   "type": "module",
   "main": "package.json",
   "scripts": {
-    "build": "sanity build",
     "deploy": "sanity deploy",
     "deploy-graphql": "sanity graphql deploy",
     "dev": "sanity dev",

--- a/fixtures/worst-case-studio/package.json
+++ b/fixtures/worst-case-studio/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sanity/worst-case-studio",
+  "name": "worst-case-studio",
   "version": "1.0.0",
   "private": true,
   "keywords": [
@@ -9,7 +9,6 @@
   "type": "module",
   "main": "package.json",
   "scripts": {
-    "build": "sanity build",
     "deploy": "sanity deploy",
     "deploy-graphql": "sanity graphql deploy",
     "dev": "sanity dev",


### PR DESCRIPTION
### Description

Turbo builds the fixtures at the moment, which I don't think it needs to. They're not required after publish - certainly not the compiled output, and the tests etc explicitly builds if they need to, or uses the prebuilt fixtures. Lets see if CI passes and proves me wrong ;)

Also simplified the fixture names to be consistent (drop the `@sanity` prefix)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
