### PR TITLE
fix: replace @vercel/fs-detectors with inline implementation

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -89,7 +89,6 @@
     "@sanity/ui": "^3.1.13",
     "@sanity/worker-channels": "^2.0.0",
     "@vercel/frameworks": "3.8.4",
-    "@vercel/fs-detectors": "5.5.2",
     "@vitejs/plugin-react": "catalog:",
     "chokidar": "^5.0.0",
     "console-table-printer": "^2.15.0",

--- a/packages/@sanity/cli/src/actions/init/bootstrapRemoteTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapRemoteTemplate.ts
@@ -5,10 +5,10 @@ import {Output, subdebug} from '@sanity/cli-core'
 import {logSymbols, spinner} from '@sanity/cli-core/ux'
 import {getMonoRepo, GitHubFileReader, validateTemplate} from '@sanity/template-validator'
 import {type Framework, frameworks} from '@vercel/frameworks'
-import {detectFrameworkRecord, LocalFileSystemDetector} from '@vercel/fs-detectors'
 
 import {createCorsOrigin} from '../../services/cors.js'
 import {createToken} from '../../services/tokens.js'
+import {detectFrameworkRecord} from '../../util/detectFramework.js'
 import {getDefaultPortForFramework} from '../../util/frameworkPort.js'
 import {type GenerateConfigOptions} from './createStudioConfig.js'
 import {tryGitInit} from './git.js'
@@ -98,7 +98,7 @@ export async function bootstrapRemoteTemplate(opts: BootstrapRemoteOptions): Pro
     const packagePath = join(outputPath, pkg)
     const packageFramework: Framework | null = await detectFrameworkRecord({
       frameworkList: frameworks as readonly Framework[],
-      fs: new LocalFileSystemDetector(packagePath),
+      rootPath: packagePath,
     })
 
     const port = getDefaultPortForFramework(packageFramework?.slug)

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -49,12 +49,11 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
   }
 })
 
-vi.mock('@vercel/fs-detectors', () => ({
+vi.mock('../../../util/detectFramework.js', () => ({
   detectFrameworkRecord: vi.fn().mockResolvedValue({
     name: 'Next.js',
     slug: 'nextjs',
   }),
-  LocalFileSystemDetector: vi.fn(),
 }))
 
 vi.mock('../../../actions/auth/login/login.js', () => ({

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -71,9 +71,8 @@ vi.mock('@sanity/cli-core/ux', async () => {
   }
 })
 
-vi.mock('@vercel/fs-detectors', () => ({
+vi.mock('../../../util/detectFramework.js', () => ({
   detectFrameworkRecord: vi.fn().mockResolvedValue(undefined),
-  LocalFileSystemDetector: vi.fn(),
 }))
 
 vi.mock('../../../util/getProjectDefaults.js', () => ({

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
@@ -19,9 +19,8 @@ const mocks = vi.hoisted(() => ({
   usersGetById: vi.fn(),
 }))
 
-vi.mock('@vercel/fs-detectors', () => ({
+vi.mock('../../../util/detectFramework.js', () => ({
   detectFrameworkRecord: mocks.detectFrameworkRecord,
-  LocalFileSystemDetector: vi.fn(),
 }))
 
 vi.mock('@sanity/cli-core/ux', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
@@ -17,9 +17,8 @@ const mocks = vi.hoisted(() => ({
   select: vi.fn(),
 }))
 
-vi.mock('@vercel/fs-detectors', () => ({
+vi.mock('../../../util/detectFramework.js', () => ({
   detectFrameworkRecord: vi.fn().mockResolvedValue(null),
-  LocalFileSystemDetector: vi.fn(),
 }))
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.nextjs.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.nextjs.test.ts
@@ -89,12 +89,11 @@ vi.mock('@sanity/cli-core/ux', async () => {
   }
 })
 
-vi.mock('@vercel/fs-detectors', () => ({
+vi.mock('../../../util/detectFramework.js', () => ({
   detectFrameworkRecord: vi.fn().mockResolvedValue({
     name: 'Next.js',
     slug: 'nextjs',
   }),
-  LocalFileSystemDetector: vi.fn(),
 }))
 
 vi.mock('../../../util/getProjectDefaults.js', () => ({

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.plan.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.plan.test.ts
@@ -20,9 +20,8 @@ vi.mock('@sanity/cli-core/ux', async () => {
   }
 })
 
-vi.mock('@vercel/fs-detectors', () => ({
+vi.mock('../../../util/detectFramework.js', () => ({
   detectFrameworkRecord: mockDetectedFramework,
-  LocalFileSystemDetector: vi.fn(),
 }))
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -10,9 +10,8 @@ const mocks = vi.hoisted(() => ({
   getGitHubRepoInfo: vi.fn(),
 }))
 
-vi.mock('@vercel/fs-detectors', () => ({
+vi.mock('../../../util/detectFramework.js', () => ({
   detectFrameworkRecord: mocks.detectFrameworkRecord,
-  LocalFileSystemDetector: vi.fn(),
 }))
 
 vi.mock('../../../actions/init/remoteTemplate.js', () => ({

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -17,7 +17,6 @@ import {type DatasetAclMode, isHttpError} from '@sanity/client'
 import {DatasetImportCommand} from '@sanity/import'
 import {type TelemetryTrace} from '@sanity/telemetry'
 import {type Framework, frameworks} from '@vercel/frameworks'
-import {detectFrameworkRecord, LocalFileSystemDetector} from '@vercel/fs-detectors'
 import {execa, type Options} from 'execa'
 import deburr from 'lodash-es/deburr.js'
 
@@ -74,6 +73,7 @@ import {getPlanId, getPlanIdFromCoupon} from '../services/plans.js'
 import {createProject, listProjects, updateProjectInitializedAt} from '../services/projects.js'
 import {getCliUser} from '../services/user.js'
 import {CLIInitStepCompleted, type InitStepResult} from '../telemetry/init.telemetry.js'
+import {detectFrameworkRecord} from '../util/detectFramework.js'
 import {absolutify, validateEmptyPath} from '../util/fsUtils.js'
 import {getProjectDefaults} from '../util/getProjectDefaults.js'
 import {getPeerDependencies} from '../util/packageManager/getPeerDependencies.js'
@@ -323,7 +323,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
 
     const detectedFramework = await detectFrameworkRecord({
       frameworkList: frameworks as readonly Framework[],
-      fs: new LocalFileSystemDetector(process.cwd()),
+      rootPath: process.cwd(),
     })
     const isNextJs = detectedFramework?.slug === 'nextjs'
 

--- a/packages/@sanity/cli/src/util/__tests__/detectFramework.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/detectFramework.test.ts
@@ -1,0 +1,377 @@
+import {existsSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {type Framework, frameworks} from '@vercel/frameworks'
+import {afterEach, beforeEach, describe, expect, test} from 'vitest'
+
+import {detectFrameworkRecord} from '../detectFramework.js'
+
+describe('detectFrameworkRecord', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'detect-fw-'))
+  })
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, {recursive: true})
+    }
+  })
+
+  test('detects Next.js from package.json dependencies', async () => {
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({dependencies: {next: '14.0.0'}}))
+
+    const result = await detectFrameworkRecord({
+      frameworkList: frameworks as readonly Framework[],
+      rootPath: tmpDir,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result?.slug).toBe('nextjs')
+    expect(result?.detectedVersion).toBe('14.0.0')
+  })
+
+  test('detects framework from devDependencies', async () => {
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({devDependencies: {astro: '4.0.0'}}))
+
+    const result = await detectFrameworkRecord({
+      frameworkList: frameworks as readonly Framework[],
+      rootPath: tmpDir,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result?.slug).toBe('astro')
+  })
+
+  test('returns null when no framework matches', async () => {
+    writeFileSync(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({dependencies: {'some-unknown-package': '1.0.0'}}),
+    )
+
+    const result = await detectFrameworkRecord({
+      frameworkList: frameworks as readonly Framework[],
+      rootPath: tmpDir,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test('returns null for empty directory', async () => {
+    const result = await detectFrameworkRecord({
+      frameworkList: frameworks as readonly Framework[],
+      rootPath: tmpDir,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test('detects framework via file path detector', async () => {
+    // Sanity Studio is detected by the presence of sanity.config.ts (or .js/.mjs etc)
+    // and having sanity in package.json
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({dependencies: {sanity: '3.0.0'}}))
+    writeFileSync(join(tmpDir, 'sanity.config.ts'), 'export default {}')
+
+    const result = await detectFrameworkRecord({
+      frameworkList: frameworks as readonly Framework[],
+      rootPath: tmpDir,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result?.slug).toBe('sanity-v3')
+  })
+
+  test('handles supersedes (more specific framework wins)', async () => {
+    // Create a custom framework list where A supersedes B
+    const frameworkB: Framework = {
+      description: '',
+      detectors: {
+        every: [{matchPackage: 'base-pkg'}],
+      },
+      getOutputDirName: async () => '.',
+      logo: '',
+      name: 'Base',
+      settings: {
+        buildCommand: {value: ''},
+        devCommand: {value: ''},
+        installCommand: {placeholder: ''},
+        outputDirectory: {placeholder: ''},
+      },
+      slug: 'base',
+    }
+    const frameworkA: Framework = {
+      description: '',
+      detectors: {
+        every: [{matchPackage: 'extended-pkg'}],
+      },
+      getOutputDirName: async () => '.',
+      logo: '',
+      name: 'Extended',
+      settings: {
+        buildCommand: {value: ''},
+        devCommand: {value: ''},
+        installCommand: {placeholder: ''},
+        outputDirectory: {placeholder: ''},
+      },
+      slug: 'extended',
+      supersedes: ['base'],
+    }
+
+    writeFileSync(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({
+        dependencies: {'base-pkg': '1.0.0', 'extended-pkg': '2.0.0'},
+      }),
+    )
+
+    const result = await detectFrameworkRecord({
+      frameworkList: [frameworkB, frameworkA],
+      rootPath: tmpDir,
+    })
+
+    expect(result?.slug).toBe('extended')
+  })
+
+  test('matchContent detector matches file content with regex', async () => {
+    const customFramework: Framework = {
+      description: '',
+      detectors: {
+        every: [{matchContent: '"engine":\\s*"custom"', path: 'config.json'}],
+      },
+      getOutputDirName: async () => '.',
+      logo: '',
+      name: 'Custom',
+      settings: {
+        buildCommand: {value: ''},
+        devCommand: {value: ''},
+        installCommand: {placeholder: ''},
+        outputDirectory: {placeholder: ''},
+      },
+      slug: 'custom',
+    }
+
+    writeFileSync(join(tmpDir, 'config.json'), '{"engine": "custom"}')
+
+    const result = await detectFrameworkRecord({
+      frameworkList: [customFramework],
+      rootPath: tmpDir,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result?.slug).toBe('custom')
+  })
+
+  test('does not match framework with empty every array (vacuous truth guard)', async () => {
+    const emptyDetectors: Framework = {
+      description: '',
+      detectors: {
+        every: [],
+      },
+      getOutputDirName: async () => '.',
+      logo: '',
+      name: 'Empty',
+      settings: {
+        buildCommand: {value: ''},
+        devCommand: {value: ''},
+        installCommand: {placeholder: ''},
+        outputDirectory: {placeholder: ''},
+      },
+      slug: 'empty',
+    }
+
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({dependencies: {anything: '1.0.0'}}))
+
+    const result = await detectFrameworkRecord({
+      frameworkList: [emptyDetectors],
+      rootPath: tmpDir,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test('escapes regex metacharacters in matchPackage names', async () => {
+    const dotFramework: Framework = {
+      description: '',
+      detectors: {
+        every: [{matchPackage: 'socket.io'}],
+      },
+      getOutputDirName: async () => '.',
+      logo: '',
+      name: 'SocketIO',
+      settings: {
+        buildCommand: {value: ''},
+        devCommand: {value: ''},
+        installCommand: {placeholder: ''},
+        outputDirectory: {placeholder: ''},
+      },
+      slug: 'socketio',
+    }
+
+    // "socketXio" should NOT match "socket.io" — the dot must be literal
+    writeFileSync(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({dependencies: {socketXio: '1.0.0'}}),
+    )
+
+    const noMatch = await detectFrameworkRecord({
+      frameworkList: [dotFramework],
+      rootPath: tmpDir,
+    })
+    expect(noMatch).toBeNull()
+
+    // "socket.io" should match
+    writeFileSync(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({dependencies: {'socket.io': '4.0.0'}}),
+    )
+
+    const match = await detectFrameworkRecord({
+      frameworkList: [dotFramework],
+      rootPath: tmpDir,
+    })
+    expect(match).not.toBeNull()
+    expect(match?.slug).toBe('socketio')
+    expect(match?.detectedVersion).toBe('4.0.0')
+  })
+
+  test('matchContent detector returns null when content does not match', async () => {
+    const customFramework: Framework = {
+      description: '',
+      detectors: {
+        every: [{matchContent: '"engine":\\s*"custom"', path: 'config.json'}],
+      },
+      getOutputDirName: async () => '.',
+      logo: '',
+      name: 'Custom',
+      settings: {
+        buildCommand: {value: ''},
+        devCommand: {value: ''},
+        installCommand: {placeholder: ''},
+        outputDirectory: {placeholder: ''},
+      },
+      slug: 'custom',
+    }
+
+    writeFileSync(join(tmpDir, 'config.json'), '{"engine": "other"}')
+
+    const result = await detectFrameworkRecord({
+      frameworkList: [customFramework],
+      rootPath: tmpDir,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test('detects framework via some detector (first match wins)', async () => {
+    const multiConfig: Framework = {
+      description: '',
+      detectors: {
+        some: [{path: 'app.config.ts'}, {path: 'app.config.js'}],
+      },
+      getOutputDirName: async () => '.',
+      logo: '',
+      name: 'MultiConfig',
+      settings: {
+        buildCommand: {value: ''},
+        devCommand: {value: ''},
+        installCommand: {placeholder: ''},
+        outputDirectory: {placeholder: ''},
+      },
+      slug: 'multiconfig',
+    }
+
+    // Only the .js variant exists — some should still match
+    writeFileSync(join(tmpDir, 'app.config.js'), 'module.exports = {}')
+
+    const result = await detectFrameworkRecord({
+      frameworkList: [multiConfig],
+      rootPath: tmpDir,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result?.slug).toBe('multiconfig')
+  })
+
+  test('returns null when no some detector matches', async () => {
+    const multiConfig: Framework = {
+      description: '',
+      detectors: {
+        some: [{path: 'app.config.ts'}, {path: 'app.config.js'}],
+      },
+      getOutputDirName: async () => '.',
+      logo: '',
+      name: 'MultiConfig',
+      settings: {
+        buildCommand: {value: ''},
+        devCommand: {value: ''},
+        installCommand: {placeholder: ''},
+        outputDirectory: {placeholder: ''},
+      },
+      slug: 'multiconfig',
+    }
+
+    // Neither file exists
+    const result = await detectFrameworkRecord({
+      frameworkList: [multiConfig],
+      rootPath: tmpDir,
+    })
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('@vercel/frameworks integration guard', () => {
+  // These tests catch upstream breaking changes in the framework definitions
+  // that would silently break our detection logic.
+
+  const knownFrameworks = ['nextjs', 'remix', 'astro', 'svelte', 'nuxtjs', 'gatsby', 'sanity-v3']
+
+  test('known frameworks exist in the frameworks list', () => {
+    const slugs = (frameworks as readonly Framework[]).map((f) => f.slug)
+    for (const slug of knownFrameworks) {
+      expect(slugs, `Expected framework "${slug}" to exist in @vercel/frameworks`).toContain(slug)
+    }
+  })
+
+  test('all frameworks with detectors have valid detector shape', () => {
+    for (const fw of frameworks as readonly Framework[]) {
+      if (!fw.detectors) continue
+
+      if (fw.detectors.every) {
+        expect(
+          Array.isArray(fw.detectors.every),
+          `${fw.slug}: detectors.every should be an array`,
+        ).toBe(true)
+        for (const d of fw.detectors.every) {
+          expect(
+            typeof d.path === 'string' || typeof d.matchPackage === 'string',
+            `${fw.slug}: every detector must have "path" or "matchPackage"`,
+          ).toBe(true)
+        }
+      }
+
+      if (fw.detectors.some) {
+        expect(
+          Array.isArray(fw.detectors.some),
+          `${fw.slug}: detectors.some should be an array`,
+        ).toBe(true)
+        for (const d of fw.detectors.some) {
+          expect(
+            typeof d.path === 'string' || typeof d.matchPackage === 'string',
+            `${fw.slug}: some detector must have "path" or "matchPackage"`,
+          ).toBe(true)
+        }
+      }
+    }
+  })
+
+  test('Next.js detector uses matchPackage for "next"', () => {
+    const nextjs = (frameworks as readonly Framework[]).find((f) => f.slug === 'nextjs')
+    expect(nextjs).toBeDefined()
+    expect(nextjs?.detectors?.every).toBeDefined()
+    const hasNextDetector = nextjs?.detectors?.every?.some((d) => d.matchPackage === 'next')
+    expect(hasNextDetector, 'Next.js should detect via matchPackage "next"').toBe(true)
+  })
+})

--- a/packages/@sanity/cli/src/util/detectFramework.ts
+++ b/packages/@sanity/cli/src/util/detectFramework.ts
@@ -1,0 +1,176 @@
+import {readFile, stat} from 'node:fs/promises'
+import {join} from 'node:path'
+
+import {type Framework} from '@vercel/frameworks'
+
+type VersionedFramework = Framework & {detectedVersion?: string}
+
+interface DetectorMatch {
+  framework: Framework
+
+  detectedVersion?: string
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    const s = await stat(filePath)
+    return s.isFile()
+  } catch {
+    return false
+  }
+}
+
+async function checkDetector(
+  rootPath: string,
+  framework: Framework,
+  detector: {matchContent?: string; matchPackage?: string; path?: string},
+): Promise<DetectorMatch | undefined> {
+  let {matchContent, path: filePath} = detector
+  const {matchPackage} = detector
+
+  if (matchPackage && matchContent) {
+    throw new Error(
+      `Cannot specify "matchPackage" and "matchContent" in the same detector for "${framework.slug}"`,
+    )
+  }
+  if (matchPackage && filePath) {
+    throw new Error(
+      `Cannot specify "matchPackage" and "path" in the same detector for "${framework.slug}"`,
+    )
+  }
+  if (!filePath && !matchPackage) {
+    throw new Error(
+      `Must specify either "path" or "matchPackage" in detector for "${framework.slug}".`,
+    )
+  }
+
+  if (!filePath) {
+    filePath = 'package.json'
+  }
+
+  if (matchPackage) {
+    const escapedPkg = matchPackage.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+    matchContent = String.raw`"(dev)?(d|D)ependencies":\s*{[^}]*"${escapedPkg}":\s*"(.+?)"[^}]*}`
+  }
+
+  const fullPath = join(rootPath, filePath)
+
+  if (!(await fileExists(fullPath))) {
+    return undefined
+  }
+
+  if (matchContent) {
+    if (!(await isFile(fullPath))) {
+      return undefined
+    }
+    const content = await readFile(fullPath, 'utf8')
+    const match = content.match(new RegExp(matchContent, 'm'))
+    if (!match) {
+      return undefined
+    }
+    if (matchPackage && match[3]) {
+      return {detectedVersion: match[3], framework}
+    }
+  }
+
+  return {framework}
+}
+
+async function matchFramework(
+  rootPath: string,
+  framework: Framework,
+): Promise<DetectorMatch | undefined> {
+  const {detectors} = framework
+  if (!detectors) return undefined
+
+  const {every, some} = detectors
+  if (every !== undefined && !Array.isArray(every)) return undefined
+  if (some !== undefined && !Array.isArray(some)) return undefined
+
+  const results: (DetectorMatch | undefined)[] = []
+
+  if (every) {
+    const everyResults = await Promise.all(
+      every.map((item) => checkDetector(rootPath, framework, item)),
+    )
+    results.push(...everyResults)
+  }
+
+  if (some) {
+    let someResult: DetectorMatch | undefined
+    for (const item of some) {
+      const result = await checkDetector(rootPath, framework, item)
+      if (result) {
+        someResult = result
+        break
+      }
+    }
+    results.push(someResult)
+  }
+
+  if (results.length === 0) return undefined
+
+  if (!results.every((r) => r !== undefined)) {
+    return undefined
+  }
+
+  const detectedVersion = results.find(
+    (r): r is DetectorMatch => r !== undefined && r.detectedVersion !== undefined,
+  )?.detectedVersion
+
+  return {detectedVersion, framework}
+}
+
+function removeSupersededFrameworks(matches: (Framework | null)[]): void {
+  // Snapshot to avoid mutation-during-iteration when splice shifts elements
+  const snapshot = [...matches]
+  for (const match of snapshot) {
+    if (match?.supersedes) {
+      for (const slug of match.supersedes) {
+        removeSupersededFramework(matches, slug)
+      }
+    }
+  }
+}
+
+function removeSupersededFramework(matches: (Framework | null)[], slug: string): void {
+  const index = matches.findIndex((f) => f?.slug === slug)
+  const framework = matches[index]
+  if (framework) {
+    matches.splice(index, 1)
+    if (framework.supersedes) {
+      for (const s of framework.supersedes) {
+        removeSupersededFramework(matches, s)
+      }
+    }
+  }
+}
+
+export async function detectFrameworkRecord(options: {
+  frameworkList: readonly Framework[]
+  rootPath: string
+}): Promise<VersionedFramework | null> {
+  const {frameworkList, rootPath} = options
+
+  const results = await Promise.all(
+    frameworkList.map(async (fw): Promise<VersionedFramework | null> => {
+      const match = await matchFramework(rootPath, fw)
+      if (match) {
+        return {...fw, detectedVersion: match.detectedVersion}
+      }
+      return null
+    }),
+  )
+
+  removeSupersededFrameworks(results)
+  return results.find((r) => r !== null) ?? null
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,9 +475,6 @@ importers:
       '@vercel/frameworks':
         specifier: 3.8.4
         version: 3.8.4
-      '@vercel/fs-detectors':
-        specifier: 5.5.2
-        version: 5.5.2
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 5.1.4(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -4668,12 +4665,6 @@ packages:
   '@vercel/frameworks@3.8.4':
     resolution: {integrity: sha512-mJHrZM0hZftUYPvRkwb78WKG92atIx2dQ+xXWbzW13tdf1tdwqpD8Ynf7wX0a/zxjSjbC1YrHF6FmPLTF+aLDQ==}
 
-  '@vercel/fs-detectors@5.5.2':
-    resolution: {integrity: sha512-u/ADdlJo3HGWli7yaeHCBJ6e9XGGNSlAyZfNUDnCiUlYJjWMcp7pL38xhu9Kfgn7rM5dqsOjGCkUlspmSBWjRA==}
-
-  '@vercel/routing-utils@5.1.1':
-    resolution: {integrity: sha512-EyOik06V2fPXAbKY087BM7DMOQOJK+9mubwwox1TkDi21tMeJcMYwsXwepm6ZmyZ5u0j1TpJW172fP4MbzaCcg==}
-
   '@vitejs/plugin-react@5.1.4':
     resolution: {integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6229,9 +6220,6 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6364,11 +6352,6 @@ packages:
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
-
-  glob@8.0.3:
-    resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==}
-    engines: {node: '>=12'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -6606,10 +6589,6 @@ packages:
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -6951,10 +6930,6 @@ packages:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -7037,11 +7012,6 @@ packages:
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
-    hasBin: true
-
-  json5@2.2.2:
-    resolution: {integrity: sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==}
-    engines: {node: '>=6'}
     hasBin: true
 
   json5@2.2.3:
@@ -7789,9 +7759,6 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
-
-  path-to-regexp@6.1.0:
-    resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -14893,24 +14860,6 @@ snapshots:
       '@vercel/error-utils': 2.0.3
       js-yaml: 3.13.1
 
-  '@vercel/fs-detectors@5.5.2':
-    dependencies:
-      '@vercel/error-utils': 2.0.3
-      '@vercel/frameworks': 3.8.4
-      '@vercel/routing-utils': 5.1.1
-      glob: 8.0.3
-      js-yaml: 4.1.0
-      json5: 2.2.2
-      minimatch: 3.1.2
-      semver: 6.3.1
-
-  '@vercel/routing-utils@5.1.1':
-    dependencies:
-      path-to-regexp: 6.1.0
-      path-to-regexp-updated: path-to-regexp@6.3.0
-    optionalDependencies:
-      ajv: 6.12.6
-
   '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
@@ -16741,8 +16690,6 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
-  fs.realpath@1.0.0: {}
-
   fsevents@2.3.3:
     optional: true
 
@@ -16903,14 +16850,6 @@ snapshots:
       minimatch: 10.2.4
       minipass: 7.1.3
       path-scurry: 2.0.2
-
-  glob@8.0.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.6
-      once: 1.4.0
 
   global-directory@4.0.1:
     dependencies:
@@ -17149,11 +17088,6 @@ snapshots:
   indent-string@5.0.0: {}
 
   index-to-position@1.2.0: {}
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -17471,10 +17405,6 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -17603,8 +17533,6 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
-
-  json5@2.2.2: {}
 
   json5@2.2.3: {}
 
@@ -18367,8 +18295,6 @@ snapshots:
     dependencies:
       lru-cache: 11.2.6
       minipass: 7.1.3
-
-  path-to-regexp@6.1.0: {}
 
   path-to-regexp@6.3.0: {}
 


### PR DESCRIPTION
## Summary

- Replaces `@vercel/fs-detectors` with a ~170-line inline utility (`src/util/detectFramework.ts`)
- Eliminates deprecated `glob@8` and `inflight` transitive dependency warnings at install time
- Simplifies the API: takes a `rootPath` string instead of a `LocalFileSystemDetector` object
- Keeps `@vercel/frameworks` pinned at `3.8.4` for framework definitions
- Adds integration guard tests that validate the `@vercel/frameworks` data shape to catch upstream breakage

## Background

`@vercel/fs-detectors` depends on `glob@8` and `inflight`, both of which are deprecated and produce warnings during `npm install` / `pnpm install`. We only use two exports from the package: `detectFrameworkRecord` and `LocalFileSystemDetector`. The detection logic is straightforward (~170 lines), while the rest of the package (workspace detection, monorepo detection, builder detection) is unused and is what pulls in the deprecated transitive deps.

An upstream PR to fix this (https://github.com/vercel/vercel/pull/15294) has been open without activity.

## Test plan

- [x] New unit tests for `detectFrameworkRecord` (11 tests covering: Next.js detection, devDependencies, no match, empty directory, file path detectors, supersedes logic, matchContent regex)
- [x] Integration guard tests validating `@vercel/frameworks` data shape compatibility
- [x] All 7 existing init command test files updated and passing
- [x] Full test suite passes (1713 tests)
- [x] Type check, lint, build, depcheck all clean
- [x] `glob@8` and `inflight` no longer in dependency tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)