### PR TITLE
fix: prevent duplicate deprecation warnings during sanity deploy

### DIFF
--- a/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.appIdWarning.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.appIdWarning.test.ts
@@ -132,8 +132,6 @@ describe('buildStudio appId warning', () => {
 
   test('should not warn about missing appId when auto-updates are disabled', async () => {
     mockGetAppId.mockReturnValue(undefined)
-    // buildStudio ignores options.autoUpdatesEnabled — it calls shouldAutoUpdate() internally,
-    // so the mock above is what actually controls the behavior in this test.
     vi.mocked(shouldAutoUpdate).mockReturnValueOnce(false)
     const output = createMockOutput()
 
@@ -147,6 +145,23 @@ describe('buildStudio appId warning', () => {
     })
 
     expect(mockWarnAboutMissingAppId).not.toHaveBeenCalled()
+  })
+
+  test('should not call shouldAutoUpdate when called from deploy', async () => {
+    mockGetAppId.mockReturnValue('my-app-id')
+    const output = createMockOutput()
+
+    await buildStudio({
+      autoUpdatesEnabled: true,
+      calledFromDeploy: true,
+      cliConfig: {deployment: {autoUpdates: true}},
+      flags: FLAGS,
+      outDir: '/tmp/dist',
+      output,
+      workDir: '/tmp',
+    })
+
+    expect(shouldAutoUpdate).not.toHaveBeenCalled()
   })
 
   test('should not warn about missing appId when appId is configured', async () => {

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -48,7 +48,9 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     workDir,
   })
 
-  let autoUpdatesEnabled = shouldAutoUpdate({cliConfig, flags, output})
+  let autoUpdatesEnabled = options.calledFromDeploy
+    ? options.autoUpdatesEnabled
+    : shouldAutoUpdate({cliConfig, flags, output})
 
   let autoUpdatesImports = {}
 


### PR DESCRIPTION
## Summary

- When `deployStudio` calls `buildStudio`, `shouldAutoUpdate()` was invoked twice — once in deploy (line 35) and again in build (line 51) — causing deprecation warnings to print twice
- `buildStudio` now reuses the pre-computed `options.autoUpdatesEnabled` when `calledFromDeploy` is true, matching how `buildApp` already handles this
- Added test verifying `shouldAutoUpdate` is not called when `calledFromDeploy: true`

## Test plan

- [x] `pnpm test packages/@sanity/cli/src/actions/build/__tests__/buildStudio.appIdWarning.test.ts` — 5 tests pass
- [x] `pnpm test packages/@sanity/cli/src/actions/build/__tests__/shouldAutoUpdate.test.ts` — 13 tests pass
- [x] `pnpm test packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts` — 28 tests pass
- [x] `pnpm check:types` — no errors
- [x] `pnpm check:lint` — no new warnings
- [x] `pnpm check:deps` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)