### PR TITLE
fix: issues with jsx in CLI code

### DIFF
--- a/packages/@sanity/cli/.swcrc
+++ b/packages/@sanity/cli/.swcrc
@@ -13,6 +13,9 @@
     },
     "target": "es2023"
   },
+  "module": {
+    "type": "nodenext"
+  },
   "isModule": true,
   "sourceMaps": true
 }

--- a/packages/@sanity/cli/src/actions/build/renderDocument.ts
+++ b/packages/@sanity/cli/src/actions/build/renderDocument.ts
@@ -1,6 +1,3 @@
-import {dirname} from 'node:path'
-import {fileURLToPath} from 'node:url'
-
 import {ux} from '@oclif/core'
 import {tsxWorkerTask} from '@sanity/cli-core'
 
@@ -34,16 +31,13 @@ interface RenderDocumentWorkerResult {
 }
 
 export async function renderDocument(options: RenderDocumentOptions): Promise<string> {
-  const filename = fileURLToPath(import.meta.url)
-  const dir = dirname(fileURLToPath(import.meta.url))
-
-  buildDebug('Starting worker thread for %s', filename)
+  buildDebug('Starting worker thread for %s', import.meta.url)
   try {
     const msg = await tsxWorkerTask<RenderDocumentWorkerResult>(
       new URL(`renderDocument.worker.js`, import.meta.url),
       {
         name: 'renderDocument',
-        rootPath: dir,
+        rootPath: options.studioRootPath,
         workerData: {...options, shouldWarn: true},
       },
     )

--- a/packages/@sanity/cli/src/actions/build/renderDocumentWorker/components/BasicDocument.tsx
+++ b/packages/@sanity/cli/src/actions/build/renderDocumentWorker/components/BasicDocument.tsx
@@ -1,13 +1,13 @@
 /**
  * App HTML Document, this is in the _internal package
- * to avoid importing styled-components from sanity pacakge
+ * to avoid importing styled-components from sanity package
  */
 
 import {type JSX} from 'react'
 
-import {Favicons} from './Favicons'
-import {GlobalErrorHandler} from './GlobalErrorHandler'
-import {NoJavascript} from './NoJavascript'
+import {Favicons} from './Favicons.js'
+import {GlobalErrorHandler} from './GlobalErrorHandler.js'
+import {NoJavascript} from './NoJavascript.js'
 
 /**
  * @internal

--- a/packages/@sanity/cli/src/actions/build/renderDocumentWorker/components/DefaultDocument.tsx
+++ b/packages/@sanity/cli/src/actions/build/renderDocumentWorker/components/DefaultDocument.tsx
@@ -1,6 +1,6 @@
-import {Favicons} from './Favicons'
-import {GlobalErrorHandler} from './GlobalErrorHandler'
-import {NoJavascript} from './NoJavascript'
+import {Favicons} from './Favicons.js'
+import {GlobalErrorHandler} from './GlobalErrorHandler.js'
+import {NoJavascript} from './NoJavascript.js'
 
 const globalStyles = `
   @font-face {

--- a/packages/@sanity/cli/src/actions/build/renderDocumentWorker/getDocumentComponent.ts
+++ b/packages/@sanity/cli/src/actions/build/renderDocumentWorker/getDocumentComponent.ts
@@ -2,8 +2,8 @@ import path from 'node:path'
 import {type MessagePort} from 'node:worker_threads'
 
 import {buildDebug} from '../buildDebug.js'
-import {BasicDocument} from './components/BasicDocument.jsx'
-import {DefaultDocument} from './components/DefaultDocument.jsx'
+import {BasicDocument} from './components/BasicDocument.js'
+import {DefaultDocument} from './components/DefaultDocument.js'
 import {tryLoadDocumentComponent} from './tryLoadDocumentComponent.js'
 
 /**

--- a/packages/@sanity/cli/src/actions/build/renderDocumentWorker/renderDocumentWorker.ts
+++ b/packages/@sanity/cli/src/actions/build/renderDocumentWorker/renderDocumentWorker.ts
@@ -1,6 +1,6 @@
 import {type MessagePort} from 'node:worker_threads'
 
-import {getDocumentHtml} from './getDocumentHtml.jsx'
+import {getDocumentHtml} from './getDocumentHtml.js'
 import {type DocumentProps} from './types.js'
 
 /**


### PR DESCRIPTION
Transpiles JSX -> JS so that we don't directly use JSX in the codebase making it more node compatible 