### PR TITLE
fix(cli): pass appId to compareDependencyVersions for correct module URL

### DIFF
--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -75,7 +75,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     autoUpdatesImports = getAutoUpdatesImportMap(sanityDependencies, {appId})
 
     // Check the versions
-    const result = await compareDependencyVersions(sanityDependencies, workDir)
+    const result = await compareDependencyVersions(sanityDependencies, workDir, {appId})
 
     // If it is in unattended mode, we don't want to prompt
     if (result?.length && !unattendedMode) {

--- a/packages/@sanity/cli/src/util/__tests__/compareDependencyVersions.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/compareDependencyVersions.test.ts
@@ -489,4 +489,61 @@ describe('compareDependencyVersions', () => {
       ])
     })
   })
+
+  describe('module URL selection', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('should use the default module endpoint when no appId is provided', async () => {
+      mockedFetch.mockResolvedValue({
+        headers: {
+          get: vi.fn<(name: string) => string | null>().mockReturnValue('3.40.0'),
+        },
+        ok: false,
+        status: 302,
+      })
+      mockGetLocalPackageVersion.mockResolvedValue('3.40.0')
+      mockReadPackageJson.mockResolvedValueOnce({
+        dependencies: {sanity: '^3.40.0'},
+        devDependencies: {},
+        name: 'test-package',
+        version: '0.0.0',
+      })
+
+      await compareDependencyVersions([{name: 'sanity', version: '3.40.0'}], '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
+
+      const url = mockedFetch.mock.calls[0][0] as string
+      expect(url).toContain('/v1/modules/sanity/default/')
+      expect(url).not.toContain('/by-app/')
+    })
+
+    it('should use the app-specific module endpoint when appId is provided', async () => {
+      mockedFetch.mockResolvedValue({
+        headers: {
+          get: vi.fn<(name: string) => string | null>().mockReturnValue('3.40.0'),
+        },
+        ok: false,
+        status: 302,
+      })
+      mockGetLocalPackageVersion.mockResolvedValue('3.40.0')
+      mockReadPackageJson.mockResolvedValueOnce({
+        dependencies: {sanity: '^3.40.0'},
+        devDependencies: {},
+        name: 'test-package',
+        version: '0.0.0',
+      })
+
+      await compareDependencyVersions([{name: 'sanity', version: '3.40.0'}], '/test/workdir', {
+        appId: 'my-app-id',
+        fetchFn: mockedFetch,
+      })
+
+      const url = mockedFetch.mock.calls[0][0] as string
+      expect(url).toContain('/v1/modules/by-app/my-app-id/')
+      expect(url).not.toContain('/default/')
+    })
+  })
 })

--- a/packages/@sanity/cli/src/util/compareDependencyVersions.ts
+++ b/packages/@sanity/cli/src/util/compareDependencyVersions.ts
@@ -34,6 +34,13 @@ interface CompareDependencyVersions {
   remote: string
 }
 
+interface CompareDependencyVersionsOptions {
+  /** When provided, uses the app-specific module endpoint instead of the default endpoint. */
+  appId?: string
+  /** {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API | Fetch}-compatible function to use for requesting the current remote version of a module. */
+  fetchFn?: typeof fetch
+}
+
 /**
  * @internal
  *
@@ -46,9 +53,9 @@ interface CompareDependencyVersions {
  * The failed dependencies are anything that does not strictly match the remote version.
  * This means that if a version is lower or greater by even a patch it will be marked as failed.
  *
- * @param autoUpdatesImports - An object mapping package names to their remote import URLs.
+ * @param packages - An array of packages with their name and version to compare against remote.
  * @param workDir - The path to the working directory containing the package.json file.
- * @param fetchFn - Optional {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API | Fetch}-compatible function to use for requesting the current remote version of a module
+ * @param options - Optional configuration for version comparison.
  *
  * @returns A promise that resolves to an array of objects, each containing
  * the name of a package whose local and remote versions do not match, along with the local and remote versions.
@@ -59,7 +66,7 @@ interface CompareDependencyVersions {
 export async function compareDependencyVersions(
   packages: {name: string; version: string}[],
   workDir: string,
-  {fetchFn = globalThis.fetch}: {appId?: string; fetchFn?: typeof fetch} = {},
+  {appId, fetchFn = globalThis.fetch}: CompareDependencyVersionsOptions = {},
 ): Promise<Array<CompareDependencyVersions>> {
   const manifest = await readPackageJson(path.join(workDir, 'package.json'), {
     skipSchemaValidation: true,
@@ -69,7 +76,7 @@ export async function compareDependencyVersions(
   const failedDependencies: Array<CompareDependencyVersions> = []
 
   for (const pkg of packages) {
-    const resolvedVersion = await getRemoteResolvedVersion(fetchFn, getModuleUrl(pkg))
+    const resolvedVersion = await getRemoteResolvedVersion(fetchFn, getModuleUrl(pkg, {appId}))
 
     const packageVersion = await getLocalPackageVersion(pkg.name, workDir)
 


### PR DESCRIPTION
`compareDependencyVersions` accepted an `appId` option but never passed it through to `getModuleUrl`, always using the legacy `/default/` endpoint instead of the `/by-app/{appId}/` endpoint. `buildStudio` also omitted passing `appId` entirely.
