### PR TITLE
feat(organizations): add `sanity organizations list` command

### DIFF
--- a/packages/@sanity/cli/src/commands/organizations/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/organizations/__tests__/list.test.ts
@@ -1,0 +1,134 @@
+import {mockApi, testCommand} from '@sanity/cli-test'
+import nock from 'nock'
+import {afterEach, describe, expect, test} from 'vitest'
+
+import {ORGANIZATIONS_API_VERSION} from '../../../services/organizations.js'
+import {ListOrganizationsCommand} from '../list.js'
+
+describe('#organizations list', () => {
+  afterEach(() => {
+    const pending = nock.pendingMocks()
+    nock.cleanAll()
+    expect(pending, 'pending mocks').toEqual([])
+  })
+
+  test('displays organizations correctly', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [
+      {id: 'org-1', name: 'Acme Corp', slug: 'acme'},
+      {id: 'org-2', name: 'Beta Inc', slug: 'beta'},
+    ])
+
+    const {error, stdout} = await testCommand(ListOrganizationsCommand)
+
+    if (error) throw error
+    expect(stdout).toContain('org-1')
+    expect(stdout).toContain('Acme Corp')
+    expect(stdout).toContain('acme')
+    expect(stdout).toContain('org-2')
+    expect(stdout).toContain('Beta Inc')
+    expect(stdout).toContain('beta')
+  })
+
+  test('sorts by name ascending by default', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [
+      {id: 'org-2', name: 'Zebra Ltd', slug: 'zebra'},
+      {id: 'org-1', name: 'Acme Corp', slug: 'acme'},
+    ])
+
+    const {error, stdout} = await testCommand(ListOrganizationsCommand)
+
+    if (error) throw error
+    const lines = stdout.split('\n').filter(Boolean)
+    const acmeIndex = lines.findIndex((line) => line.includes('Acme Corp'))
+    const zebraIndex = lines.findIndex((line) => line.includes('Zebra Ltd'))
+
+    expect(acmeIndex).toBeGreaterThan(0)
+    expect(zebraIndex).toBeGreaterThan(0)
+    expect(acmeIndex).toBeLessThan(zebraIndex)
+  })
+
+  test('sorts in descending order when --order desc is specified', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [
+      {id: 'org-1', name: 'Acme Corp', slug: 'acme'},
+      {id: 'org-2', name: 'Zebra Ltd', slug: 'zebra'},
+    ])
+
+    const {error, stdout} = await testCommand(ListOrganizationsCommand, ['--order', 'desc'])
+
+    if (error) throw error
+    const lines = stdout.split('\n').filter(Boolean)
+    const acmeIndex = lines.findIndex((line) => line.includes('Acme Corp'))
+    const zebraIndex = lines.findIndex((line) => line.includes('Zebra Ltd'))
+
+    expect(zebraIndex).toBeLessThan(acmeIndex)
+  })
+
+  test('sorts by id when --sort id is specified', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [
+      {id: 'org-2', name: 'Acme Corp', slug: 'acme'},
+      {id: 'org-1', name: 'Zebra Ltd', slug: 'zebra'},
+    ])
+
+    const {error, stdout} = await testCommand(ListOrganizationsCommand, ['--sort', 'id'])
+
+    if (error) throw error
+    const lines = stdout.split('\n').filter(Boolean)
+    const org1Index = lines.findIndex((line) => line.includes('org-1'))
+    const org2Index = lines.findIndex((line) => line.includes('org-2'))
+
+    expect(org1Index).toBeLessThan(org2Index)
+  })
+
+  test('displays only header when no organizations exist', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [])
+
+    const {error, stdout} = await testCommand(ListOrganizationsCommand)
+
+    if (error) throw error
+    const lines = stdout.split('\n').filter(Boolean)
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('id')
+    expect(lines[0]).toContain('name')
+    expect(lines[0]).toContain('slug')
+  })
+
+  test('handles organizations with null slug', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [{id: 'org-1', name: 'No Slug Org', slug: null}])
+
+    const {error, stdout} = await testCommand(ListOrganizationsCommand)
+
+    if (error) throw error
+    expect(stdout).toContain('org-1')
+    expect(stdout).toContain('No Slug Org')
+  })
+
+  test('displays an error if the API request fails', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(500, {message: 'Internal Server Error'})
+
+    const {error} = await testCommand(ListOrganizationsCommand)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Failed to list organizations')
+  })
+})

--- a/packages/@sanity/cli/src/commands/organizations/list.ts
+++ b/packages/@sanity/cli/src/commands/organizations/list.ts
@@ -1,0 +1,74 @@
+import {styleText} from 'node:util'
+
+import {Flags} from '@oclif/core'
+import {SanityCommand, subdebug} from '@sanity/cli-core'
+import size from 'lodash-es/size.js'
+import sortBy from 'lodash-es/sortBy.js'
+
+import {listOrganizations} from '../../services/organizations.js'
+
+const sortFields = ['id', 'name', 'slug']
+
+const debug = subdebug('organizations')
+
+export class ListOrganizationsCommand extends SanityCommand<typeof ListOrganizationsCommand> {
+  static override description = 'Lists organizations you have access to'
+  static override examples = [
+    {
+      command: '<%= config.bin %> <%= command.id %>',
+      description: 'List organizations',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --sort=name --order=desc',
+      description: 'List organizations sorted by name in descending order',
+    },
+  ]
+
+  static override flags = {
+    order: Flags.string({
+      default: 'asc',
+      options: ['asc', 'desc'],
+    }),
+    sort: Flags.string({
+      default: 'name',
+      options: sortFields,
+    }),
+  }
+
+  static override hiddenAliases: string[] = ['organization:list']
+
+  public async run() {
+    const {order, sort} = this.flags
+
+    try {
+      const organizations = await listOrganizations()
+      const ordered = sortBy(
+        organizations.map(({id, name, slug}) => {
+          return [id, name, slug ?? ''].map(String)
+        }),
+        [sortFields.indexOf(sort)],
+      )
+
+      const rows = order === 'asc' ? ordered : ordered.toReversed()
+
+      // Initialize maxWidths with the width of each header
+      const maxWidths = sortFields.map((str) => size(str))
+
+      // Calculate maximum width for each column
+      for (const row of rows) {
+        for (const [i, element] of row.entries()) {
+          maxWidths[i] = Math.max(size(element), maxWidths[i])
+        }
+      }
+
+      const printRow = (row: string[]) =>
+        row.map((col, i) => `${col}`.padEnd(maxWidths[i])).join('   ')
+
+      this.log(styleText('cyan', printRow(sortFields)))
+      for (const row of rows) this.log(printRow(row))
+    } catch (error) {
+      debug('Error listing organizations', error)
+      this.error('Failed to list organizations', {exit: 1})
+    }
+  }
+}

--- a/packages/@sanity/cli/src/topicAliases.ts
+++ b/packages/@sanity/cli/src/topicAliases.ts
@@ -23,6 +23,7 @@ export const topicAliases: Record<string, string[]> = {
   documents: ['document'],
   functions: ['function'],
   hooks: ['hook'],
+  organizations: ['organization'],
   projects: ['project'],
   schemas: ['schema'],
   tokens: ['token'],


### PR DESCRIPTION
Adds `sanity organizations list` to display organizations the user has access to.

Displays id, name, and slug in a tabular format. Supports `--sort` and `--order` flags matching the `projects list` pattern. Includes singular topic alias so `sanity organization list` also works.