### PR TITLE
test(cli-e2e): add E2E testing package with pnpm pack integration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,16 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      cli_version:
+        description: 'npm version/tag to test (e.g., latest, 3.82.0)'
+        required: true
+        default: 'latest'
+      cli_package:
+        description: 'Package to install — must provide the "sanity" binary (e.g., @sanity/cli, sanity)'
+        required: false
+        default: '@sanity/cli'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,7 +27,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      should_run: ${{ github.event_name == 'push' || steps.filter.outputs.cli == 'true' }}
+      should_run: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || steps.filter.outputs.cli == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
@@ -55,8 +65,20 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Build CLI
+      - name: Build CLI (pack mode)
+        if: ${{ !inputs.cli_version }}
         run: pnpm build:cli
+
+      - name: Install CLI from npm (registry mode)
+        if: ${{ inputs.cli_version }}
+        env:
+          CLI_VERSION: ${{ inputs.cli_version }}
+          CLI_PACKAGE: ${{ inputs.cli_package || '@sanity/cli' }}
+        run: |
+          INSTALL_DIR=$(mktemp -d)
+          npm install --prefix "$INSTALL_DIR" "${CLI_PACKAGE}@${CLI_VERSION}"
+          echo "E2E_BINARY_PATH=$INSTALL_DIR/node_modules/.bin/sanity" >> "$GITHUB_ENV"
+          "$INSTALL_DIR/node_modules/.bin/sanity" --version
 
       - name: Run E2E tests
         env:
@@ -64,6 +86,44 @@ jobs:
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: ${{ secrets.SANITY_E2E_DATASET }}
         run: pnpm --filter @sanity/cli-e2e test
+
+  notify-failure:
+    if: ${{ failure() && inputs.cli_version }}
+    needs: [e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook: ${{ secrets.SLACK_E2E_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ${{ toJSON(format('Post-release E2E failed for {0}@{1}', inputs.cli_package || '@sanity/cli', inputs.cli_version)) }},
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":red_circle: *Post-release E2E failed*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJSON(format('*Package:* `{0}@{1}`', inputs.cli_package || '@sanity/cli', inputs.cli_version)) }}
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJSON(format('*Run:* <{0}/{1}/actions/runs/{2}|View logs>', github.server_url, github.repository, github.run_id)) }}
+                  }
+                }
+              ]
+            }
 
   e2e-status:
     if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write # for gh workflow run in post-release
   contents: write # for version bump commits and tags
   pull-requests: write # for creating Version Packages PR
   id-token: write # to enable use of OIDC for npm provenance
@@ -20,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
 
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -104,3 +106,16 @@ jobs:
           repository_name: ${{ github.event.repository.name }}
           initial_state_id: 'c56956cd-c281-4ca5-889f-6189ce231a6d'
           done_state_id: '5a35b7bf-6d37-4cc2-854a-2f18d160e2e5'
+
+      - name: Trigger post-release E2E tests
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISHED_PACKAGES: ${{ needs.release.outputs.publishedPackages }}
+        run: |
+          CLI_VERSION=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | select(.name == "@sanity/cli") | .version')
+          if [ -n "$CLI_VERSION" ]; then
+            echo "Triggering E2E tests for @sanity/cli@$CLI_VERSION"
+            gh workflow run e2e.yml -f cli_version="$CLI_VERSION"
+          else
+            echo "No @sanity/cli in published packages, skipping E2E"
+          fi


### PR DESCRIPTION
Add registry mode to the E2E workflow so tests can run against a
published npm package instead of the local build:

- Add workflow_dispatch trigger with cli_version and cli_package inputs
- Conditional build (pack mode) vs npm install (registry mode)
- Skip path filtering for workflow_dispatch events
- Slack notification on E2E failure in registry mode
- Release workflow triggers E2E after publishing @sanity/cli

When cli_version is provided, the workflow installs the package from
npm, sets E2E_BINARY_PATH, and globalSetup skips the pack step.

CLOSES SDK-1203

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>