### PR TITLE
fix: bump react+react-dom to latest on new installs

### DIFF
--- a/packages/@sanity/cli/src/actions/init/sdkAppDependencies.ts
+++ b/packages/@sanity/cli/src/actions/init/sdkAppDependencies.ts
@@ -3,13 +3,13 @@ export const sdkAppDependencies = {
     // change these to 'latest' as in studioDependencies.ts once SDK v3 is released
     '@sanity/sdk': '^2',
     '@sanity/sdk-react': '^2',
-    react: '^19.2',
-    'react-dom': '^19.2',
+    react: '^19.2.4',
+    'react-dom': '^19.2.4',
   },
 
   devDependencies: {
     '@sanity/eslint-config-studio': 'latest',
-    '@types/react': '^19.1',
+    '@types/react': '^19.2.14',
     eslint: '^9.28',
     prettier: '^3.5',
     sanity: 'latest',

--- a/packages/@sanity/cli/src/actions/init/studioDependencies.ts
+++ b/packages/@sanity/cli/src/actions/init/studioDependencies.ts
@@ -8,8 +8,8 @@ export const studioDependencies = {
     '@sanity/vision': 'latest',
 
     // Non-Sanity dependencies
-    react: '^19.1',
-    'react-dom': '^19.1',
+    react: '^19.2.4',
+    'react-dom': '^19.2.4',
     'styled-components': '^6.1.18',
   },
 
@@ -17,7 +17,7 @@ export const studioDependencies = {
     // Linting/tooling
     '@sanity/eslint-config-studio': 'latest',
     // When using typescript, we'll want the these types too, so might as well install them
-    '@types/react': '^19.1',
+    '@types/react': '^19.2.14',
     eslint: '^9.28',
     prettier: '^3.5',
     typescript: '^5.8', // Peer dependency of eslint-config-studio (implicitly)


### PR DESCRIPTION
### Description

Just bumps these deps to latest versions, as we want people to be on the latest. pnpm sometimes installs the "lowest compatible" - we don't want 19.1 to be installed for studios.

### What to review

Versions look okay

### Testing

Nothing except creating a new studio/app