### PR TITLE
fix(init): duplicate default dataset help text

### DIFF
--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -883,7 +883,6 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       const existingDatasetNames = datasets.map((ds) => ds.name)
       debug('User wants to create a new dataset, prompting for name')
       if (opts.showDefaultConfigPrompt && !existingDatasetNames.includes('production')) {
-        this.log(datasetInfo)
         defaultConfig = await promptForDefaultConfig()
       }
 


### PR DESCRIPTION
### Description

Fixed issue where `init` was still showing help text when prompting for default dataset name. This had been moved into the prompt itself (`promptForDefaultConfig.ts`) so it was displaying twice.

Also some formatting made its way in.