### PR TITLE
ci: increase Linux test shards from 4 to 6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,10 +52,39 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     strategy:
       matrix:
-        node-version: [20, 22, 24]
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
-        os: [ubuntu-latest, windows-8core]
+        include:
+          # Linux: 6 shards × 3 Node versions
+          - {os: ubuntu-latest, node-version: 20, shardIndex: 1, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 20, shardIndex: 2, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 20, shardIndex: 3, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 20, shardIndex: 4, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 20, shardIndex: 5, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 20, shardIndex: 6, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 22, shardIndex: 1, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 22, shardIndex: 2, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 22, shardIndex: 3, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 22, shardIndex: 4, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 22, shardIndex: 5, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 22, shardIndex: 6, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 24, shardIndex: 1, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 24, shardIndex: 2, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 24, shardIndex: 3, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 24, shardIndex: 4, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 24, shardIndex: 5, shardTotal: 6}
+          - {os: ubuntu-latest, node-version: 24, shardIndex: 6, shardTotal: 6}
+          # Windows: 4 shards × 3 Node versions
+          - {os: windows-8core, node-version: 20, shardIndex: 1, shardTotal: 4}
+          - {os: windows-8core, node-version: 20, shardIndex: 2, shardTotal: 4}
+          - {os: windows-8core, node-version: 20, shardIndex: 3, shardTotal: 4}
+          - {os: windows-8core, node-version: 20, shardIndex: 4, shardTotal: 4}
+          - {os: windows-8core, node-version: 22, shardIndex: 1, shardTotal: 4}
+          - {os: windows-8core, node-version: 22, shardIndex: 2, shardTotal: 4}
+          - {os: windows-8core, node-version: 22, shardIndex: 3, shardTotal: 4}
+          - {os: windows-8core, node-version: 22, shardIndex: 4, shardTotal: 4}
+          - {os: windows-8core, node-version: 24, shardIndex: 1, shardTotal: 4}
+          - {os: windows-8core, node-version: 24, shardIndex: 2, shardTotal: 4}
+          - {os: windows-8core, node-version: 24, shardIndex: 3, shardTotal: 4}
+          - {os: windows-8core, node-version: 24, shardIndex: 4, shardTotal: 4}
       fail-fast: false
 
     steps:


### PR DESCRIPTION
## Summary

Increases the test shard count for Linux from 4 to 6 while keeping Windows at 4 shards.

## Performance Results

Compared against the [main branch run](https://github.com/sanity-io/cli/actions/runs/22911095396) from the same time window:

| Metric | Before (4 shards) | After (6 shards) | Improvement |
|--------|-------------------|-------------------|-------------|
| **Linux slowest shard** | 13.3m | 8.5m | **-4.8m (36% faster)** |
| **Linux avg shard** | 8.9m | 6.5m | **-2.4m (27% faster)** |
| **Overall wall-clock** | 13.3m | 8.5m | **-4.8m (36% faster)** |
| Windows slowest shard | 8.1m | 8.3m | ~same |

The bottleneck was Linux — with 4 shards, the slowest Linux shard (node20 shard4) took 13.3m while Windows finished in ~8m. By splitting Linux into 6 shards, the slowest Linux shard drops to 8.5m, bringing it in line with Windows and reducing overall CI wall-clock time by ~5 minutes.

## Changes

Replaces the cross-product matrix (`node-version × shardIndex × os`) with explicit `include` entries to support different shard counts per OS:

| OS | Shards | Node versions | Jobs |
|----|--------|---------------|------|
| `ubuntu-latest` | **6** | 20, 22, 24 | 18 |
| `windows-8core` | 4 | 20, 22, 24 | 12 |
| **Total** | | | **30** (was 24) |

Coverage blob reports are unaffected — they use `${{ matrix.shardIndex }}` for artifact names and a wildcard pattern for download, so the extra 2 shards are picked up automatically.