### PR TITLE
fix: resolve vendor dependencies using node module resolution

### DIFF
--- a/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
+++ b/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
@@ -1,9 +1,9 @@
-import path, {resolve} from 'node:path'
+import path from 'node:path'
 
 import semver from 'semver'
 import {build} from 'vite'
 
-import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
+import {getLocalPackageDir, getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 import {createExternalFromImportMap} from './createExternalFromImportMap.js'
 
 // Directory where vendor packages will be stored
@@ -152,6 +152,10 @@ export async function buildVendorDependencies({
 
     const subpaths = ranges[matchedRange]
 
+    // Resolve the actual package directory using Node module resolution,
+    // so that hoisted packages in monorepos/workspaces are found correctly
+    const packageDir = getLocalPackageDir(packageName, cwd)
+
     // Iterate over each subpath and its corresponding entry point
     for (const [subpath, relativeEntryPoint] of Object.entries(subpaths)) {
       const specifier = path.posix.join(packageName, subpath)
@@ -160,7 +164,7 @@ export async function buildVendorDependencies({
         path.relative(packageName, specifier) || 'index',
       )
 
-      entry[chunkName] = resolve(`node_modules/${packageName}/${relativeEntryPoint}`)
+      entry[chunkName] = path.join(packageDir, relativeEntryPoint)
       imports[specifier] = path.posix.join('/', basePath, VENDOR_DIR, `${chunkName}.mjs`)
     }
   }

--- a/packages/@sanity/cli/src/actions/schema/getExtractOptions.ts
+++ b/packages/@sanity/cli/src/actions/schema/getExtractOptions.ts
@@ -31,11 +31,8 @@ export function getExtractOptions({
     const resolved = resolve(join(projectRoot.directory, pathFlag))
     const isExistingDirectory = existsSync(resolved) && statSync(resolved).isDirectory()
 
-    if (isExistingDirectory || !extname(resolved)) {
-      outputPath = join(resolved, 'schema.json')
-    } else {
-      outputPath = resolved
-    }
+    outputPath =
+      isExistingDirectory || !extname(resolved) ? join(resolved, 'schema.json') : resolved
   } else {
     outputPath = resolve(join(projectRoot.directory, 'schema.json'))
   }

--- a/packages/@sanity/cli/src/util/__tests__/getLocalPackageVersion.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/getLocalPackageVersion.test.ts
@@ -5,7 +5,7 @@ import {type PackageJson} from '@sanity/cli-core'
 import {moduleResolve} from 'import-meta-resolve'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {getLocalPackageVersion} from '../getLocalPackageVersion.js'
+import {getLocalPackageDir, getLocalPackageVersion} from '../getLocalPackageVersion.js'
 
 const mockReadPackageJson = vi.hoisted(() => vi.fn())
 
@@ -39,6 +39,7 @@ describe('getLocalPackageVersion', () => {
     const mockPackageUrl = pathToFileURL(
       resolve(mockWorkDir, 'node_modules', mockModuleId, 'package.json'),
     )
+    const expectedPackageDir = resolve(mockWorkDir, 'node_modules', mockModuleId)
     const mockVersion = '1.0.0'
 
     mockedModuleResolve.mockReturnValueOnce(mockPackageUrl)
@@ -53,7 +54,7 @@ describe('getLocalPackageVersion', () => {
       `${mockModuleId}/package.json`,
       pathToFileURL(resolve(mockWorkDir, 'noop.js')),
     )
-    expect(mockReadPackageJson).toHaveBeenCalledWith(mockPackageUrl)
+    expect(mockReadPackageJson).toHaveBeenCalledWith(join(expectedPackageDir, 'package.json'))
     expect(result).toBe(mockVersion)
   })
 
@@ -61,6 +62,7 @@ describe('getLocalPackageVersion', () => {
     const mockPackageUrl = pathToFileURL(
       resolve(mockWorkDir, 'node_modules', mockModuleId, 'package.json'),
     )
+    const expectedPackageDir = resolve(mockWorkDir, 'node_modules', mockModuleId)
 
     mockedModuleResolve.mockReturnValueOnce(mockPackageUrl)
     mockReadPackageJson.mockRejectedValueOnce(new Error('Failed to read package.json'))
@@ -68,16 +70,14 @@ describe('getLocalPackageVersion', () => {
     const result = await getLocalPackageVersion(mockModuleId, mockWorkDir)
 
     expect(mockedModuleResolve).toHaveBeenCalledOnce()
-    expect(mockReadPackageJson).toHaveBeenCalledWith(mockPackageUrl)
+    expect(mockReadPackageJson).toHaveBeenCalledWith(join(expectedPackageDir, 'package.json'))
     expect(result).toBeNull()
   })
 
   test('returns version via fallback when package has strict exports', async () => {
     const mainEntryPath = resolve(mockWorkDir, 'node_modules', mockModuleId, 'dist', 'index.js')
     const mainEntryUrl = pathToFileURL(mainEntryPath)
-    const expectedPackageJsonUrl = pathToFileURL(
-      join(resolve(mockWorkDir, 'node_modules', mockModuleId), 'package.json'),
-    )
+    const expectedPackageDir = resolve(mockWorkDir, 'node_modules', mockModuleId)
     const mockVersion = '2.0.0'
     const dirUrl = pathToFileURL(resolve(mockWorkDir, 'noop.js'))
 
@@ -97,7 +97,7 @@ describe('getLocalPackageVersion', () => {
     expect(mockedModuleResolve).toHaveBeenCalledTimes(2)
     expect(mockedModuleResolve).toHaveBeenNthCalledWith(1, `${mockModuleId}/package.json`, dirUrl)
     expect(mockedModuleResolve).toHaveBeenNthCalledWith(2, mockModuleId, dirUrl)
-    expect(mockReadPackageJson).toHaveBeenCalledWith(expectedPackageJsonUrl)
+    expect(mockReadPackageJson).toHaveBeenCalledWith(join(expectedPackageDir, 'package.json'))
     expect(result).toBe(mockVersion)
   })
 
@@ -171,5 +171,81 @@ describe('getLocalPackageVersion', () => {
     expect(mockedModuleResolve).toHaveBeenCalledOnce()
     expect(mockReadPackageJson).not.toHaveBeenCalled()
     expect(result).toBeNull()
+  })
+})
+
+describe('getLocalPackageDir', () => {
+  const mockWorkDir = '/mock/work/dir'
+  const mockModuleId = '@sanity/test'
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns package directory when package.json is resolved', () => {
+    const mockPackageUrl = pathToFileURL(
+      resolve(mockWorkDir, 'node_modules', mockModuleId, 'package.json'),
+    )
+
+    mockedModuleResolve.mockReturnValueOnce(mockPackageUrl)
+
+    const result = getLocalPackageDir(mockModuleId, mockWorkDir)
+
+    expect(result).toBe(resolve(mockWorkDir, 'node_modules', mockModuleId))
+    expect(mockedModuleResolve).toHaveBeenCalledWith(
+      `${mockModuleId}/package.json`,
+      pathToFileURL(resolve(mockWorkDir, 'noop.js')),
+    )
+  })
+
+  test('resolves hoisted packages in monorepo root node_modules', () => {
+    // Simulate a monorepo where react is hoisted to root
+    const monorepoRoot = '/project'
+    const workspaceDir = '/project/packages/frontend'
+    const hoistedPackageUrl = pathToFileURL(
+      resolve(monorepoRoot, 'node_modules', 'react', 'package.json'),
+    )
+
+    mockedModuleResolve.mockReturnValueOnce(hoistedPackageUrl)
+
+    const result = getLocalPackageDir('react', workspaceDir)
+
+    expect(result).toBe(resolve(monorepoRoot, 'node_modules', 'react'))
+  })
+
+  test('falls back to main entry point when package.json is not exported', () => {
+    const mainEntryPath = resolve(mockWorkDir, 'node_modules', mockModuleId, 'dist', 'index.js')
+    const mainEntryUrl = pathToFileURL(mainEntryPath)
+
+    mockedModuleResolve
+      .mockImplementationOnce(() => {
+        throw createNodeError('ERR_PACKAGE_PATH_NOT_EXPORTED', 'Package path not exported')
+      })
+      .mockReturnValueOnce(mainEntryUrl)
+
+    const result = getLocalPackageDir(mockModuleId, mockWorkDir)
+
+    expect(result).toBe(resolve(mockWorkDir, 'node_modules', mockModuleId))
+    expect(mockedModuleResolve).toHaveBeenCalledTimes(2)
+  })
+
+  test('throws when moduleResolve throws a non-fallback error', () => {
+    mockedModuleResolve.mockImplementationOnce(() => {
+      throw createNodeError('ERR_MODULE_NOT_FOUND', 'Module not found')
+    })
+
+    expect(() => getLocalPackageDir(mockModuleId, mockWorkDir)).toThrow('Module not found')
+  })
+
+  test('throws when both resolution strategies fail', () => {
+    mockedModuleResolve
+      .mockImplementationOnce(() => {
+        throw createNodeError('ERR_PACKAGE_PATH_NOT_EXPORTED', 'Package path not exported')
+      })
+      .mockImplementationOnce(() => {
+        throw createNodeError('ERR_MODULE_NOT_FOUND', 'Module not found')
+      })
+
+    expect(() => getLocalPackageDir(mockModuleId, mockWorkDir)).toThrow('Module not found')
   })
 })

--- a/packages/@sanity/cli/src/util/getLocalPackageVersion.ts
+++ b/packages/@sanity/cli/src/util/getLocalPackageVersion.ts
@@ -17,31 +17,46 @@ export async function getLocalPackageVersion(
   workDir: string,
 ): Promise<string | null> {
   try {
-    // Handle import.meta.url being passed instead of a directory path
-    const dir = workDir.startsWith('file://') ? dirname(fileURLToPath(workDir)) : workDir
-    const dirUrl = pathToFileURL(resolve(dir, 'noop.js'))
-
-    let packageJsonUrl: URL
-    try {
-      packageJsonUrl = moduleResolve(`${moduleName}/package.json`, dirUrl)
-    } catch (err: unknown) {
-      if (isErrPackagePathNotExported(err)) {
-        // Fallback: resolve main entry point and derive package root
-        const mainUrl = moduleResolve(moduleName, dirUrl)
-        const mainPath = fileURLToPath(mainUrl)
-        const normalizedName = normalize(moduleName)
-        const idx = mainPath.lastIndexOf(normalizedName)
-        const moduleRoot = mainPath.slice(0, idx + normalizedName.length)
-        packageJsonUrl = pathToFileURL(join(moduleRoot, 'package.json'))
-      } else {
-        throw err
-      }
-    }
-
-    return (await readPackageJson(packageJsonUrl)).version
+    const packageDir = getLocalPackageDir(moduleName, workDir)
+    return (await readPackageJson(join(packageDir, 'package.json'))).version
   } catch {
     return null
   }
+}
+
+/**
+ * Resolve the filesystem directory of a locally installed package using Node
+ * module resolution. Works correctly with hoisted packages in monorepos/workspaces,
+ * pnpm symlinks, and other non-standard node_modules layouts.
+ *
+ * @param moduleName - The name of the package in npm.
+ * @param workDir - The working directory to resolve the module from. (aka project root)
+ * @returns The absolute path to the package directory.
+ * @internal
+ */
+export function getLocalPackageDir(moduleName: string, workDir: string): string {
+  // Handle import.meta.url being passed instead of a directory path
+  const dir = workDir.startsWith('file://') ? dirname(fileURLToPath(workDir)) : workDir
+  const dirUrl = pathToFileURL(resolve(dir, 'noop.js'))
+
+  try {
+    const packageJsonUrl = moduleResolve(`${moduleName}/package.json`, dirUrl)
+    return dirname(fileURLToPath(packageJsonUrl))
+  } catch (err: unknown) {
+    if (!isErrPackagePathNotExported(err)) {
+      throw err
+    }
+  }
+
+  // Fallback: resolve main entry point and derive package root
+  const mainUrl = moduleResolve(moduleName, dirUrl)
+  const mainPath = fileURLToPath(mainUrl)
+  const normalizedName = normalize(moduleName)
+  const idx = mainPath.lastIndexOf(normalizedName)
+  if (idx === -1) {
+    throw new Error(`Could not determine package directory for '${moduleName}'`)
+  }
+  return mainPath.slice(0, idx + normalizedName.length)
 }
 
 function isErrPackagePathNotExported(err: unknown): boolean {


### PR DESCRIPTION
### Description

`buildVendorDependencies` resolved vendor entry points (react, react-dom, styled-components) using a naive `node_modules/` relative path:

```ts
entry[chunkName] = resolve(`node_modules/${packageName}/${relativeEntryPoint}`)
```

This breaks in monorepos with hoisted dependencies (npm/yarn workspaces) where packages live in the root `node_modules/` rather than the workspace's local one. The result is a Rollup error during `sanity deploy`:

```
RollupError: Could not resolve entry module "node_modules/react/cjs/react.production.js"
```

The fix extracts a `getLocalPackageDir()` function that uses `import-meta-resolve` to find the actual filesystem location of a package - the same resolution strategy `getLocalPackageVersion` already used for reading versions. This handles hoisted packages, pnpm symlinks, and other non-standard `node_modules` layouts.

Fixes https://github.com/sanity-io/cli/issues/639#issuecomment-4060680820

### What to review

- `getLocalPackageVersion.ts` - the new `getLocalPackageDir()` function and the refactored `getLocalPackageVersion()` that now delegates to it. The fallback path for packages that don't export `./package.json` is worth a look.
- `buildVendorDependencies.ts` - the one-line change from `resolve(...)` to `path.join(packageDir, relativeEntryPoint)`
- The test changes are mechanical (updated assertions since `readPackageJson` now receives a string path instead of a URL) plus new `getLocalPackageDir` tests.

### Testing

Updated existing `getLocalPackageVersion` tests and added tests for `getLocalPackageDir` covering:
- Direct `package.json` resolution (happy path)
- Hoisted packages resolving to a parent `node_modules/`
- Fallback when `./package.json` isn't in the package exports map
- Error propagation for missing packages

The monorepo scenario itself is hard to test in an automated way without setting up a real workspace fixture - the test mocks `moduleResolve` to return a hoisted path, which validates the logic but not the end-to-end resolution.
