### PR TITLE
perf: cache reading cli config multiple times

### DIFF
--- a/packages/@sanity/cli-core/src/config/__tests__/getCliConfig.test.ts
+++ b/packages/@sanity/cli-core/src/config/__tests__/getCliConfig.test.ts
@@ -1,0 +1,199 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+const mockImportModule = vi.hoisted(() => vi.fn())
+const mockFindPathForFiles = vi.hoisted(() => vi.fn())
+
+vi.mock('../../util/importModule.js', () => ({
+  importModule: mockImportModule,
+}))
+
+vi.mock('../util/findConfigsPaths.js', () => ({
+  findPathForFiles: mockFindPathForFiles,
+}))
+
+const ROOT = '/mock/project'
+
+function setupSingleConfig(configPath = `${ROOT}/sanity.cli.ts`) {
+  mockFindPathForFiles.mockResolvedValue([
+    {exists: true, path: configPath},
+    {exists: false, path: `${ROOT}/sanity.cli.js`},
+  ])
+}
+
+async function freshImport() {
+  const mod = await import('../cli/getCliConfig.js')
+  return mod.getCliConfig
+}
+
+describe('getCliConfig', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  test('returns parsed config', async () => {
+    const getCliConfig = await freshImport()
+    setupSingleConfig()
+    mockImportModule.mockResolvedValue({api: {dataset: 'prod', projectId: 'abc'}})
+
+    const config = await getCliConfig(ROOT)
+
+    expect(config).toEqual({api: {dataset: 'prod', projectId: 'abc'}})
+    expect(mockImportModule).toHaveBeenCalledOnce()
+  })
+
+  test('throws when no config found', async () => {
+    const getCliConfig = await freshImport()
+    mockFindPathForFiles.mockResolvedValue([
+      {exists: false, path: `${ROOT}/sanity.cli.ts`},
+      {exists: false, path: `${ROOT}/sanity.cli.js`},
+    ])
+
+    await expect(getCliConfig(ROOT)).rejects.toThrow('No CLI config found at')
+  })
+
+  test('throws when multiple config files found', async () => {
+    const getCliConfig = await freshImport()
+    mockFindPathForFiles.mockResolvedValue([
+      {exists: true, path: `${ROOT}/sanity.cli.ts`},
+      {exists: true, path: `${ROOT}/sanity.cli.js`},
+    ])
+
+    await expect(getCliConfig(ROOT)).rejects.toThrow('Multiple CLI config files found')
+  })
+
+  test('throws when import fails', async () => {
+    const getCliConfig = await freshImport()
+    setupSingleConfig()
+    mockImportModule.mockRejectedValue(new Error('syntax error'))
+
+    await expect(getCliConfig(ROOT)).rejects.toThrow('CLI config cannot be loaded')
+  })
+
+  test('throws on schema validation failure', async () => {
+    const getCliConfig = await freshImport()
+    setupSingleConfig()
+    mockImportModule.mockResolvedValue({api: {projectId: 123}})
+
+    await expect(getCliConfig(ROOT)).rejects.toThrow('Invalid CLI config')
+  })
+
+  test('caches result — subsequent calls only import once', async () => {
+    const getCliConfig = await freshImport()
+    setupSingleConfig()
+    mockImportModule.mockResolvedValue({api: {projectId: 'abc'}})
+
+    const first = await getCliConfig(ROOT)
+    const second = await getCliConfig(ROOT)
+
+    expect(first).toBe(second)
+    expect(mockImportModule).toHaveBeenCalledOnce()
+  })
+
+  test('evicts cache on import error so next call retries', async () => {
+    const getCliConfig = await freshImport()
+    setupSingleConfig()
+    mockImportModule.mockRejectedValueOnce(new Error('transient'))
+
+    await expect(getCliConfig(ROOT)).rejects.toThrow('CLI config cannot be loaded')
+
+    // Second call should retry
+    mockImportModule.mockResolvedValue({api: {projectId: 'ok'}})
+
+    const config = await getCliConfig(ROOT)
+
+    expect(config).toEqual({api: {projectId: 'ok'}})
+    expect(mockImportModule).toHaveBeenCalledTimes(2)
+  })
+
+  test('evicts cache on NotFoundError so next call retries', async () => {
+    const getCliConfig = await freshImport()
+
+    // First call — no config files
+    mockFindPathForFiles.mockResolvedValueOnce([
+      {exists: false, path: `${ROOT}/sanity.cli.ts`},
+      {exists: false, path: `${ROOT}/sanity.cli.js`},
+    ])
+
+    await expect(getCliConfig(ROOT)).rejects.toThrow('No CLI config found at')
+
+    // Second call — config now exists
+    setupSingleConfig()
+    mockImportModule.mockResolvedValue({api: {dataset: 'dev'}})
+
+    const config = await getCliConfig(ROOT)
+
+    expect(config).toEqual({api: {dataset: 'dev'}})
+  })
+
+  test('deduplicates concurrent calls — only one import', async () => {
+    const getCliConfig = await freshImport()
+    setupSingleConfig()
+    mockImportModule.mockResolvedValue({api: {projectId: 'concurrent'}})
+
+    const [a, b, c] = await Promise.all([
+      getCliConfig(ROOT),
+      getCliConfig(ROOT),
+      getCliConfig(ROOT),
+    ])
+
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+    expect(mockImportModule).toHaveBeenCalledOnce()
+  })
+
+  test('caches independently per rootPath', async () => {
+    const getCliConfig = await freshImport()
+    const OTHER_ROOT = '/mock/other-project'
+
+    // Setup for ROOT
+    mockFindPathForFiles.mockResolvedValueOnce([
+      {exists: true, path: `${ROOT}/sanity.cli.ts`},
+      {exists: false, path: `${ROOT}/sanity.cli.js`},
+    ])
+    mockImportModule.mockResolvedValueOnce({api: {projectId: 'abc'}})
+
+    // Setup for OTHER_ROOT
+    mockFindPathForFiles.mockResolvedValueOnce([
+      {exists: true, path: `${OTHER_ROOT}/sanity.cli.ts`},
+      {exists: false, path: `${OTHER_ROOT}/sanity.cli.js`},
+    ])
+    mockImportModule.mockResolvedValueOnce({api: {projectId: 'xyz'}})
+
+    const configA = await getCliConfig(ROOT)
+    const configB = await getCliConfig(OTHER_ROOT)
+
+    expect(configA).toEqual({api: {projectId: 'abc'}})
+    expect(configB).toEqual({api: {projectId: 'xyz'}})
+    expect(mockImportModule).toHaveBeenCalledTimes(2)
+
+    // Subsequent calls return cached values
+    const configA2 = await getCliConfig(ROOT)
+    const configB2 = await getCliConfig(OTHER_ROOT)
+
+    expect(configA2).toBe(configA)
+    expect(configB2).toBe(configB)
+    expect(mockImportModule).toHaveBeenCalledTimes(2)
+  })
+
+  test('concurrent callers all receive the rejection', async () => {
+    const getCliConfig = await freshImport()
+    setupSingleConfig()
+    mockImportModule.mockRejectedValue(new Error('boom'))
+
+    const results = await Promise.allSettled([
+      getCliConfig(ROOT),
+      getCliConfig(ROOT),
+      getCliConfig(ROOT),
+    ])
+
+    for (const result of results) {
+      expect(result.status).toBe('rejected')
+      if (result.status === 'rejected') {
+        expect(result.reason.message).toBe('CLI config cannot be loaded')
+      }
+    }
+
+    expect(mockImportModule).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/@sanity/cli-core/src/config/cli/getCliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/getCliConfig.ts
@@ -5,21 +5,39 @@ import {findPathForFiles} from '../util/findConfigsPaths.js'
 import {cliConfigSchema} from './schemas.js'
 import {type CliConfig} from './types/cliConfig.js'
 
+const cache = new Map<string, Promise<CliConfig>>()
+
 /**
  * Get the CLI config for a project, given the root path.
  *
- * We really want to avoid loading the CLI config in the main thread, as we'll need
- * TypeScript loading logic, potentially with ts path aliases, syntax extensions and all
- * sorts of nonsense. Thus, we _attempt_ to use a worker thread - but have to fall back
- * to using the main thread if not possible. This can be the case if the configuration
- * contains non-serializable properties, such as functions. This is unfortunately used
- * by the vite config, for example.
+ * Results are cached in-memory keyed by rootPath for the lifetime of the
+ * process. Since the CLI always runs from a single project root, the config
+ * won't change during a command's execution, so caching avoids redundant
+ * filesystem reads and jiti imports from the prerun hook, SanityCommand
+ * helpers, and action files.
+ *
+ * If loading fails the cached promise is evicted so the next call retries.
  *
  * @param rootPath - Root path for the project, eg where `sanity.cli.(ts|js)` is located.
  * @returns The CLI config
  * @internal
  */
-export async function getCliConfig(rootPath: string): Promise<CliConfig> {
+export function getCliConfig(rootPath: string): Promise<CliConfig> {
+  const cached = cache.get(rootPath)
+  if (cached) {
+    return cached
+  }
+
+  const promise = loadCliConfig(rootPath).catch((err) => {
+    cache.delete(rootPath)
+    throw err
+  })
+
+  cache.set(rootPath, promise)
+  return promise
+}
+
+async function loadCliConfig(rootPath: string): Promise<CliConfig> {
   const paths = await findPathForFiles(rootPath, ['sanity.cli.ts', 'sanity.cli.js'])
   const configPaths = paths.filter((path) => path.exists)
 

--- a/packages/@sanity/cli/src/__tests__/getCliConfig.test.ts
+++ b/packages/@sanity/cli/src/__tests__/getCliConfig.test.ts
@@ -2,8 +2,7 @@ import {readdirSync} from 'node:fs'
 import {dirname, join} from 'node:path'
 import {fileURLToPath} from 'node:url'
 
-import {getCliConfig} from '@sanity/cli-core'
-import {describe, expect, test} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
 const FIXTURES_DIR = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -16,12 +15,18 @@ const fixtureNames = readdirSync(FIXTURES_DIR, {withFileTypes: true})
   .toSorted()
 
 describe('#getCliConfig', () => {
+  afterEach(() => {
+    vi.resetModules()
+  })
+
   test('should error when both ts and js files are present', async () => {
+    const {getCliConfig} = await import('@sanity/cli-core')
     const cwd = join(FIXTURES_DIR, 'error-both-ts-and-js')
     await expect(getCliConfig(cwd)).rejects.toThrow('Multiple CLI config files found')
   })
 
   test.each(fixtureNames)('%s', async (fixtureName) => {
+    const {getCliConfig} = await import('@sanity/cli-core')
     const cwd = join(FIXTURES_DIR, fixtureName)
 
     const config = await getCliConfig(cwd)


### PR DESCRIPTION
I don't think it's super perf boost but nice to not double read if not needed especially since telemetry reads it first then commands.