### PR TITLE
ci: skip test workflow on docs-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,7 @@
 name: Test
 
 on:
-  # Build on pushes to branches that have a PR (including drafts)
   pull_request:
-  # Build on pushes to the main branch
   push:
     branches:
       - main
@@ -13,7 +11,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ github.event_name == 'push' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!LICENSE'
+              - '!.editorconfig'
+              - '!.prettierrc'
+              - '!.prettierignore'
+              - '!.claude/**'
+              - '!.cursor/**'
+              - '!.gitignore'
+              - '!.husky/**'
+              - '!.changeset/**'
+              - '!.github/workflows/**'
+              - '!knip.config.ts'
+              - '!commitlint.config.ts'
+              - '!release-please-config.json'
+              - '!.release-please-manifest.json'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ${{ matrix.os }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -70,8 +102,8 @@ jobs:
           retention-days: 1
 
   report-coverage:
-    if: ${{ !cancelled() }}
-    needs: test
+    needs: [changes, test]
+    if: ${{ !cancelled() && needs.changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -129,3 +161,20 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: node packages/@repo/coverage-delta/src/coverage-delta.ts
+
+  test-status:
+    if: always()
+    needs: [changes, test, report-coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check status
+        run: |
+          # Fail if any needed job failed or was cancelled
+          results=("${{ needs.changes.result }}" "${{ needs.test.result }}" "${{ needs.report-coverage.result }}")
+          for result in "${results[@]}"; do
+            if [ "$result" == "failure" ] || [ "$result" == "cancelled" ]; then
+              echo "Job failed or was cancelled: $result"
+              exit 1
+            fi
+          done
+          echo "All jobs passed or were skipped"


### PR DESCRIPTION
## Summary

Adds path-based filtering to the **Test** workflow so it skips the expensive 24-job matrix when only non-code files change (docs, config, AI editor settings, workflows).

## Approach

Instead of `paths-ignore` (which causes the workflow to be "skipped" and blocks required status checks), the test workflow now uses a 3-tier pattern:

1. **`changes` job** — Always runs (cheap). Uses [`dorny/paths-filter`](https://github.com/dorny/paths-filter) (pinned to SHA) with `predicate-quantifier: 'every'` and negated patterns to detect if code-affecting files changed.
2. **`test` + `report-coverage`** — Conditional on `needs.changes.outputs.should_run == 'true'`. Skipped for docs-only changes.
3. **`test-status` gate job** — Always runs. Passes when jobs succeed or are skipped, fails when jobs actually fail. **This is what branch protection should point to.**

### Required status check (after merging)

Update branch protection: `test` → **`test-status`**

## Why negated patterns?

Uses a **blocklist** approach instead of a whitelist — everything triggers tests *except* known non-code files. This is safer because new code directories are automatically covered without updating the filter.

### Files excluded from triggering tests:

| Pattern | Reason |
|---------|--------|
| `**/*.md` | Documentation |
| `LICENSE` | Legal text |
| `.editorconfig` | Editor settings |
| `.prettierrc`, `.prettierignore` | Formatter config |
| `.claude/**`, `.cursor/**` | AI editor settings |
| `.gitignore` | Git ignore rules |
| `.husky/**` | Git hooks |
| `.changeset/**` | Changeset files |
| `.github/workflows/**` | CI workflows (don't affect test results) |
| `knip.config.ts` | Depcheck config (doesn't affect tests) |
| `commitlint.config.ts` | Commit lint config (doesn't affect tests) |
| `release-please-config.json` | Release config |
| `.release-please-manifest.json` | Release manifest |

Everything else (packages, fixtures, patches, lockfile, tsconfig, turbo config, vitest config, etc.) triggers the full test matrix.

## Why only test.yml?

The test workflow runs **24 parallel jobs** (3 Node versions × 4 shards × 2 OS including Windows 8-core) — it's by far the most expensive. Build, lint, and depcheck are quick and cheap, so they're left as-is.

## Design Decisions

- **Negated patterns with `predicate-quantifier: 'every'`** — Cleaner than maintaining a whitelist of code paths
- **Push to main always runs** — `github.event_name == 'push'` ensures full CI on main regardless of paths
- **Gate job checks for `failure` AND `cancelled`** — Ensures the gate fails if the workflow was cancelled mid-run
- **Action pinned to SHA** — `dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36` (v3)