### PR TITLE
fix(init): fix unattended mode flags for --no-git, --missing, and --bare

### DIFF
--- a/.changeset/pr-903.md
+++ b/.changeset/pr-903.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+Fixed init command unattended mode: respect `--no-git` flag to skip git initialization, pass `--missing` to dataset import to avoid errors when dataset already exists, and allow `--bare` mode without requiring `--output-path`.

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   input: vi.fn(),
   listDatasets: vi.fn(),
   select: vi.fn(),
+  tryGitInit: vi.fn(),
   usersGetById: vi.fn(),
 }))
 
@@ -122,6 +123,10 @@ vi.mock('../../../actions/init/bootstrapTemplate.js', () => ({
 
 vi.mock('../../datasets/import.js', () => ({
   ImportDatasetCommand: {run: mocks.importDatasetRun},
+}))
+
+vi.mock('../../../actions/init/git.js', () => ({
+  tryGitInit: mocks.tryGitInit,
 }))
 
 vi.mock('../../../actions/init/resolvePackageManager.js', () => ({
@@ -558,6 +563,7 @@ describe('#init: create new project', () => {
         'production',
         '--token',
         'test-token',
+        '--missing',
       ]),
       expect.objectContaining({root: expect.any(String)}),
     )
@@ -636,5 +642,82 @@ describe('#init: create new project', () => {
     expect(stdout).toContain('npx sanity docs browse')
     expect(stdout).toContain('npx sanity manage')
     expect(stdout).toContain('npx sanity help')
+  })
+
+  test('--no-git skips git initialization', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      method: 'get',
+      uri: '/organizations',
+    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
+
+    mockApi({
+      apiVersion: PROJECTS_API_VERSION,
+      method: 'get',
+      uri: '/projects/test',
+    }).reply(200, {
+      id: 'test',
+      metadata: {
+        cliInitializedAt: '',
+      },
+    })
+
+    const {error} = await testCommand(
+      InitCommand,
+      [
+        '--yes',
+        '--output-path=/test/output',
+        '--project=test',
+        '--dataset=test',
+        '--package-manager=npm',
+        '--no-git',
+      ],
+      {
+        mocks: {
+          ...defaultMocks,
+        },
+      },
+    )
+
+    if (error) throw error
+    expect(mocks.tryGitInit).not.toHaveBeenCalled()
+  })
+
+  test('initializes git by default when --no-git is not passed', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      method: 'get',
+      uri: '/organizations',
+    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
+
+    mockApi({
+      apiVersion: PROJECTS_API_VERSION,
+      method: 'get',
+      uri: '/projects/test',
+    }).reply(200, {
+      id: 'test',
+      metadata: {
+        cliInitializedAt: '',
+      },
+    })
+
+    const {error} = await testCommand(
+      InitCommand,
+      [
+        '--yes',
+        '--output-path=/test/output',
+        '--project=test',
+        '--dataset=test',
+        '--package-manager=npm',
+      ],
+      {
+        mocks: {
+          ...defaultMocks,
+        },
+      },
+    )
+
+    if (error) throw error
+    expect(mocks.tryGitInit).toHaveBeenCalled()
   })
 })

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -205,6 +205,25 @@ describe('#init: oclif command setup', () => {
     expect(error?.oclif?.exit).toBe(1)
   })
 
+  test('does not require `output-path` in unattended mode when `bare` is used', async () => {
+    mocks.detectFrameworkRecord.mockResolvedValueOnce(null)
+
+    const {error} = await testCommand(
+      InitCommand,
+      ['--yes', '--bare', '--dataset=production', '--project=test-project'],
+      {
+        mocks: {
+          ...defaultMocks,
+        },
+      },
+    )
+
+    // Should NOT throw output-path error — bare mode doesn't need it
+    expect(error?.message ?? '').not.toContain(
+      '`--output-path` must be specified in unattended mode',
+    )
+  })
+
   test('throws error when in unattended mode and `project` and `project-name` not set', async () => {
     mocks.detectFrameworkRecord.mockResolvedValueOnce({
       name: 'Next.js',

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -611,7 +611,8 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       workDir,
     })
 
-    const useGit = this.flags.git === undefined || Boolean(this.flags.git)
+    const useGit =
+      !this.flags['no-git'] && (this.flags.git === undefined || Boolean(this.flags.git))
     const commitMessage = this.flags.git
     await this.writeStagingEnvIfNeeded(outputPath)
 
@@ -635,6 +636,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
           datasetName,
           '--token',
           token,
+          '--missing',
         ],
         {
           root: outputPath,
@@ -756,8 +758,8 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       })
     }
 
-    // output-path is required in unattended mode when not using nextjs
-    if (!isNextJs && !this.flags['output-path']) {
+    // output-path is required in unattended mode when not using nextjs or bare
+    if (!isNextJs && !this.flags.bare && !this.flags['output-path']) {
       this.error(`\`--output-path\` must be specified in unattended mode`, {
         exit: 1,
       })


### PR DESCRIPTION
## Summary
- Respect `--no-git` flag when determining whether to initialize git repository
- Pass `--missing` to dataset import to avoid errors when dataset already exists
- Allow `--bare` mode without requiring `--output-path` in unattended mode

These bugs also existed in the original CLI (sanity-labs/sanity-old-cli-bkp) — they are not regressions from the migration.

## Test plan
- [x] Added test: `--no-git` skips git initialization
- [x] Added test: git initializes by default when `--no-git` is not passed
- [x] Updated test: `--import-dataset` asserts `--missing` is included in args
- [x] Added test: `--bare` in unattended mode does not require `--output-path`
- [x] All 81 init tests pass

## Notes for Release 

Fixed `--no-git` flag being ignored during git initialization, `--missing` not being passed to dataset import, and `--bare` incorrectly requiring `--output-path` in unattended mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)