### PR TITLE
feat: add app resources to sanity.cli.ts

### DIFF
--- a/.changeset/pr-878.md
+++ b/.changeset/pr-878.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+---
+
+add app resources to sanity.cli.ts

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -1,9 +1,7 @@
 export * from '../config/cli/getCliConfig.js'
 export * from '../config/cli/getCliConfigSync.js'
 export {
-  type AppCanvasResource,
   type AppDatasetResource,
-  type AppMediaLibraryResource,
   type AppResource,
   type CliConfig,
 } from '../config/cli/types/cliConfig.js'

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -1,6 +1,12 @@
 export * from '../config/cli/getCliConfig.js'
 export * from '../config/cli/getCliConfigSync.js'
-export {type CliConfig} from '../config/cli/types/cliConfig.js'
+export {
+  type AppCanvasResource,
+  type AppDatasetResource,
+  type AppMediaLibraryResource,
+  type AppResource,
+  type CliConfig,
+} from '../config/cli/types/cliConfig.js'
 export {type UserViteConfig} from '../config/cli/types/userViteConfig.js'
 export * from '../config/findProjectRoot.js'
 export * from '../config/findProjectRootSync.js'

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -1,10 +1,6 @@
 export * from '../config/cli/getCliConfig.js'
 export * from '../config/cli/getCliConfigSync.js'
-export {
-  type AppDatasetResource,
-  type AppResource,
-  type CliConfig,
-} from '../config/cli/types/cliConfig.js'
+export {type AppResource, type CliConfig} from '../config/cli/types/cliConfig.js'
 export {type UserViteConfig} from '../config/cli/types/userViteConfig.js'
 export * from '../config/findProjectRoot.js'
 export * from '../config/findProjectRootSync.js'

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/schemas.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/schemas.test.ts
@@ -21,35 +21,11 @@ describe('cliConfigSchema', () => {
     })
   })
 
-  test('accepts media library app resources', () => {
-    const result = cliConfigSchema.parse({
-      app: {
-        resources: {
-          media: {
-            mediaLibraryId: 'library-123',
-          },
-        },
-      },
-    })
-
-    expect(result.app?.resources?.media).toEqual({
-      mediaLibraryId: 'library-123',
-    })
-  })
-
-  test('accepts canvas app resources', () => {
-    const result = cliConfigSchema.parse({
-      app: {
-        resources: {
-          canvas: {
-            canvasId: 'canvas-123',
-          },
-        },
-      },
-    })
-
-    expect(result.app?.resources?.canvas).toEqual({
-      canvasId: 'canvas-123',
-    })
+  test('rejects unknown resource shapes', () => {
+    expect(() =>
+      cliConfigSchema.parse({
+        app: {resources: {bad: {}}},
+      }),
+    ).toThrow()
   })
 })

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/schemas.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/schemas.test.ts
@@ -1,0 +1,55 @@
+import {describe, expect, test} from 'vitest'
+
+import {cliConfigSchema} from '../schemas.js'
+
+describe('cliConfigSchema', () => {
+  test('accepts dataset app resources', () => {
+    const result = cliConfigSchema.parse({
+      app: {
+        resources: {
+          default: {
+            dataset: 'production',
+            projectId: 'project-123',
+          },
+        },
+      },
+    })
+
+    expect(result.app?.resources?.default).toEqual({
+      dataset: 'production',
+      projectId: 'project-123',
+    })
+  })
+
+  test('accepts media library app resources', () => {
+    const result = cliConfigSchema.parse({
+      app: {
+        resources: {
+          media: {
+            mediaLibraryId: 'library-123',
+          },
+        },
+      },
+    })
+
+    expect(result.app?.resources?.media).toEqual({
+      mediaLibraryId: 'library-123',
+    })
+  })
+
+  test('accepts canvas app resources', () => {
+    const result = cliConfigSchema.parse({
+      app: {
+        resources: {
+          canvas: {
+            canvasId: 'canvas-123',
+          },
+        },
+      },
+    })
+
+    expect(result.app?.resources?.canvas).toEqual({
+      canvasId: 'canvas-123',
+    })
+  })
+})

--- a/packages/@sanity/cli-core/src/config/cli/schemas.ts
+++ b/packages/@sanity/cli-core/src/config/cli/schemas.ts
@@ -21,6 +21,23 @@ export const cliConfigSchema = z.object({
       icon: z.optional(z.string()),
       id: z.optional(z.string()),
       organizationId: z.optional(z.string()),
+      resources: z.optional(
+        z.record(
+          z.string(),
+          z.union([
+            z.object({
+              dataset: z.string(),
+              projectId: z.string(),
+            }),
+            z.object({
+              mediaLibraryId: z.string(),
+            }),
+            z.object({
+              canvasId: z.string(),
+            }),
+          ]),
+        ),
+      ),
       title: z.optional(z.string()),
     }),
   ),

--- a/packages/@sanity/cli-core/src/config/cli/schemas.ts
+++ b/packages/@sanity/cli-core/src/config/cli/schemas.ts
@@ -24,18 +24,10 @@ export const cliConfigSchema = z.object({
       resources: z.optional(
         z.record(
           z.string(),
-          z.union([
-            z.object({
-              dataset: z.string(),
-              projectId: z.string(),
-            }),
-            z.object({
-              mediaLibraryId: z.string(),
-            }),
-            z.object({
-              canvasId: z.string(),
-            }),
-          ]),
+          z.object({
+            dataset: z.string(),
+            projectId: z.string(),
+          }),
         ),
       ),
       title: z.optional(z.string()),

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -11,6 +11,37 @@ export interface TypeGenConfig {
 }
 
 /**
+ * A named project/dataset resource that the app will access.
+ * @public
+ */
+export interface AppDatasetResource {
+  dataset: string
+  projectId: string
+}
+
+/**
+ * A named canvas resource that the app will access.
+ * @public
+ */
+export interface AppCanvasResource {
+  canvasId: string
+}
+
+/**
+ * A named media library resource that the app will access.
+ * @public
+ */
+export interface AppMediaLibraryResource {
+  mediaLibraryId: string
+}
+
+/**
+ * A named app resource that the app will access.
+ * @public
+ */
+export type AppResource = AppCanvasResource | AppDatasetResource | AppMediaLibraryResource
+
+/**
  * @public
  */
 export interface CliConfig {
@@ -33,6 +64,8 @@ export interface CliConfig {
     id?: string
     /** The ID for the Sanity organization that manages this application */
     organizationId?: string
+    /** The named project/dataset resources that the app will access */
+    resources?: Record<string, AppResource>
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
   }

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -12,7 +12,7 @@ export interface TypeGenConfig {
 
 /**
  * A named project/dataset resource that the app will access.
- * @public
+ * @beta
  */
 export interface AppDatasetResource {
   dataset: string
@@ -20,26 +20,10 @@ export interface AppDatasetResource {
 }
 
 /**
- * A named canvas resource that the app will access.
- * @public
- */
-export interface AppCanvasResource {
-  canvasId: string
-}
-
-/**
- * A named media library resource that the app will access.
- * @public
- */
-export interface AppMediaLibraryResource {
-  mediaLibraryId: string
-}
-
-/**
  * A named app resource that the app will access.
- * @public
+ * @beta
  */
-export type AppResource = AppCanvasResource | AppDatasetResource | AppMediaLibraryResource
+export type AppResource = AppDatasetResource
 
 /**
  * @public
@@ -64,7 +48,10 @@ export interface CliConfig {
     id?: string
     /** The ID for the Sanity organization that manages this application */
     organizationId?: string
-    /** The named project/dataset resources that the app will access */
+    /**
+     * The named project/dataset resources that the app will access
+     * @beta
+     */
     resources?: Record<string, AppResource>
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -11,19 +11,13 @@ export interface TypeGenConfig {
 }
 
 /**
- * A named project/dataset resource that the app will access.
+ * A named project/dataset resource that SDK apps will access.
  * @beta
  */
-export interface AppDatasetResource {
+export type AppResource = {
   dataset: string
   projectId: string
 }
-
-/**
- * A named app resource that the app will access.
- * @beta
- */
-export type AppResource = AppDatasetResource
 
 /**
  * @public

--- a/packages/@sanity/cli/src/actions/init/__tests__/createAppCliConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/createAppCliConfig.test.ts
@@ -9,6 +9,21 @@ vi.mock('../processTemplate.js', () => ({
 const {createAppCliConfig} = await import('../createAppCliConfig.js')
 
 describe('createAppCliConfig', () => {
+  test('allows empty project and dataset values to flow through the template processor', () => {
+    createAppCliConfig({
+      entry: './src/App.tsx',
+      organizationId: 'org-123',
+    })
+
+    expect(mockProcessTemplate).toHaveBeenCalledWith({
+      template: expect.any(String),
+      variables: {
+        entry: './src/App.tsx',
+        organizationId: 'org-123',
+      },
+    })
+  })
+
   test('passes default app resources to the template processor', () => {
     const result = createAppCliConfig({
       dataset: 'production',

--- a/packages/@sanity/cli/src/actions/init/__tests__/createAppCliConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/createAppCliConfig.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, test, vi} from 'vitest'
+
+const mockProcessTemplate = vi.hoisted(() => vi.fn().mockReturnValue('// generated config'))
+
+vi.mock('../processTemplate.js', () => ({
+  processTemplate: mockProcessTemplate,
+}))
+
+const {createAppCliConfig} = await import('../createAppCliConfig.js')
+
+describe('createAppCliConfig', () => {
+  test('passes default app resources to the template processor', () => {
+    const result = createAppCliConfig({
+      dataset: 'production',
+      entry: './src/App.tsx',
+      organizationId: 'org-123',
+      projectId: 'project-123',
+    })
+
+    expect(result).toBe('// generated config')
+    expect(mockProcessTemplate).toHaveBeenCalledWith({
+      template: expect.stringContaining(`resources: {`),
+      variables: {
+        dataset: 'production',
+        entry: './src/App.tsx',
+        organizationId: 'org-123',
+        projectId: 'project-123',
+      },
+    })
+  })
+})

--- a/packages/@sanity/cli/src/actions/init/__tests__/createAppCliConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/createAppCliConfig.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, test, vi} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
 const mockProcessTemplate = vi.hoisted(() => vi.fn().mockReturnValue('// generated config'))
 
@@ -9,14 +9,18 @@ vi.mock('../processTemplate.js', () => ({
 const {createAppCliConfig} = await import('../createAppCliConfig.js')
 
 describe('createAppCliConfig', () => {
-  test('allows empty project and dataset values to flow through the template processor', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('uses template without resources when projectId and dataset are missing', () => {
     createAppCliConfig({
       entry: './src/App.tsx',
       organizationId: 'org-123',
     })
 
     expect(mockProcessTemplate).toHaveBeenCalledWith({
-      template: expect.any(String),
+      template: expect.not.stringContaining('resources'),
       variables: {
         entry: './src/App.tsx',
         organizationId: 'org-123',
@@ -24,7 +28,24 @@ describe('createAppCliConfig', () => {
     })
   })
 
-  test('passes default app resources to the template processor', () => {
+  test('uses template without resources when only projectId is provided', () => {
+    createAppCliConfig({
+      entry: './src/App.tsx',
+      organizationId: 'org-123',
+      projectId: 'project-123',
+    })
+
+    expect(mockProcessTemplate).toHaveBeenCalledWith({
+      template: expect.not.stringContaining('resources'),
+      variables: {
+        entry: './src/App.tsx',
+        organizationId: 'org-123',
+        projectId: 'project-123',
+      },
+    })
+  })
+
+  test('uses template with resources when both projectId and dataset are provided', () => {
     const result = createAppCliConfig({
       dataset: 'production',
       entry: './src/App.tsx',
@@ -34,7 +55,7 @@ describe('createAppCliConfig', () => {
 
     expect(result).toBe('// generated config')
     expect(mockProcessTemplate).toHaveBeenCalledWith({
-      template: expect.stringContaining(`resources: {`),
+      template: expect.stringContaining('resources'),
       variables: {
         dataset: 'production',
         entry: './src/App.tsx',

--- a/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
@@ -140,8 +140,10 @@ export async function bootstrapLocalTemplate(
   // ...and a CLI config (`sanity.cli.[ts|js]`)
   const cliConfig = isAppTemplate
     ? createAppCliConfig({
+        dataset: variables.dataset,
         entry: template.entry!,
         organizationId: variables.organizationId,
+        projectId: variables.projectId,
       })
     : createCliConfig({
         autoUpdates: variables.autoUpdates,

--- a/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
@@ -1,6 +1,6 @@
 import {processTemplate} from './processTemplate.js'
 
-const defaultAppTemplate = `
+const appTemplateWithResources = `
 import {defineCliConfig} from 'sanity/cli'
 
 export default defineCliConfig({
@@ -17,18 +17,34 @@ export default defineCliConfig({
 })
 `
 
+const appTemplateWithoutResources = `
+import {defineCliConfig} from 'sanity/cli'
+
+export default defineCliConfig({
+  app: {
+    organizationId: '%organizationId%',
+    entry: '%entry%',
+  },
+})
+`
+
 interface GenerateCliConfigOptions {
   entry: string
 
   dataset?: string
-
   organizationId?: string
   projectId?: string
 }
 
+function hasResources(options: GenerateCliConfigOptions): boolean {
+  return Boolean(options.projectId && options.dataset)
+}
+
 export function createAppCliConfig(options: GenerateCliConfigOptions): string {
+  const template = hasResources(options) ? appTemplateWithResources : appTemplateWithoutResources
+
   return processTemplate({
-    template: defaultAppTemplate,
+    template,
     variables: options,
   })
 }

--- a/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
@@ -18,11 +18,12 @@ export default defineCliConfig({
 `
 
 interface GenerateCliConfigOptions {
-  dataset: string
   entry: string
-  projectId: string
+
+  dataset?: string
 
   organizationId?: string
+  projectId?: string
 }
 
 export function createAppCliConfig(options: GenerateCliConfigOptions): string {

--- a/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
@@ -7,12 +7,20 @@ export default defineCliConfig({
   app: {
     organizationId: '%organizationId%',
     entry: '%entry%',
+    resources: {
+      default: {
+        projectId: '%projectId%',
+        dataset: '%dataset%',
+      },
+    },
   },
 })
 `
 
 interface GenerateCliConfigOptions {
+  dataset: string
   entry: string
+  projectId: string
 
   organizationId?: string
 }


### PR DESCRIPTION
### Description

This PR adds CLI config support for named app resources and updates app scaffolding to generate those resources by default.

It introduces `app.resources` to the CLI config types and schema, exports the related resource types from `@sanity/cli-core`, and updates `createAppCliConfig()` / `bootstrapLocalTemplate()` so newly scaffolded apps emit a `resources.default` entry with the selected `projectId` and `dataset`. This creates a shared config foundation for the later SDK v3 runtime work.

### What to review

- Review the new `app.resources` type surface in `@sanity/cli-core`
- Confirm the schema accepts the supported resource shapes:
  - dataset resource
  - media library resource
  - canvas resource
- Review the app init/template changes to ensure scaffolded `sanity.cli.ts` files now include:
  - `app.resources.default.projectId`
  - `app.resources.default.dataset`
- Check that the exported types from `@sanity/cli-core` are the right public API for follow-up work

### Testing

- Added schema parsing tests for all supported `app.resources` variants
- Added init template tests covering:
  - default app resource generation
  - allowing empty `projectId` / `dataset` values to flow through the template processor
- Ran:
  - `pnpm test packages/@sanity/cli-core/src/config/cli/__tests__/schemas.test.ts packages/@sanity/cli/src/actions/init/__tests__/createAppCliConfig.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new public config surface (`app.resources`) and changes app project scaffolding output, which could affect downstream consumers and generated config expectations. Scope is limited to config typing/validation and init template generation.
> 
> **Overview**
> Adds **named app resources** support via `app.resources` in `sanity.cli.*`, including a new `AppResource` type and Zod schema validation for `{projectId, dataset}` resource entries.
> 
> Updates app initialization scaffolding so `createAppCliConfig()` emits a `resources.default` block *only when both* `projectId` and `dataset` are available, and wires those variables through `bootstrapLocalTemplate()`. Adds targeted tests for schema acceptance/rejection and for template selection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c73dc976adddc00db06f6c397ee2330696af6b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->