### PR TITLE
fix: use `stdin`, not `stdout` for interactive checks

### DIFF
--- a/packages/@sanity/cli-core/src/util/__tests__/isInteractive.test.ts
+++ b/packages/@sanity/cli-core/src/util/__tests__/isInteractive.test.ts
@@ -1,0 +1,67 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {isInteractive} from '../isInteractive.js'
+
+describe('isInteractive', () => {
+  const originalStdinIsTTY = process.stdin.isTTY
+  const originalStdoutIsTTY = process.stdout.isTTY
+
+  afterEach(() => {
+    process.stdin.isTTY = originalStdinIsTTY
+    process.stdout.isTTY = originalStdoutIsTTY
+    vi.unstubAllEnvs()
+  })
+
+  test('returns true when stdin is a TTY and not in CI', () => {
+    process.stdin.isTTY = true
+    vi.stubEnv('CI', undefined)
+    vi.stubEnv('TERM', undefined)
+
+    expect(isInteractive()).toBe(true)
+  })
+
+  test('returns false when stdin is not a TTY', () => {
+    process.stdin.isTTY = false
+    vi.stubEnv('CI', undefined)
+    vi.stubEnv('TERM', undefined)
+
+    expect(isInteractive()).toBe(false)
+  })
+
+  test('returns false when TERM is dumb', () => {
+    process.stdin.isTTY = true
+    vi.stubEnv('TERM', 'dumb')
+    vi.stubEnv('CI', undefined)
+
+    expect(isInteractive()).toBe(false)
+  })
+
+  test('returns false when CI env var is set', () => {
+    process.stdin.isTTY = true
+    vi.stubEnv('TERM', undefined)
+    vi.stubEnv('CI', 'true')
+
+    expect(isInteractive()).toBe(false)
+  })
+
+  test('returns true when stdout is not a TTY but stdin is', () => {
+    // This is the key scenario: `sanity build > output.log`
+    // stdout is piped but stdin is still interactive
+    process.stdin.isTTY = true
+    process.stdout.isTTY = false
+    vi.stubEnv('CI', undefined)
+    vi.stubEnv('TERM', undefined)
+
+    expect(isInteractive()).toBe(true)
+  })
+
+  test('returns false when stdin is not a TTY even if stdout is', () => {
+    // stdin is piped (e.g., `echo "input" | sanity command`)
+    process.stdin.isTTY = false
+    process.stdout.isTTY = true
+    vi.stubEnv('CI', undefined)
+    vi.stubEnv('TERM', undefined)
+
+    expect(isInteractive()).toBe(false)
+  })
+})

--- a/packages/@sanity/cli-core/src/util/isInteractive.ts
+++ b/packages/@sanity/cli-core/src/util/isInteractive.ts
@@ -1,3 +1,3 @@
 export function isInteractive(): boolean {
-  return process.stdout.isTTY && process.env.TERM !== 'dumb' && !('CI' in process.env)
+  return Boolean(process.stdin.isTTY) && process.env.TERM !== 'dumb' && !('CI' in process.env)
 }


### PR DESCRIPTION
### Description

This one is embarrassing - but Claude is right that we should of course be using `stdin`, not `stdout` to detect interactive support 😅


### What to review

Change looks safe?

### Testing

Added comprehensive tests for the `isInteractive` util