### PR TITLE
refactor: merge coverage delta columns into single Statements column

### DIFF
--- a/packages/@repo/coverage-delta/src/__tests__/lib.test.ts
+++ b/packages/@repo/coverage-delta/src/__tests__/lib.test.ts
@@ -126,19 +126,19 @@ describe('computeDeltas', () => {
 
 describe('formatDelta', () => {
   test('formats null as new', () => {
-    expect(formatDelta(null)).toBe('new ↗')
+    expect(formatDelta(null)).toBe('<font color="green">(new)</font>')
   })
 
   test('formats positive delta', () => {
-    expect(formatDelta(2.5)).toBe('+2.5% ↗')
+    expect(formatDelta(2.5)).toBe('<font color="green">(+&nbsp;2.5%)</font>')
   })
 
   test('formats negative delta', () => {
-    expect(formatDelta(-3.2)).toBe('-3.2% ↘')
+    expect(formatDelta(-3.2)).toBe('<font color="red">(-&nbsp;3.2%)</font>')
   })
 
   test('formats zero delta', () => {
-    expect(formatDelta(0)).toBe('±0% —')
+    expect(formatDelta(0)).toBe('<font color="green">(±0%)</font>')
   })
 })
 
@@ -153,22 +153,20 @@ describe('buildMarkdown', () => {
     expect(md).toContain('No covered files changed')
   })
 
-  test('includes delta column when baseline exists', () => {
+  test('includes delta in statements column when baseline exists', () => {
     const deltas = [{baseline: 80, current: 85, delta: 5, displayName: 'src/a.ts'}]
     const md = buildMarkdown(deltas, baseline, 'abc123')
-    expect(md).toContain('| File | Stmts | Delta |')
+    expect(md).toContain('| File | Statements |')
     expect(md).toContain('src/a.ts')
-    expect(md).toContain('80.0% → 85.0%')
-    expect(md).toContain('+5.0% ↗')
+    expect(md).toContain('85.0%&nbsp;<font color="green">(+&nbsp;5.0%)</font>')
     expect(md).toContain('abc123')
   })
 
-  test('omits delta column when no baseline', () => {
+  test('shows only percentage when no baseline', () => {
     const deltas = [{baseline: null, current: 70, delta: null, displayName: 'src/b.ts'}]
     const md = buildMarkdown(deltas, null, null)
-    expect(md).not.toContain('| Delta |')
-    expect(md).toContain('| File | Stmts |')
-    expect(md).toContain('new → 70.0%')
+    expect(md).toContain('| File | Statements |')
+    expect(md).toContain('| src/b.ts | 70.0% |')
     expect(md).toContain('No baseline available')
   })
 

--- a/packages/@repo/coverage-delta/src/lib.ts
+++ b/packages/@repo/coverage-delta/src/lib.ts
@@ -74,10 +74,10 @@ export function computeDeltas(
 }
 
 export function formatDelta(delta: number | null): string {
-  if (delta === null) return 'new ↗'
-  if (delta > 0) return `+${delta.toFixed(1)}% ↗`
-  if (delta < 0) return `${delta.toFixed(1)}% ↘`
-  return '±0% —'
+  if (delta === null) return '<font color="green">(new)</font>'
+  if (delta > 0) return `<font color="green">(+&nbsp;${delta.toFixed(1)}%)</font>`
+  if (delta < 0) return `<font color="red">(-&nbsp;${Math.abs(delta).toFixed(1)}%)</font>`
+  return '<font color="green">(±0%)</font>'
 }
 
 export function buildMarkdown(
@@ -91,18 +91,13 @@ export function buildMarkdown(
 
   const hasBaseline = baseline !== null
 
-  const headerRow = hasBaseline ? '| File | Stmts | Delta |' : '| File | Stmts |'
-  const separatorRow = hasBaseline ? '| ---- | ----- | ----- |' : '| ---- | ----- |'
+  const headerRow = '| File | Statements |'
+  const separatorRow = '| ---- | ---- |'
 
-  const rows = deltas.map(({baseline, current, delta, displayName}) => {
-    const coverage =
-      baseline === null
-        ? `new → ${current.toFixed(1)}%`
-        : `${baseline.toFixed(1)}% → ${current.toFixed(1)}%`
-
-    return hasBaseline
-      ? `| ${displayName} | ${coverage} | ${formatDelta(delta)} |`
-      : `| ${displayName} | ${coverage} |`
+  const rows = deltas.map(({current, delta, displayName}) => {
+    const pct = `${current.toFixed(1)}%`
+    const cell = hasBaseline ? `${pct}&nbsp;${formatDelta(delta)}` : pct
+    return `| ${displayName} | ${cell} |`
   })
 
   const count = deltas.length


### PR DESCRIPTION
## Summary
- Merges the separate `Stmts` and `Delta` columns into a single `Statements` column
- Inline colored deltas: `85.0%&nbsp;(+&nbsp;5.0%)` with green/red `<font>` tags
- Uses `&nbsp;` to prevent wrapping in markdown tables
- Green for positive, zero, and new; red for negative

## Test plan
- [x] All 26 existing tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)