### PR TITLE
fix: use non-deprecated --project-id flag for dataset import during init

### DIFF
--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -607,7 +607,15 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
         this.error('Authentication required to import dataset', {exit: 1})
       }
       await ImportDatasetCommand.run(
-        [template.datasetUrl, '--project', projectId, '--dataset', datasetName, '--token', token],
+        [
+          template.datasetUrl,
+          '--project-id',
+          projectId,
+          '--dataset',
+          datasetName,
+          '--token',
+          token,
+        ],
         {
           root: outputPath,
         },


### PR DESCRIPTION
## Summary

- The `init` command was passing the deprecated `--project` flag when invoking `ImportDatasetCommand` for template dataset imports (e.g. the moviedb template). Changed to `--project-id`, which is the current flag.

## Test plan

- [ ] Run `sanity init` with the moviedb template and confirm dataset import still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)