### PR TITLE
chore(deps): fixes depcheck issues in dist files

### DIFF
--- a/packages/@sanity/cli-core/package.config.ts
+++ b/packages/@sanity/cli-core/package.config.ts
@@ -3,6 +3,7 @@ import {defineConfig} from '@sanity/pkg-utils'
 
 export default defineConfig({
   ...baseConfig,
+  external: ['sanity'],
   extract: {
     ...baseConfig.extract,
     // Disable rules for now

--- a/packages/@sanity/cli-test/src/test/createTestClient.ts
+++ b/packages/@sanity/cli-test/src/test/createTestClient.ts
@@ -1,4 +1,4 @@
-import {type ClientConfig, createClient} from '@sanity/client'
+import {type ClientConfig, createClient, type SanityClient} from '@sanity/client'
 import {vi} from 'vitest'
 
 /**
@@ -49,7 +49,10 @@ export interface CreateTestClientOptions extends ClientConfig {
  * }).reply(200, {data: [...]})
  * ```
  */
-export function createTestClient(options: CreateTestClientOptions) {
+export function createTestClient(options: CreateTestClientOptions): {
+  client: SanityClient
+  request: ReturnType<typeof vi.fn>
+} {
   const {apiVersion, projectId, token, ...rest} = options
 
   const client = createClient({

--- a/packages/@sanity/cli/src/config/createCliConfig.ts
+++ b/packages/@sanity/cli/src/config/createCliConfig.ts
@@ -4,6 +4,6 @@ import {type CliConfig, cliConfigSchema} from '@sanity/cli-core'
  * @deprecated Use `defineCliConfig` instead
  * @public
  */
-export function createCliConfig(config: CliConfig) {
+export function createCliConfig(config: CliConfig): CliConfig {
   return cliConfigSchema.parse(config)
 }


### PR DESCRIPTION
Fixes issues in the built out types file including bunch of babel and sanity package references. The fixes are 
- Return explicit type for `createCliConfig` the inferred type included all of zod and babel things. 
- Mark sanity as external for cli-core since we only use the types from sanity
- Explicitly return the `SanityClient` from `@sanity/client` because cli-test is inferring it from sanity and it's not a peer dep of cli-test causing failure

How to test, run `pnpm build:cli && pnpm depcheck` 