### PR TITLE
chore: lint ignore prebuilt fixtures

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,4 +3,8 @@ import {resolve} from 'node:path'
 import {includeIgnoreFile} from '@eslint/compat'
 import eslintConfig from '@sanity/eslint-config-cli'
 
-export default [includeIgnoreFile(resolve(import.meta.dirname, '.gitignore')), ...eslintConfig]
+export default [
+  includeIgnoreFile(resolve(import.meta.dirname, '.gitignore')),
+  {ignores: ['**/fixtures/prebuilt-*/dist/**']},
+  ...eslintConfig,
+]


### PR DESCRIPTION
Prebuilt fixtures contain build output and so shouldnt be included.
