### PR TITLE
fix: lazy-load icon resolver to avoid pulling in @sanity/ui at import time

### DIFF
--- a/packages/@sanity/cli/src/actions/manifest/extractWorkspaceManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractWorkspaceManifest.ts
@@ -1,19 +1,27 @@
-import {resolveLocalPackage} from '@sanity/cli-core'
+import {doImport, resolveLocalPackage} from '@sanity/cli-core'
 import {type Schema} from '@sanity/types'
 import {type Workspace} from 'sanity'
 
-import {resolveIcon} from './iconResolver.js'
+import {type resolveIcon as resolveIconFn} from './iconResolver.js'
 import {type SchemaIconProps} from './SchemaIcon.js'
 import {transformType} from './schemaTypeTransformer.js'
 import {type CreateWorkspaceManifest, type ManifestSchemaType, type ManifestTool} from './types.js'
 
+const iconResolverPath = new URL('iconResolver.js', import.meta.url).href
+
+async function lazyResolveIcon(): Promise<typeof resolveIconFn> {
+  const mod = await doImport(iconResolverPath)
+  return mod.resolveIcon
+}
+
 /**
  * Extracts manifest data from an array of workspaces
  */
-export function extractWorkspaceManifest(
+export async function extractWorkspaceManifest(
   workspaces: Workspace[],
   workDir: string,
 ): Promise<CreateWorkspaceManifest[]> {
+  const resolveIcon = await lazyResolveIcon()
   return Promise.all(
     workspaces.map(async (workspace) => {
       const [icon, serializedSchema, serializedTools] = await Promise.all([
@@ -24,7 +32,7 @@ export function extractWorkspaceManifest(
           workDir,
         }),
         extractManifestSchemaTypes(workspace.schema as Schema, workDir),
-        extractManifestTools(workspace.tools, workDir),
+        extractManifestTools(workspace.tools, workDir, resolveIcon),
       ])
 
       return {
@@ -73,8 +81,9 @@ export async function extractManifestSchemaTypes(
 const extractManifestTools = async (
   tools: Workspace['tools'],
   workDir: string,
-): Promise<ManifestTool[]> =>
-  Promise.all(
+  resolveIcon: typeof resolveIconFn,
+): Promise<ManifestTool[]> => {
+  return Promise.all(
     tools.map(async (tool) => {
       const {
         __internalApplicationType: type,
@@ -94,3 +103,4 @@ const extractManifestTools = async (
       } satisfies ManifestTool
     }),
   )
+}

--- a/packages/@sanity/cli/src/actions/schema/uploadSchemaToLexicon.ts
+++ b/packages/@sanity/cli/src/actions/schema/uploadSchemaToLexicon.ts
@@ -1,13 +1,14 @@
 import {styleText} from 'node:util'
 
 import {ux} from '@oclif/core/ux'
-import {getProjectCliClient, resolveLocalPackage, subdebug} from '@sanity/cli-core'
+import {doImport, getProjectCliClient, resolveLocalPackage, subdebug} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {type StudioManifest, type Workspace} from 'sanity'
 
 import {SCHEMA_API_VERSION} from '../../services/schemas.js'
 import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
-import {resolveIcon} from '../manifest/iconResolver.js'
+
+const iconResolverPath = new URL('../manifest/iconResolver.js', import.meta.url).href
 
 interface UploadSchemaToLexiconOptions {
   projectId: string
@@ -82,12 +83,15 @@ export async function uploadSchemaToLexicon(
       }
     }
 
+    // Lazy import to avoid pulling in @sanity/ui at module load time
+    const {resolveIcon} = await doImport(iconResolverPath)
+
     // Generate studio manifest using the shared utility
     const manifest = await generateStudioManifest({
       buildId: JSON.stringify(Date.now()),
       bundleVersion,
+      // @todo replace with import from @sanity/schema/_internal in future
       resolveIcon: async (workspace) =>
-        // @todo replace with import from @sanity/schema/_internal in future
         (await resolveIcon({
           icon: workspace.icon,
           subtitle: workspace.subtitle,


### PR DESCRIPTION
## Summary

- `@sanity/cli/_internal` statically imported the icon resolver, which pulls in `@sanity/ui` and `styled-components` at module load time
- This broke `sanity exec` because tsx's ESM loader misresolves `styled-components` to its CJS entry (no named exports), causing a `SyntaxError` when `@sanity/ui` tries to import from it
- Switches icon resolver imports to lazy `doImport()` calls so the heavy UI dependencies are only loaded when actually needed (manifest extraction), not when importing `sanity/cli`

## Root cause

`sanity/cli.js` re-exports `getStudioEnvironmentVariables` from `@sanity/cli/_internal`. That module also exports `extractManifestSchemaTypes`, which statically imports `iconResolver` -> `SchemaIcon` -> `@sanity/ui` -> `styled-components`. Since ESM loads the entire module graph eagerly, simply importing `getCliClient` from `sanity/cli` pulled in the full UI dependency chain.

## Test plan

- [x] `pnpm build:cli` succeeds
- [x] `pnpm test packages/@sanity/cli/src/actions/schema/__tests__/uploadSchemaToLexicon.test.ts` passes
- [x] `pnpm check:lint` has no errors
- [x] Verified manually: `sanity exec myscript.ts` works in an ESM studio with `sanity@5.15.0` after linking the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)