### PR TITLE
refactor: drop exports for unused types

### DIFF
--- a/packages/@sanity/cli/src/actions/dataset/create.ts
+++ b/packages/@sanity/cli/src/actions/dataset/create.ts
@@ -10,7 +10,7 @@ const debug = subdebug('dataset:create')
 /**
  * Options for creating a dataset
  */
-export interface CreateDatasetOptions {
+interface CreateDatasetOptions {
   /**
    * Name of the dataset to create
    */

--- a/packages/@sanity/cli/src/actions/dataset/determineDatasetAclMode.ts
+++ b/packages/@sanity/cli/src/actions/dataset/determineDatasetAclMode.ts
@@ -6,7 +6,7 @@ import {promptForDatasetAclMode} from '../../prompts/promptForDatasetAclMode.js'
 /**
  * Options for determining the ACL mode for a dataset
  */
-export interface DetermineDatasetAclModeOptions {
+interface DetermineDatasetAclModeOptions {
   /**
    * Whether the project has the capability to create private datasets
    */

--- a/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
@@ -20,7 +20,7 @@ import {updateInitialTemplateMetadata} from './updateInitialTemplateMetadata.js'
 
 const debug = subdebug('init:bootstrapRemoteTemplate')
 
-export interface BootstrapLocalOptions {
+interface BootstrapLocalOptions {
   output: Output
   outputPath: string
   packageName: string

--- a/packages/@sanity/cli/src/actions/init/bootstrapRemoteTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapRemoteTemplate.ts
@@ -24,7 +24,7 @@ import {updateInitialTemplateMetadata} from './updateInitialTemplateMetadata.js'
 
 const debug = subdebug('init:bootstrapRemoteTemplate')
 
-export interface BootstrapRemoteOptions {
+interface BootstrapRemoteOptions {
   output: Output
   outputPath: string
   packageName: string

--- a/packages/@sanity/cli/src/actions/init/bootstrapTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapTemplate.ts
@@ -5,7 +5,7 @@ import {bootstrapRemoteTemplate} from './bootstrapRemoteTemplate.js'
 import {type GenerateConfigOptions} from './createStudioConfig.js'
 import {type RepoInfo} from './remoteTemplate.js'
 
-export interface BootstrapTemplateOptions {
+interface BootstrapTemplateOptions {
   autoUpdates: boolean
   bearerToken: string | undefined
   dataset: string

--- a/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
@@ -11,7 +11,7 @@ export default defineCliConfig({
 })
 `
 
-export interface GenerateCliConfigOptions {
+interface GenerateCliConfigOptions {
   entry: string
 
   organizationId?: string

--- a/packages/@sanity/cli/src/actions/init/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createCliConfig.ts
@@ -18,7 +18,7 @@ export default defineCliConfig({
 })
 `
 
-export interface GenerateCliConfigOptions {
+interface GenerateCliConfigOptions {
   autoUpdates: boolean
   dataset: string
   projectId: string

--- a/packages/@sanity/cli/src/actions/mcp/detectAvailableEditors.ts
+++ b/packages/@sanity/cli/src/actions/mcp/detectAvailableEditors.ts
@@ -9,7 +9,7 @@ import {EDITOR_CONFIGS, type EditorName} from './editorConfigs.js'
 
 const debug = subdebug('mcp:detectAvailableEditors')
 
-export interface Editor {
+interface Editor {
   configPath: string
   /** Whether Sanity MCP is already configured for this editor */
   configured: boolean

--- a/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
+++ b/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
@@ -12,7 +12,7 @@ const mcpDebug = subdebug('mcp:setup')
 
 const NO_EDITORS_DETECTED_MESSAGE = `Couldn't auto-configure Sanity MCP server for your editor. Visit ${MCP_SERVER_URL} for setup instructions.`
 
-export interface MCPSetupResult {
+interface MCPSetupResult {
   configuredEditors: EditorName[]
   detectedEditors: EditorName[]
   skipped: boolean

--- a/packages/@sanity/cli/src/services/projects.ts
+++ b/packages/@sanity/cli/src/services/projects.ts
@@ -7,7 +7,7 @@ export const PROJECTS_API_VERSION = '2025-09-22'
 
 export const CREATE_PROJECT_API_VERSION = 'v2025-05-14'
 
-export interface CreateProjectOptions {
+interface CreateProjectOptions {
   displayName: string
 
   metadata?: {

--- a/packages/@sanity/cli/src/util/getProjectDefaults.ts
+++ b/packages/@sanity/cli/src/util/getProjectDefaults.ts
@@ -10,7 +10,7 @@ import {getCliUser} from '../services/user.js'
 
 const debug = subdebug('getProjectDefaults')
 
-export interface ProjectDefaults {
+interface ProjectDefaults {
   author: string | undefined
   description: string
   gitRemote: string

--- a/packages/@sanity/cli/src/util/readdirRecursive.ts
+++ b/packages/@sanity/cli/src/util/readdirRecursive.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-export interface ReaddirItem {
+interface ReaddirItem {
   isDir: boolean
   path: string
 }


### PR DESCRIPTION
Minor, but a number of interfaces/types were exported but not imported.
Generally speaking, keeping things unexported by default prevents potential leakage/dependencies.
