### PR TITLE
refactor: minor favicon writing cleanup

### DIFF
--- a/packages/@sanity/cli/src/actions/build/writeFavicons.ts
+++ b/packages/@sanity/cli/src/actions/build/writeFavicons.ts
@@ -1,29 +1,21 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import {subdebug} from '@sanity/cli-core'
 import {readPackageUp} from 'read-package-up'
 
 import {copyDir} from '../../util/copyDir.js'
 import {writeWebManifest} from './writeWebManifest.js'
 
-const debug = subdebug('writeFavicons')
-
 export async function writeFavicons(basePath: string, destDir: string): Promise<void> {
   const sanityPkgPath = (await readPackageUp({cwd: import.meta.dirname}))?.path
 
-  debug('sanityPkgPath: %s', sanityPkgPath)
   const faviconsPath = sanityPkgPath
     ? path.join(path.dirname(sanityPkgPath), 'static', 'favicons')
     : undefined
 
-  debug('faviconsPath: %s', faviconsPath)
-
   if (!faviconsPath) {
-    throw new Error('Unable to resolve `sanity` module root')
+    throw new Error('Unable to resolve `@sanity/cli` module root')
   }
-
-  debug('destDir: %s', destDir)
 
   await fs.mkdir(destDir, {recursive: true})
   await copyDir(faviconsPath, destDir, true)


### PR DESCRIPTION
Just tidying up some debug logging we shouldn't need, and an error message