### PR TITLE
fix: deprecate `start` command (preview alias)

### DIFF
--- a/packages/@sanity/cli/src/commands/preview.ts
+++ b/packages/@sanity/cli/src/commands/preview.ts
@@ -13,6 +13,8 @@ export class PreviewCommand extends SanityCommand<typeof PreviewCommand> {
     outputDir: Args.directory({description: 'Output directory'}),
   }
 
+  static override deprecateAliases = true
+
   static override description = 'Starts a server to preview a production build'
 
   static override examples = [
@@ -29,7 +31,6 @@ export class PreviewCommand extends SanityCommand<typeof PreviewCommand> {
       description: '[default: 3333] TCP port to start server on.',
     }),
   }
-
   static override hiddenAliases: string[] = ['start']
 
   public async run(): Promise<PreviewServer | void> {


### PR DESCRIPTION
### Description

Adds `deprecateAliases = true` to the `PreviewCommand`, so that running `sanity start` now emits a deprecation warning telling users to use `sanity preview` instead.

Previously, `start` was listed in `hiddenAliases` which hid it from help output, but oclif's `deprecateAliases` flag only checked `aliases` - not `hiddenAliases`. This meant there was no way to both hide a deprecated alias from discovery _and_ warn existing users.

I fixed this upstream in [oclif/core#1555](https://github.com/oclif/core/pull/1555), which shipped in `@oclif/core@4.9.0`. We already depend on `^4.9.0`, so we can use it directly.

### What to review

- Single-line addition in `packages/@sanity/cli/src/commands/preview.ts`
- Run `sanity start` in a project directory and confirm you see the deprecation warning pointing to `sanity preview`
- Run `sanity preview` and confirm no warning is shown
- Confirm `start` does not appear in `sanity --help` output

### Testing

The deprecation warning behavior is handled by oclif core itself (tested upstream). The change here is a static property declaration, so there's no new logic to unit test on our side. Verified by running `sanity start` manually and confirming the warning appears.