### PR TITLE
ci: add bundle stats workflow

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version: 24
 
-      - uses: rexxars/bundle-stats@5b965c0d5954a27d44a7def1f8293ef677e1ecd4 # v1
+      - uses: rexxars/bundle-stats@9b04ed2500738f835b02ad4046fc9e7ed29ef72a # v1.9.5
         with:
           packages: packages/@sanity/cli, packages/@sanity/cli-core
           build-command: pnpm build:cli


### PR DESCRIPTION
## Summary
- Adds a `bundle-stats.yml` GitHub Actions workflow that reports bundle size changes on pull requests
- Uses `rexxars/bundle-stats@v1` to track `@sanity/cli` and `@sanity/cli-core` against the latest npm release
- Includes code change detection (same `dorny/paths-filter` pattern as `test.yml`) to skip docs-only PRs

## Test plan
- [ ] Verify workflow triggers on a PR with code changes
- [ ] Verify workflow is skipped for docs-only PRs
- [ ] Verify bundle stats comment appears on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)