### PR TITLE
fix(core): re-add chalk dependency

### DIFF
--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -61,6 +61,7 @@
     "@sanity/types": "catalog:",
     "babel-plugin-react-compiler": "^1.0.0",
     "boxen": "^8.0.1",
+    "chalk": "^5.6.2",
     "configstore": "^7.0.0",
     "debug": "catalog:",
     "get-tsconfig": "catalog:",

--- a/packages/@sanity/cli-core/src/_exports/ux.ts
+++ b/packages/@sanity/cli-core/src/_exports/ux.ts
@@ -1,4 +1,5 @@
 export * from '../ux/boxen.js'
+export * from '../ux/chalk.js'
 export * from '../ux/logSymbols.js'
 export * from '../ux/prompts.js'
 export * from '../ux/spinner.js'

--- a/packages/@sanity/cli-core/src/ux/chalk.ts
+++ b/packages/@sanity/cli-core/src/ux/chalk.ts
@@ -1,0 +1,3 @@
+/* eslint-disable no-restricted-imports */
+export {default as chalk} from 'chalk'
+export * from 'chalk'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,9 @@ importers:
       boxen:
         specifier: ^8.0.1
         version: 8.0.1
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
       configstore:
         specifier: ^7.0.0
         version: 7.1.0


### PR DESCRIPTION
Removing chalk should have been a breaking change so it doesn't get auto updated. This should make the export working again