### PR TITLE
fix(build): fixes issue with build failure on missing favicons

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -44,6 +44,7 @@
     "./dist",
     "./oclif.config.js",
     "./oclif.manifest.json",
+    "./static",
     "./templates"
   ],
   "scripts": {

--- a/packages/@sanity/cli/src/actions/build/writeFavicons.ts
+++ b/packages/@sanity/cli/src/actions/build/writeFavicons.ts
@@ -1,23 +1,29 @@
 import fs from 'node:fs/promises'
-import path, {dirname} from 'node:path'
-import {fileURLToPath} from 'node:url'
+import path from 'node:path'
 
+import {subdebug} from '@sanity/cli-core'
 import {readPackageUp} from 'read-package-up'
 
 import {copyDir} from '../../util/copyDir.js'
 import {writeWebManifest} from './writeWebManifest.js'
 
-export async function writeFavicons(basePath: string, destDir: string): Promise<void> {
-  const dir = dirname(fileURLToPath(import.meta.url))
+const debug = subdebug('writeFavicons')
 
-  const sanityPkgPath = (await readPackageUp({cwd: dir}))?.path
+export async function writeFavicons(basePath: string, destDir: string): Promise<void> {
+  const sanityPkgPath = (await readPackageUp({cwd: import.meta.dirname}))?.path
+
+  debug('sanityPkgPath: %s', sanityPkgPath)
   const faviconsPath = sanityPkgPath
     ? path.join(path.dirname(sanityPkgPath), 'static', 'favicons')
     : undefined
 
+  debug('faviconsPath: %s', faviconsPath)
+
   if (!faviconsPath) {
     throw new Error('Unable to resolve `sanity` module root')
   }
+
+  debug('destDir: %s', destDir)
 
   await fs.mkdir(destDir, {recursive: true})
   await copyDir(faviconsPath, destDir, true)


### PR DESCRIPTION
Fixes issue with build not working due to missing static folder. 

Hard to test for this since it read-package-up won't give this error but verified manually 

```
npx https://pkg.pr.new/sanity-io/cli/@sanity/cli@e8ba233 build
✔ Clean output folder (14ms)
✔ Build Sanity application (2460ms)
```