### PR TITLE
fix(ci): update GH action `mark-issues-done-action` to sanity-labs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Mark SDK issues as done
-        uses: sanity-io/mark-issues-done-action@main
+        uses: sanity-labs/mark-issues-done-action@main
         with:
           linear_api_key: ${{secrets.LINEAR_API_KEY}}
           repository_name: ${{github.event.repository.name}}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

The action was moved to `sanity-labs`.

See https://sanity-io.slack.com/archives/C04SJNGPL4U/p1769778517582889
