### PR TITLE
fix(ci): build cli before docs upload

### DIFF
--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: 24
-      
+
       - name: Build CLI
         run: pnpm build:cli
 


### PR DESCRIPTION
### Description

The upload docs workflow was only picking up a subset of CLI commands because it was using the pre-built manifest.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
