### PR TITLE
chore: switch post-edit hook from eslint --fix to report-only

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "file=$(jq -r '.tool_input.file_path' < /dev/stdin) && case \"$file\" in *.js|*.ts|*.mjs|*.cjs|*.jsx|*.tsx) pnpm exec eslint --fix \"$file\" || true; pnpm exec oxfmt --write \"$file\" 2>/dev/null || true;; *.md|*.json|*.yaml|*.yml) pnpm exec oxfmt --write \"$file\" 2>/dev/null || true;; esac"
+            "command": "file=$(jq -r '.tool_input.file_path' < /dev/stdin) && case \"$file\" in *.js|*.ts|*.mjs|*.cjs|*.jsx|*.tsx) pnpm exec eslint --rule '{\"unused-imports/no-unused-imports\": \"off\"}' \"$file\" || true; pnpm exec oxfmt --write \"$file\" 2>/dev/null || true;; *.md|*.json|*.yaml|*.yml) pnpm exec oxfmt --write \"$file\" 2>/dev/null || true;; esac"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Changes the Claude Code PostToolUse hook to run ESLint in report-only mode (no `--fix`) instead of auto-fixing on every edit
- Disables `unused-imports/no-unused-imports` in the hook since imports are often added before their usage during multi-step edits
- Uses JSON `--rule` syntax for ESLint v9 compatibility

## Test plan

- [x] Verify post-edit hook reports lint errors without auto-fixing them
- [x] Verify unused imports are not flagged during editing
- [x] Verify formatting (oxfmt) still runs on edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)