### PR TITLE
chore(ci): make changeset file the single source of truth

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,22 +20,3 @@ Did you add sufficient testing for this change?
 If not, please explain how you tested this change and why it was not
 possible/practical for writing an automated test
 -->
-
-### Notes for release
-
-<!--
-A changeset is auto-generated from this section. Leave empty to use the PR title, or start with "N/A" to skip. For example, "N/A: Internal only"
-If you ran `pnpm changeset` manually, write "N/A" here to avoid duplicates.
-
-Engineers do not need to worry about the final copy,
-but they must provide the docs team with enough context on:
-
-* What changed
-* How does one use it (code snippets, etc)
-* Are there limitations we should be aware of
-* [internal] Does this affect the docs team? If so, please ask a member of that team for a review
-
-If this PR is a partial implementation of a feature and is not enabled by default or if
-this PR does not contain changes that needs mention in the release notes (tooling chores etc),
-please call this out explicitly by writing "N/A – Part of feature X" in this section.
--->

--- a/.github/scripts/generate-changeset.mjs
+++ b/.github/scripts/generate-changeset.mjs
@@ -13,6 +13,7 @@ if (!GH_TOKEN || !GITHUB_REPOSITORY || !PR_NUMBER || !PR_TITLE || !PR_REPO) {
 }
 
 const CHANGESET_FILE = `.changeset/pr-${PR_NUMBER}.md`
+const AUTO_GENERATED_MARKER = '<!-- auto-generated -->'
 
 // --- Helpers ---
 
@@ -43,23 +44,6 @@ function parseConventionalCommit(title) {
   const match = title.match(/^([a-z]+)(\((.+)\))?(!)?:\s.+/)
   if (!match) return null
   return {breaking: match[4] === '!', type: match[1]}
-}
-
-function parseReleaseNotes(body) {
-  const lines = body.split('\n')
-  const startIdx = lines.findIndex((l) => l.startsWith('### Notes for release'))
-  if (startIdx === -1) return ''
-
-  const collected = []
-  for (let i = startIdx + 1; i < lines.length; i++) {
-    if (lines[i].startsWith('### ')) break
-    collected.push(lines[i])
-  }
-
-  return collected
-    .join('\n')
-    .replaceAll(/<!--[\s\S]*?-->/g, '')
-    .trim()
 }
 
 function determineBump(type, breaking, body) {
@@ -129,15 +113,24 @@ function getWorkspacePackages() {
 
 // --- Main ---
 
-// 0. Skip if any changeset already exists (manually or auto-generated)
-const changesetDir = resolve('.changeset')
-if (existsSync(changesetDir)) {
-  const existingChangesets = readdirSync(changesetDir).filter(
-    (f) => f.endsWith('.md') && f !== 'README.md',
-  )
-  if (existingChangesets.length > 0) {
-    console.log(`Skipping: found existing changeset(s): ${existingChangesets.join(', ')}`)
+// 0. Check for existing changesets using marker-based logic
+if (existsSync(CHANGESET_FILE)) {
+  const content = readFileSync(CHANGESET_FILE, 'utf8')
+  if (!content.startsWith(AUTO_GENERATED_MARKER)) {
+    console.log('Skipping: changeset was manually edited (marker removed)')
     process.exit(0)
+  }
+  // Marker present — bot still owns the file, will overwrite below
+} else {
+  const changesetDir = resolve('.changeset')
+  if (existsSync(changesetDir)) {
+    const otherChangesets = readdirSync(changesetDir).filter(
+      (f) => f.endsWith('.md') && f !== 'README.md',
+    )
+    if (otherChangesets.length > 0) {
+      console.log(`Skipping: found manual changeset(s): ${otherChangesets.join(', ')}`)
+      process.exit(0)
+    }
   }
 }
 
@@ -157,18 +150,8 @@ if (!bump) {
   process.exit(0)
 }
 
-// 3. Extract release notes
-let releaseNotes = parseReleaseNotes(PR_BODY)
-
-if (/^N\/A/i.test(releaseNotes)) {
-  console.log('Release notes set to N/A')
-  removeChangeset()
-  process.exit(0)
-}
-
-if (!releaseNotes) {
-  releaseNotes = PR_TITLE.replace(/^[a-z]+(\([^)]*\))?!?:\s*/, '')
-}
+// 3. Derive release notes from PR title
+const releaseNotes = PR_TITLE.replace(/^[a-z]+(\([^)]*\))?!?:\s*/, '')
 
 // 4. Detect affected packages
 const changedFiles = await getChangedFiles()
@@ -191,7 +174,7 @@ if (affected.size === 0) {
 
 // 5. Write changeset
 const frontmatter = [...affected].map((pkg) => `'${pkg}': ${bump}`).join('\n')
-const changesetContent = `---\n${frontmatter}\n---\n\n${releaseNotes}\n`
+const changesetContent = `${AUTO_GENERATED_MARKER}\n---\n${frontmatter}\n---\n\n${releaseNotes}\n`
 
 writeFileSync(CHANGESET_FILE, changesetContent)
 console.log('Generated changeset:')


### PR DESCRIPTION
## Summary

- Replace "skip if any changeset exists" logic with marker-based ownership detection (`<!-- auto-generated -->`)
- Auto-generated changesets can now be updated when PR title changes, while manually edited changesets are respected
- Remove "Notes for release" section from PR template — release notes are derived from PR title and edited directly in the changeset file

## How it works

1. Bot generates `.changeset/pr-{N}.md` with an `<!-- auto-generated -->` marker
2. On subsequent runs: if marker is present, the bot overwrites (PR title may have changed); if marker is absent, the bot skips (human took ownership)
3. If other (non-auto-generated) changeset files exist, the bot skips entirely

## Test plan

- [ ] Open a PR with a conventional commit title → changeset auto-generated with marker
- [ ] Edit the PR title → changeset updated (marker still present)
- [ ] Manually edit the changeset file and remove marker → bot stops overwriting
- [ ] Manually create a different changeset file → bot skips entirely
- [ ] PR with non-bump type (e.g., `chore:`) → no changeset generated
- [ ] PR with invalid title → no changeset generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)