### PR TITLE
feat: adapt binary in help output based on execution env

### DIFF
--- a/packages/@sanity/cli/src/SanityHelp.ts
+++ b/packages/@sanity/cli/src/SanityHelp.ts
@@ -75,7 +75,7 @@ export function replaceInitWithCreateCommand(help: string): string {
   // separator, but npm does. Only include it if we need to, as the commands look
   // cleaner without it.
   return help
-    .replaceAll(/(\s+)sanity(\s+)init(\s*)\n/g, `$1${createCmd}$2\n`)
+    .replaceAll(/(\s+)sanity\s+init\s*\n/g, `$1${createCmd}\n`)
     .replaceAll(/(\s+)sanity(\s+)init/g, `$1${createCmd}${flagSeparator}`)
 }
 

--- a/packages/@sanity/cli/src/__tests__/SanityHelp.test.ts
+++ b/packages/@sanity/cli/src/__tests__/SanityHelp.test.ts
@@ -162,7 +162,7 @@ describe('replaceInitWithCreateCommand', () => {
       vi.stubEnv('npm_config_user_agent', UA)
       const result = replaceInitWithCreateCommand(makeInitHelp())
       // The bare "$ sanity init\n" line gets the first regex (no flag separator)
-      expect(result).toMatch(/\$ pnpm create sanity@latest\s*\n/)
+      expect(result).toContain('$ pnpm create sanity@latest\n')
     })
 
     test('removes all "sanity init" references', () => {


### PR DESCRIPTION
### Description

Adapts the help text for commands so that they are prefixed with any execution env used. For instance, if sanity is run through npx (`npx sanity`) it will show: `npx sanity subcommand` instead of just `sanity subcommand`. The same goes for yarn, pnpm, bun etc. If we don't detect any of these being used, we instead fall back to just showing `sanity`.

Closes SDK-915

### What to review

Help output is 👍 ?

### Testing

New tests added to ensure the correct behavior (they're unit tests - ideally we'd add integration tests, but installing all the different PMs on CI is just too tedious/time consuming).

Also added some tests to ensure that we don't mangle up the `npm create …` paths in any way.
