### PR TITLE
fix(help): resolve singular topic aliases with --help flag

### DIFF
--- a/packages/@sanity/cli/src/SanityHelp.ts
+++ b/packages/@sanity/cli/src/SanityHelp.ts
@@ -1,6 +1,16 @@
 import {Command, Help, Interfaces} from '@oclif/core'
 import {getBinCommand, getRunningPackageManager} from '@sanity/cli-core/package-manager'
 
+import {topicAliases} from './topicAliases.js'
+
+// Reverse map: alias name → canonical topic name
+const aliasToCanonical = new Map<string, string>()
+for (const [canonical, aliases] of Object.entries(topicAliases)) {
+  for (const alias of aliases) {
+    aliasToCanonical.set(alias, canonical)
+  }
+}
+
 // Running `oclif readme`, we don't want to apply the `prefixBinName` transformation,
 // as it will include whatever pm was used to spawn the script in the generated readme.
 // argv will contain something like [nodeBinPath, oclifBinPath, 'readme', …] so check
@@ -38,6 +48,10 @@ export default class SanityHelp extends Help {
 
   protected formatTopic(topic: Interfaces.Topic): string {
     return prefixBinName(super.formatTopic(topic))
+  }
+
+  async showHelp(argv: string[]): Promise<void> {
+    return super.showHelp(resolveTopicAliasInArgv(argv))
   }
 }
 
@@ -84,4 +98,32 @@ function guessCreateCommand() {
 function needsFlagSeparator() {
   const pm = getRunningPackageManager()
   return pm === 'npm' || !pm
+}
+
+/**
+ * Replace the first positional argument in argv with the canonical topic name
+ * if it is a known topic alias. This ensures that `sanity dataset --help`
+ * resolves to the same help output as `sanity datasets --help`.
+ *
+ * Without this, `--help` bypasses the command_not_found hook (which normally
+ * handles alias resolution) and the help system fails to find the topic.
+ *
+ * @internal
+ */
+export function resolveTopicAliasInArgv(argv: string[]): string[] {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--') break
+    if (arg.startsWith('-')) continue
+
+    // First positional argument is the topic/command name
+    const canonical = aliasToCanonical.get(arg)
+    if (canonical) {
+      const resolved = [...argv]
+      resolved[i] = canonical
+      return resolved
+    }
+    break
+  }
+  return argv
 }

--- a/packages/@sanity/cli/src/__tests__/SanityHelp.test.ts
+++ b/packages/@sanity/cli/src/__tests__/SanityHelp.test.ts
@@ -1,6 +1,10 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {prefixBinName, replaceInitWithCreateCommand} from '../SanityHelp.js'
+import {
+  prefixBinName,
+  replaceInitWithCreateCommand,
+  resolveTopicAliasInArgv,
+} from '../SanityHelp.js'
 
 describe('prefixBinName', () => {
   afterEach(() => {
@@ -284,5 +288,53 @@ describe('replaceInitWithCreateCommand + prefixBinName interaction', () => {
 
     // With unknown PM, getBinCommand returns "sanity" so prefixBinName is a no-op
     expect(result).toBe(afterCreate)
+  })
+})
+
+describe('resolveTopicAliasInArgv', () => {
+  test('resolves singular topic alias to canonical plural form', () => {
+    expect(resolveTopicAliasInArgv(['dataset', '--help'])).toEqual(['datasets', '--help'])
+  })
+
+  test('resolves other singular aliases', () => {
+    expect(resolveTopicAliasInArgv(['document', '--help'])).toEqual(['documents', '--help'])
+    expect(resolveTopicAliasInArgv(['user', '--help'])).toEqual(['users', '--help'])
+    expect(resolveTopicAliasInArgv(['token', '--help'])).toEqual(['tokens', '--help'])
+    expect(resolveTopicAliasInArgv(['project', '--help'])).toEqual(['projects', '--help'])
+    expect(resolveTopicAliasInArgv(['hook', '--help'])).toEqual(['hooks', '--help'])
+    expect(resolveTopicAliasInArgv(['backup', '--help'])).toEqual(['backups', '--help'])
+    expect(resolveTopicAliasInArgv(['schema', '--help'])).toEqual(['schemas', '--help'])
+  })
+
+  test('does not modify argv for canonical topic names', () => {
+    expect(resolveTopicAliasInArgv(['datasets', '--help'])).toEqual(['datasets', '--help'])
+  })
+
+  test('does not modify argv for unknown topics', () => {
+    expect(resolveTopicAliasInArgv(['unknown', '--help'])).toEqual(['unknown', '--help'])
+  })
+
+  test('resolves alias with subcommand in argv', () => {
+    expect(resolveTopicAliasInArgv(['dataset', 'list', '--help'])).toEqual([
+      'datasets',
+      'list',
+      '--help',
+    ])
+  })
+
+  test('returns original argv when no positional argument found', () => {
+    expect(resolveTopicAliasInArgv(['--help'])).toEqual(['--help'])
+  })
+
+  test('returns original argv for empty input', () => {
+    expect(resolveTopicAliasInArgv([])).toEqual([])
+  })
+
+  test('stops processing at -- separator', () => {
+    expect(resolveTopicAliasInArgv(['--', 'dataset', '--help'])).toEqual([
+      '--',
+      'dataset',
+      '--help',
+    ])
   })
 })


### PR DESCRIPTION
## Summary

- Fixes `sanity dataset --help` (and other singular topic aliases) failing with "Command dataset not found"
- Root cause: oclif intercepts `--help` before command resolution, so the `command_not_found` hook (which handles alias rewriting) never fires
- Overrides `showHelp()` in `SanityHelp` to resolve topic aliases in argv before the base class looks up the topic

Fixes SDK-1116

## Test plan

- [ ] `sanity dataset --help` shows datasets topic help
- [ ] `sanity datasets --help` still works as before
- [ ] `sanity document --help`, `sanity user --help`, etc. all resolve correctly
- [ ] `sanity dataset list --help` still works (via existing hiddenAliases)
- [ ] `sanity unknown --help` still shows "Command unknown not found"
- [ ] Unit tests pass for `resolveTopicAliasInArgv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)