### PR TITLE
chore: move claude code review prompt to command

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,26 @@
+Review the changes and identify only issues that need fixing. If no PR context is provided, get the diff with:
+```
+git diff main...HEAD  # committed changes on this branch
+git diff --cached     # staged but not yet committed
+```
+
+For each issue found:
+- State the problem in 1-2 sentences
+- Provide the fix or recommendation
+- Include line numbers when relevant
+
+Skip:
+- Compliments or positive observations
+- General assessments
+- Explanations of what the code does
+
+Focus on:
+- Bugs or logic errors
+- Security vulnerabilities
+- Performance problems
+- Missing error handling
+- Inadequate test coverage
+- Code matches the existing codebase
+- Ensure any new dependency installed is truly necessary or could be accomplished with existing dependencies
+
+Keep the entire review short and concise. Be direct and actionable.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Read review prompt
+        id: review-prompt
+        run: |
+          {
+            echo 'content<<PROMPT_EOF'
+            cat .claude/commands/review.md
+            echo PROMPT_EOF
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code Review
         if: github.actor != 'renovate[bot]'
         id: claude-review
@@ -35,27 +44,7 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this PR and identify only issues that need fixing.
-            For each issue found:
-            - State the problem in 1-2 sentences
-            - Provide the fix or recommendation
-            - Include line numbers when relevant
-
-            Skip:
-            - Compliments or positive observations
-            - General assessments
-            - Explanations of what the code does
-
-            Focus on:
-            - Bugs or logic errors
-            - Security vulnerabilities
-            - Performance problems
-            - Missing error handling
-            - Inadequate test coverage
-            - Code matches the existing codebase
-            - Ensure any new dependency installed is truly necessary or could be accomplished with existing dependencies
-
-            Try to keep the entire review short and concise. Be direct and actionable.
+            ${{ steps.review-prompt.outputs.content }}
           use_sticky_comment: true
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*)"


### PR DESCRIPTION
### Description

Quite often I find myself making changes, pushing, opening a PR, waiting, only to have claude give me actionable review feedback. We can shorten this cycle. With this PR, I propose we move the review prompt out of the workflow and into a claude command. This means you can simply do `/review` and it'll do it locally. That isn't a guarantee that it won't find new issues once pushed, but it will reduce the amount of noise for fairly obvious ones.

Note: the claude code review failing here is expected (security thing)

### What to review

Does the review prompt look alright? It's pretty much the same except it tries to guide it towards what to review locally, eg committed changes that are not on `main`, as well as staged but not yet committed changes.

### Testing

…