### PR TITLE
chore: add conventional commit skill and enforce PR template usage

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: commit
+description: Use when creating git commits - enforces conventional commit format with correct type prefixes for release-triggering vs non-release changes
+---
+
+# Conventional Commits
+
+## Format
+
+```
+<type>[(scope)]: <description>
+```
+
+- Type and description are **lowercase**
+- No period at end
+- Imperative mood: "add" not "added"
+- Under 100 characters
+- Scope is optional, use package or feature area (e.g., `init`, `deploy`, `cli-core`, `deps`, `ci`)
+
+## Release-Triggering Types
+
+These types generate changesets and trigger npm releases:
+
+| Type             | Bump      | Use for                                                    |
+| ---------------- | --------- | ---------------------------------------------------------- |
+| `feat`           | minor     | New commands, flags, features                              |
+| `fix`            | patch     | Bug fixes, crash fixes, incorrect output                   |
+| `perf`           | patch     | Performance improvements                                   |
+| `revert`         | patch     | Reverting previous changes                                 |
+| `feat!` / `fix!` | **major** | Breaking changes (removed commands, changed flag behavior) |
+
+## Non-Release Types
+
+These do **not** trigger releases or changesets:
+
+| Type       | Use for                                    |
+| ---------- | ------------------------------------------ |
+| `chore`    | Tooling, build config, dependency updates  |
+| `refactor` | Code restructuring without behavior change |
+| `test`     | Adding or updating tests                   |
+| `docs`     | Documentation only                         |
+| `style`    | Formatting, whitespace                     |
+| `build`    | Build system changes                       |
+| `ci`       | CI/CD pipeline changes                     |
+
+## Decision Guide
+
+- Does it change what users experience? Use `feat` or `fix`
+- Does it break existing behavior? Add `!` suffix (e.g., `feat!`)
+- Is it internal-only with no user impact? Use `chore`, `refactor`, `test`, etc.
+- Dependency updates? Use `chore(deps)` unless fixing a user-facing bug, then `fix(deps)`
+
+## Examples from This Repo
+
+```
+feat: auto-generate changesets from PR descriptions
+feat(embeddings): add projection validation using groq-js
+feat(cli): inject __SANITY_STAGING__ global in staging builds
+fix(init): strip filename before counting nested folders in import path
+fix(deploy): stop spinner before returning from app lookup
+refactor(cli-core): replace oclif ux.colorize with node:util styleText
+refactor(cli): migrate from zod to zod/mini for smaller bundle size
+chore: skip auto-generated changeset when one already exists
+chore(ci): use squiggler-app bot as changeset commit author
+chore(deps): update swc-tooling
+```

--- a/.claude/skills/commit
+++ b/.claude/skills/commit
@@ -1,0 +1,1 @@
+../../.agents/skills/commit

--- a/Claude.md
+++ b/Claude.md
@@ -17,6 +17,7 @@ All commands are run from the root of the repo.
 
 - Be sure to typecheck, lint, build, depcheck and run tests when you are done.
 - Testing coverage should be maximized. Prefer running tests with coverage and the goal is to achieve maximum testing coverage for any new code added.
+- When creating pull requests, always follow the template in `.github/PULL_REQUEST_TEMPLATE.md`. Do not use your own format.
 
 # Testing Rules
 


### PR DESCRIPTION
### Description

Adds a conventional commit skill for AI agents and enforces PR template usage.

- Added `.agents/skills/commit/SKILL.md` — a conventional commit reference skill that guides agents on proper commit type prefixes (release-triggering vs non-release types)
- Added symlink at `.claude/skills/commit` so Claude Code discovers the skill
- Updated `Claude.md` to enforce using `.github/PULL_REQUEST_TEMPLATE.md` when creating PRs

### What to review

- Does the commit skill cover the right conventions for this project?
- Is the PR template enforcement rule in CLAUDE.md clear enough?

### Testing

No code changes — these are agent configuration/documentation files.

### Notes for release

N/A: Internal only