### PR TITLE
fix(cli-core): read isTTY from stdin instead of stdout

### DIFF
--- a/packages/@sanity/cli-core/src/util/isInteractive.ts
+++ b/packages/@sanity/cli-core/src/util/isInteractive.ts
@@ -1,3 +1,3 @@
 export function isInteractive(): boolean {
-  return process.stdout.isTTY && process.env.TERM !== 'dumb' && !('CI' in process.env)
+  return process.stdin.isTTY && process.env.TERM !== 'dumb' && !('CI' in process.env)
 }


### PR DESCRIPTION
### Description
~According to Node.js docs, [writeStream.isTTY](https://nodejs.org/api/tty.html#writestreamistty) is always `true` , which means the current `isInteractive()` check may incorrectly classify non-interactive environments as interactive.~

### What to review


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
