### PR TITLE
fix: mock getUserConfig in telemetry test and update debug namespace

### DIFF
--- a/packages/@sanity/cli-core/src/util/getCliTelemetry.ts
+++ b/packages/@sanity/cli-core/src/util/getCliTelemetry.ts
@@ -14,6 +14,7 @@ type TraceErrorReporter = (error: Error) => void
 
 interface CliTelemetryState {
   logger: CLITelemetryStore
+
   reportTraceError?: TraceErrorReporter
 }
 

--- a/packages/@sanity/cli/src/actions/telemetry/telemetryDebug.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/telemetryDebug.ts
@@ -1,3 +1,3 @@
-import {subdebug} from '@sanity/cli-core'
+import debugIt from 'debug'
 
-export const telemetryDebug = subdebug('telemetry')
+export const telemetryDebug = debugIt('telemetry:sanity:cli')

--- a/packages/@sanity/cli/src/services/__tests__/telemetry.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/telemetry.test.ts
@@ -1,6 +1,6 @@
 import {getUserConfig} from '@sanity/cli-core'
 import {mockApi} from '@sanity/cli-test'
-import {beforeEach, describe, expect, test} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {
   fetchTelemetryConsent,
@@ -8,10 +8,34 @@ import {
   TELEMETRY_CONSENT_CONFIG_KEY,
 } from '../telemetry.js'
 
+/** In-memory config store compatible with the ConfigStoreApi interface used by createExpiringConfig */
+function createInMemoryConfigStore() {
+  const store = new Map<string, unknown>()
+  return {
+    delete: (key: string) => store.delete(key),
+    get: (key: string) => store.get(key),
+    set: (key: string, value: unknown) => store.set(key, value),
+  }
+}
+
+const testConfigStore = createInMemoryConfigStore()
+
+vi.mock('@sanity/cli-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/cli-core')>()
+  return {
+    ...actual,
+    getUserConfig: vi.fn(() => testConfigStore),
+  }
+})
+
 describe('#fetchTelemetryConsent', () => {
   beforeEach(() => {
     const userConfig = getUserConfig()
     userConfig.delete(TELEMETRY_CONSENT_CONFIG_KEY)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   test('should return the telemetry consent status', async () => {

--- a/packages/@sanity/cli/src/util/telemetry/telemetryStoreDebug.ts
+++ b/packages/@sanity/cli/src/util/telemetry/telemetryStoreDebug.ts
@@ -1,7 +1,7 @@
-import {subdebug} from '@sanity/cli-core'
+import {telemetryDebug} from '../../actions/telemetry/telemetryDebug.js'
 
 /**
  * Debug logger for telemetry store operations
  * @internal
  */
-export const telemetryStoreDebug = subdebug('telemetry:telemetryStore')
+export const telemetryStoreDebug = telemetryDebug.extend('telemetryStore')


### PR DESCRIPTION
## Summary
- Mock `getUserConfig()` in the telemetry test with an in-memory config store to avoid writing to the real `~/.config/sanity/config.json` during test runs
- Update telemetry debug logging to use a dedicated `telemetry:sanity:cli` namespace via the `debug` package directly instead of `subdebug`
- Add `afterEach` with `vi.clearAllMocks()` per project conventions

## Test plan
- [x] `pnpm test packages/@sanity/cli/src/services/__tests__/telemetry.test.ts` passes
- [x] `pnpm check:types` passes
- [x] `pnpm check:lint` passes
- [ ] Verify `~/.config/sanity/config.json` is not modified when running the test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)