### PR TITLE
fix: allow catalog-versioned styled components dependency

### DIFF
--- a/packages/@sanity/cli/src/actions/build/__tests__/checkRequiredDependencies.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/checkRequiredDependencies.test.ts
@@ -223,6 +223,84 @@ describe('#checkRequiredDependencies', () => {
     )
   })
 
+  test('should not error on catalog: prefix for styled-components version', async () => {
+    mockedDetermineIsApp.mockReturnValue(false)
+    mockReadPackageJson.mockResolvedValue({
+      dependencies: {'styled-components': 'catalog:'},
+      devDependencies: {},
+      name: 'test-studio',
+      version: '1.0.0',
+    })
+    mockedGetLocalPackageVersion.mockImplementation(async (module: string) => {
+      if (module === 'sanity') return '3.2.0'
+      if (module === 'styled-components') return '6.1.15'
+      return null
+    })
+
+    const result = await checkRequiredDependencies({
+      cliConfig: mockCliConfig as CliConfig,
+      output: mockOutput,
+      workDir,
+    })
+
+    expect(result).toEqual({installedSanityVersion: '3.2.0'})
+    expect(mockOutput.error).not.toHaveBeenCalled()
+    expect(mockOutput.warn).not.toHaveBeenCalled()
+  })
+
+  test('should not warn on version comparison when using catalog: prefix', async () => {
+    mockedDetermineIsApp.mockReturnValue(false)
+    mockReadPackageJson.mockResolvedValue({
+      dependencies: {'styled-components': 'catalog:react'},
+      devDependencies: {},
+      name: 'test-studio',
+      version: '1.0.0',
+    })
+    mockedGetLocalPackageVersion.mockImplementation(async (module: string) => {
+      if (module === 'sanity') return '3.2.0'
+      if (module === 'styled-components') return '6.1.15'
+      return null
+    })
+
+    const result = await checkRequiredDependencies({
+      cliConfig: mockCliConfig as CliConfig,
+      output: mockOutput,
+      workDir,
+    })
+
+    expect(result).toEqual({installedSanityVersion: '3.2.0'})
+    expect(mockOutput.error).not.toHaveBeenCalled()
+    expect(mockOutput.warn).not.toHaveBeenCalled()
+  })
+
+  test('should still warn on incompatible installed version when using catalog: prefix', async () => {
+    mockedDetermineIsApp.mockReturnValue(false)
+    mockReadPackageJson.mockResolvedValue({
+      dependencies: {'styled-components': 'catalog:'},
+      devDependencies: {},
+      name: 'test-studio',
+      version: '1.0.0',
+    })
+    mockedGetLocalPackageVersion.mockImplementation(async (module: string) => {
+      if (module === 'sanity') return '3.2.0'
+      if (module === 'styled-components') return '5.3.6'
+      return null
+    })
+
+    await checkRequiredDependencies({
+      cliConfig: mockCliConfig as CliConfig,
+      output: mockOutput,
+      workDir,
+    })
+
+    expect(mockOutput.error).not.toHaveBeenCalled()
+    expect(mockOutput.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Installed version of styled-components (5.3.6) is not compatible with the version required by sanity (^6.1.15)',
+      ),
+    )
+  })
+
   test('should succeed on happy path', async () => {
     mockedDetermineIsApp.mockReturnValue(false)
     mockReadPackageJson.mockResolvedValue({

--- a/packages/@sanity/cli/src/actions/build/checkRequiredDependencies.ts
+++ b/packages/@sanity/cli/src/actions/build/checkRequiredDependencies.ts
@@ -82,6 +82,9 @@ export async function checkRequiredDependencies(
     return {installedSanityVersion}
   }
 
+  // We ignore catalog identifiers since we check the actual version anyway
+  const isStyledComponentsVersionRangeInCatalog =
+    declaredStyledComponentsVersion.startsWith('catalog:')
   // Theoretically the version specified in package.json could be incorrect, eg `foo`
   let minDeclaredStyledComponentsVersion: SemVer | null = null
   try {
@@ -90,7 +93,7 @@ export async function checkRequiredDependencies(
     // Intentional fall-through (variable will be left as null, throwing below)
   }
 
-  if (!minDeclaredStyledComponentsVersion) {
+  if (!minDeclaredStyledComponentsVersion && !isStyledComponentsVersionRangeInCatalog) {
     output.error(
       oneline`
       Declared dependency \`styled-components\` has an invalid version range:
@@ -108,8 +111,9 @@ export async function checkRequiredDependencies(
   // to anything is going to be challenging, so only compare "simple" ranges/versions
   // (^x.x.x / ~x.x.x / x.x.x)
   if (
+    !isStyledComponentsVersionRangeInCatalog &&
     isComparableRange(declaredStyledComponentsVersion) &&
-    !semver.satisfies(minDeclaredStyledComponentsVersion, wantedStyledComponentsVersionRange)
+    !semver.satisfies(minDeclaredStyledComponentsVersion!, wantedStyledComponentsVersionRange)
   ) {
     output.warn(oneline`
       Declared version of styled-components (${declaredStyledComponentsVersion})


### PR DESCRIPTION
### Description

Backporting the change from https://github.com/sanity-io/sanity/pull/9613/changes#diff-114b74023f5b5ea0cf34ad250557729979b4cade19af5ea4eeabdd16933f6630

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
