### PR TITLE
fix(cli-core): remove @sanity/telemetry as a peer dependency

### DIFF
--- a/.changeset/pr-902.md
+++ b/.changeset/pr-902.md
@@ -1,0 +1,6 @@
+---
+'@sanity/cli-core': patch
+'@sanity/cli': patch
+---
+
+remove @sanity/telemetry as a peer dependency

--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -102,9 +102,6 @@
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
-  "peerDependencies": {
-    "@sanity/telemetry": ">=0.9.0 <0.10.0"
-  },
   "engines": {
     "node": ">=20.19.1 <22 || >=22.12"
   }

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -28,6 +28,7 @@ export {
   setCliTelemetry,
 } from '../telemetry/getCliTelemetry.js'
 export {getTelemetryBaseInfo} from '../telemetry/getTelemetryBaseInfo.js'
+export {noopLogger} from '../telemetry/noopTelemetry.js'
 export {
   type CLITelemetryStore,
   type ConsentInformation,

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -25,6 +25,7 @@ export {
   clearCliTelemetry,
   CLI_TELEMETRY_SYMBOL,
   getCliTelemetry,
+  noopLogger,
   setCliTelemetry,
 } from '../telemetry/getCliTelemetry.js'
 export {getTelemetryBaseInfo} from '../telemetry/getTelemetryBaseInfo.js'

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -25,7 +25,6 @@ export {
   clearCliTelemetry,
   CLI_TELEMETRY_SYMBOL,
   getCliTelemetry,
-  noopLogger,
   setCliTelemetry,
 } from '../telemetry/getCliTelemetry.js'
 export {getTelemetryBaseInfo} from '../telemetry/getTelemetryBaseInfo.js'

--- a/packages/@sanity/cli-core/src/telemetry/__tests__/getCliTelemetry.test.ts
+++ b/packages/@sanity/cli-core/src/telemetry/__tests__/getCliTelemetry.test.ts
@@ -1,10 +1,10 @@
-import {noopLogger} from '@sanity/telemetry'
 import {afterEach, describe, expect, test} from 'vitest'
 
 import {
   clearCliTelemetry,
   CLI_TELEMETRY_SYMBOL,
   getCliTelemetry,
+  noopLogger,
   setCliTelemetry,
 } from '../getCliTelemetry.js'
 import {type CLITelemetryStore} from '../types.js'

--- a/packages/@sanity/cli-core/src/telemetry/__tests__/getCliTelemetry.test.ts
+++ b/packages/@sanity/cli-core/src/telemetry/__tests__/getCliTelemetry.test.ts
@@ -4,9 +4,9 @@ import {
   clearCliTelemetry,
   CLI_TELEMETRY_SYMBOL,
   getCliTelemetry,
-  noopLogger,
   setCliTelemetry,
 } from '../getCliTelemetry.js'
+import {noopLogger} from '../noopTelemetry.js'
 import {type CLITelemetryStore} from '../types.js'
 
 describe('#getCliTelemetry', () => {

--- a/packages/@sanity/cli-core/src/telemetry/getCliTelemetry.ts
+++ b/packages/@sanity/cli-core/src/telemetry/getCliTelemetry.ts
@@ -1,7 +1,31 @@
 import {ux} from '@oclif/core'
-import {noopLogger} from '@sanity/telemetry'
+import {type TelemetryTrace} from '@sanity/telemetry'
 
-import {type CLITelemetryStore} from './types.js'
+import {type CLITelemetryStore, type TelemetryUserProperties} from './types.js'
+
+// Inline noop implementation — avoids a runtime dependency on @sanity/telemetry
+// (types-only usage keeps it as a devDependency). Explicit types ensure this
+// stays structurally in sync with TelemetryLogger/TelemetryTrace.
+const noopTrace: TelemetryTrace<TelemetryUserProperties, never> = {
+  await: <P extends Promise<unknown>>(promise: P): P => promise,
+  complete: () => {},
+  error: () => {},
+  log: () => {},
+  newContext: (): CLITelemetryStore => noopLogger,
+  start: () => {},
+}
+
+/**
+ * Fallback logger used when telemetry has not been initialized.
+ * Exported for use in tests only — do not use in plugins or external code.
+ * @internal
+ */
+export const noopLogger: CLITelemetryStore = {
+  log: () => {},
+  resume: () => {},
+  trace: () => noopTrace,
+  updateUserProperties: () => {},
+}
 
 /**
  * @public

--- a/packages/@sanity/cli-core/src/telemetry/getCliTelemetry.ts
+++ b/packages/@sanity/cli-core/src/telemetry/getCliTelemetry.ts
@@ -1,31 +1,7 @@
 import {ux} from '@oclif/core'
-import {type TelemetryTrace} from '@sanity/telemetry'
 
-import {type CLITelemetryStore, type TelemetryUserProperties} from './types.js'
-
-// Inline noop implementation — avoids a runtime dependency on @sanity/telemetry
-// (types-only usage keeps it as a devDependency). Explicit types ensure this
-// stays structurally in sync with TelemetryLogger/TelemetryTrace.
-const noopTrace: TelemetryTrace<TelemetryUserProperties, never> = {
-  await: <P extends Promise<unknown>>(promise: P): P => promise,
-  complete: () => {},
-  error: () => {},
-  log: () => {},
-  newContext: (): CLITelemetryStore => noopLogger,
-  start: () => {},
-}
-
-/**
- * Fallback logger used when telemetry has not been initialized.
- * Exported for use in tests only — do not use in plugins or external code.
- * @internal
- */
-export const noopLogger: CLITelemetryStore = {
-  log: () => {},
-  resume: () => {},
-  trace: () => noopTrace,
-  updateUserProperties: () => {},
-}
+import {noopLogger} from './noopTelemetry.js'
+import {type CLITelemetryStore} from './types.js'
 
 /**
  * @public

--- a/packages/@sanity/cli-core/src/telemetry/noopTelemetry.ts
+++ b/packages/@sanity/cli-core/src/telemetry/noopTelemetry.ts
@@ -1,0 +1,27 @@
+import {type TelemetryTrace} from '@sanity/telemetry'
+
+import {type CLITelemetryStore, type TelemetryUserProperties} from './types.js'
+
+// Inline noop implementation — avoids a runtime dependency on @sanity/telemetry
+// (types-only usage keeps it as a devDependency). Explicit types ensure this
+// stays structurally in sync with TelemetryLogger/TelemetryTrace.
+const noopTrace: TelemetryTrace<TelemetryUserProperties, never> = {
+  await: <P extends Promise<unknown>>(promise: P): P => promise,
+  complete: () => {},
+  error: () => {},
+  log: () => {},
+  newContext: (): CLITelemetryStore => noopLogger,
+  start: () => {},
+}
+
+/**
+ * Fallback logger used when telemetry has not been initialized.
+ * Exported for use in tests only — do not use in plugins or external code.
+ * @internal
+ */
+export const noopLogger: CLITelemetryStore = {
+  log: () => {},
+  resume: () => {},
+  trace: () => noopTrace,
+  updateUserProperties: () => {},
+}

--- a/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
@@ -1,7 +1,7 @@
 import {join} from 'node:path'
 
+import {noopLogger} from '@sanity/cli-core'
 import {convertToSystemPath} from '@sanity/cli-test'
-import {noopLogger} from '@sanity/telemetry'
 import {type ConfigEnv, type InlineConfig} from 'vite'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 

--- a/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
@@ -1,5 +1,6 @@
 import {join} from 'node:path'
 
+import {noopLogger} from '@sanity/cli-core'
 import {convertToSystemPath} from '@sanity/cli-test'
 import {type ConfigEnv, type InlineConfig} from 'vite'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
@@ -12,8 +13,6 @@ import {
 
 const mockExtractSchemaPlugin = vi.hoisted(() => vi.fn())
 const mockTypegenPlugin = vi.hoisted(() => vi.fn())
-const mockGetCliTelemetry = vi.hoisted(() => vi.fn())
-const mockTelemetryLogger = vi.hoisted(() => ({}))
 
 // Mock all external dependencies
 vi.mock('read-package-up', () => ({
@@ -78,7 +77,6 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
   return {
     ...actual,
     findProjectRoot: vi.fn().mockResolvedValue({path: '/mock/config/path'}),
-    getCliTelemetry: mockGetCliTelemetry.mockReturnValue(mockTelemetryLogger),
   }
 })
 
@@ -378,7 +376,7 @@ describe('#getViteConfig', () => {
       configPath: '/mock/config/path',
       enforceRequiredFields: true,
       outputPath: 'custom-schema.json',
-      telemetryLogger: mockTelemetryLogger,
+      telemetryLogger: noopLogger,
       workDir: mockTestCwd,
       workspaceName: 'production',
     })
@@ -430,7 +428,7 @@ describe('#getViteConfig', () => {
         generates: 'sanity.types.ts',
         schema: 'custom-schema.json',
       },
-      telemetryLogger: mockTelemetryLogger,
+      telemetryLogger: noopLogger,
       workDir: mockTestCwd,
     })
     expect(typegenPlugin).toBeDefined()

--- a/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
@@ -1,6 +1,5 @@
 import {join} from 'node:path'
 
-import {noopLogger} from '@sanity/cli-core'
 import {convertToSystemPath} from '@sanity/cli-test'
 import {type ConfigEnv, type InlineConfig} from 'vite'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
@@ -13,6 +12,8 @@ import {
 
 const mockExtractSchemaPlugin = vi.hoisted(() => vi.fn())
 const mockTypegenPlugin = vi.hoisted(() => vi.fn())
+const mockGetCliTelemetry = vi.hoisted(() => vi.fn())
+const mockTelemetryLogger = vi.hoisted(() => ({}))
 
 // Mock all external dependencies
 vi.mock('read-package-up', () => ({
@@ -77,6 +78,7 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
   return {
     ...actual,
     findProjectRoot: vi.fn().mockResolvedValue({path: '/mock/config/path'}),
+    getCliTelemetry: mockGetCliTelemetry.mockReturnValue(mockTelemetryLogger),
   }
 })
 
@@ -376,7 +378,7 @@ describe('#getViteConfig', () => {
       configPath: '/mock/config/path',
       enforceRequiredFields: true,
       outputPath: 'custom-schema.json',
-      telemetryLogger: noopLogger,
+      telemetryLogger: mockTelemetryLogger,
       workDir: mockTestCwd,
       workspaceName: 'production',
     })
@@ -428,7 +430,7 @@ describe('#getViteConfig', () => {
         generates: 'sanity.types.ts',
         schema: 'custom-schema.json',
       },
-      telemetryLogger: noopLogger,
+      telemetryLogger: mockTelemetryLogger,
       workDir: mockTestCwd,
     })
     expect(typegenPlugin).toBeDefined()


### PR DESCRIPTION
### Description

- Inlines `noopLogger` to remove need of `@sanity/telemetry` peer dependency from `cli-core`

Fixes the same issue as https://github.com/sanity-io/cli/pull/891 without making it a direct dependency

### Testing

- Update import for `getViteConfig` test to use local noopLogger instead of one from `@sanity/telemetry`

### Notes for release

<!--
A changeset is auto-generated from this section. Leave empty to use the PR title, or start with "N/A" to skip. For example, "N/A: Internal only"
If you ran `pnpm changeset` manually, write "N/A" here to avoid duplicates.

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
