### PR TITLE
fix: only show users projects they have access to

### DIFF
--- a/packages/@sanity/cli/src/commands/projects/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/list.test.ts
@@ -15,6 +15,7 @@ describe('#list', () => {
   test('displays projects correctly', async () => {
     mockApi({
       apiVersion: PROJECTS_API_VERSION,
+      query: {onlyExplicitMembership: 'true'},
       uri: '/projects',
     }).reply(200, [
       {
@@ -39,6 +40,7 @@ describe('#list', () => {
   test('sorts by members when --sort members is specified', async () => {
     mockApi({
       apiVersion: PROJECTS_API_VERSION,
+      query: {onlyExplicitMembership: 'true'},
       uri: '/projects',
     }).reply(200, [
       {
@@ -83,6 +85,7 @@ describe('#list', () => {
   test('sorts in ascending order when --order asc is specified', async () => {
     mockApi({
       apiVersion: PROJECTS_API_VERSION,
+      query: {onlyExplicitMembership: 'true'},
       uri: '/projects',
     }).reply(200, [
       {
@@ -124,6 +127,7 @@ describe('#list', () => {
   test('displays an error if the API request fails', async () => {
     mockApi({
       apiVersion: PROJECTS_API_VERSION,
+      query: {onlyExplicitMembership: 'true'},
       uri: '/projects',
     }).reply(500, {message: 'Internal Server Error'})
 

--- a/packages/@sanity/cli/src/services/projects.ts
+++ b/packages/@sanity/cli/src/services/projects.ts
@@ -95,13 +95,17 @@ export async function inviteUser({email, projectId, role}: InviteUserOptions) {
   })
 }
 
-export async function listProjects() {
+export async function listProjects({
+  onlyExplicitMembership = true,
+}: {
+  onlyExplicitMembership?: boolean
+} = {}) {
   const client = await getGlobalCliClient({
     apiVersion: PROJECTS_API_VERSION,
     requireUser: true,
   })
 
-  return client.projects.list()
+  return client.projects.list({onlyExplicitMembership})
 }
 
 export async function getProjectInvites(projectId: string) {


### PR DESCRIPTION
This affects `init` `projects list` and `promptForProject` but maybe that is better then showing everything? 