### PR TITLE
chore: add Claude Code settings with auto-format hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(jq -r '.tool_input.file_path' < /dev/stdin) && case \"$file\" in *.js|*.ts|*.mjs|*.cjs|*.jsx|*.tsx) pnpm exec eslint --fix \"$file\" || true; pnpm exec oxfmt --write \"$file\" 2>/dev/null || true;; *.md|*.json|*.yaml|*.yml) pnpm exec oxfmt --write \"$file\" 2>/dev/null || true;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage/
 .vitest-reports/
 
 # Claude
-.claude/
+.claude/*
+!.claude/settings.json
 .worktrees/
 /docs/plans


### PR DESCRIPTION
## Summary
- Add shared `.claude/settings.json` with PostToolUse hooks that auto-run ESLint and oxfmt on edited files
- Update `.gitignore` to track `.claude/settings.json` while ignoring other `.claude/` files

## Test plan
- [x] Verify `.claude/settings.json` is properly tracked by git
- [x] Confirm ESLint/oxfmt hooks trigger on file edits in Claude Code