### PR TITLE
chore: sync minimum release age between pnpm and renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["local>sanity-io/renovate-config"],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
   "schedule": ["before 5am"],
+  "minimumReleaseAge": "3 days",
   "prConcurrentLimit": 3,
   "automerge": true,
   "dependencyDashboardApproval": false,
@@ -90,6 +91,17 @@
       "matchDepTypes": ["dependencies", "peerDependencies"],
       "rangeStrategy": "bump",
       "semanticCommitType": "fix"
+    },
+    {
+      "description": "Disable minimumReleaseAge for trusted packages (keep in sync with pnpm-workspace.yaml minimumReleaseAgeExclude)",
+      "matchPackageNames": [
+        "@portabletext/*",
+        "@sanity/*",
+        "groq-js",
+        "groq",
+        "sanity"
+      ],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,14 +63,11 @@ catalog:
   '@types/debug': ^4.1.12
   '@types/jsdom': ^28.0.0
 
+# Keep minimumReleaseAge and minimumReleaseAgeExclude in sync with .github/renovate.json
 minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - '@portabletext/*'
   - '@sanity/*'
-  - '@rexxars/jiti'
   - 'groq-js'
   - 'groq'
-  - 'react-rx'
   - 'sanity'
-  - 'use-effect-event'
-  - 'get-latest-version@6.0.1'


### PR DESCRIPTION
### Description

Annoying to get dependency updates that fail in CI because its younger than our minimum age pnpm policy. The renovate docs says to duplicate the config unfortunately 🤷‍♂️ 

Also took the chance to remove some dependencies that we no longer need to have exceptions for (either unused or should now follow same policies as other deps)
