### PR TITLE
chore(dataset:alias): removing `~` prefix examples as commands take alias names without prefix

### DIFF
--- a/packages/@sanity/cli/src/commands/datasets/alias/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/create.ts
@@ -44,10 +44,6 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
       command: '<%= config.bin %> <%= command.id %> conference conf-2025',
       description: 'Create alias "conference" linked to "conf-2025" dataset',
     },
-    {
-      command: '<%= config.bin %> <%= command.id %> ~conference conf-2025',
-      description: 'Create alias with explicit ~ prefix',
-    },
   ]
 
   static override flags = {

--- a/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
@@ -26,10 +26,6 @@ export class DeleteAliasCommand extends SanityCommand<typeof DeleteAliasCommand>
       description: 'Delete alias named "conference" with confirmation prompt',
     },
     {
-      command: '<%= config.bin %> <%= command.id %> ~conference',
-      description: 'Delete alias with explicit ~ prefix',
-    },
-    {
       command: '<%= config.bin %> <%= command.id %> conference --force',
       description: 'Delete alias named "conference" without confirmation prompt',
     },

--- a/packages/@sanity/cli/src/commands/datasets/alias/link.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/link.ts
@@ -42,10 +42,6 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
       description: 'Link alias "conference" to "conf-2025" dataset',
     },
     {
-      command: '<%= config.bin %> <%= command.id %> ~conference conf-2025',
-      description: 'Link alias with explicit ~ prefix',
-    },
-    {
       command: '<%= config.bin %> <%= command.id %> conference conf-2025 --force',
       description: 'Force link without confirmation (skip relink prompt)',
     },

--- a/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
@@ -31,10 +31,6 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
       description: 'Unlink alias "conference" with confirmation prompt',
     },
     {
-      command: '<%= config.bin %> <%= command.id %> ~conference',
-      description: 'Unlink alias with explicit ~ prefix',
-    },
-    {
       command: '<%= config.bin %> <%= command.id %> conference --force',
       description: 'Unlink alias "conference" without confirmation prompt',
     },


### PR DESCRIPTION
### Description

Examples were added to new cli that showed you can add `~` prefix to dataset alias name for `dataset alias` commands. The examples would cause errors in some shells. Removed as you can use alias names without `~` and want to provide example which do not confuse users.