### PR TITLE
test: mock execa/which to speed up tests on windows

### DIFF
--- a/packages/@sanity/cli/src/commands/__tests__/doctor.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/doctor.test.ts
@@ -6,6 +6,13 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {DoctorCommand} from '../doctor.js'
 
+// Prevent real subprocess spawning (npm/pnpm/yarn global queries have 10s timeouts each)
+const mockExeca = vi.hoisted(() => vi.fn())
+vi.mock('execa', () => ({execa: mockExeca}))
+
+const mockWhich = vi.hoisted(() => vi.fn())
+vi.mock('which', () => ({default: mockWhich}))
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const fixturesDir = path.join(
   __dirname,
@@ -23,6 +30,9 @@ describe('doctor command', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default: no global package manager installations found
+    mockWhich.mockRejectedValue(new Error('not found'))
+    mockExeca.mockRejectedValue(new Error('not found'))
   })
 
   afterEach(() => {


### PR DESCRIPTION
### Description

The doctor tests are really slow on Windows CI, potentially due to a large amount of shell calls to `execa`/`which`. Going to see if it makes a difference if we mock these in tests for now (they're tested more explicitly elsewhere)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
