### PR TITLE
fix: deprecate `sanity start` alias

### DIFF
--- a/packages/@sanity/cli/src/commands/preview.ts
+++ b/packages/@sanity/cli/src/commands/preview.ts
@@ -9,9 +9,6 @@ import {type PreviewServer} from '../server/previewServer.js'
 export const previewDebug = subdebug('preview')
 
 export class PreviewCommand extends SanityCommand<typeof PreviewCommand> {
-  // sanity start is an alias for sanity preview
-  static override aliases: string[] = ['start']
-
   static override args = {
     outputDir: Args.directory({description: 'Output directory'}),
   }
@@ -32,6 +29,8 @@ export class PreviewCommand extends SanityCommand<typeof PreviewCommand> {
       description: '[default: 3333] TCP port to start server on.',
     }),
   }
+
+  static override hiddenAliases: string[] = ['start']
 
   public async run(): Promise<PreviewServer | void> {
     const {args, flags} = await this.parse(PreviewCommand)


### PR DESCRIPTION
## Summary

- `sanity start` is an alias for `sanity preview` — move it from `aliases` to `hiddenAliases` so it no longer shows in `sanity --help` output
- The command still works as before, just hidden from discovery

Note: oclif `deprecateAliases` only checks `aliases`, not `hiddenAliases`, so there is no built-in way to both hide an alias and warn on use. [Filing an upstream issue for that](https://github.com/oclif/core/pull/1555). Once fixed we can add a deprecation warning when `sanity start` is used.

## Test plan

- [x] Type check and lint pass
- [x] Manual: `sanity --help` no longer lists `start`
- [x] Manual: `sanity start` still works