### PR TITLE
fix: don't throw an error when telemetry is not initialized

### DIFF
--- a/packages/@sanity/cli-core/src/util/__tests__/getCliTelemetry.test.ts
+++ b/packages/@sanity/cli-core/src/util/__tests__/getCliTelemetry.test.ts
@@ -1,5 +1,5 @@
-import {CLIError} from '@oclif/core/errors'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {noopLogger} from '@sanity/telemetry'
+import {afterEach, describe, expect, test} from 'vitest'
 
 import {type CLITelemetryStore} from '../../telemetry/types.js'
 import {
@@ -11,7 +11,6 @@ import {
 
 describe('#getCliTelemetry', () => {
   afterEach(() => {
-    vi.unstubAllEnvs()
     clearCliTelemetry()
   })
 
@@ -27,40 +26,10 @@ describe('#getCliTelemetry', () => {
     expect(result).toBe(mockTelemetry)
   })
 
-  test('throws CLIError when not initialized and TEST env is falsy', () => {
-    vi.stubEnv('TEST', '')
-
-    expect(() => getCliTelemetry()).toThrow(CLIError)
-    expect(() => getCliTelemetry()).toThrow('CLI telemetry not initialized')
-  })
-
-  test('returns undefined without throwing when TEST env is truthy', () => {
-    vi.stubEnv('TEST', 'true')
-
+  test('returns noop logger when not initialized', () => {
     const result = getCliTelemetry()
 
-    expect(result).toBeUndefined()
-  })
-
-  test('returns undefined when TEST env is set to any truthy value', () => {
-    vi.stubEnv('TEST', '1')
-
-    const result = getCliTelemetry()
-
-    expect(result).toBeUndefined()
-  })
-
-  test('returns cliTelemetry even when TEST env is set', () => {
-    const mockTelemetry = {
-      log: () => {},
-    } as unknown as CLITelemetryStore
-
-    setCliTelemetry(mockTelemetry)
-    vi.stubEnv('TEST', 'true')
-
-    const result = getCliTelemetry()
-
-    expect(result).toBe(mockTelemetry)
+    expect(result).toBe(noopLogger)
   })
 
   test('uses Symbol.for to ensure global registry consistency', () => {

--- a/packages/@sanity/cli-core/src/util/getCliTelemetry.ts
+++ b/packages/@sanity/cli-core/src/util/getCliTelemetry.ts
@@ -1,7 +1,7 @@
-import {CLIError} from '@oclif/core/errors'
+import {ux} from '@oclif/core'
+import {noopLogger} from '@sanity/telemetry'
 
 import {type CLITelemetryStore} from '../telemetry/types.js'
-import {isTrueish} from './isTrueish.js'
 
 /**
  * @public
@@ -19,13 +19,13 @@ type GlobalWithTelemetry = typeof globalThis & {
  */
 export function getCliTelemetry(): CLITelemetryStore {
   const global = globalThis as GlobalWithTelemetry
-  // This should never happen, but just in case.
-  // Ignore this error in tests to avoid failing tests as tests don't run to
-  if (!global[CLI_TELEMETRY_SYMBOL] && !isTrueish(process.env.TEST)) {
-    throw new CLIError('CLI telemetry not initialized', {exit: 1})
+  // This should never happen, but if it does, we return a noop logger to avoid errors.
+  if (!global[CLI_TELEMETRY_SYMBOL]) {
+    ux.warn('CLI telemetry not initialized, returning noop logger')
+    return noopLogger
   }
 
-  return global[CLI_TELEMETRY_SYMBOL] as CLITelemetryStore
+  return global[CLI_TELEMETRY_SYMBOL]
 }
 
 /**

--- a/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
@@ -1,6 +1,7 @@
 import {join} from 'node:path'
 
 import {convertToSystemPath} from '@sanity/cli-test'
+import {noopLogger} from '@sanity/telemetry'
 import {type ConfigEnv, type InlineConfig} from 'vite'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -361,7 +362,7 @@ describe('#getViteConfig', () => {
       configPath: '/mock/config/path',
       enforceRequiredFields: true,
       outputPath: 'custom-schema.json',
-      telemetryLogger: undefined,
+      telemetryLogger: noopLogger,
       workDir: mockTestCwd,
       workspaceName: 'production',
     })
@@ -413,7 +414,7 @@ describe('#getViteConfig', () => {
         generates: 'sanity.types.ts',
         schema: 'custom-schema.json',
       },
-      telemetryLogger: undefined,
+      telemetryLogger: noopLogger,
       workDir: mockTestCwd,
     })
     expect(typegenPlugin).toBeDefined()


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Don't throw an error if telemetry is not found, instead show a warning and add a noop logger

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Existing tests updated