### PR TITLE
fix: make `@sanity/telemetry` a regular dep

### DIFF
--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -67,6 +67,7 @@
     "@oclif/core": "catalog:",
     "@rexxars/jiti": "^2.6.2",
     "@sanity/client": "catalog:",
+    "@sanity/telemetry": "catalog:",
     "babel-plugin-react-compiler": "^1.0.0",
     "boxen": "^8.0.1",
     "debug": "catalog:",
@@ -90,7 +91,6 @@
     "@repo/tsconfig": "workspace:*",
     "@sanity/eslint-config-cli": "workspace:*",
     "@sanity/pkg-utils": "catalog:",
-    "@sanity/telemetry": "catalog:",
     "@swc/cli": "catalog:",
     "@swc/core": "catalog:",
     "@types/debug": "catalog:",
@@ -101,9 +101,6 @@
     "sanity": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
-  },
-  "peerDependencies": {
-    "@sanity/telemetry": ">=0.9.0 <0.10.0"
   },
   "engines": {
     "node": ">=20.19.1 <22 || >=22.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,9 @@ importers:
       '@sanity/client':
         specifier: ^7.20.0
         version: 7.20.0(debug@4.4.3)
+      '@sanity/telemetry':
+        specifier: 'catalog:'
+        version: 0.9.0(react@19.2.4)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -830,9 +833,6 @@ importers:
       '@sanity/pkg-utils':
         specifier: 'catalog:'
         version: 10.4.13(@types/babel__core@7.20.5)(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(debug@4.4.3)(oxc-resolver@11.19.1)(typescript@5.9.3)
-      '@sanity/telemetry':
-        specifier: 'catalog:'
-        version: 0.9.0(react@19.2.4)
       '@swc/cli':
         specifier: 'catalog:'
         version: 0.8.0(@swc/core@1.15.21)(chokidar@5.0.0)


### PR DESCRIPTION
### Description

Having `@sanity/telemetry` specified as a peer dependency of `@sanity/cli-core` is causing some problems. When `@sanity/telemetry` v0.9 dropped the `sanity` package itself updated faster than `@sanity/cli-core` updated its peer dependency range to allow it.
It can lead to odd branching in pnpm, with nasty workarounds: https://github.com/sanity-io/next-sanity/blob/370bbfb24ba82f50029f94d177c36a60c6a81969/.pnpmfile.cjs#L6-L13
`@sanity/cli` itself, like `sanity`, lists `@sanity/telemetry` as a direct dependency, not a peer.
It's far better to have it as a direct dependency, as deduping will happen when possible. And if deduping is not possible, instead of peer dependency warnings and unpredictable duplicated node_modules trees, it'll copy multiple versions of `@sanity/telemetry` in predictable and manageable ways.

### What to review

I ran an analysis with claude on the repo to see if there's any singleton patterns or equivalent that would explain why it's a peer, but none could be found so it looks like this change should be fine?

### Testing

CI should be sufficient.
