### PR TITLE
fix: load all .env file variables into process.env

### DIFF
--- a/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLoader.worker.ts
+++ b/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLoader.worker.ts
@@ -173,7 +173,10 @@ await server.pluginContainer.buildStart({})
 // Load environment variables from `.env` files in the same way as Vite does.
 // Note that Sanity also provides environment variables through `process.env.*` for compat reasons,
 // and so we need to do the same here.
-const env = loadEnv(server.config.mode, server.config.envDir, viteConfig.envPrefix ?? '')
+// Load ALL env vars from .env files (not just studio-prefixed ones) so non-Sanity-prefixed
+// vars (e.g. NEXT_PUBLIC_*, VITE_*) are available via process.env at runtime.
+// The ??= on the next line prevents overwriting existing process.env values.
+const env = loadEnv(server.config.mode, server.config.envDir, '')
 for (const key in env) {
   process.env[key] ??= env[key]
 }

--- a/packages/@sanity/cli/src/actions/build/__tests__/getStudioEnvironmentVariables.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getStudioEnvironmentVariables.test.ts
@@ -1,0 +1,150 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {
+  getAppEnvironmentVariables,
+  getStudioEnvironmentVariables,
+} from '../getStudioEnvironmentVariables.js'
+
+describe('#getStudioEnvironmentVariables', () => {
+  beforeEach(() => {
+    // Set a controlled process.env with both prefixed and non-prefixed vars
+    vi.stubEnv('SANITY_STUDIO_API_KEY', 'studio-key-123')
+    vi.stubEnv('SANITY_STUDIO_PROJECT_ID', 'proj-abc')
+    vi.stubEnv('SANITY_APP_SECRET', 'app-secret-456')
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://next.example.com')
+    vi.stubEnv('VITE_CUSTOM_VAR', 'vite-value')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  test('only returns SANITY_STUDIO_ prefixed vars from process.env', () => {
+    const result = getStudioEnvironmentVariables()
+
+    expect(result).toHaveProperty('SANITY_STUDIO_API_KEY', 'studio-key-123')
+    expect(result).toHaveProperty('SANITY_STUDIO_PROJECT_ID', 'proj-abc')
+
+    // Must NOT contain non-prefixed vars
+    const keys = Object.keys(result)
+    for (const key of keys) {
+      expect(key).toMatch(/^SANITY_STUDIO_/)
+    }
+  })
+
+  test('does not return PATH, HOME, NEXT_PUBLIC_*, VITE_*, or SANITY_APP_* vars', () => {
+    const result = getStudioEnvironmentVariables()
+
+    expect(result).not.toHaveProperty('PATH')
+    expect(result).not.toHaveProperty('HOME')
+    expect(result).not.toHaveProperty('NEXT_PUBLIC_API_URL')
+    expect(result).not.toHaveProperty('VITE_CUSTOM_VAR')
+    expect(result).not.toHaveProperty('SANITY_APP_SECRET')
+  })
+
+  test('applies jsonEncode option', () => {
+    const result = getStudioEnvironmentVariables({jsonEncode: true})
+
+    expect(result).toHaveProperty('SANITY_STUDIO_API_KEY', '"studio-key-123"')
+    expect(result).toHaveProperty('SANITY_STUDIO_PROJECT_ID', '"proj-abc"')
+  })
+
+  test('applies prefix option', () => {
+    const result = getStudioEnvironmentVariables({prefix: 'process.env.'})
+
+    expect(result).toHaveProperty('process.env.SANITY_STUDIO_API_KEY', 'studio-key-123')
+    expect(result).toHaveProperty('process.env.SANITY_STUDIO_PROJECT_ID', 'proj-abc')
+    expect(result).not.toHaveProperty('SANITY_STUDIO_API_KEY')
+  })
+
+  test('applies both prefix and jsonEncode options', () => {
+    const result = getStudioEnvironmentVariables({jsonEncode: true, prefix: 'process.env.'})
+
+    expect(result).toHaveProperty('process.env.SANITY_STUDIO_API_KEY', '"studio-key-123"')
+  })
+
+  test('returns empty object when no SANITY_STUDIO_ vars exist', () => {
+    // Stub any SANITY_STUDIO_ vars as undefined so they're removed from process.env
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('SANITY_STUDIO_')) {
+        vi.stubEnv(key, undefined as unknown as string)
+      }
+    }
+
+    const result = getStudioEnvironmentVariables()
+
+    const studioKeys = Object.keys(result).filter((k) => k.startsWith('SANITY_STUDIO_'))
+    expect(studioKeys).toHaveLength(0)
+  })
+})
+
+describe('#getAppEnvironmentVariables', () => {
+  beforeEach(() => {
+    vi.stubEnv('SANITY_APP_SECRET', 'app-secret-456')
+    vi.stubEnv('SANITY_APP_ORG_ID', 'org-789')
+    vi.stubEnv('SANITY_STUDIO_API_KEY', 'studio-key-123')
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://next.example.com')
+    vi.stubEnv('VITE_CUSTOM_VAR', 'vite-value')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  test('only returns SANITY_APP_ prefixed vars from process.env', () => {
+    const result = getAppEnvironmentVariables()
+
+    expect(result).toHaveProperty('SANITY_APP_SECRET', 'app-secret-456')
+    expect(result).toHaveProperty('SANITY_APP_ORG_ID', 'org-789')
+
+    // Must NOT contain non-prefixed vars
+    const keys = Object.keys(result)
+    for (const key of keys) {
+      expect(key).toMatch(/^SANITY_APP_/)
+    }
+  })
+
+  test('does not return PATH, HOME, NEXT_PUBLIC_*, VITE_*, or SANITY_STUDIO_* vars', () => {
+    const result = getAppEnvironmentVariables()
+
+    expect(result).not.toHaveProperty('PATH')
+    expect(result).not.toHaveProperty('HOME')
+    expect(result).not.toHaveProperty('NEXT_PUBLIC_API_URL')
+    expect(result).not.toHaveProperty('VITE_CUSTOM_VAR')
+    expect(result).not.toHaveProperty('SANITY_STUDIO_API_KEY')
+  })
+
+  test('applies jsonEncode option', () => {
+    const result = getAppEnvironmentVariables({jsonEncode: true})
+
+    expect(result).toHaveProperty('SANITY_APP_SECRET', '"app-secret-456"')
+    expect(result).toHaveProperty('SANITY_APP_ORG_ID', '"org-789"')
+  })
+
+  test('applies prefix option', () => {
+    const result = getAppEnvironmentVariables({prefix: 'process.env.'})
+
+    expect(result).toHaveProperty('process.env.SANITY_APP_SECRET', 'app-secret-456')
+    expect(result).toHaveProperty('process.env.SANITY_APP_ORG_ID', 'org-789')
+    expect(result).not.toHaveProperty('SANITY_APP_SECRET')
+  })
+
+  test('applies both prefix and jsonEncode options', () => {
+    const result = getAppEnvironmentVariables({jsonEncode: true, prefix: 'process.env.'})
+
+    expect(result).toHaveProperty('process.env.SANITY_APP_SECRET', '"app-secret-456"')
+  })
+
+  test('returns empty object when no SANITY_APP_ vars exist', () => {
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('SANITY_APP_')) {
+        vi.stubEnv(key, undefined as unknown as string)
+      }
+    }
+
+    const result = getAppEnvironmentVariables()
+
+    const appKeys = Object.keys(result).filter((k) => k.startsWith('SANITY_APP_'))
+    expect(appKeys).toHaveLength(0)
+  })
+})

--- a/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
@@ -136,6 +136,13 @@ describe('#getViteConfig', () => {
       'process.env.STUDIO_VAR': '"studio-value"',
     })
 
+    // Non-Sanity vars must NOT appear in define
+    expect(config.define).not.toHaveProperty('process.env.PATH')
+    expect(config.define).not.toHaveProperty('process.env.HOME')
+    expect(config.define).not.toHaveProperty('process.env.NEXT_PUBLIC_API_URL')
+    expect(config.define).not.toHaveProperty('process.env.VITE_CUSTOM_VAR')
+    expect(config.define).not.toHaveProperty('process.env.APP_VAR')
+
     expect(config.plugins).toHaveLength(4)
     expect(config.resolve?.dedupe).toEqual(['react', 'react-dom', 'sanity', 'styled-components'])
   })
@@ -154,6 +161,13 @@ describe('#getViteConfig', () => {
     expect(config.define).toMatchObject({
       'process.env.APP_VAR': '"app-value"',
     })
+
+    // Non-app vars must NOT appear in define
+    expect(config.define).not.toHaveProperty('process.env.STUDIO_VAR')
+    expect(config.define).not.toHaveProperty('process.env.PATH')
+    expect(config.define).not.toHaveProperty('process.env.HOME')
+    expect(config.define).not.toHaveProperty('process.env.NEXT_PUBLIC_API_URL')
+    expect(config.define).not.toHaveProperty('process.env.VITE_CUSTOM_VAR')
   })
 
   test('should create production config with minification', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/build.app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/build.app.test.ts
@@ -90,6 +90,27 @@ describe('#build app', {timeout: (platform() === 'win32' ? 120 : 60) * 1000}, ()
     expect(stdout).toContain('SANITY_APP_TEST_VAR')
   })
 
+  test('should not include non-prefixed env vars in build output', async () => {
+    const cwd = await testFixture('basic-app')
+    process.chdir(cwd)
+
+    vi.stubEnv('SANITY_APP_BUNDLE_VAR', 'app-value')
+    vi.stubEnv('NEXT_PUBLIC_LEAKED', 'next-value')
+    vi.stubEnv('VITE_LEAKED', 'vite-value')
+
+    const {error, stdout} = await testCommand(BuildCommand, ['--yes'], {
+      config: {root: cwd},
+    })
+
+    if (error) throw error
+
+    // Prefixed var should appear in the build output env var listing
+    expect(stdout).toContain('SANITY_APP_BUNDLE_VAR')
+    // Non-prefixed vars must NOT appear
+    expect(stdout).not.toContain('NEXT_PUBLIC_LEAKED')
+    expect(stdout).not.toContain('VITE_LEAKED')
+  })
+
   test('should error when @sanity/sdk-react is not installed', async () => {
     const cwd = await testFixture('basic-app', {
       tempDir: tmpdir(),

--- a/packages/@sanity/cli/src/commands/__tests__/build.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/build.studio.test.ts
@@ -117,6 +117,27 @@ describe('#build studio', {timeout: (platform() === 'win32' ? 120 : 60) * 1000},
     expect(stdout).toContain('SANITY_STUDIO_TEST_VAR')
   })
 
+  test('should not include non-prefixed env vars in build output', async () => {
+    const cwd = await testFixture('basic-studio')
+    process.chdir(cwd)
+
+    vi.stubEnv('SANITY_STUDIO_BUNDLE_VAR', 'studio-value')
+    vi.stubEnv('NEXT_PUBLIC_LEAKED', 'next-value')
+    vi.stubEnv('VITE_LEAKED', 'vite-value')
+
+    const {error, stdout} = await testCommand(BuildCommand, ['--yes'], {
+      config: {root: cwd},
+    })
+
+    if (error) throw error
+
+    // Prefixed var should appear in the build output env var listing
+    expect(stdout).toContain('SANITY_STUDIO_BUNDLE_VAR')
+    // Non-prefixed vars must NOT appear
+    expect(stdout).not.toContain('NEXT_PUBLIC_LEAKED')
+    expect(stdout).not.toContain('VITE_LEAKED')
+  })
+
   test('should error when styled-components is not installed', async () => {
     const cwd = await testFixture('basic-studio', {
       tempDir: tmpdir(),


### PR DESCRIPTION
## Summary

Fixes `sanity schema extract` (and other `studioWorkerTask` commands) failing for projects that use non-Sanity-prefixed environment variables like `NEXT_PUBLIC_*` or `VITE_*`, particularly when validation libraries like `@t3-oss/env-nextjs` check for them at import time.

Fixes #724

## Why it worked before

The old CLI used `esbuild-register` in **CJS mode** ([`mockBrowserEnvironment.ts#L60-L72`](https://github.com/sanity-labs/sanity-old-cli-bkp/blob/main/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts#L60-L72)):

```typescript
const {unregister: unregisterESBuild} = registerESBuild({
  target: 'node18',
  format: 'cjs',
  define: {
    ...getStudioEnvironmentVariables({prefix: 'process.env.', jsonEncode: true}),
    ...getStudioEnvironmentVariables({prefix: 'import.meta.env.', jsonEncode: true}),
  },
})
```

[`getStudioEnvironmentVariables`](https://github.com/sanity-labs/sanity-old-cli-bkp/blob/main/packages/sanity/src/_internal/cli/server/getStudioEnvironmentVariables.ts#L51-L63) only returned `SANITY_STUDIO_*` vars — so `NEXT_PUBLIC_*` vars were **not** in the `define` config. But that was fine: esbuild in CJS mode only replaces `process.env.X` when there's a matching `define` entry. Unmatched accesses like `process.env.NEXT_PUBLIC_FOO` stayed as real runtime property lookups on the Node.js `process.env` object, which resolved normally.

## Why it broke

The new CLI uses Vite + `ViteNodeRunner` with `ssr.noExternal: true`, which processes **all** dependencies (including `@t3-oss/env-nextjs`) through Vite's transform pipeline. The `define` config still only covers `SANITY_STUDIO_*` vars, and the worker loader only loaded Sanity-prefixed vars into `process.env`. So non-prefixed env vars from `.env` files were never available — neither as compile-time constants nor as runtime `process.env` values.

## What this changes

The **worker loader** (`studioWorkerLoader.worker.ts`) now loads **all** `.env` file variables into `process.env` (using `loadEnv` with an empty prefix), not just Sanity-prefixed ones. This is scoped to the worker process only — the **prerun hook** remains unchanged, loading only `SANITY_STUDIO_*`/`SANITY_APP_*`/`SANITY_INTERNAL_*` prefixed vars, matching the original CLI behavior.

Existing `process.env` values are never overwritten (uses `??=`). The `define` config and `envPrefix` remain unchanged — `import.meta.env` is still scoped to `SANITY_STUDIO_*` / `SANITY_APP_*` vars only.

## Test plan

- [x] Existing `injectEnvVariables` tests passing — assertions confirm non-prefixed vars are NOT loaded by prerun hook
- [x] New unit tests for `getStudioEnvironmentVariables` / `getAppEnvironmentVariables` verifying only prefixed vars are returned
- [x] Negative assertions in `getViteConfig` tests confirming `PATH`, `HOME`, `NEXT_PUBLIC_*`, `VITE_*` are excluded from `define`
- [x] Integration tests in `build.studio` and `build.app` confirming non-prefixed env vars don't appear in build output
- [x] Test pollution fixed — `vi.stubEnv` used instead of `delete process.env[key]`
- [ ] Verify `sanity schema extract` works with a project using `NEXT_PUBLIC_*` vars and `@t3-oss/env-nextjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)