### PR TITLE
feat(deploy): `--app-title` flag for unattended sdk app deployments

### DIFF
--- a/packages/@sanity/cli/src/actions/deploy/createUserApplicationForApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/createUserApplicationForApp.ts
@@ -7,16 +7,19 @@ import {deployDebug} from './deployDebug.js'
 
 export async function createUserApplicationForApp(
   organizationId?: string,
+  appTitle?: string,
 ): Promise<UserApplication> {
   if (!organizationId) {
     throw new Error(NO_ORGANIZATION_ID)
   }
 
-  // First get the title from the user
-  const title = await input({
-    message: 'Enter a title for your application:',
-    validate: (input: string) => input.length > 0 || 'Title is required',
-  })
+  // Use provided title or prompt the user for one
+  const title =
+    appTitle ??
+    (await input({
+      message: 'Enter a title for your application:',
+      validate: (value: string) => value.length > 0 || 'Title is required',
+    }))
 
   return tryCreateApp(title, organizationId)
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -3,6 +3,7 @@ import {styleText} from 'node:util'
 import {createGzip} from 'node:zlib'
 
 import {CLIError} from '@oclif/core/errors'
+import {exitCodes} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {pack} from 'tar-fs'
 
@@ -33,11 +34,14 @@ export async function deployApp(options: DeployAppOptions) {
 
   const organizationId = cliConfig.app?.organizationId
   const appId = getAppId(cliConfig)
+  const appTitle = flags['app-title']
   const isAutoUpdating = shouldAutoUpdate({cliConfig, flags, output})
   const installedSdkVersion = await getLocalPackageVersion('@sanity/sdk-react', workDir)
 
   if (!installedSdkVersion) {
-    output.error(`Failed to find installed @sanity/sdk-react version`, {exit: 1})
+    output.error(`Failed to find installed @sanity/sdk-react version`, {
+      exit: 1,
+    })
     return
   }
 
@@ -47,25 +51,52 @@ export async function deployApp(options: DeployAppOptions) {
   }
 
   if (flags.external) {
-    output.error('Deploying an app to an external host is not supported.', {exit: 1})
+    output.error('Deploying an app to an external host is not supported.', {
+      exit: 1,
+    })
+  }
+
+  // Warn if --app-title is passed but will be ignored because appId is already configured
+  if (appId && appTitle) {
+    output.warn(
+      '--app-title is ignored because an existing application ID is configured in your sanity.cli file',
+    )
+  }
+
+  // Fail fast in unattended mode if no appId and no --app-title
+  if (!appId && flags.yes && !appTitle) {
+    output.error(
+      'Cannot prompt for application title in unattended mode. Use --app-title to specify the application title.',
+      {exit: exitCodes.USAGE_ERROR},
+    )
+    return
   }
 
   let spin = spinner('Verifying local content...')
 
   try {
-    let userApplication = await findUserApplicationForApp({
-      cliConfig,
-      organizationId,
-      output,
-    })
+    let userApplication
 
-    deployDebug(`User application found`, userApplication)
-
-    if (!userApplication) {
-      deployDebug(`No user application found. Creating a new one`)
-
-      userApplication = await createUserApplicationForApp(organizationId)
+    if (!appId && appTitle) {
+      // --app-title provided and no existing appId: go straight to create
+      deployDebug(`Creating new user application with title from --app-title flag`)
+      userApplication = await createUserApplicationForApp(organizationId, appTitle)
       deployDebug(`User application created`, userApplication)
+    } else {
+      // Normal flow: find existing app by appId or prompt to select/create
+      userApplication = await findUserApplicationForApp({
+        cliConfig,
+        organizationId,
+        output,
+      })
+
+      deployDebug(`User application found`, userApplication)
+
+      if (!userApplication) {
+        deployDebug(`No user application found. Creating a new one`)
+        userApplication = await createUserApplicationForApp(organizationId)
+        deployDebug(`User application created`, userApplication)
+      }
     }
 
     // Always build the project, unless --no-build is passed

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -3,6 +3,7 @@ import {styleText} from 'node:util'
 import {createGzip, type Gzip} from 'node:zlib'
 
 import {CLIError} from '@oclif/core/errors'
+import {type Output} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {type StudioManifest} from 'sanity'
 import {pack} from 'tar-fs'
@@ -21,6 +22,7 @@ import {deployDebug} from './deployDebug.js'
 import {deployStudioSchemasAndManifests} from './deployStudioSchemasAndManifests.js'
 import {findUserApplicationForStudio} from './findUserApplicationForStudio.js'
 import {type DeployAppOptions} from './types.js'
+import {normalizeUrl, validateUrl} from './urlUtils.js'
 
 export async function deployStudio(options: DeployAppOptions) {
   const {cliConfig, flags, output, projectRoot, sourceDir} = options
@@ -28,7 +30,6 @@ export async function deployStudio(options: DeployAppOptions) {
   const workDir = projectRoot.directory
   const configPath = projectRoot.path
 
-  const appHost = cliConfig.studioHost
   const appId = getAppId(cliConfig)
   const projectId = cliConfig.api?.projectId
   const installedSanityVersion = await getLocalPackageVersion('sanity', workDir)
@@ -36,6 +37,9 @@ export async function deployStudio(options: DeployAppOptions) {
 
   const isExternal = !!flags.external
   const urlType: 'external' | 'internal' = isExternal ? 'external' : 'internal'
+
+  // Resolve the app host from --url flag (takes precedence) or studioHost config
+  const appHost = resolveAppHost({flags, isExternal, output, studioHost: cliConfig.studioHost})
 
   if (!installedSanityVersion) {
     output.error(`Failed to find installed sanity version`, {exit: 1})
@@ -55,10 +59,22 @@ export async function deployStudio(options: DeployAppOptions) {
       appId,
       output,
       projectId,
+      unattended: !!flags.yes,
       urlType,
     })
 
     if (!userApplication) {
+      if (flags.yes) {
+        const flagHint = isExternal
+          ? 'Use --url to specify the external studio URL'
+          : 'Use --url to specify the studio hostname'
+        output.error(
+          `Cannot prompt for ${isExternal ? 'external studio URL' : 'studio hostname'} in unattended mode. ${flagHint}.`,
+          {exit: 1},
+        )
+        return
+      }
+
       if (isExternal) {
         output.log('Your project has not been registered with an external studio URL.')
         output.log('Please enter the full URL where your studio is hosted.')
@@ -180,4 +196,34 @@ export default defineCliConfig({
     deployDebug('Error deploying studio', error)
     output.error(`Error deploying studio: ${error}`, {exit: 1})
   }
+}
+
+function resolveAppHost({
+  flags,
+  isExternal,
+  output,
+  studioHost,
+}: {
+  flags: DeployAppOptions['flags']
+  isExternal: boolean
+  output: Output
+  studioHost: string | undefined
+}): string | undefined {
+  const url = flags.url
+  if (!url) {
+    return studioHost
+  }
+
+  if (isExternal) {
+    const normalized = normalizeUrl(url)
+    const validation = validateUrl(normalized)
+    if (validation !== true) {
+      output.error(validation, {exit: 1})
+      return undefined
+    }
+    return normalized
+  }
+
+  // For internal deploys, strip .sanity.studio suffix if present
+  return url.replace(/\.sanity\.studio\/?$/i, '')
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -3,7 +3,7 @@ import {styleText} from 'node:util'
 import {createGzip, type Gzip} from 'node:zlib'
 
 import {CLIError} from '@oclif/core/errors'
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {type StudioManifest} from 'sanity'
 import {pack} from 'tar-fs'
@@ -70,7 +70,7 @@ export async function deployStudio(options: DeployAppOptions) {
           : 'Use --url to specify the studio hostname'
         output.error(
           `Cannot prompt for ${isExternal ? 'external studio URL' : 'studio hostname'} in unattended mode. ${flagHint}.`,
-          {exit: 1},
+          {exit: exitCodes.USAGE_ERROR},
         )
         return
       }
@@ -186,9 +186,9 @@ export default defineCliConfig({
       output.log(`\n${example}`)
     }
   } catch (error) {
-    // if the error is a CLIError, we can just output the message and exit
+    // if the error is a CLIError, we can just output the message and preserve its exit code
     if (error instanceof CLIError) {
-      output.error(error.message, {exit: 1})
+      output.error(error.message, {exit: error.oclif?.exit ?? exitCodes.RUNTIME_ERROR})
       return
     }
 
@@ -218,7 +218,7 @@ function resolveAppHost({
     const normalized = normalizeUrl(url)
     const validation = validateUrl(normalized)
     if (validation !== true) {
-      output.error(validation, {exit: 1})
+      output.error(validation, {exit: exitCodes.USAGE_ERROR})
       return undefined
     }
     return normalized
@@ -231,7 +231,7 @@ function resolveAppHost({
   if (hostname.includes('.')) {
     output.error(
       `"${hostname}" does not look like a sanity.studio hostname. Did you mean to use --external?`,
-      {exit: 1},
+      {exit: exitCodes.USAGE_ERROR},
     )
     return undefined
   }
@@ -240,7 +240,7 @@ function resolveAppHost({
   if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test(hostname)) {
     output.error(
       `Invalid studio hostname "${hostname}". Hostnames can only contain letters, numbers, and hyphens.`,
-      {exit: 1},
+      {exit: exitCodes.USAGE_ERROR},
     )
     return undefined
   }

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -224,6 +224,6 @@ function resolveAppHost({
     return normalized
   }
 
-  // For internal deploys, strip .sanity.studio suffix if present
-  return url.replace(/\.sanity\.studio\/?$/i, '')
+  // For internal deploys, strip protocol prefix and .sanity.studio suffix if present
+  return url.replace(/^https?:\/\//i, '').replace(/\.sanity\.studio\/?$/i, '')
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -225,5 +225,25 @@ function resolveAppHost({
   }
 
   // For internal deploys, strip protocol prefix and .sanity.studio suffix if present
-  return url.replace(/^https?:\/\//i, '').replace(/\.sanity\.studio\/?$/i, '')
+  const hostname = url.replace(/^https?:\/\//i, '').replace(/\.sanity\.studio\/?$/i, '')
+
+  // If the result still looks like a URL (contains dots), the user likely meant --external
+  if (hostname.includes('.')) {
+    output.error(
+      `"${hostname}" does not look like a sanity.studio hostname. Did you mean to use --external?`,
+      {exit: 1},
+    )
+    return undefined
+  }
+
+  // Validate hostname characters (alphanumeric and hyphens only)
+  if (!/^[a-z0-9][a-z0-9-]*$/i.test(hostname)) {
+    output.error(
+      `Invalid studio hostname "${hostname}". Hostnames can only contain letters, numbers, and hyphens.`,
+      {exit: 1},
+    )
+    return undefined
+  }
+
+  return hostname
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -237,7 +237,7 @@ function resolveAppHost({
   }
 
   // Validate hostname characters (alphanumeric and hyphens only)
-  if (!/^[a-z0-9][a-z0-9-]*$/i.test(hostname)) {
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test(hostname)) {
     output.error(
       `Invalid studio hostname "${hostname}". Hostnames can only contain letters, numbers, and hyphens.`,
       {exit: 1},

--- a/packages/@sanity/cli/src/actions/deploy/findUserApplicationForStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/findUserApplicationForStudio.ts
@@ -20,11 +20,12 @@ interface FindUserApplicationForStudioOptions {
 
   appHost?: string
   appId?: string
+  unattended?: boolean
   urlType?: 'external' | 'internal'
 }
 
 export async function findUserApplicationForStudio(options: FindUserApplicationForStudioOptions) {
-  const {appHost, appId, output, projectId, urlType = 'internal'} = options
+  const {appHost, appId, output, projectId, unattended = false, urlType = 'internal'} = options
 
   const spin = spinner('Checking project info').start()
 
@@ -61,6 +62,19 @@ export async function findUserApplicationForStudio(options: FindUserApplicationF
   // If no applications are found, return null
   if (!userApplications?.length) {
     return null
+  }
+
+  // In unattended mode, we can't prompt the user to select a studio
+  if (unattended) {
+    const flagHint =
+      urlType === 'external'
+        ? 'Use --url to specify the external studio URL'
+        : 'Use --url to specify the studio hostname'
+    output.error(
+      `Multiple studios found for this project. Cannot select in unattended mode. ${flagHint}.`,
+      {exit: 1},
+    )
+    return
   }
 
   // If there are user applications, allow the user to select one of the existing host names,

--- a/packages/@sanity/cli/src/actions/deploy/findUserApplicationForStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/findUserApplicationForStudio.ts
@@ -74,7 +74,7 @@ export async function findUserApplicationForStudio(options: FindUserApplicationF
       `Multiple studios found for this project. Cannot select in unattended mode. ${flagHint}.`,
       {exit: 1},
     )
-    return
+    return null
   }
 
   // If there are user applications, allow the user to select one of the existing host names,

--- a/packages/@sanity/cli/src/actions/deploy/findUserApplicationForStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/findUserApplicationForStudio.ts
@@ -64,17 +64,9 @@ export async function findUserApplicationForStudio(options: FindUserApplicationF
     return null
   }
 
-  // In unattended mode, we can't prompt the user to select a studio
+  // In unattended mode, we can't prompt the user to select a studio.
+  // Return null and let the caller handle the error messaging.
   if (unattended) {
-    const flagHint =
-      urlType === 'external'
-        ? 'Use --url to specify the external studio URL'
-        : 'Use --url to specify the studio hostname'
-    const count = userApplications.length > 1 ? 'Multiple studios' : 'A studio'
-    output.error(
-      `${count} found for this project. Cannot select in unattended mode. ${flagHint}.`,
-      {exit: 1},
-    )
     return null
   }
 

--- a/packages/@sanity/cli/src/actions/deploy/findUserApplicationForStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/findUserApplicationForStudio.ts
@@ -70,8 +70,9 @@ export async function findUserApplicationForStudio(options: FindUserApplicationF
       urlType === 'external'
         ? 'Use --url to specify the external studio URL'
         : 'Use --url to specify the studio hostname'
+    const count = userApplications.length > 1 ? 'Multiple studios' : 'A studio'
     output.error(
-      `Multiple studios found for this project. Cannot select in unattended mode. ${flagHint}.`,
+      `${count} found for this project. Cannot select in unattended mode. ${flagHint}.`,
       {exit: 1},
     )
     return null

--- a/packages/@sanity/cli/src/actions/deploy/findUserApplicationForStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/findUserApplicationForStudio.ts
@@ -2,7 +2,7 @@
  * Helper functions to find a user application for a Sanity studio.
  */
 
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {select, Separator, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
 
 import {
@@ -143,7 +143,7 @@ async function findUserApplication(
       const validation = validateUrl(resolvedHost)
       if (validation !== true) {
         spin.fail()
-        output.error(validation, {exit: 1})
+        output.error(validation, {exit: exitCodes.USAGE_ERROR})
         return null
       }
     }

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.app.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core'
 import {confirm, input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
 import nock from 'nock'
@@ -395,6 +396,60 @@ describe('#deploy app', () => {
       message: 'Enter a title for your application:',
       validate: expect.any(Function),
     })
+  })
+
+  test('should create new app using --app-title without prompting in interactive mode', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    const newAppId = 'new-app-id'
+    const deploymentId = 'deployment-id'
+
+    // No GET mock — --app-title skips lookup entirely
+    mockApi({
+      apiVersion: USER_APPLICATIONS_API_VERSION,
+      method: 'post',
+      query: {
+        appType: 'coreApp',
+        organizationId,
+      },
+      uri: `/user-applications`,
+    }).reply(200, {
+      appHost: 'generated-host',
+      createdAt: '2024-01-01T00:00:00Z',
+      id: newAppId,
+      organizationId,
+      projectId: null,
+      title: 'My App',
+      type: 'coreApp',
+      updatedAt: '2024-01-01T00:00:00Z',
+      urlType: 'internal',
+    })
+
+    mockApi({
+      apiVersion: USER_APPLICATIONS_API_VERSION,
+      method: 'post',
+      query: {
+        appType: 'coreApp',
+      },
+      uri: `/user-applications/${newAppId}/deployments`,
+    }).reply(201, {id: deploymentId}, {location: 'https://generated-host.sanity.app/'})
+
+    const {error, stdout} = await testCommand(DeployCommand, ['--app-title', 'My App'], {
+      config: {root: cwd},
+      mocks: {
+        cliConfig: {
+          app: {
+            organizationId,
+          },
+        },
+      },
+    })
+
+    if (error) throw error
+    expect(mockInput).not.toHaveBeenCalled()
+    expect(stdout).toContain('Success! Application deployed')
+    expect(stdout).toContain(`appId: '${newAppId}'`)
   })
 
   test('should skip build when --no-build flag is used', async () => {
@@ -969,6 +1024,135 @@ describe('#deploy app', () => {
       `Add the deployment.appId to your sanity.cli.js or sanity.cli.ts file:`,
     )
     expect(stdout).toContain(`deployment: {\n  appId: '${newAppId}',`)
+  })
+
+  describe('unattended mode (--yes)', () => {
+    test('should create new app with --app-title without prompting', async () => {
+      const cwd = await testFixture('basic-app')
+      process.cwd = () => cwd
+
+      const newAppId = 'new-app-id'
+      const deploymentId = 'deployment-id'
+
+      // No GET mock — --app-title skips lookup entirely
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {
+          appType: 'coreApp',
+          organizationId,
+        },
+        uri: `/user-applications`,
+      }).reply(200, {
+        appHost: 'generated-host',
+        createdAt: '2024-01-01T00:00:00Z',
+        id: newAppId,
+        organizationId,
+        projectId: null,
+        title: 'My New App',
+        type: 'coreApp',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'internal',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {
+          appType: 'coreApp',
+        },
+        uri: `/user-applications/${newAppId}/deployments`,
+      }).reply(201, {id: deploymentId}, {location: 'https://generated-host.sanity.app/'})
+
+      const {error, stdout} = await testCommand(
+        DeployCommand,
+        ['--yes', '--app-title', 'My New App'],
+        {
+          config: {root: cwd},
+          mocks: {
+            cliConfig: {
+              app: {
+                organizationId,
+              },
+            },
+          },
+        },
+      )
+
+      if (error) throw error
+      expect(mockInput).not.toHaveBeenCalled()
+      expect(mockSelect).not.toHaveBeenCalled()
+      expect(stdout).toContain('Success! Application deployed')
+      expect(stdout).toContain(`appId: '${newAppId}'`)
+    })
+
+    test('should warn when --app-title is passed but appId is already configured', async () => {
+      const cwd = await testFixture('basic-app')
+      process.cwd = () => cwd
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appType: 'coreApp',
+        },
+        uri: `/user-applications/${appId}`,
+      }).reply(200, {
+        appHost: 'existing-host',
+        createdAt: '2024-01-01T00:00:00Z',
+        id: appId,
+        organizationId,
+        projectId: null,
+        title: 'Existing App',
+        type: 'coreApp',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'internal',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {
+          appType: 'coreApp',
+        },
+        uri: `/user-applications/${appId}/deployments`,
+      }).reply(201, {id: 'deployment-id'}, {location: 'https://existing-host.sanity.app/'})
+
+      const {error, stderr} = await testCommand(
+        DeployCommand,
+        ['--yes', '--app-title', 'My New App'],
+        {
+          config: {root: cwd},
+          mocks: defaultMocks,
+        },
+      )
+
+      if (error) throw error
+      expect(stderr).toContain('--app-title is ignored because an existing application ID is')
+      expect(stderr).toContain('configured in your sanity.cli file')
+    })
+
+    test('should error when --yes is used without --app-title and no appId is configured', async () => {
+      const cwd = await testFixture('basic-app')
+      process.cwd = () => cwd
+
+      // No API mocks — should fail fast before any API calls
+      const {error} = await testCommand(DeployCommand, ['--yes'], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            app: {
+              organizationId,
+            },
+          },
+        },
+      })
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain(
+        'Cannot prompt for application title in unattended mode. Use --app-title to specify the application title.',
+      )
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+    })
   })
 
   test('should throw an error if organizationId is not set', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
@@ -1,4 +1,4 @@
-import {studioWorkerTask} from '@sanity/cli-core'
+import {exitCodes, studioWorkerTask} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
 import nock from 'nock'
@@ -459,7 +459,9 @@ describe('#deploy studio (external)', () => {
       },
     })
 
+    expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('URL must use http or https protocol')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   describe('--url flag', () => {
@@ -639,6 +641,7 @@ describe('#deploy studio (external)', () => {
 
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain('URL must use http or https protocol')
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
 
     test('should normalize --url with trailing slash for external deploy', async () => {
@@ -721,6 +724,7 @@ describe('#deploy studio (external)', () => {
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain('Cannot prompt for external studio URL in unattended mode')
       expect(error?.message).toContain('Use --url to specify the external studio URL')
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
 
     test('should error when --external --yes with multiple studios and no appId', async () => {
@@ -771,6 +775,7 @@ describe('#deploy studio (external)', () => {
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain('Cannot prompt for external studio URL in unattended mode')
       expect(error?.message).toContain('Use --url to specify the external studio URL')
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
       expect(mockSelect).not.toHaveBeenCalled()
     })
   })

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
@@ -462,6 +462,319 @@ describe('#deploy studio (external)', () => {
     expect(error?.message).toContain('URL must use http or https protocol')
   })
 
+  describe('--url flag', () => {
+    test('should use --url flag as external studio URL', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const externalUrl = 'https://studio.example.com'
+      const studioAppId = 'external-app-id'
+      const deploymentId = 'deployment-id'
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: externalUrl,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: externalUrl,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'External Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'external',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
+      }).reply(201, {id: deploymentId, location: externalUrl}, {location: externalUrl})
+
+      const {error, stdout} = await testCommand(
+        DeployCommand,
+        ['--external', '--url', externalUrl],
+        {
+          config: {root: cwd},
+          mocks: {
+            cliConfig: {
+              api: {projectId},
+            },
+          },
+        },
+      )
+
+      if (error) throw error
+      expect(stdout).toContain('Success! Studio registered')
+      expect(mockInput).not.toHaveBeenCalled()
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+
+    test('should use --url flag with --yes for unattended external deploy', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const externalUrl = 'https://studio.example.com'
+      const studioAppId = 'external-app-id'
+      const deploymentId = 'deployment-id'
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: externalUrl,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: externalUrl,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'External Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'external',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
+      }).reply(201, {id: deploymentId, location: externalUrl}, {location: externalUrl})
+
+      const {error, stdout} = await testCommand(
+        DeployCommand,
+        ['--external', '--yes', '--url', externalUrl],
+        {
+          config: {root: cwd},
+          mocks: {
+            cliConfig: {
+              api: {projectId},
+            },
+          },
+        },
+      )
+
+      if (error) throw error
+      expect(stdout).toContain('Success! Studio registered')
+      expect(mockInput).not.toHaveBeenCalled()
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+
+    test('should --url flag take precedence over studioHost config', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const flagUrl = 'https://new-studio.example.com'
+      const studioAppId = 'external-app-id'
+      const deploymentId = 'deployment-id'
+
+      // The --url value should be used for lookup, not the studioHost config
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: flagUrl,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: flagUrl,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'External Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'external',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
+      }).reply(201, {id: deploymentId, location: flagUrl}, {location: flagUrl})
+
+      const {error, stdout} = await testCommand(DeployCommand, ['--external', '--url', flagUrl], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+            studioHost: 'https://old-studio.example.com',
+          },
+        },
+      })
+
+      if (error) throw error
+      expect(stdout).toContain('Success! Studio registered')
+    })
+
+    test('should reject invalid --url for external deploy', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+
+      const {error} = await testCommand(
+        DeployCommand,
+        ['--external', '--url', 'ftp://invalid.com'],
+        {
+          config: {root: cwd},
+          mocks: {
+            cliConfig: {
+              api: {projectId},
+            },
+          },
+        },
+      )
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('URL must use http or https protocol')
+    })
+
+    test('should normalize --url with trailing slash for external deploy', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const normalizedUrl = 'https://studio.example.com'
+      const studioAppId = 'external-app-id'
+      const deploymentId = 'deployment-id'
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: normalizedUrl,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: normalizedUrl,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'External Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'external',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
+      }).reply(201, {id: deploymentId, location: normalizedUrl}, {location: normalizedUrl})
+
+      const {error, stdout} = await testCommand(
+        DeployCommand,
+        ['--external', '--url', 'https://studio.example.com/'],
+        {
+          config: {root: cwd},
+          mocks: {
+            cliConfig: {
+              api: {projectId},
+            },
+          },
+        },
+      )
+
+      if (error) throw error
+      expect(stdout).toContain('Success! Studio registered')
+    })
+  })
+
+  describe('unattended mode', () => {
+    test('should error when --external --yes used without --url and no studioHost', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+
+      // No apps exist for this project
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications`,
+      })
+        .once()
+        .reply(200, [])
+
+      const {error} = await testCommand(DeployCommand, ['--external', '--yes'], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+          },
+        },
+      })
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('Cannot prompt for external studio URL in unattended mode')
+      expect(error?.message).toContain('Use --url to specify the external studio URL')
+    })
+
+    test('should error when --external --yes with multiple studios and no appId', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+
+      // Return multiple external apps
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications`,
+      })
+        .once()
+        .reply(200, [
+          {
+            appHost: 'https://studio-one.example.com',
+            createdAt: '2024-01-01T00:00:00Z',
+            id: 'app-1',
+            projectId,
+            title: 'Studio One',
+            type: 'studio',
+            updatedAt: '2024-01-01T00:00:00Z',
+            urlType: 'external',
+          },
+          {
+            appHost: 'https://studio-two.example.com',
+            createdAt: '2024-01-01T00:00:00Z',
+            id: 'app-2',
+            projectId,
+            title: 'Studio Two',
+            type: 'studio',
+            updatedAt: '2024-01-01T00:00:00Z',
+            urlType: 'external',
+          },
+        ])
+
+      const {error} = await testCommand(DeployCommand, ['--external', '--yes'], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+          },
+        },
+      })
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('Multiple studios found for this project')
+      expect(error?.message).toContain('Use --url to specify the external studio URL')
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+  })
+
   describe('schema and manifest deployment', () => {
     test('should pass isExternal to worker for external deploy', async () => {
       const cwd = await testFixture('basic-studio')

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
@@ -769,7 +769,7 @@ describe('#deploy studio (external)', () => {
       })
 
       expect(error).toBeInstanceOf(Error)
-      expect(error?.message).toContain('Multiple studios found for this project')
+      expect(error?.message).toContain('Cannot prompt for external studio URL in unattended mode')
       expect(error?.message).toContain('Use --url to specify the external studio URL')
       expect(mockSelect).not.toHaveBeenCalled()
     })

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
@@ -1,4 +1,4 @@
-import {getCliTelemetry, studioWorkerTask} from '@sanity/cli-core'
+import {exitCodes, getCliTelemetry, studioWorkerTask} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
 import nock from 'nock'
@@ -1504,6 +1504,7 @@ describe('#deploy studio', () => {
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain('does not look like a sanity.studio hostname')
       expect(error?.message).toContain('--external')
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
 
     test('should reject --url with invalid hostname characters', async () => {
@@ -1524,6 +1525,7 @@ describe('#deploy studio', () => {
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain('Invalid studio hostname')
       expect(error?.message).toContain('letters, numbers, and hyphens')
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
 
     test('should reject --url with trailing hyphen', async () => {
@@ -1543,6 +1545,7 @@ describe('#deploy studio', () => {
 
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain('Invalid studio hostname')
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
   })
 
@@ -1574,6 +1577,7 @@ describe('#deploy studio', () => {
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain('Cannot prompt for studio hostname in unattended mode')
       expect(error?.message).toContain('Use --url to specify the studio hostname')
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
 
     test('should error when --yes used with multiple studios and no appId', async () => {
@@ -1624,6 +1628,7 @@ describe('#deploy studio', () => {
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain('Cannot prompt for studio hostname in unattended mode')
       expect(error?.message).toContain('Use --url to specify the studio hostname')
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
       expect(mockSelect).not.toHaveBeenCalled()
     })
 

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
@@ -1208,6 +1208,360 @@ describe('#deploy studio', () => {
     expect(error?.oclif?.exit).toBe(1)
   })
 
+  describe('--url flag', () => {
+    test('should use --url flag as studio hostname', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const studioHost = 'my-studio'
+      const studioAppId = 'studio-app-id'
+      const deploymentId = 'deployment-id'
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: studioHost,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: studioHost,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'My Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'internal',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
+      }).reply(
+        201,
+        {id: deploymentId, location: `https://${studioHost}.sanity.studio`},
+        {location: `https://${studioHost}.sanity.studio`},
+      )
+
+      const {error, stdout} = await testCommand(DeployCommand, ['--url', studioHost], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+          },
+        },
+      })
+
+      if (error) throw error
+      expect(stdout).toContain('Success! Studio deployed')
+      expect(mockInput).not.toHaveBeenCalled()
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+
+    test('should strip .sanity.studio suffix from --url flag', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const studioHost = 'my-studio'
+      const studioAppId = 'studio-app-id'
+      const deploymentId = 'deployment-id'
+
+      // The stripped hostname should be used for lookup
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: studioHost,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: studioHost,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'My Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'internal',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
+      }).reply(
+        201,
+        {id: deploymentId, location: `https://${studioHost}.sanity.studio`},
+        {location: `https://${studioHost}.sanity.studio`},
+      )
+
+      const {error, stdout} = await testCommand(
+        DeployCommand,
+        ['--url', 'my-studio.sanity.studio'],
+        {
+          config: {root: cwd},
+          mocks: {
+            cliConfig: {
+              api: {projectId},
+            },
+          },
+        },
+      )
+
+      if (error) throw error
+      expect(stdout).toContain('Success! Studio deployed')
+    })
+
+    test('should strip .sanity.studio/ suffix with trailing slash from --url flag', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const studioHost = 'my-studio'
+      const studioAppId = 'studio-app-id'
+      const deploymentId = 'deployment-id'
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: studioHost,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: studioHost,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'My Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'internal',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
+      }).reply(
+        201,
+        {id: deploymentId, location: `https://${studioHost}.sanity.studio`},
+        {location: `https://${studioHost}.sanity.studio`},
+      )
+
+      const {error, stdout} = await testCommand(
+        DeployCommand,
+        ['--url', 'my-studio.sanity.studio/'],
+        {
+          config: {root: cwd},
+          mocks: {
+            cliConfig: {
+              api: {projectId},
+            },
+          },
+        },
+      )
+
+      if (error) throw error
+      expect(stdout).toContain('Success! Studio deployed')
+    })
+
+    test('should --url flag take precedence over studioHost config', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const studioHost = 'url-studio'
+      const studioAppId = 'studio-app-id'
+      const deploymentId = 'deployment-id'
+
+      // The --url value should be used for lookup, not the studioHost config
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: studioHost,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: studioHost,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'URL Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'internal',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
+      }).reply(
+        201,
+        {id: deploymentId, location: `https://${studioHost}.sanity.studio`},
+        {location: `https://${studioHost}.sanity.studio`},
+      )
+
+      const {error, stdout} = await testCommand(DeployCommand, ['--url', studioHost], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+            studioHost: 'config-studio',
+          },
+        },
+      })
+
+      if (error) throw error
+      expect(stdout).toContain('Success! Studio deployed')
+    })
+  })
+
+  describe('unattended mode', () => {
+    test('should error when --yes used without --url and no studioHost (no studios)', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+
+      // No apps exist for this project
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications`,
+      })
+        .once()
+        .reply(200, [])
+
+      const {error} = await testCommand(DeployCommand, ['--yes'], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+          },
+        },
+      })
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('Cannot prompt for studio hostname in unattended mode')
+      expect(error?.message).toContain('Use --url to specify the studio hostname')
+    })
+
+    test('should error when --yes used with multiple studios and no appId', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+
+      // Return multiple internal apps
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications`,
+      })
+        .once()
+        .reply(200, [
+          {
+            appHost: 'studio-one',
+            createdAt: '2024-01-01T00:00:00Z',
+            id: 'app-1',
+            projectId,
+            title: 'Studio One',
+            type: 'studio',
+            updatedAt: '2024-01-01T00:00:00Z',
+            urlType: 'internal',
+          },
+          {
+            appHost: 'studio-two',
+            createdAt: '2024-01-01T00:00:00Z',
+            id: 'app-2',
+            projectId,
+            title: 'Studio Two',
+            type: 'studio',
+            updatedAt: '2024-01-01T00:00:00Z',
+            urlType: 'internal',
+          },
+        ])
+
+      const {error} = await testCommand(DeployCommand, ['--yes'], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+          },
+        },
+      })
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('Multiple studios found for this project')
+      expect(error?.message).toContain('Use --url to specify the studio hostname')
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+
+    test('should succeed with --yes and --url when no studioHost configured', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const studioHost = 'my-studio'
+      const studioAppId = 'studio-app-id'
+      const deploymentId = 'deployment-id'
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: studioHost,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: studioHost,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'My Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'internal',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
+      }).reply(
+        201,
+        {id: deploymentId, location: `https://${studioHost}.sanity.studio`},
+        {location: `https://${studioHost}.sanity.studio`},
+      )
+
+      const {error, stdout} = await testCommand(DeployCommand, ['--yes', '--url', studioHost], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+          },
+        },
+      })
+
+      if (error) throw error
+      expect(stdout).toContain('Success! Studio deployed')
+      expect(mockInput).not.toHaveBeenCalled()
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+  })
+
   describe('schema and manifest deployment', () => {
     test('should handle worker error with SchemaExtractionError', async () => {
       const cwd = await testFixture('basic-studio')

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
@@ -1373,6 +1373,62 @@ describe('#deploy studio', () => {
       expect(stdout).toContain('Success! Studio deployed')
     })
 
+    test('should strip https:// prefix and .sanity.studio suffix from --url flag', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const studioHost = 'my-studio'
+      const studioAppId = 'studio-app-id'
+      const deploymentId = 'deployment-id'
+
+      // The stripped hostname should be used for lookup
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: studioHost,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: studioHost,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'My Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'internal',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        method: 'post',
+        query: {appType: 'studio'},
+        uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
+      }).reply(
+        201,
+        {id: deploymentId, location: `https://${studioHost}.sanity.studio`},
+        {location: `https://${studioHost}.sanity.studio`},
+      )
+
+      const {error, stdout} = await testCommand(
+        DeployCommand,
+        ['--url', 'https://my-studio.sanity.studio'],
+        {
+          config: {root: cwd},
+          mocks: {
+            cliConfig: {
+              api: {projectId},
+            },
+          },
+        },
+      )
+
+      if (error) throw error
+      expect(stdout).toContain('Success! Studio deployed')
+    })
+
     test('should --url flag take precedence over studioHost config', async () => {
       const cwd = await testFixture('basic-studio')
       process.cwd = () => cwd

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
@@ -1603,7 +1603,7 @@ describe('#deploy studio', () => {
       })
 
       expect(error).toBeInstanceOf(Error)
-      expect(error?.message).toContain('Multiple studios found for this project')
+      expect(error?.message).toContain('Cannot prompt for studio hostname in unattended mode')
       expect(error?.message).toContain('Use --url to specify the studio hostname')
       expect(mockSelect).not.toHaveBeenCalled()
     })

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
@@ -1525,6 +1525,25 @@ describe('#deploy studio', () => {
       expect(error?.message).toContain('Invalid studio hostname')
       expect(error?.message).toContain('letters, numbers, and hyphens')
     })
+
+    test('should reject --url with trailing hyphen', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+
+      const {error} = await testCommand(DeployCommand, ['--url', 'my-studio-'], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+          },
+        },
+      })
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('Invalid studio hostname')
+    })
   })
 
   describe('unattended mode', () => {

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
@@ -1481,6 +1481,50 @@ describe('#deploy studio', () => {
       if (error) throw error
       expect(stdout).toContain('Success! Studio deployed')
     })
+
+    test('should reject --url that looks like a non-sanity.studio URL', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+
+      const {error} = await testCommand(
+        DeployCommand,
+        ['--url', 'https://my-studio.other-domain.com'],
+        {
+          config: {root: cwd},
+          mocks: {
+            cliConfig: {
+              api: {projectId},
+            },
+          },
+        },
+      )
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('does not look like a sanity.studio hostname')
+      expect(error?.message).toContain('--external')
+    })
+
+    test('should reject --url with invalid hostname characters', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+
+      const {error} = await testCommand(DeployCommand, ['--url', 'my studio!'], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+          },
+        },
+      })
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('Invalid studio hostname')
+      expect(error?.message).toContain('letters, numbers, and hyphens')
+    })
   })
 
   describe('unattended mode', () => {

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -37,9 +37,20 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
       command: '<%= config.bin %> <%= command.id %> --external',
       description: 'Register an externally hosted studio (studioHost contains full URL)',
     },
+    {
+      command: '<%= config.bin %> <%= command.id %> --url my-studio --yes',
+      description: 'Deploy a studio in unattended mode using a specific hostname',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --app-title "My App" --yes',
+      description: 'Deploy a new application to Sanity hosting in unattended mode',
+    },
   ]
 
   static override flags = {
+    'app-title': Flags.string({
+      description: 'Title for a new application deployment, skipping the interactive title prompt',
+    }),
     'auto-updates': Flags.boolean({
       allowNo: true,
       deprecated: true,
@@ -71,7 +82,7 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
     }),
     url: Flags.string({
       description:
-        'Studio URL for deployment. For external studios, the full URL. For hosted studios, the hostname (e.g. "my-studio" or "my-studio.sanity.studio")',
+        'Hostname or URL for studio deployment. For hosted studios, provide the subdomain (e.g. "my-studio" or "my-studio.sanity.studio"). For externally hosted studios, provide the full URL (requires --external). Required when using --yes (unattended mode).',
     }),
     verbose: Flags.boolean({
       default: false,

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -69,6 +69,10 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
       default: false,
       description: 'Enable source maps for built bundles (increases size of bundle)',
     }),
+    url: Flags.string({
+      description:
+        'Studio URL for deployment. For external studios, the full URL. For hosted studios, the hostname (e.g. "my-studio" or "my-studio.sanity.studio")',
+    }),
     verbose: Flags.boolean({
       default: false,
       description: 'Enable verbose logging',


### PR DESCRIPTION
### Description

- add `--app-title` to skip app selection prompt
- the `appId` (or  deprecated`app.id`) will still take precedence over the flag, and the user will be warned
- `--app-title` will skip finding user applications and go into creation as an app name currently is not unique

### Testing

- Added unit tests to cover unattended app deployment
