### PR TITLE
chore: add `@types/*` to pnpm minimum release age exceptions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,6 +67,7 @@ minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - '@portabletext/*'
   - '@sanity/*'
+  - '@types/*'
   - '@rexxars/jiti'
   - 'groq-js'
   - 'groq'


### PR DESCRIPTION
## Summary

Adds `@types/*` to the `minimumReleaseAgeExclude` list in `pnpm-workspace.yaml`.

Matches https://github.com/sanity-io/renovate-config/blob/8d7d0774b4653e52472fdcaafd1a8a6069e6edc6/min-age-3days.json#L14

## Change

`@types` packages (like `@types/node`, `@types/debug`, `@types/jsdom`) are DefinitelyTyped packages that simply provide type definitions. They don't contain runtime code, so the 3-day minimum release age gate is unnecessary for them and just slows down type definition updates.

```diff
 minimumReleaseAgeExclude:
   - '@portabletext/*'
   - '@sanity/*'
+  - '@types/*'
   - '@rexxars/jiti'
```