### PR TITLE
chore: publish non-CLI packages with latest tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,22 +55,25 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
-      - name: Publish packages
+      - name: Publish @sanity/cli (alpha)
         if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
-        # TODO: Remove the tag once we have a proper release
-        run: pnpm publish -r --filter="@sanity/cli" --filter="@sanity/cli*" --filter="@sanity/eslint-config-cli" --tag alpha
+        run: pnpm publish -r --filter="@sanity/cli" --tag alpha
+
+      - name: Publish packages (latest)
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
+        run: pnpm publish -r --filter="@sanity/cli-core" --filter="@sanity/cli-test" --filter="@sanity/eslint-config-cli"
 
       - name: Summary
         if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
         run: |
           echo "## Published Packages 🚀" >> $GITHUB_STEP_SUMMARY
           echo "All CLI packages published:" >> $GITHUB_STEP_SUMMARY
-          echo "| Package | Version |" >> $GITHUB_STEP_SUMMARY
-          echo "|---------|---------|" >> $GITHUB_STEP_SUMMARY
-          echo "| @sanity/cli-core | ${{ steps.release.outputs['packages/@sanity/cli-core--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| @sanity/cli-test | ${{ steps.release.outputs['packages/@sanity/cli-test--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| @sanity/cli | ${{ steps.release.outputs['packages/@sanity/cli--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| @sanity/eslint-config-cli | ${{ steps.release.outputs['packages/@sanity/eslint-config-cli--version'] || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Package | Version | Tag |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|---------|-----|" >> $GITHUB_STEP_SUMMARY
+          echo "| @sanity/cli-core | ${{ steps.release.outputs['packages/@sanity/cli-core--version'] || 'N/A' }} | latest |" >> $GITHUB_STEP_SUMMARY
+          echo "| @sanity/cli-test | ${{ steps.release.outputs['packages/@sanity/cli-test--version'] || 'N/A' }} | latest |" >> $GITHUB_STEP_SUMMARY
+          echo "| @sanity/cli | ${{ steps.release.outputs['packages/@sanity/cli--version'] || 'N/A' }} | alpha |" >> $GITHUB_STEP_SUMMARY
+          echo "| @sanity/eslint-config-cli | ${{ steps.release.outputs['packages/@sanity/eslint-config-cli--version'] || 'N/A' }} | latest |" >> $GITHUB_STEP_SUMMARY
 
   post-release-steps:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Split the npm publish step in the release-please workflow so that non-CLI packages publish with the `latest` tag instead of `alpha`.

### Before

All packages published with `--tag alpha`:
```
pnpm publish -r --filter="@sanity/cli" --filter="@sanity/cli*" --filter="@sanity/eslint-config-cli" --tag alpha
```

### After

| Package | Tag |
|---------|-----|
| `@sanity/cli` | `alpha` (prerelease) |
| `@sanity/cli-core` | `latest` |
| `@sanity/cli-test` | `latest` |
| `@sanity/eslint-config-cli` | `latest` |

The publish step is split into two:
1. **Publish @sanity/cli (alpha)** — continues using `--tag alpha`
2. **Publish packages (latest)** — publishes cli-core, cli-test, and eslint-config-cli with the default `latest` tag

Also updates the summary table to show which tag each package was published with.