### PR TITLE
feat: sdk templates are ESM by default

### DIFF
--- a/packages/@sanity/cli-core/src/util/readPackageJson.ts
+++ b/packages/@sanity/cli-core/src/util/readPackageJson.ts
@@ -37,6 +37,7 @@ const packageJsonSchema = z.looseObject({
     })
     .optional(),
   scripts: z.record(z.string(), z.string()).optional(),
+  type: z.enum(['module', 'commonjs']).optional(),
 })
 
 /**

--- a/packages/@sanity/cli/src/actions/init/__tests__/createPackageManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/createPackageManifest.test.ts
@@ -1,0 +1,199 @@
+import {describe, expect, test} from 'vitest'
+
+import {createPackageManifest} from '../createPackageManifest.js'
+
+describe('createPackageManifest', () => {
+  test('includes type field when type is "module"', () => {
+    const result = createPackageManifest({
+      name: 'test-app',
+      type: 'module',
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg.type).toBe('module')
+  })
+
+  test('includes type field when type is "commonjs"', () => {
+    const result = createPackageManifest({
+      name: 'test-app',
+      type: 'commonjs',
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg.type).toBe('commonjs')
+  })
+
+  test('omits type field when not provided', () => {
+    const result = createPackageManifest({
+      name: 'test-studio',
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg).not.toHaveProperty('type')
+  })
+
+  test('omits prettier config when isAppTemplate is true', () => {
+    const result = createPackageManifest({
+      isAppTemplate: true,
+      name: 'test-app',
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg).not.toHaveProperty('prettier')
+  })
+
+  test('includes prettier config when isAppTemplate is falsy', () => {
+    const result = createPackageManifest({
+      name: 'test-studio',
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg.prettier).toEqual({
+      bracketSpacing: false,
+      printWidth: 100,
+      semi: false,
+      singleQuote: true,
+    })
+  })
+
+  test('uses default scripts when none provided', () => {
+    const result = createPackageManifest({
+      name: 'test-studio',
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg.scripts).toEqual({
+      build: 'sanity build',
+      deploy: 'sanity deploy',
+      'deploy-graphql': 'sanity graphql deploy',
+      dev: 'sanity dev',
+      start: 'sanity start',
+    })
+  })
+
+  test('uses custom scripts when provided', () => {
+    const customScripts = {
+      build: 'sanity build',
+      dev: 'sanity dev',
+      start: 'sanity start',
+    }
+    const result = createPackageManifest({
+      name: 'test-app',
+      scripts: customScripts,
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg.scripts).toEqual(customScripts)
+  })
+
+  test('sorts dependencies alphabetically', () => {
+    const result = createPackageManifest({
+      dependencies: {
+        '@sanity/sdk': '^1',
+        '@sanity/sdk-react': '^1',
+        react: '^19',
+        'react-dom': '^19',
+      },
+      name: 'test-app',
+    })
+    const pkg = JSON.parse(result)
+    const depKeys = Object.keys(pkg.dependencies)
+
+    expect(depKeys).toEqual(['@sanity/sdk', '@sanity/sdk-react', 'react', 'react-dom'])
+  })
+
+  test('sorts devDependencies alphabetically', () => {
+    const result = createPackageManifest({
+      devDependencies: {
+        '@types/react': '^18',
+        eslint: '^9',
+        typescript: '^5',
+      },
+      name: 'test-app',
+    })
+    const pkg = JSON.parse(result)
+    const devDepKeys = Object.keys(pkg.devDependencies)
+
+    expect(devDepKeys).toEqual(['@types/react', 'eslint', 'typescript'])
+  })
+
+  test('sets private to true when license is UNLICENSED', () => {
+    const result = createPackageManifest({
+      name: 'test-app',
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg.private).toBe(true)
+    expect(pkg.license).toBe('UNLICENSED')
+  })
+
+  test('does not set private when license is provided', () => {
+    const result = createPackageManifest({
+      license: 'MIT',
+      name: 'test-app',
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg.private).toBeUndefined()
+    expect(pkg.license).toBe('MIT')
+  })
+
+  test('includes repository when gitRemote is provided', () => {
+    const result = createPackageManifest({
+      gitRemote: 'https://github.com/test/repo.git',
+      name: 'test-app',
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg.repository).toEqual({
+      type: 'git',
+      url: 'https://github.com/test/repo.git',
+    })
+  })
+
+  test('produces valid JSON ending with newline', () => {
+    const result = createPackageManifest({
+      name: 'test-app',
+    })
+
+    expect(result.endsWith('\n')).toBe(true)
+    expect(() => JSON.parse(result)).not.toThrow()
+  })
+
+  test('app template scenario: type module, no prettier, custom scripts', () => {
+    const result = createPackageManifest({
+      dependencies: {
+        '@sanity/sdk': '^1',
+        '@sanity/sdk-react': '^1',
+        react: '^19',
+        'react-dom': '^19',
+      },
+      devDependencies: {
+        typescript: '^5',
+      },
+      isAppTemplate: true,
+      name: 'my-app',
+      scripts: {
+        build: 'sanity build',
+        dev: 'sanity dev',
+        start: 'sanity start',
+      },
+      type: 'module',
+    })
+    const pkg = JSON.parse(result)
+
+    expect(pkg.type).toBe('module')
+    expect(pkg).not.toHaveProperty('prettier')
+    expect(pkg.scripts).toEqual({
+      build: 'sanity build',
+      dev: 'sanity dev',
+      start: 'sanity start',
+    })
+    expect(Object.keys(pkg.dependencies)).toEqual([
+      '@sanity/sdk',
+      '@sanity/sdk-react',
+      'react',
+      'react-dom',
+    ])
+  })
+})

--- a/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
@@ -113,6 +113,7 @@ export async function bootstrapLocalTemplate(
     isAppTemplate,
     name: packageJsonName,
     scripts: template.scripts,
+    type: template.type,
   })
 
   // ...and a studio config (`sanity.config.[ts|js]`)

--- a/packages/@sanity/cli/src/actions/init/createPackageManifest.ts
+++ b/packages/@sanity/cli/src/actions/init/createPackageManifest.ts
@@ -4,6 +4,7 @@ const manifestPropOrder = [
   'name',
   'private',
   'version',
+  'type',
   'description',
   'main',
   'author',
@@ -48,11 +49,18 @@ export function createPackageManifest(data: CreatePackageManifestOptions): strin
         },
       }
 
+  const type = data.type
+    ? {
+        type: data.type,
+      }
+    : {}
+
   const pkg: PackageJson = {
     ...getCommonManifest(data),
 
     keywords: ['sanity'],
     main: 'package.json',
+    ...type,
     scripts: data.scripts || {
       build: 'sanity build',
       deploy: 'sanity deploy',

--- a/packages/@sanity/cli/src/actions/init/templates/appQuickstart.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/appQuickstart.ts
@@ -25,6 +25,7 @@ const appTemplate: ProjectTemplate = {
     dev: 'sanity dev',
     start: 'sanity start',
   },
+  type: 'module',
 }
 
 export default appTemplate

--- a/packages/@sanity/cli/src/actions/init/templates/appSanityUi.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/appSanityUi.ts
@@ -27,6 +27,7 @@ const appSanityUiTemplate: ProjectTemplate = {
     dev: 'sanity dev',
     start: 'sanity start',
   },
+  type: 'module',
 }
 
 export default appSanityUiTemplate

--- a/packages/@sanity/cli/src/actions/init/types.ts
+++ b/packages/@sanity/cli/src/actions/init/types.ts
@@ -14,5 +14,6 @@ export interface ProjectTemplate {
   entry?: string
   importPrompt?: string
   scripts?: Record<string, string>
+  type?: 'commonjs' | 'module'
   typescriptOnly?: boolean
 }

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -234,6 +234,90 @@ describe('#init: bootstrap-app-initialization', () => {
     expect(error?.oclif?.exit).toBe(0)
   })
 
+  test('initializes app-quickstart template with app-specific output', async () => {
+    // Reset select mock to clear any unconsumed mockResolvedValueOnce from prior tests
+    mocks.select.mockReset()
+
+    // Mock organizations endpoint with app-specific query params
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      method: 'get',
+      query: {includeImplicitMemberships: 'true', includeMembers: 'true'},
+      uri: '/organizations',
+    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
+
+    // Mock organization grants check for attach permission
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      method: 'get',
+      uri: '/organizations/org-1/grants',
+    }).reply(200, {
+      'sanity.organization.projects': [{grants: [{name: 'attach'}]}],
+    })
+
+    // select is called once for organization selection (template comes from --template flag)
+    mocks.select.mockResolvedValueOnce('org-1') // organization
+
+    mockApi({
+      apiVersion: MCP_JOURNEY_API_VERSION,
+      method: 'get',
+      uri: '/journey/mcp/post-init-prompt',
+    }).reply(200, {
+      message: 'Setup your Cursor IDE',
+    })
+
+    const {stdout} = await testCommand(
+      InitCommand,
+      [
+        '--template=app-quickstart',
+        '--output-path=/test/output',
+        '--package-manager=npm',
+        '--typescript',
+      ],
+      {
+        mocks: {
+          ...defaultMocks,
+          isInteractive: true,
+        },
+      },
+    )
+
+    expect(mocks.bootstrapTemplate).toHaveBeenCalledWith({
+      autoUpdates: true,
+      bearerToken: undefined,
+      dataset: '',
+      organizationId: 'org-1',
+      output: expect.any(Object),
+      outputPath: convertToSystemPath('/test/output'),
+      overwriteFiles: undefined,
+      packageName: '',
+      projectId: '',
+      projectName: 'test-project',
+      remoteTemplateInfo: undefined,
+      templateName: 'app-quickstart',
+      useTypeScript: true,
+    })
+
+    // App-specific success message (not Studio message)
+    expect(stdout).toContain('Your custom app has been scaffolded')
+    expect(stdout).not.toContain('Your Studio has been created')
+
+    // App-specific guidance
+    expect(stdout).toContain('src/App.tsx')
+    expect(stdout).toContain('https://www.sanity.io/docs/app-sdk/sdk-configuration')
+
+    // App-specific commands (not Studio commands)
+    expect(stdout).toContain('npx sanity dev')
+    expect(stdout).toContain('npx sanity deploy')
+    expect(stdout).toContain('npx sanity docs browse')
+    expect(stdout).not.toContain('npx sanity manage')
+    expect(stdout).not.toContain('npx sanity help')
+
+    // MCP setup message
+    expect(stdout).toContain('Setup your Cursor IDE')
+    expect(stdout).toContain('Learn more: https://mcp.sanity.io')
+  })
+
   test('initializes app in unattended mode', async () => {
     // Mock to resolve correctly up to initializing nextjs app
     mockApi({


### PR DESCRIPTION
### TL;DR

Added support for the `type` field in package.json generation for Sanity CLI project initialization, with app templates defaulting to ES modules.

### What changed?

- Extended the package.json schema to include the optional `type` field with values "module" or "commonjs"
- Modified `createPackageManifest` to accept and include the `type` field in generated package.json files
- Updated app templates (app-quickstart and app-sanityUi) to use `type: 'module'` by default
- Added comprehensive test coverage for the `createPackageManifest` function including type field handling
- Enhanced the bootstrap process to pass through the template's type configuration

### How to test?

Run the existing test suite, particularly the new `createPackageManifest.test.ts` tests. Initialize new projects using app templates and verify the generated package.json contains `"type": "module"`. Test both app and studio templates to ensure proper type field inclusion/omission.

### Why make this change?

This enables proper ES module configuration for Sanity app projects, ensuring the generated package.json correctly specifies the module type. App templates benefit from ES module support while maintaining backward compatibility for projects that don't specify a type.