### PR TITLE
fix(deps): upgrade `get-latest-version` to 6.0.1

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -98,7 +98,7 @@
     "execa": "catalog:",
     "form-data": "^4.0.5",
     "get-it": "^8.7.0",
-    "get-latest-version": "^5.1.0",
+    "get-latest-version": "^6.0.1",
     "get-tsconfig": "catalog:",
     "git-user-info": "^2.0.3",
     "gunzip-maybe": "^1.4.2",

--- a/packages/@sanity/cli/src/actions/versions/tryFindLatestVersion.ts
+++ b/packages/@sanity/cli/src/actions/versions/tryFindLatestVersion.ts
@@ -1,4 +1,4 @@
-import getLatestVersion from 'get-latest-version'
+import {getLatestVersion} from 'get-latest-version'
 
 import {versionsDebug} from './versionsDebug.js'
 

--- a/packages/@sanity/cli/src/commands/__tests__/versions.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/versions.test.ts
@@ -1,5 +1,5 @@
 import {testCommand} from '@sanity/cli-test'
-import getLatestVersion from 'get-latest-version'
+import {getLatestVersion} from 'get-latest-version'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {Versions} from '../../commands/versions.js'

--- a/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
+++ b/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
@@ -30,7 +30,7 @@ vi.mock('@sanity/cli-core', async () => ({
 }))
 
 vi.mock('get-latest-version', () => ({
-  default: mockGetLatestVersion,
+  getLatestVersion: mockGetLatestVersion,
 }))
 
 vi.mock('is-installed-globally', () => mockIsInstalledGlobally)

--- a/packages/@sanity/cli/src/util/resolveLatestVersions.ts
+++ b/packages/@sanity/cli/src/util/resolveLatestVersions.ts
@@ -1,4 +1,4 @@
-import latestVersion from 'get-latest-version'
+import {getLatestVersion} from 'get-latest-version'
 import promiseProps from 'promise-props-recursive'
 
 /**
@@ -13,7 +13,7 @@ export function resolveLatestVersions(
   const lookups: Record<string, Promise<string> | string> = {}
   for (const [packageName, range] of Object.entries(pkgs)) {
     lookups[packageName] =
-      range === 'latest' ? latestVersion(packageName, {range}).then(caretify) : range
+      range === 'latest' ? getLatestVersion(packageName, {range}).then(caretify) : range
   }
 
   return promiseProps(lookups)

--- a/packages/@sanity/cli/src/util/update/fetchLatestVersion.ts
+++ b/packages/@sanity/cli/src/util/update/fetchLatestVersion.ts
@@ -1,5 +1,5 @@
 import {subdebug} from '@sanity/cli-core'
-import getLatestVersion from 'get-latest-version'
+import {getLatestVersion} from 'get-latest-version'
 
 import {promiseRaceWithTimeout} from '../promiseRaceWithTimeout.js'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,8 +456,8 @@ importers:
         specifier: ^8.7.0
         version: 8.7.0(debug@4.4.3)
       get-latest-version:
-        specifier: ^5.1.0
-        version: 5.1.0(debug@4.4.3)
+        specifier: ^6.0.1
+        version: 6.0.1(debug@4.4.3)
       get-tsconfig:
         specifier: 'catalog:'
         version: 4.13.6
@@ -5957,6 +5957,10 @@ packages:
     resolution: {integrity: sha512-Q6IBWr/zzw57zIkJmNhI23eRTw3nZ4BWWK034meLwOYU9L3J3IpXiyM73u2pYUwN6U7ahkerCwg2T0jlxiLwsw==}
     engines: {node: '>=14.18'}
 
+  get-latest-version@6.0.1:
+    resolution: {integrity: sha512-6Zub9FhioDbCJzGTZtetVvAkLeA5UnvQEbKfFZUc62hcZm3gO3Txr21oRGOcT6SdiKhjI0vWd/Jxct+wuLJgHA==}
+    engines: {node: '>=20'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
@@ -6276,6 +6280,10 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ini@5.0.0:
+    resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   inspect-with-kind@1.0.5:
     resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
@@ -7791,6 +7799,10 @@ packages:
     resolution: {integrity: sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==}
     engines: {node: '>=8'}
 
+  registry-url@7.2.0:
+    resolution: {integrity: sha512-I5UEBQ+09LWKInA1fPswOMZps0cs2Z+IQXb5Z5EkTJiUmIN52Vm/FD3ji5X82c5jIXL3nWEWOrYK0RkON6Oqyg==}
+    engines: {node: '>=18'}
+
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
 
@@ -7999,6 +8011,11 @@ packages:
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -14108,7 +14125,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.3
+      semver: 7.7.4
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14122,7 +14139,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 9.0.5
-      semver: 7.7.3
+      semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -14831,7 +14848,7 @@ snapshots:
   bin-version-check@5.1.0:
     dependencies:
       bin-version: 6.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       semver-truncate: 3.0.0
 
   bin-version@6.0.0:
@@ -15579,7 +15596,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
-      semver: 7.7.3
+      semver: 7.7.4
 
   eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
@@ -16125,7 +16142,16 @@ snapshots:
       get-it: 8.7.0(debug@4.4.3)
       registry-auth-token: 5.1.1
       registry-url: 5.1.0
-      semver: 7.7.3
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - debug
+
+  get-latest-version@6.0.1(debug@4.4.3):
+    dependencies:
+      get-it: 8.7.0(debug@4.4.3)
+      registry-auth-token: 5.1.1
+      registry-url: 7.2.0
+      semver: 7.7.4
     transitivePeerDependencies:
       - debug
 
@@ -16465,6 +16491,8 @@ snapshots:
 
   ini@4.1.1: {}
 
+  ini@5.0.0: {}
+
   inspect-with-kind@1.0.5:
     dependencies:
       kind-of: 6.0.3
@@ -16525,7 +16553,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   is-callable@1.2.7: {}
 
@@ -17113,7 +17141,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   markdown-it@14.1.0:
     dependencies:
@@ -17307,7 +17335,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.3
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -18032,6 +18060,11 @@ snapshots:
   registry-url@5.1.0:
     dependencies:
       rc: 1.2.8
+
+  registry-url@7.2.0:
+    dependencies:
+      find-up-simple: 1.0.1
+      ini: 5.0.0
 
   regjsgen@0.8.0: {}
 
@@ -18787,7 +18820,7 @@ snapshots:
 
   semver-truncate@3.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   semver@5.7.2: {}
 
@@ -18798,6 +18831,8 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.7.3: {}
+
+  semver@7.7.4: {}
 
   sentence-case@3.0.4:
     dependencies:
@@ -18948,7 +18983,7 @@ snapshots:
       get-stdin: 9.0.0
       git-hooks-list: 3.2.0
       is-plain-obj: 4.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       sort-object-keys: 1.1.3
       tinyglobby: 0.2.15
 
@@ -18958,7 +18993,7 @@ snapshots:
       detect-newline: 4.0.1
       git-hooks-list: 4.2.1
       is-plain-obj: 4.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       sort-object-keys: 2.1.0
       tinyglobby: 0.2.15
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,3 +71,4 @@ minimumReleaseAgeExclude:
   - 'react-rx'
   - 'sanity'
   - 'use-effect-event'
+  - 'get-latest-version@6.0.1'


### PR DESCRIPTION
### Description

Silences a deprecation warning:

```
(node:36584) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
    at urlParse (node:url:136:13)
    at Object.urlResolve [as resolve] (node:url:725:10)
    at getLatestVersion (…/node_modules/get-latest-version/src/index.js:46:22)
```

### What to review

Stuff still works

### Testing

Existing tests should hopefully be enough (although theres a deal of mocking going on, so lets see)