### PR TITLE
chore: ignore rest siblings for unused vars

### DIFF
--- a/packages/@sanity/eslint-config-cli/eslint.config.mjs
+++ b/packages/@sanity/eslint-config-cli/eslint.config.mjs
@@ -102,6 +102,7 @@ export default defineConfig(
         'error',
         {
           argsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
         },
       ],
       '@typescript-eslint/no-useless-constructor': 'error',
@@ -270,6 +271,7 @@ export default defineConfig(
         {
           args: 'after-used',
           argsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
           vars: 'all',
           varsIgnorePattern: '^_',
         },


### PR DESCRIPTION
This pattern is pretty common, but you currently get a lint error because (in the below example) the `internals` variable is unused. Even assigning it to something like `internals: _internals` doesn't help. This change in eslint config ensures this pattern is allowed.

```ts
function omitInterals(thing) {
  const {internals, ...others} = thing
  return others
}
```
