### PR TITLE
fix: vite version showing `null` in dev/preview output

### DIFF
--- a/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
@@ -147,7 +147,7 @@ export async function startStudioDevServer(
       const url = `http://${httpHost || 'localhost'}:${port}${config.basePath}`
       const appType = 'Sanity Studio'
 
-      const viteVersion = await getLocalPackageVersion('vite', import.meta.url)
+      const viteVersion = await getLocalPackageVersion('vite', workDir)
       spin.succeed()
 
       loggerInfo(

--- a/packages/@sanity/cli/src/server/previewServer.ts
+++ b/packages/@sanity/cli/src/server/previewServer.ts
@@ -100,7 +100,7 @@ export async function startPreviewServer(options: PreviewServerOptions): Promise
 
   const startupDuration = Date.now() - startTime
 
-  const viteVersion = await getLocalPackageVersion('vite', import.meta.url)
+  const viteVersion = await getLocalPackageVersion('vite', workDir)
 
   info(
     `Sanity ${isApp ? 'application' : 'Studio'} ` +

--- a/packages/@sanity/cli/src/util/__tests__/getLocalPackageVersion.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/getLocalPackageVersion.test.ts
@@ -135,6 +135,30 @@ describe('getLocalPackageVersion', () => {
     expect(result).toBeNull()
   })
 
+  test('handles file:// URL as workDir by converting to path', async () => {
+    const fileUrl = 'file:///mock/work/dir/some-file.ts'
+    const convertedPath = '/mock/work/dir/some-file.ts'
+    const mockPackageUrl = pathToFileURL(
+      resolve(convertedPath, 'node_modules', mockModuleId, 'package.json'),
+    )
+    const mockVersion = '3.0.0'
+
+    mockedModuleResolve.mockReturnValueOnce(mockPackageUrl)
+    mockReadPackageJson.mockResolvedValueOnce({
+      name: mockModuleId,
+      version: mockVersion,
+    } as PackageJson)
+
+    const result = await getLocalPackageVersion(mockModuleId, fileUrl)
+
+    // The URL is converted to a path and noop.js is appended (moduleResolve walks up to find node_modules)
+    expect(mockedModuleResolve).toHaveBeenCalledWith(
+      `${mockModuleId}/package.json`,
+      pathToFileURL(resolve(convertedPath, 'noop.js')),
+    )
+    expect(result).toBe(mockVersion)
+  })
+
   test('returns null when moduleResolve throws a non-fallback error', async () => {
     mockedModuleResolve.mockImplementationOnce(() => {
       throw createNodeError('ERR_MODULE_NOT_FOUND', 'Module not found')

--- a/packages/@sanity/cli/src/util/getLocalPackageVersion.ts
+++ b/packages/@sanity/cli/src/util/getLocalPackageVersion.ts
@@ -17,7 +17,9 @@ export async function getLocalPackageVersion(
   workDir: string,
 ): Promise<string | null> {
   try {
-    const dirUrl = pathToFileURL(resolve(workDir, 'noop.js'))
+    // Convert file:// URLs to paths — workDir may be import.meta.url by mistake
+    const dir = workDir.startsWith('file://') ? fileURLToPath(workDir) : workDir
+    const dirUrl = pathToFileURL(resolve(dir, 'noop.js'))
 
     let packageJsonUrl: URL
     try {


### PR DESCRIPTION
## Summary

- `getLocalPackageVersion('vite', import.meta.url)` was passing a `file://` URL where a filesystem path was expected, causing module resolution to silently fail and return `null` — resulting in `vite@null` in the startup message
- Fixed both call sites (`startStudioDevServer.ts`, `previewServer.ts`) to pass `workDir` instead
- Added a guard in `getLocalPackageVersion` to convert `file://` URLs to paths, preventing this class of bug from silently returning `null` in the future

## Test plan

- [x] Existing `getLocalPackageVersion` tests pass
- [x] New test added for `file://` URL handling
- [x] `dev.test.ts` and `preview-studio.test.ts` pass
- [x] Type check, lint, and formatter pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)