### PR TITLE
fix: upload-docs — only run for CLI releases + strip system fields from version docs

### DIFF
--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -12,6 +12,9 @@ concurrency:
 jobs:
   upload-docs:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.release.tag_name, 'cli-v')
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/packages/@repo/upload-docs/src/manifest.ts
+++ b/packages/@repo/upload-docs/src/manifest.ts
@@ -438,7 +438,8 @@ async function main() {
         )
 
         const vId = createVersionId(releaseId, existingDoc._id)
-        tx.create({...existingDoc, _id: vId})
+        const {_createdAt, _updatedAt, _rev, ...docWithoutSystemFields} = existingDoc
+        tx.create({...docWithoutSystemFields, _id: vId})
         tx.patch(vId, {
           set: {
             automationId: `cli-${group.command}-reference`,


### PR DESCRIPTION
## Summary

Two fixes for the `upload-docs` workflow and its manifest script.

### 1. Only run workflow for `@sanity/cli` releases

The `upload-docs` workflow triggers on every `release: published` event in the monorepo. Since this is a monorepo with multiple packages (`@sanity/cli`, `@sanity/cli-core`, `@sanity/cli-test`, `@sanity/eslint-config-cli`, `create-sanity`), it runs redundantly for every package release when only `@sanity/cli` docs need uploading.

**Fix:** Added an `if` condition to the job that checks the release tag:

```yaml
if: >-
  github.event_name == 'workflow_dispatch' ||
  startsWith(github.event.release.tag_name, 'cli-v')
```

- **Release events**: Only runs when the tag starts with `cli-v` (e.g., `cli-v6.0.0-alpha.21`)
- **Manual dispatch**: Still works unconditionally
- Tags from other packages (`cli-core-v*`, `cli-test-v*`, `eslint-config-cli-v*`, `create-sanity-v*`) are skipped

### 2. Strip system fields when creating version documents

In `manifest.ts`, when updating an existing document, the code was spreading the entire existing document (including `_updatedAt`, `_createdAt`, `_rev`) into the new version document:

```typescript
// Before — merges stale _updatedAt, _createdAt, _rev into the transaction
tx.create({...existingDoc, _id: vId})

// After — strips system fields first
const {_createdAt, _updatedAt, _rev, ...docWithoutSystemFields} = existingDoc
tx.create({...docWithoutSystemFields, _id: vId})
```

This was causing the old `_updatedAt` value to be written into the content release version, which is incorrect — the system should set these fields automatically.