### PR TITLE
fix(import): use stored CLI token instead of requiring --token flag

### DIFF
--- a/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
@@ -304,18 +304,6 @@ describe('#dataset:import', () => {
   })
 
   describe('error handling', () => {
-    test('errors when token is not provided', async () => {
-      const {error} = await testCommand(
-        ImportDatasetCommand,
-        ['test-source.ndjson', '--dataset', 'test-dataset'],
-        {mocks: defaultMocks},
-      )
-
-      expect(error).toBeInstanceOf(Error)
-      expect(error?.message).toContain('--token')
-      expect(error?.oclif?.exit).toBe(1)
-    })
-
     test('handles import failure', async () => {
       mockSanityImport.mockRejectedValueOnce(new Error('Connection timeout'))
 
@@ -442,7 +430,7 @@ describe('#dataset:import', () => {
   })
 
   describe('client configuration', () => {
-    test('creates client with correct options', async () => {
+    test('creates client with correct options when --token is provided', async () => {
       mockSanityImport.mockResolvedValueOnce({numDocs: 0, warnings: []})
 
       const {error} = await testCommand(ImportDatasetCommand, BASE_FLAGS, {
@@ -454,7 +442,27 @@ describe('#dataset:import', () => {
         apiVersion: 'v2025-02-19',
         dataset: 'test-dataset',
         projectId: 'test-project',
+        requireUser: true,
         token: 'test-token',
+      })
+    })
+
+    test('uses stored CLI token when --token is not provided', async () => {
+      mockSanityImport.mockResolvedValueOnce({numDocs: 5, warnings: []})
+
+      const {error, stdout} = await testCommand(
+        ImportDatasetCommand,
+        ['test-source.ndjson', '--dataset', 'test-dataset'],
+        {mocks: defaultMocks},
+      )
+
+      if (error) throw error
+      expect(stdout).toContain('Done! Imported 5 documents')
+      expect(mockGetProjectCliClient).toHaveBeenCalledWith({
+        apiVersion: 'v2025-02-19',
+        dataset: 'test-dataset',
+        projectId: 'test-project',
+        requireUser: true,
       })
     })
   })

--- a/packages/@sanity/cli/src/commands/datasets/import.ts
+++ b/packages/@sanity/cli/src/commands/datasets/import.ts
@@ -71,18 +71,21 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
 
   static override examples = [
     {
-      command:
-        '<%= config.bin %> <%= command.id %> -d staging -t someSecretToken my-dataset.ndjson',
+      command: '<%= config.bin %> <%= command.id %> -d staging my-dataset.ndjson',
       description: 'Import "./my-dataset.ndjson" into dataset "staging"',
     },
     {
-      command: 'cat my-dataset.ndjson | <%= config.bin %> <%= command.id %> -d test -t someToken -',
+      command: 'cat my-dataset.ndjson | <%= config.bin %> <%= command.id %> -d test -',
       description: 'Import into dataset "test" from stdin',
     },
     {
-      command:
-        '<%= config.bin %> <%= command.id %> -p projectId -d staging -t someSecretToken my-dataset.ndjson',
+      command: '<%= config.bin %> <%= command.id %> -p projectId -d staging my-dataset.ndjson',
       description: 'Import with explicit project ID (overrides CLI configuration)',
+    },
+    {
+      command:
+        '<%= config.bin %> <%= command.id %> -d staging -t someSecretToken my-dataset.ndjson',
+      description: 'Import with an explicit token (e.g. for CI/CD)',
     },
   ]
 
@@ -197,11 +200,6 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
       })
     }
 
-    const tokenString: string | undefined = token
-    if (!tokenString) {
-      this.error('Flag `--token` is required (or set SANITY_IMPORT_TOKEN)', {exit: 1})
-    }
-
     let operation: 'create' | 'createIfNotExists' | 'createOrReplace' = 'create'
     let releasesOperation: 'fail' | 'ignore' | 'replace' = 'fail'
 
@@ -214,7 +212,8 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
       apiVersion: 'v2025-02-19',
       dataset,
       projectId,
-      token: tokenString,
+      requireUser: true,
+      ...(token ? {token} : {}),
     })
 
     try {


### PR DESCRIPTION
## Summary

- `sanity import` was the only dataset command that required an explicit `--token` flag, erroring out even when the user was logged in via `sanity login`
- Changed to use `getProjectCliClient({ requireUser: true })` like `sanity export` and all other commands, falling back to the stored CLI token
- The `--token` flag still works as an override for CI/CD workflows

## Test plan

- [x] Existing tests updated and passing (23/23)
- [x] Type check passes
- [x] Lint passes
- [ ] Manual: run `sanity import` without `--token` after `sanity login` - should work
- [ ] Manual: run `sanity import` with `--token` - should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)