### PR TITLE
fix(init): strip filename before counting nested folders in import path

### DIFF
--- a/packages/@sanity/cli/src/actions/init/__tests__/countNestedFolders.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/countNestedFolders.test.ts
@@ -1,0 +1,60 @@
+import path from 'node:path'
+
+import {describe, expect, test} from 'vitest'
+
+import {countNestedFolders} from '../countNestedFolders.js'
+
+describe('countNestedFolders', () => {
+  test('counts all segments in a path with leading slash', () => {
+    expect(countNestedFolders('/src/app/studio/[[...tool]]/page.tsx')).toBe(5)
+  })
+
+  test('counts segments without leading slash', () => {
+    expect(countNestedFolders('src/app')).toBe(2)
+  })
+
+  test('counts single segment with trailing slash', () => {
+    expect(countNestedFolders('/src/')).toBe(1)
+  })
+
+  test('counts segments in a Windows-style path', () => {
+    expect(countNestedFolders('\\src\\app\\page.tsx')).toBe(3)
+  })
+
+  test('returns 0 for root path', () => {
+    expect(countNestedFolders('/')).toBe(0)
+  })
+})
+
+describe('embedded studio import path generation', () => {
+  test('produces correct relative import when using path.dirname to strip filename', () => {
+    // Simulates the logic in init.ts:1290
+    const workDir = '/projects/my-app'
+    const embeddedStudioRouteFilePath = '/projects/my-app/src/app/studio/[[...tool]]/page.tsx'
+    const sliced = embeddedStudioRouteFilePath.slice(workDir.length)
+
+    const importPath = `${'../'.repeat(countNestedFolders(path.dirname(sliced)))}sanity.config`
+
+    expect(importPath).toBe('../../../../sanity.config')
+  })
+
+  test('produces correct relative import for shallow studio path', () => {
+    const workDir = '/projects/my-app'
+    const embeddedStudioRouteFilePath = '/projects/my-app/app/studio/[[...tool]]/page.tsx'
+    const sliced = embeddedStudioRouteFilePath.slice(workDir.length)
+
+    const importPath = `${'../'.repeat(countNestedFolders(path.dirname(sliced)))}sanity.config`
+
+    expect(importPath).toBe('../../../sanity.config')
+  })
+
+  test('produces correct relative import for custom deep studio path', () => {
+    const workDir = '/projects/my-app'
+    const embeddedStudioRouteFilePath = '/projects/my-app/src/app/admin/studio/[[...tool]]/page.tsx'
+    const sliced = embeddedStudioRouteFilePath.slice(workDir.length)
+
+    const importPath = `${'../'.repeat(countNestedFolders(path.dirname(sliced)))}sanity.config`
+
+    expect(importPath).toBe('../../../../../sanity.config')
+  })
+})

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -1287,7 +1287,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
         embeddedStudioRouteFilePath,
         sanityStudioTemplate.replace(
           ':configPath:',
-          `${'../'.repeat(countNestedFolders(embeddedStudioRouteFilePath.slice(workDir.length)))}sanity.config`,
+          `${'../'.repeat(countNestedFolders(path.dirname(embeddedStudioRouteFilePath.slice(workDir.length))))}sanity.config`,
         ),
         workDir,
       )


### PR DESCRIPTION
### Description

Running `sanity init` inside a Next.js app with embedded studio is broken. The generated `page.tsx` gets an incorrect import path that overshoots the project root by one level. The module resolver starts from the parent of the project directory, where there's no `node_modules`, so any import resolution from that file fails. Depending on the project's setup this shows up as `Can't resolve` errors for various packages, broken builds, or infinite error loops in dev mode.

This happens because `countNestedFolders` is called with a full file path including the filename (`page.tsx`), so it counts 5 segments instead of 4. The extra `../` pushes the import one directory above the project root.

The fix wraps the caller's argument in `path.dirname()` to strip the filename before counting.

### Reproduction

1. Create a Next.js app with `src/app` directory structure
2. Run `sanity init` and select the embedded studio option
3. Check the generated `page.tsx` in `src/app/studio/[[...tool]]/` — the `sanity.config` import has one too many `../`
4. Run `pnpm dev` — the app fails to compile with unresolved module errors

### What to review

- The one-line change in `init.ts:1290`
- Test coverage: unit tests for `countNestedFolders` plus integration-style tests that verify the composed import path for standard, shallow, and deep studio paths

### Testing

- All 8 new tests pass
- Full `@sanity/cli` suite: 2479 passed, 0 failures