### PR TITLE
refactor: replace recast with simple string replacement

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -70,7 +70,6 @@
     "watch": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ --watch src"
   },
   "dependencies": {
-    "@babel/traverse": "^7.29.0",
     "@oclif/core": "catalog:",
     "@oclif/plugin-help": "catalog:",
     "@oclif/plugin-not-found": "catalog:",
@@ -125,7 +124,6 @@
     "react-dom": "^19.2.4",
     "react-is": "^19.2.4",
     "read-package-up": "catalog:",
-    "recast": "^0.23.11",
     "rimraf": "catalog:",
     "rxjs": "catalog:",
     "semver": "^7.7.4",
@@ -150,7 +148,6 @@
     "@sanity/pkg-utils": "catalog:",
     "@swc/cli": "catalog:",
     "@swc/core": "catalog:",
-    "@types/babel__traverse": "^7.28.0",
     "@types/debug": "catalog:",
     "@types/gunzip-maybe": "^1.4.3",
     "@types/lodash-es": "catalog:",

--- a/packages/@sanity/cli/src/actions/init/__tests__/processTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/processTemplate.test.ts
@@ -1,0 +1,202 @@
+import {describe, expect, test} from 'vitest'
+
+import {processTemplate} from '../processTemplate.js'
+
+describe('processTemplate', () => {
+  test('replaces string placeholders with single quotes', () => {
+    const result = processTemplate({
+      template: `const id = '%projectId%'`,
+      variables: {projectId: 'abc123'},
+    })
+    expect(result).toBe(`const id = 'abc123'`)
+  })
+
+  test('replaces string placeholders with double quotes', () => {
+    const result = processTemplate({
+      template: `const id = "%projectId%"`,
+      variables: {projectId: 'abc123'},
+    })
+    expect(result).toBe(`const id = "abc123"`)
+  })
+
+  test('replaces multiple string placeholders', () => {
+    const result = processTemplate({
+      template: `const config = { projectId: '%projectId%', dataset: '%dataset%' }`,
+      variables: {dataset: 'production', projectId: 'abc123'},
+    })
+    expect(result).toContain(`projectId: 'abc123'`)
+    expect(result).toContain(`dataset: 'production'`)
+  })
+
+  test('replaces boolean placeholders when includeBooleanTransform is true', () => {
+    const result = processTemplate({
+      includeBooleanTransform: true,
+      template: `const config = { autoUpdates: __BOOL__autoUpdates__ }`,
+      variables: {autoUpdates: true},
+    })
+    expect(result).toContain('autoUpdates: true')
+  })
+
+  test('replaces boolean false values', () => {
+    const result = processTemplate({
+      includeBooleanTransform: true,
+      template: `const config = { autoUpdates: __BOOL__autoUpdates__ }`,
+      variables: {autoUpdates: false},
+    })
+    expect(result).toContain('autoUpdates: false')
+  })
+
+  test('handles boolean variable names containing underscores', () => {
+    const result = processTemplate({
+      includeBooleanTransform: true,
+      template: `const config = { autoUpdates: __BOOL__auto_updates__ }`,
+      variables: {auto_updates: true},
+    })
+    expect(result).toContain('autoUpdates: true')
+    expect(result).not.toContain('__BOOL__')
+  })
+
+  test('does not replace boolean placeholders when includeBooleanTransform is false', () => {
+    const result = processTemplate({
+      template: `const config = { autoUpdates: __BOOL__autoUpdates__ }`,
+      variables: {autoUpdates: true},
+    })
+    expect(result).toContain('__BOOL__autoUpdates__')
+  })
+
+  test('escapes single quotes in values within single-quoted strings', () => {
+    const result = processTemplate({
+      template: `const name = '%projectName%'`,
+      variables: {projectName: "John's Studio"},
+    })
+    expect(result).toBe(`const name = 'John\\'s Studio'`)
+  })
+
+  test('escapes double quotes in values within double-quoted strings', () => {
+    const result = processTemplate({
+      template: `const name = "%projectName%"`,
+      variables: {projectName: 'My "Cool" Project'},
+    })
+    expect(result).toBe(`const name = "My \\"Cool\\" Project"`)
+  })
+
+  test('escapes backslashes in values', () => {
+    const result = processTemplate({
+      template: `const path = '%entry%'`,
+      variables: {entry: 'src\\app\\main'},
+    })
+    expect(result).toBe(`const path = 'src\\\\app\\\\main'`)
+  })
+
+  test('replaces non-string values with empty string', () => {
+    const result = processTemplate({
+      template: `const id = '%projectId%'`,
+      variables: {projectId: 42 as unknown as string},
+    })
+    expect(result).toBe(`const id = ''`)
+  })
+
+  test('trims leading whitespace from template', () => {
+    const result = processTemplate({
+      template: `\n\n  const id = '%projectId%'`,
+      variables: {projectId: 'abc'},
+    })
+    expect(result).toMatch(/^\s*const/)
+    expect(result).not.toMatch(/^\n\n/)
+  })
+
+  test('throws on undefined string variable', () => {
+    expect(() =>
+      processTemplate({
+        template: `const id = '%missing%'`,
+        variables: {},
+      }),
+    ).toThrow("Template variable '%missing%' not defined")
+  })
+
+  test('throws on undefined boolean variable', () => {
+    expect(() =>
+      processTemplate({
+        includeBooleanTransform: true,
+        template: `const x = __BOOL__missing__`,
+        variables: {},
+      }),
+    ).toThrow("Template variable 'missing' not defined")
+  })
+
+  test('throws when boolean variable is not a boolean', () => {
+    expect(() =>
+      processTemplate({
+        includeBooleanTransform: true,
+        template: `const x = __BOOL__value__`,
+        variables: {value: 'not-a-boolean'},
+      }),
+    ).toThrow("Expected boolean value for 'value'")
+  })
+
+  test('handles a realistic CLI config template', () => {
+    const template = `
+import {defineCliConfig} from 'sanity/cli'
+
+export default defineCliConfig({
+  api: {
+    projectId: '%projectId%',
+    dataset: '%dataset%'
+  },
+  deployment: {
+    autoUpdates: __BOOL__autoUpdates__,
+  }
+})
+`
+    const result = processTemplate({
+      includeBooleanTransform: true,
+      template,
+      variables: {
+        autoUpdates: true,
+        dataset: 'production',
+        projectId: 'xyz789',
+      },
+    })
+    expect(result).toContain(`projectId: 'xyz789'`)
+    expect(result).toContain(`dataset: 'production'`)
+    expect(result).toContain('autoUpdates: true')
+    expect(result).not.toContain('%')
+    expect(result).not.toContain('__BOOL__')
+  })
+
+  test('handles a realistic studio config template', () => {
+    const template = `
+import {defineConfig} from 'sanity'
+import {structureTool} from 'sanity/structure'
+import {visionTool} from '@sanity/vision'
+import {schemaTypes} from './schemaTypes'
+
+export default defineConfig({
+  name: '%sourceName%',
+  title: '%projectName%',
+
+  projectId: '%projectId%',
+  dataset: '%dataset%',
+
+  plugins: [structureTool(), visionTool()],
+
+  schema: {
+    types: schemaTypes,
+  },
+})
+`
+    const result = processTemplate({
+      template,
+      variables: {
+        dataset: 'staging',
+        projectId: 'test123',
+        projectName: 'My Studio',
+        sourceName: 'default',
+      },
+    })
+    expect(result).toContain(`name: 'default'`)
+    expect(result).toContain(`title: 'My Studio'`)
+    expect(result).toContain(`projectId: 'test123'`)
+    expect(result).toContain(`dataset: 'staging'`)
+  })
+})

--- a/packages/@sanity/cli/src/actions/init/processTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/processTemplate.ts
@@ -1,8 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import _traverse from '@babel/traverse'
-import {parse, print} from 'recast'
-import * as parser from 'recast/parsers/typescript.js'
-
 interface TemplateOptions<T> {
   template: string
   variables: T
@@ -10,51 +5,44 @@ interface TemplateOptions<T> {
   includeBooleanTransform?: boolean
 }
 
-// @ts-expect-error - Babel's ESM exports require accessing .default
-const traverse = _traverse.default
-
+/**
+ * Process a template string by replacing placeholder variables with actual values.
+ *
+ * String variables use the format `'%variableName%'` (inside string literals).
+ * Boolean variables use the format `__BOOL__variableName__` (as bare identifiers).
+ */
 export function processTemplate<T extends object>(options: TemplateOptions<T>): string {
   const {includeBooleanTransform = false, template, variables} = options
-  const ast = parse(template.trimStart(), {parser})
 
-  traverse(ast, {
-    StringLiteral: {
-      enter({node}: {node: any}) {
-        const value = node.value
-        if (!value.startsWith('%') || !value.endsWith('%')) {
-          return
-        }
-        const variableName = value.slice(1, -1) as keyof T
-        if (!(variableName in variables)) {
-          throw new Error(`Template variable '${value}' not defined`)
-        }
-        const newValue = variables[variableName]
-        /*
-         * although there are valid non-strings in our config,
-         * they're not in StringLiteral nodes, so assume undefined
-         */
-        node.value = typeof newValue === 'string' ? newValue : ''
-      },
-    },
-    ...(includeBooleanTransform && {
-      Identifier: {
-        enter(path: any) {
-          if (!path.node.name.startsWith('__BOOL__')) {
-            return
-          }
-          const variableName = path.node.name.replace(/^__BOOL__(.+?)__$/, '$1') as keyof T
-          if (!(variableName in variables)) {
-            throw new Error(`Template variable '${variableName.toString()}' not defined`)
-          }
-          const value = variables[variableName]
-          if (typeof value !== 'boolean') {
-            throw new TypeError(`Expected boolean value for '${variableName.toString()}'`)
-          }
-          path.replaceWith({type: 'BooleanLiteral', value})
-        },
-      },
-    }),
-  })
+  // Replace string placeholders: '%variableName%' or "%variableName%"
+  let result = template
+    .trimStart()
+    .replaceAll(/(['"])%([\w]+)%\1/g, (_match, quote: string, variableName: string) => {
+      if (!(variableName in variables)) {
+        throw new Error(`Template variable '%${variableName}%' not defined`)
+      }
+      const newValue =
+        typeof variables[variableName as keyof T] === 'string'
+          ? variables[variableName as keyof T]
+          : ''
+      // Escape backslashes first, then the surrounding quote character
+      const escaped = (newValue as string).replaceAll('\\', '\\\\').replaceAll(quote, `\\${quote}`)
+      return `${quote}${escaped}${quote}`
+    })
 
-  return print(ast, {quote: 'single'}).code
+  // Replace boolean placeholders: __BOOL__variableName__
+  if (includeBooleanTransform) {
+    result = result.replaceAll(/__BOOL__(\w+)__/g, (_match, variableName: string) => {
+      if (!(variableName in variables)) {
+        throw new Error(`Template variable '${variableName}' not defined`)
+      }
+      const value = variables[variableName as keyof T]
+      if (typeof value !== 'boolean') {
+        throw new TypeError(`Expected boolean value for '${variableName}'`)
+      }
+      return String(value)
+    })
+  }
+
+  return result
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,9 +450,6 @@ importers:
 
   packages/@sanity/cli:
     dependencies:
-      '@babel/traverse':
-        specifier: ^7.29.0
-        version: 7.29.0
       '@oclif/core':
         specifier: 'catalog:'
         version: 4.8.3
@@ -615,9 +612,6 @@ importers:
       read-package-up:
         specifier: 'catalog:'
         version: 12.0.0
-      recast:
-        specifier: ^0.23.11
-        version: 0.23.11
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -685,9 +679,6 @@ importers:
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.18
-      '@types/babel__traverse':
-        specifier: ^7.28.0
-        version: 7.28.0
       '@types/debug':
         specifier: 'catalog:'
         version: 4.1.12
@@ -5011,10 +5002,6 @@ packages:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
 
-  ast-types@0.16.1:
-    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
-    engines: {node: '>=4'}
-
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
@@ -7995,10 +7982,6 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
-  recast@0.23.11:
-    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
-    engines: {node: '>= 4'}
-
   redeyed@2.1.1:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
 
@@ -8562,9 +8545,6 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
-  tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tiny-jsonc@1.0.2:
     resolution: {integrity: sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw==}
@@ -12678,56 +12658,12 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@sanity/cli-core@0.1.0-alpha.15(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)':
-    dependencies:
-      '@inquirer/prompts': 8.3.0(@types/node@25.0.10)
-      '@oclif/core': 4.8.3
-      '@rexxars/jiti': 2.6.2
-      '@sanity/client': 7.17.0(debug@4.4.3)
-      '@sanity/telemetry': 0.8.1(react@19.2.4)
-      '@sanity/types': 5.14.1(debug@4.4.3)
-      babel-plugin-react-compiler: 1.0.0
-      boxen: 8.0.1
-      configstore: 7.1.0
-      debug: 4.4.3(supports-color@8.1.1)
-      get-it: 8.7.0(debug@4.4.3)
-      get-tsconfig: 4.13.6
-      import-meta-resolve: 4.2.0
-      jsdom: 27.4.0(@noble/hashes@2.0.1)
-      json-lexer: 1.2.0
-      log-symbols: 7.0.1
-      ora: 9.3.0
-      read-package-up: 12.0.0
-      rxjs: 7.8.2
-      tinyglobby: 0.2.15
-      tsx: 4.21.0
-      typeid-js: 1.2.0
-      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@noble/hashes'
-      - '@types/node'
-      - '@types/react'
-      - bufferutil
-      - canvas
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - utf-8-validate
-      - yaml
-
   '@sanity/cli@5.14.1(@noble/hashes@2.0.1)(@types/node@25.0.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(lightningcss@1.31.1)(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)':
     dependencies:
       '@babel/parser': 7.29.0
       '@babel/traverse': 7.29.0
       '@sanity/client': 7.17.0(debug@4.4.3)
-      '@sanity/codegen': 5.10.1(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
+      '@sanity/codegen': 5.10.1(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@25.0.10)(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
       '@sanity/runtime-cli': 14.5.0(@types/node@25.0.10)(debug@4.4.3)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       '@sanity/telemetry': 0.8.1(react@19.2.4)
       '@sanity/template-validator': 3.0.0
@@ -12868,50 +12804,6 @@ snapshots:
       '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       '@sanity/cli-core': 0.1.0-alpha.15(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@25.0.10)(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
-      '@sanity/telemetry': 0.8.1(react@19.2.4)
-      '@sanity/worker-channels': 1.1.0
-      chokidar: 3.6.0
-      debug: 4.4.3(supports-color@8.1.1)
-      globby: 11.1.0
-      groq: 5.11.0
-      groq-js: 1.29.0
-      json5: 2.2.3
-      lodash-es: 4.17.23
-      prettier: 3.8.1
-      reselect: 5.1.1
-      tsconfig-paths: 4.2.0
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@noble/hashes'
-      - '@types/node'
-      - '@types/react'
-      - bufferutil
-      - canvas
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - utf-8-validate
-      - yaml
-
-  '@sanity/codegen@5.10.1(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.0
-      '@babel/preset-env': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/register': 7.28.6(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@oclif/core': 4.8.3
-      '@oclif/plugin-help': 6.2.37
-      '@sanity/cli-core': 0.1.0-alpha.15(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
       '@sanity/telemetry': 0.8.1(react@19.2.4)
       '@sanity/worker-channels': 1.1.0
       chokidar: 3.6.0
@@ -13151,7 +13043,7 @@ snapshots:
   '@sanity/insert-menu@3.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.14.1(@types/react@19.2.14)(debug@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.4)
-      '@sanity/types': 5.14.1(@types/react@19.2.14)(debug@4.4.3)
+      '@sanity/types': 5.14.1(@types/react@19.2.14)
       '@sanity/ui': 3.1.13(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       lodash-es: 4.17.23
       react: 19.2.4
@@ -13557,7 +13449,7 @@ snapshots:
       '@sanity/client': 7.17.0(debug@4.4.3)
       '@sanity/message-protocol': 0.18.2
       '@sanity/sdk': 2.6.0(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
-      '@sanity/types': 5.14.1(@types/react@19.2.14)(debug@4.4.3)
+      '@sanity/types': 5.14.1(@types/react@19.2.14)
       '@types/lodash-es': 4.17.12
       groq: 3.88.1-typegen-experimental.0
       lodash-es: 4.17.23
@@ -13606,7 +13498,7 @@ snapshots:
       '@sanity/json-match': 1.0.5
       '@sanity/message-protocol': 0.18.2
       '@sanity/mutate': 0.12.6(debug@4.4.3)
-      '@sanity/types': 5.14.1(@types/react@19.2.14)(debug@4.4.3)
+      '@sanity/types': 5.14.1(@types/react@19.2.14)
       groq: 3.88.1-typegen-experimental.0
       groq-js: 1.29.0
       lodash-es: 4.17.23
@@ -13647,7 +13539,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/types@5.14.1(@types/react@19.2.14)(debug@4.4.3)':
+  '@sanity/types@5.14.1(@types/react@19.2.14)':
     dependencies:
       '@sanity/client': 7.17.0(debug@4.4.3)
       '@sanity/media-library-types': 1.2.0
@@ -13655,10 +13547,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/types@5.14.1(debug@4.4.3)':
+  '@sanity/types@5.14.1(@types/react@19.2.14)(debug@4.4.3)':
     dependencies:
       '@sanity/client': 7.17.0(debug@4.4.3)
       '@sanity/media-library-types': 1.2.0
+      '@types/react': 19.2.14
     transitivePeerDependencies:
       - debug
 
@@ -13737,7 +13630,7 @@ snapshots:
     dependencies:
       '@sanity/client': 7.17.0(debug@4.4.3)
     optionalDependencies:
-      '@sanity/types': 5.14.1(@types/react@19.2.14)(debug@4.4.3)
+      '@sanity/types': 5.14.1(@types/react@19.2.14)
 
   '@sanity/worker-channels@1.1.0': {}
 
@@ -14964,10 +14857,6 @@ snapshots:
       '@babel/parser': 8.0.0-rc.2
       estree-walker: 3.0.3
       pathe: 2.0.3
-
-  ast-types@0.16.1:
-    dependencies:
-      tslib: 2.8.1
 
   async-mutex@0.5.0:
     dependencies:
@@ -18095,14 +17984,6 @@ snapshots:
 
   readdirp@5.0.0: {}
 
-  recast@0.23.11:
-    dependencies:
-      ast-types: 0.16.1
-      esprima: 4.0.1
-      source-map: 0.6.1
-      tiny-invariant: 1.3.3
-      tslib: 2.8.1
-
   redeyed@2.1.1:
     dependencies:
       esprima: 4.0.1
@@ -18587,7 +18468,7 @@ snapshots:
       '@sanity/schema': 5.14.1(@types/react@19.2.14)(debug@4.4.3)
       '@sanity/sdk': 2.1.2(@types/react@19.2.14)(debug@4.4.3)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
       '@sanity/telemetry': 0.8.1(react@19.2.4)
-      '@sanity/types': 5.14.1(@types/react@19.2.14)(debug@4.4.3)
+      '@sanity/types': 5.14.1(@types/react@19.2.14)
       '@sanity/ui': 3.1.13(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@sanity/util': 5.14.1(@types/react@19.2.14)(debug@4.4.3)
       '@sanity/uuid': 3.0.2
@@ -19066,8 +18947,6 @@ snapshots:
       readable-stream: 3.6.2
 
   through@2.3.8: {}
-
-  tiny-invariant@1.3.3: {}
 
   tiny-jsonc@1.0.2: {}
 


### PR DESCRIPTION
## Summary

Removes `recast`, `@babel/traverse`, and `@types/babel__traverse` from `@sanity/cli`. Replaces the AST-based template processing with simple string replacement.

## Why

`recast` has an undeclared dependency on `@babel/parser` - it does a bare `require("@babel/parser")` at runtime without listing it in its `package.json`. In our monorepo, `@babel/parser@8.0.0-rc.2` (pulled in by `rolldown-plugin-dts` via `@sanity/pkg-utils`) gets resolved instead of v7. Babel 8 removed the `"minimal"` proposal for the `pipelineOperator` parser plugin, which recast hardcodes, breaking template processing during `sanity init`:

```
Error: "pipelineOperator" requires "proposal" option whose value must be one of: "fsharp", "hack".
```

See #650 for the full writeup.

## What changed

`processTemplate` previously parsed the template into an AST with recast/babel, traversed it to find and replace placeholder nodes, then printed it back. The new implementation uses two regex replacements:

- `'%variableName%'` string placeholders - replaced with the escaped value
- `__BOOL__variableName__` boolean placeholders - replaced with `true`/`false`

This drops the entire AST pipeline (recast + @babel/parser + @babel/traverse + ast-types + esprima + source-map + tslib) in favor of ~45 lines with zero dependencies.

## Why this is safe

**Template strings are not user-controlled.** All templates are hardcoded string literals checked into the repo. Remote templates (from GitHub) use a completely separate code path - they apply variables to `.env` files, not code templates, and never go through `processTemplate`.

**The variable set is fixed and typed:**
- `projectId`, `dataset`, `organizationId` - API-derived, alphanumeric
- `sourceName`, `sourceTitle` - hardcoded defaults (`'default'`, `'Default'`)
- `autoUpdates` - boolean from CLI flags
- `projectName` - the only user-provided free-text value (prompt or API `displayName`)

**Values are escaped.** The replacement escapes backslashes and the surrounding quote character, so a project name like `John's Studio` produces valid JS (`'John\'s Studio'`). The old recast approach handled this via Babel's code generator; the new approach replicates that behavior explicitly.

**Placeholder format is restrictive.** The regex `(['"])%([\w]+)%\1` only matches `%word%` wrapped in matching quotes. Variable names are validated against the provided object - undefined variables throw.

## Test plan

- [x] 16 unit tests covering string/boolean replacement, quote escaping, error cases, and realistic template scenarios
- [x] Full test suite passes (2195 tests)
- [x] Types, lint, depcheck all clean
- [ ] Manual: \`sanity init\` produces correct config files

Closes #650