### PR TITLE
feat(cli): use app.title from config in SDK app HTML title

### DIFF
--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -159,6 +159,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     timer.start('bundleStudio')
 
     const bundle = await buildStaticFiles({
+      appTitle: cliConfig && 'app' in cliConfig ? cliConfig.app?.title : undefined,
       basePath,
       cwd: workDir,
       entry: cliConfig && 'app' in cliConfig ? cliConfig.app?.entry : undefined,

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -26,6 +26,7 @@ interface StaticBuildOptions {
   cwd: string
   outputDir: string
 
+  appTitle?: string
   entry?: string
   importMap?: {imports?: Record<string, string>}
   isApp?: boolean
@@ -45,6 +46,7 @@ export async function buildStaticFiles(
   options: StaticBuildOptions,
 ): Promise<{chunks: ChunkStats[]}> {
   const {
+    appTitle,
     basePath,
     cwd,
     entry,
@@ -59,6 +61,7 @@ export async function buildStaticFiles(
 
   buildDebug('Writing Sanity runtime files')
   await writeSanityRuntime({
+    appTitle,
     basePath,
     cwd,
     entry,

--- a/packages/@sanity/cli/src/actions/build/renderDocument.ts
+++ b/packages/@sanity/cli/src/actions/build/renderDocument.ts
@@ -8,6 +8,7 @@ interface DocumentProps {
 
   css?: string[]
   entryPath?: string
+  title?: string
 }
 
 interface RenderDocumentOptions {

--- a/packages/@sanity/cli/src/actions/build/renderDocumentWorker/components/BasicDocument.tsx
+++ b/packages/@sanity/cli/src/actions/build/renderDocumentWorker/components/BasicDocument.tsx
@@ -14,6 +14,7 @@ import {NoJavascript} from './NoJavascript.js'
  */
 interface BasicDocumentProps {
   entryPath: string
+  title?: string
 
   // Currently unused, but kept for potential future use
   basePath?: string
@@ -27,7 +28,7 @@ const EMPTY_ARRAY: never[] = []
  * @internal
  */
 export function BasicDocument(props: BasicDocumentProps): JSX.Element {
-  const {css = EMPTY_ARRAY, entryPath} = props
+  const {css = EMPTY_ARRAY, entryPath, title} = props
 
   return (
     <html lang="en">
@@ -38,7 +39,7 @@ export function BasicDocument(props: BasicDocumentProps): JSX.Element {
         <meta content="same-origin" name="referrer" />
 
         <Favicons />
-        <title>Sanity CORE App</title>
+        <title>{title || 'Sanity App'}</title>
         <GlobalErrorHandler />
 
         {css.map((href) => (

--- a/packages/@sanity/cli/src/actions/build/renderDocumentWorker/types.ts
+++ b/packages/@sanity/cli/src/actions/build/renderDocumentWorker/types.ts
@@ -6,4 +6,5 @@ export interface DocumentProps {
 
   css?: string[]
   entryPath?: string
+  title?: string
 }

--- a/packages/@sanity/cli/src/actions/build/writeSanityRuntime.ts
+++ b/packages/@sanity/cli/src/actions/build/writeSanityRuntime.ts
@@ -17,6 +17,7 @@ interface RuntimeOptions {
   reactStrictMode: boolean
   watch: boolean
 
+  appTitle?: string
   basePath?: string
   entry?: string
   isApp?: boolean
@@ -31,7 +32,7 @@ interface RuntimeOptions {
  * @internal
  */
 export async function writeSanityRuntime(options: RuntimeOptions): Promise<FSWatcher | undefined> {
-  const {basePath, cwd, entry, isApp, reactStrictMode, watch} = options
+  const {appTitle, basePath, cwd, entry, isApp, reactStrictMode, watch} = options
   const runtimeDir = path.join(cwd, '.sanity', 'runtime')
 
   buildDebug('Making runtime directory')
@@ -46,6 +47,7 @@ export async function writeSanityRuntime(options: RuntimeOptions): Promise<FSWat
           props: {
             basePath: basePath || '/',
             entryPath: `/${toForwardSlashes(path.relative(cwd, path.join(runtimeDir, 'app.js')))}`,
+            title: appTitle,
           },
           studioRootPath: cwd,
         }),

--- a/packages/@sanity/cli/src/actions/dev/startAppDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startAppDevServer.ts
@@ -34,7 +34,8 @@ export async function startAppDevServer(
   try {
     output.log('Starting dev server')
 
-    const {close, server} = await startDevServer({...config, isApp: true})
+    const appTitle = cliConfig && 'app' in cliConfig ? cliConfig.app?.title : undefined
+    const {close, server} = await startDevServer({...config, appTitle, isApp: true})
 
     const {port} = server.config.server
     const httpHost = config.httpHost || 'localhost'

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -19,6 +19,7 @@ export interface DevServerOptions {
 
   staticPath: string
 
+  appTitle?: string
   entry?: string
   httpHost?: string
   isApp?: boolean
@@ -37,6 +38,7 @@ interface DevServer {
 
 export async function startDevServer(options: DevServerOptions): Promise<DevServer> {
   const {
+    appTitle,
     basePath,
     cwd,
     entry,
@@ -52,6 +54,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
 
   debug('Writing Sanity runtime files')
   const watcher = await writeSanityRuntime({
+    appTitle,
     basePath,
     cwd,
     entry,


### PR DESCRIPTION
### Description

When building an SDK app, the CLI currently hardcodes `<title>Sanity CORE App</title>` in the generated HTML. This means the browser tab always shows "Sanity CORE App" until JavaScript takes over, and the bridge sends this placeholder to the dashboard.

This PR threads `app.title` from the CLI config through the build pipeline so the HTML `<title>` element reflects the configured app name. Falls back to "Sanity App" when no title is configured.

This is part of a cross-repo effort to bring SDK app browser tab titles and favicons to parity with studio workspaces:
- **This PR (CLI)**: Seeds the correct `<title>` at build time — the foundation that makes titles work without any runtime code
- **SDK**: sanity-io/sdk#436 — Adds an opt-in `useDocumentTitle` hook for view-specific titles (e.g., `"Movies | My App"`)
- **Ada**: sanity-io/ada#3228 — Uses `app.icon` as the browser tab favicon and fixes a double-wrapping bug in the title hook

These can be deployed in any order since each is backward-compatible, but the CLI change has the most impact since it makes the default title correct without any developer effort.

### What to review

The change touches the document rendering pipeline: `buildApp` / `startAppDevServer` → `buildStaticFiles` / `writeSanityRuntime` → `renderDocument` → `BasicDocument`. Each layer threads the new `title` (or `appTitle`) prop through to `BasicDocument`, which uses it in the `<title>` element.

### Testing

The change is a straightforward prop threading. Existing build tests cover the pipeline; the new prop is optional and falls back gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)