### PR TITLE
fix: validate MCP tokens against Sanity API instead of MCP server

### DIFF
--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -861,10 +861,11 @@ describe('#mcp:configure', () => {
       }),
     )
 
-    // Token validation succeeds against MCP server
-    nock('https://mcp.sanity.io')
-      .post('/')
-      .reply(406, {error: {code: -32_000, message: 'Not Acceptable'}})
+    // Token validation succeeds against Sanity API
+    mockApi({apiVersion: MCP_API_VERSION, method: 'get', uri: '/users/me'}).reply(200, {
+      id: 'user-123',
+      name: 'Test User',
+    })
 
     const {stdout} = await testCommand(ConfigureMcpCommand, [])
 
@@ -892,8 +893,12 @@ describe('#mcp:configure', () => {
       }),
     )
 
-    // Token validation fails against MCP server
-    nock('https://mcp.sanity.io').post('/').reply(401, {error: 'invalid_token'})
+    // Token validation fails against Sanity API (dead token)
+    mockApi({apiVersion: MCP_API_VERSION, method: 'get', uri: '/users/me'}).reply(401, {
+      error: 'Unauthorized',
+      message: 'Invalid token',
+      statusCode: 401,
+    })
 
     mockCheckbox.mockResolvedValue(['Cursor'])
 
@@ -948,10 +953,11 @@ describe('#mcp:configure', () => {
       return '{}'
     })
 
-    // Token validation succeeds against MCP server
-    nock('https://mcp.sanity.io')
-      .post('/')
-      .reply(406, {error: {code: -32_000, message: 'Not Acceptable'}})
+    // Token validation succeeds against Sanity API
+    mockApi({apiVersion: MCP_API_VERSION, method: 'get', uri: '/users/me'}).reply(200, {
+      id: 'user-123',
+      name: 'Test User',
+    })
 
     // User selects only the unconfigured editor (Gemini CLI)
     mockCheckbox.mockResolvedValue(['Gemini CLI'])

--- a/packages/@sanity/cli/src/services/__tests__/mcp.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/mcp.test.ts
@@ -2,40 +2,51 @@ import {afterEach, describe, expect, test, vi} from 'vitest'
 
 const mockRequest = vi.hoisted(() => vi.fn())
 
-vi.mock('@sanity/cli-core/request', () => ({
-  createRequester: vi.fn().mockReturnValue(mockRequest),
-}))
+vi.mock('@sanity/cli-core', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sanity/cli-core')>()
+  return {
+    ...original,
+    getGlobalCliClient: vi.fn().mockResolvedValue({request: mockRequest}),
+  }
+})
 
-// Must import after mocking so the module picks up the mock
-const {MCP_SERVER_URL, validateMCPToken} = await import('../mcp.js')
+const {validateMCPToken} = await import('../mcp.js')
+
+/** Build an error object that satisfies `isHttpError()` from sanity client */
+function httpError(statusCode: number) {
+  const err = new Error(`HTTP ${statusCode}`)
+  Object.assign(err, {
+    response: {
+      body: {},
+      headers: {},
+      method: 'GET',
+      statusCode,
+      statusMessage: null,
+      url: 'https://api.sanity.io/v2025-12-09/users/me',
+    },
+    statusCode,
+  })
+  return err
+}
 
 describe('validateMCPToken', () => {
   afterEach(() => {
     vi.clearAllMocks()
   })
 
-  test('returns true when server responds with 406', async () => {
-    mockRequest.mockResolvedValue({statusCode: 406})
+  test('returns true when /users/me responds successfully', async () => {
+    mockRequest.mockResolvedValue({id: 'user-123', name: 'Test User'})
 
     const result = await validateMCPToken('valid-token')
 
     expect(result).toBe(true)
     expect(mockRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: '{}',
-        headers: {
-          Authorization: 'Bearer valid-token',
-          'Content-Type': 'application/json',
-        },
-        method: 'POST',
-        timeout: 2500,
-        url: MCP_SERVER_URL,
-      }),
+      expect.objectContaining({timeout: 2500, uri: '/users/me'}),
     )
   })
 
   test('returns false when server responds with 401', async () => {
-    mockRequest.mockResolvedValue({statusCode: 401})
+    mockRequest.mockRejectedValue(httpError(401))
 
     const result = await validateMCPToken('expired-token')
 
@@ -43,48 +54,36 @@ describe('validateMCPToken', () => {
   })
 
   test('returns false when server responds with 403', async () => {
-    mockRequest.mockResolvedValue({statusCode: 403})
+    mockRequest.mockRejectedValue(httpError(403))
 
     const result = await validateMCPToken('forbidden-token')
 
     expect(result).toBe(false)
   })
 
-  test('returns true on 500 server error (assumes valid)', async () => {
-    mockRequest.mockResolvedValue({statusCode: 500})
+  test('propagates 500 server error (caller decides)', async () => {
+    mockRequest.mockRejectedValue(httpError(500))
 
-    const result = await validateMCPToken('some-token')
-
-    expect(result).toBe(true)
+    await expect(validateMCPToken('some-token')).rejects.toThrow('HTTP 500')
   })
 
-  test('returns true on 503 server error (assumes valid)', async () => {
-    mockRequest.mockResolvedValue({statusCode: 503})
-
-    const result = await validateMCPToken('some-token')
-
-    expect(result).toBe(true)
-  })
-
-  test('returns true on 200 response (unexpected but assumes valid)', async () => {
-    mockRequest.mockResolvedValue({statusCode: 200})
-
-    const result = await validateMCPToken('some-token')
-
-    expect(result).toBe(true)
-  })
-
-  test('propagates network errors from the requester', async () => {
+  test('propagates network errors', async () => {
     mockRequest.mockRejectedValue(new Error('ETIMEDOUT'))
 
     await expect(validateMCPToken('some-token')).rejects.toThrow('ETIMEDOUT')
   })
 
-  test('passes timeout of 2500ms in the request', async () => {
-    mockRequest.mockResolvedValue({statusCode: 406})
+  test('passes the token to getGlobalCliClient', async () => {
+    const {getGlobalCliClient} = await import('@sanity/cli-core')
+    mockRequest.mockResolvedValue({id: 'user-123'})
 
-    await validateMCPToken('any-token')
+    await validateMCPToken('my-special-token')
 
-    expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({timeout: 2500}))
+    expect(getGlobalCliClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requireUser: false,
+        token: 'my-special-token',
+      }),
+    )
   })
 })

--- a/packages/@sanity/cli/src/services/mcp.ts
+++ b/packages/@sanity/cli/src/services/mcp.ts
@@ -1,22 +1,11 @@
 import {getGlobalCliClient, subdebug} from '@sanity/cli-core'
-import {createRequester, type Requester} from '@sanity/cli-core/request'
+import {isHttpError} from '@sanity/client'
 
 export const MCP_API_VERSION = '2025-12-09'
 export const MCP_SERVER_URL = 'https://mcp.sanity.io'
 export const MCP_JOURNEY_API_VERSION = 'v2024-02-23'
 
 const debug = subdebug('mcp:service')
-
-let mcpRequester: Requester | undefined
-
-function getMCPRequester(): Requester {
-  if (!mcpRequester) {
-    mcpRequester = createRequester({
-      middleware: {httpErrors: false, promise: {onlyBody: false}},
-    })
-  }
-  return mcpRequester
-}
 
 interface PostInitPromptResponse {
   message?: string
@@ -55,46 +44,44 @@ export async function createMCPToken(): Promise<string> {
 }
 
 /**
- * Validate an MCP token against the MCP server.
+ * Validate an MCP token by checking it against the Sanity API.
  *
- * MCP tokens are scoped to mcp.sanity.io and are not valid against
- * api.sanity.io, so we validate against the MCP server itself.
+ * MCP tokens are standard Sanity session tokens (`sk…`), so we validate
+ * by calling `/users/me` on `api.sanity.io`. A 200 means the token is
+ * alive; a 401/403 means it is dead and the caller should prompt for
+ * re-configuration.
  *
- * Sends a minimal POST with just the Authorization header — the server
- * checks auth before content negotiation, so a valid token gets 406
- * (missing Accept header) while an invalid token gets 401. This avoids
- * the cost of a full initialize handshake.
+ * Transient errors (5xx, network failures, timeouts) are rethrown so the
+ * caller can decide how to handle them — typically by assuming the token
+ * is still valid rather than falsely marking it as expired.
+ *
+ * We intentionally do NOT probe `mcp.sanity.io` because the MCP server
+ * lets invalid bearer tokens through for protocol-compatibility reasons,
+ * which causes the CLI to falsely treat dead tokens as valid.
  *
  * @internal
  */
 export async function validateMCPToken(token: string): Promise<boolean> {
-  const request = getMCPRequester()
-
-  // Use a 2500ms timeout — long enough for VPN/proxy/distant-region latency,
-  // short enough to not stall the init flow. If the request times out or the
-  // server returns an unexpected status, we assume the token is valid rather
-  // than falsely marking it as expired (see below).
-  const res = await request({
-    body: '{}',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    method: 'POST',
-    timeout: 2500,
-    url: MCP_SERVER_URL,
+  const client = await getGlobalCliClient({
+    apiVersion: MCP_API_VERSION,
+    requireUser: false,
+    token,
   })
 
-  // 401/403 are the only responses that definitively mean "bad token".
-  // Everything else (406 = valid, 5xx = server issue, 2xx = unexpected)
-  // is treated as "assume valid" — we'd rather skip a re-auth prompt
-  // than force users to re-configure because of a transient server error.
-  if (res.statusCode === 401 || res.statusCode === 403) {
-    debug('MCP token validation failed with %d', res.statusCode)
-    return false
-  }
+  try {
+    await client.request({timeout: 2500, uri: '/users/me'})
+    return true
+  } catch (err) {
+    // 401/403 definitively mean "dead token"
+    if (isHttpError(err) && (err.statusCode === 401 || err.statusCode === 403)) {
+      debug('MCP token validation failed with %d', err.statusCode)
+      return false
+    }
 
-  return true
+    // Everything else (5xx, network errors, timeouts) is rethrown so the
+    // caller can decide — typically assumes valid rather than forcing re-auth.
+    throw err
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

When a user re-runs `sanity login`, the CLI destroys the old parent session. Child sessions (including the MCP token created by `mcp configure`) are cascade-deleted. Running `mcp configure` to fix it doesn't work because `validateMCPToken()` probes `mcp.sanity.io`, which intentionally lets invalid hard-coded bearer tokens through to provide better UX for re-authing. The CLI gets 406 instead of 401, thinks the token is valid, and reports "All detected editors are already configured."

This PR changes `validateMCPToken()` to call `api.sanity.io/users/me` with the token instead. Since MCP tokens are standard `sk…` session tokens, this correctly returns 200 for valid tokens and 401/403 for dead ones. Transient errors (5xx, network) are rethrown so the caller (`validateEditorTokens`) can assume-valid rather than falsely expiring tokens.

- Removed the raw HTTP requester (`getMCPRequester`) — no longer needed
- Updated unit tests to mock the Sanity client instead of the raw requester
- Updated integration tests in `configure.test.ts` to mock `/users/me` instead of `mcp.sanity.io`

Fixes AIGRO-4686

## Test plan

- [x] `mcp.test.ts` — 6/6 passed (valid token, 401, 403, 5xx rethrow, network error rethrow, token passthrough)
- [x] `validateEditorTokens.test.ts` — 7/7 passed (no changes needed, catch-path still works)
- [x] `configure.test.ts` — 29/29 passed (updated nock mocks)
- [ ] Manual: after `sanity login` kills MCP session, `sanity mcp configure` should detect dead token and offer re-configuration