### PR TITLE
test(cli): migrate another `process.env` occurence to use `stubEnv`

### DIFF
--- a/packages/@sanity/cli/README.md
+++ b/packages/@sanity/cli/README.md
@@ -3060,7 +3060,7 @@ EXAMPLES
     $ sanity typegen generate
 ```
 
-_See code: [@sanity/codegen](https://github.com/sanity-io/codegen/blob/v5.9.1/src/commands/typegen/generate.ts)_
+_See code: [@sanity/codegen](https://github.com/sanity-io/codegen/blob/v5.9.2/src/commands/typegen/generate.ts)_
 
 ## `sanity undeploy`
 

--- a/packages/@sanity/cli/src/commands/documents/__tests__/query.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/query.test.ts
@@ -31,6 +31,7 @@ vi.mock('@sanity/cli-core', async () => {
 describe('#documents:query', () => {
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
   })
 
   test('executes query successfully with basic options', async () => {
@@ -64,8 +65,7 @@ describe('#documents:query', () => {
     mockFetch.mockResolvedValue(mockResults)
 
     // Set FORCE_COLOR to enable colorization
-    const originalForceColor = process.env.FORCE_COLOR
-    process.env.FORCE_COLOR = '1'
+    vi.stubEnv('FORCE_COLOR', '1')
 
     const {stdout} = await testCommand(QueryDocumentCommand, ['*[_type == "movie"]', '--pretty'], {
       capture: {
@@ -73,13 +73,6 @@ describe('#documents:query', () => {
       },
       mocks: defaultMocks,
     })
-
-    // Reset FORCE_COLOR
-    if (originalForceColor === undefined) {
-      delete process.env.FORCE_COLOR
-    } else {
-      process.env.FORCE_COLOR = originalForceColor
-    }
 
     expect(mockFetch).toHaveBeenCalledWith('*[_type == "movie"]')
     expect(stdout).toContain('"_id"')
@@ -239,7 +232,5 @@ describe('#documents:query', () => {
 
     expect(stdout).toContain('"_id": "test"')
     expect(mockFetch).toHaveBeenCalledWith('*[_type == "movie"]')
-
-    vi.unstubAllEnvs()
   })
 })


### PR DESCRIPTION
### Description

Addressing some PR feedback post-merge

### What to review

…

### Testing

…