### PR TITLE
fix(cli): align studio dependency requirements with old cli

### DIFF
--- a/packages/@sanity/cli/src/actions/build/__tests__/checkStudioDependencyVersions.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/checkStudioDependencyVersions.test.ts
@@ -80,12 +80,12 @@ describe('checkStudioDependencyVersions', () => {
     test('should handle packages with valid versions', async () => {
       setupMocks({
         dependencies: {
-          react: '^18.0.0',
-          'react-dom': '^18.0.0',
+          react: '^19.2.2',
+          'react-dom': '^19.2.2',
         },
         localVersions: {
-          react: '18.2.0',
-          'react-dom': '18.2.0',
+          react: '19.2.2',
+          'react-dom': '19.2.2',
         },
       })
 
@@ -109,7 +109,7 @@ describe('checkStudioDependencyVersions', () => {
         ),
       )
       expect(mockOutput.warn).toHaveBeenCalledWith(
-        expect.stringContaining('react (installed: 20.0.0, want: ^18 || ^19)'),
+        expect.stringContaining('react (installed: 20.0.0, want: ^19.2.2)'),
       )
       expect(mockOutput.warn).toHaveBeenCalledWith(
         expect.stringContaining('To downgrade, run either:'),
@@ -133,11 +133,33 @@ describe('checkStudioDependencyVersions', () => {
         {exit: 1},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
-        expect.stringContaining('react (installed: 16.14.0, want: ^18 || ^19)'),
+        expect.stringContaining('react (installed: 16.14.0, want: ^19.2.2)'),
         {exit: 1},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('To upgrade, run either:'),
+        {exit: 1},
+      )
+    })
+
+    test('should handle React 18 as unsupported', async () => {
+      setupMocks({
+        dependencies: {react: '^18.0.0'},
+        localVersions: {react: '18.2.0'},
+      })
+
+      await expect(checkStudioDependencyVersions(workDir, mockOutput)).rejects.toThrow(
+        'process.exit called',
+      )
+
+      expect(mockOutput.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The following package versions are no longer supported and needs to be upgraded:',
+        ),
+        {exit: 1},
+      )
+      expect(mockOutput.error).toHaveBeenCalledWith(
+        expect.stringContaining('react (installed: 18.2.0, want: ^19.2.2)'),
         {exit: 1},
       )
     })
@@ -168,8 +190,8 @@ describe('checkStudioDependencyVersions', () => {
 
     test('should handle packages installed in devDependencies', async () => {
       setupMocks({
-        devDependencies: {react: '^18.0.0'},
-        localVersions: {react: '18.2.0'},
+        devDependencies: {react: '^19.2.2'},
+        localVersions: {react: '19.2.2'},
       })
 
       await checkStudioDependencyVersions(workDir, mockOutput)
@@ -180,7 +202,7 @@ describe('checkStudioDependencyVersions', () => {
 
     test('should fall back to dependency version string when local version cannot be resolved', async () => {
       setupMocks({
-        dependencies: {react: '^18.0.0'},
+        dependencies: {react: '^19.2.2'},
         localVersions: {react: null},
       })
 
@@ -231,12 +253,12 @@ describe('checkStudioDependencyVersions', () => {
 
       // Should warn about untested versions
       expect(mockOutput.warn).toHaveBeenCalledWith(
-        expect.stringContaining('react-dom (installed: 20.0.0, want: ^18 || ^19)'),
+        expect.stringContaining('react-dom (installed: 20.0.0, want: ^19.2.2)'),
       )
 
       // Should error about unsupported versions
       expect(mockOutput.error).toHaveBeenCalledWith(
-        expect.stringContaining('react (installed: 16.14.0, want: ^18 || ^19)'),
+        expect.stringContaining('react (installed: 16.14.0, want: ^19.2.2)'),
         {exit: 1},
       )
     })
@@ -289,15 +311,15 @@ describe('checkStudioDependencyVersions', () => {
       )
 
       expect(mockOutput.error).toHaveBeenCalledWith(
-        expect.stringContaining('npm install "react@18.0.0"'),
+        expect.stringContaining('npm install "react@^19.2.2"'),
         {exit: 1},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
-        expect.stringContaining('yarn add "react@18.0.0"'),
+        expect.stringContaining('yarn add "react@^19.2.2"'),
         {exit: 1},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
-        expect.stringContaining('pnpm add "react@18.0.0"'),
+        expect.stringContaining('pnpm add "react@^19.2.2"'),
         {exit: 1},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
@@ -315,13 +337,13 @@ describe('checkStudioDependencyVersions', () => {
       await checkStudioDependencyVersions(workDir, mockOutput)
 
       expect(mockOutput.warn).toHaveBeenCalledWith(
-        expect.stringContaining('yarn add "react@18.0.0"'),
+        expect.stringContaining('yarn add "react@^19.2.2"'),
       )
       expect(mockOutput.warn).toHaveBeenCalledWith(
-        expect.stringContaining('npm install "react@18.0.0"'),
+        expect.stringContaining('npm install "react@^19.2.2"'),
       )
       expect(mockOutput.warn).toHaveBeenCalledWith(
-        expect.stringContaining('pnpm install "react@18.0.0"'),
+        expect.stringContaining('pnpm install "react@^19.2.2"'),
       )
     })
 
@@ -342,11 +364,11 @@ describe('checkStudioDependencyVersions', () => {
       )
 
       expect(mockOutput.error).toHaveBeenCalledWith(
-        expect.stringContaining('react (installed: 16.14.0, want: ^18 || ^19)'),
+        expect.stringContaining('react (installed: 16.14.0, want: ^19.2.2)'),
         {exit: 1},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
-        expect.stringContaining('react-dom (installed: 16.14.0, want: ^18 || ^19)'),
+        expect.stringContaining('react-dom (installed: 16.14.0, want: ^19.2.2)'),
         {exit: 1},
       )
     })
@@ -402,15 +424,37 @@ describe('checkStudioDependencyVersions', () => {
       expect(mockOutput.error).not.toHaveBeenCalled()
     })
 
-    test('should handle @sanity/ui package correctly', async () => {
+    test('should handle @sanity/ui v3 package correctly', async () => {
       setupMocks({
-        dependencies: {'@sanity/ui': '^2.0.0'},
-        localVersions: {'@sanity/ui': '2.0.0'},
+        dependencies: {'@sanity/ui': '^3.0.0'},
+        localVersions: {'@sanity/ui': '3.0.0'},
       })
 
       await checkStudioDependencyVersions(workDir, mockOutput)
 
       expect(mockOutput.warn).not.toHaveBeenCalled()
+      expect(mockOutput.error).not.toHaveBeenCalled()
+    })
+
+    test('should warn about @sanity/ui v2 being deprecated', async () => {
+      setupMocks({
+        dependencies: {'@sanity/ui': '^2.0.0'},
+        localVersions: {'@sanity/ui': '2.8.0'},
+      })
+
+      await checkStudioDependencyVersions(workDir, mockOutput)
+
+      expect(mockOutput.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The following package versions have been deprecated and should be upgraded:',
+        ),
+      )
+      expect(mockOutput.warn).toHaveBeenCalledWith(
+        expect.stringContaining('@sanity/ui (installed: 2.8.0, want: ^3)'),
+      )
+      expect(mockOutput.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Support for these will be removed in a future release!'),
+      )
       expect(mockOutput.error).not.toHaveBeenCalled()
     })
 

--- a/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
+++ b/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
@@ -62,13 +62,7 @@ type VendorImports = {
 // Define the vendor packages and their corresponding versions and entry points
 const VENDOR_IMPORTS: VendorImports = {
   react: {
-    '^18.0.0': {
-      '.': './cjs/react.production.min.js',
-      './jsx-dev-runtime': './cjs/react-jsx-dev-runtime.production.min.js',
-      './jsx-runtime': './cjs/react-jsx-runtime.production.min.js',
-      './package.json': './package.json',
-    },
-    '^19.0.0': {
+    '^19.2.0': {
       '.': './cjs/react.production.js',
       './compiler-runtime': './cjs/react-compiler-runtime.production.js',
       './jsx-dev-runtime': './cjs/react-jsx-dev-runtime.production.js',
@@ -77,14 +71,7 @@ const VENDOR_IMPORTS: VendorImports = {
     },
   },
   'react-dom': {
-    '^18.0.0': {
-      '.': './cjs/react-dom.production.min.js',
-      './client': './cjs/react-dom.production.min.js',
-      './package.json': './package.json',
-      './server': './cjs/react-dom-server-legacy.browser.production.min.js',
-      './server.browser': './cjs/react-dom-server-legacy.browser.production.min.js',
-    },
-    '^19.0.0': {
+    '^19.2.0': {
       '.': './cjs/react-dom.production.js',
       './client': './cjs/react-dom-client.production.js',
       './package.json': './package.json',
@@ -99,7 +86,7 @@ const VENDOR_IMPORTS: VendorImports = {
 const STYLED_COMPONENTS_IMPORTS = {
   'styled-components': {
     '^6.1.0': {
-      '.': './dist/styled-components.esm.js',
+      '.': './dist/styled-components.browser.esm.js',
       './package.json': './package.json',
     },
   },

--- a/packages/@sanity/cli/src/actions/build/checkStudioDependencyVersions.ts
+++ b/packages/@sanity/cli/src/actions/build/checkStudioDependencyVersions.ts
@@ -24,10 +24,10 @@ interface TrackedPackage {
 // NOTE: when doing changes here, also remember to update versions in help docs at
 // https://sanity.io/admin/structure/docs;helpArticle;upgrade-packages
 const DEFAULT_PACKAGES: TrackedPackage[] = [
-  {deprecatedBelow: null, name: 'react', supported: ['^18 || ^19']},
-  {deprecatedBelow: null, name: 'react-dom', supported: ['^18 || ^19']},
+  {deprecatedBelow: null, name: 'react', supported: ['^19.2.2']},
+  {deprecatedBelow: null, name: 'react-dom', supported: ['^19.2.2']},
   {deprecatedBelow: null, name: 'styled-components', supported: ['^6']},
-  {deprecatedBelow: null, name: '@sanity/ui', supported: ['^2', '^3']},
+  {deprecatedBelow: '^3', name: '@sanity/ui', supported: ['^2', '^3']},
 ]
 
 export async function checkStudioDependencyVersions(
@@ -58,11 +58,11 @@ export async function checkStudioDependencyVersions(
     // "Untested" is usually the case where we have not upgraded the React version requirements
     // before a release, but given that is usually works in a backwards-compatible way, we want
     // to indicate that it's _untested_, not necessarily _unsupported_
-    // Ex: Installed is react@19.0.0, but we've only _tested_ with react@^18
+    // Ex: Installed is react@20.0.0, but we've only _tested_ with react@^19
     const isUntested = !semver.satisfies(installed, supported) && semver.gtr(installed, supported)
 
     // "Unsupported" in that the installed version is _lower than_ the minimum version
-    // Ex: Installed is react@15.0.0, but we require react@^16
+    // Ex: Installed is react@18.0.0, but we require react@^19.2
     const isUnsupported = !semver.satisfies(installed, supported) && !isUntested
 
     // "Deprecated" in that we will stop supporting it at some point in the near future,
@@ -138,7 +138,7 @@ function getUpgradeInstructions(pkgs: PackageInfo[]) {
         .map((version) => (semver.coerce(version) || {version: ''}).version)
         .toSorted(semver.rcompare)
 
-      return `"${pkg.name}@${highestSupported}"`
+      return `"${pkg.name}@^${highestSupported}"`
     })
     .join(' ')
 
@@ -165,7 +165,7 @@ function getDowngradeInstructions(pkgs: PackageInfo[]) {
         .map((version) => (semver.coerce(version) || {version: ''}).version)
         .toSorted(semver.rcompare)
 
-      return `"${pkg.name}@${highestSupported}"`
+      return `"${pkg.name}@^${highestSupported}"`
     })
     .join(' ')
 

--- a/packages/@sanity/cli/test/__fixtures__/cli-configs/esm-full/sanity.cli.ts
+++ b/packages/@sanity/cli/test/__fixtures__/cli-configs/esm-full/sanity.cli.ts
@@ -30,7 +30,7 @@ export default defineCliConfig({
   project: {
     basePath: '/studio',
   },
-  reactCompiler: {target: '18'},
+  reactCompiler: {target: '19'},
   reactStrictMode: true,
   server: {
     hostname: '0.0.0.0',


### PR DESCRIPTION
### Description
Aligns with the old CLI in sanity-io/sanity which now requires React ^19.2.2 and has deprecated @sanity/ui v2. Remove React 18 vendor entries, update vendor ranges to ^19.2.0, and fix styled-components browser entry point.

### What to review


### Testing
Unit tests updated
