### PR TITLE
chore: Use new squiggler bot

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,7 @@ jobs:
   claude-review:
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'skip-review') &&
+      github.actor != 'squiggler[bot]' &&
       github.actor != 'squiggler-ent[bot]' &&
       (github.actor != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, '⚠️ major'))
 


### PR DESCRIPTION
### Description

We replaced the `squiggler` bot (installed in `sanity-io` organization) with the `squiggler-ent` bot (installed at the GitHub _Enterprise_ level. This allows for reuse across other organizations in our enterprise including `sanity-labs` and `portabletext`

This PR adds the new bot to the ignore list.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
