### PR TITLE
feat(dev): enable react-refresh for shared dev-server HMR

### DIFF
--- a/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
@@ -503,6 +503,44 @@ describe('#getViteConfig', () => {
     expect(federationPlugin).toBeUndefined()
   })
 
+  test('should pass reactRefreshHost to viteReact when provided', async () => {
+    const viteReactMock = (await import('@vitejs/plugin-react')).default as unknown as ReturnType<
+      typeof vi.fn
+    >
+
+    const options = {
+      cwd: mockTestCwd,
+      federation: {enabled: true},
+      mode: 'development' as const,
+      reactCompiler: undefined,
+      reactRefreshHost: 'http://localhost:3333',
+    }
+
+    await getViteConfig(options)
+
+    expect(viteReactMock).toHaveBeenCalledWith(
+      expect.objectContaining({reactRefreshHost: 'http://localhost:3333'}),
+    )
+  })
+
+  test('should not pass reactRefreshHost to viteReact when not provided', async () => {
+    const viteReactMock = (await import('@vitejs/plugin-react')).default as unknown as ReturnType<
+      typeof vi.fn
+    >
+
+    const options = {
+      cwd: mockTestCwd,
+      mode: 'development' as const,
+      reactCompiler: undefined,
+    }
+
+    await getViteConfig(options)
+
+    expect(viteReactMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({reactRefreshHost: expect.anything()}),
+    )
+  })
+
   test('should not include federation plugin when federation is undefined', async () => {
     const options = {
       cwd: mockTestCwd,

--- a/packages/@sanity/cli/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli/src/actions/build/getViteConfig.ts
@@ -59,6 +59,12 @@ interface ViteOptions extends Pick<CliConfig, 'federation' | 'schemaExtraction' 
    */
   outputDir?: string
   /**
+   * URL of the workbench dev server for react-refresh in federated builds.
+   * Passed as `reactRefreshHost` to `@vitejs/plugin-react` so the refresh
+   * preamble connects to the host application's HMR server.
+   */
+  reactRefreshHost?: string
+  /**
    * HTTP development server configuration
    */
   server?: {host?: string; port?: number}
@@ -84,6 +90,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     mode,
     outputDir,
     reactCompiler,
+    reactRefreshHost,
     schemaExtraction,
     server,
     // default to `true` when `mode=development`
@@ -109,16 +116,17 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     : getStudioEnvironmentVariables({jsonEncode: true, prefix: 'process.env.'})
 
   const sharedPlugins: PluginOption = [
-    viteReact(
-      reactCompiler
+    viteReact({
+      ...(reactCompiler
         ? {
             babel: {
               generatorOpts: {compact: true},
               plugins: [['babel-plugin-react-compiler', reactCompiler]],
             },
           }
-        : {},
-    ),
+        : {}),
+      ...(reactRefreshHost ? {reactRefreshHost} : {}),
+    }),
     ...(schemaExtraction?.enabled
       ? [
           sanitySchemaExtractionPlugin({

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -108,6 +108,38 @@ describe('devAction', () => {
     expect(mockStartStudioDevServer).not.toHaveBeenCalled()
   })
 
+  test('passes reactRefreshHost pointing to workbench when workbench is running', async () => {
+    mockStartWorkbenchDevServer.mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      httpHost: 'localhost',
+      workbenchAvailable: true,
+      workbenchPort: 3333,
+    })
+    mockStartStudioDevServer.mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      server: {config: {server: {port: 3334}}},
+    })
+
+    await devAction(createOptions())
+
+    expect(mockStartStudioDevServer).toHaveBeenCalledWith(
+      expect.objectContaining({reactRefreshHost: 'http://localhost:3333'}),
+    )
+  })
+
+  test('does not pass reactRefreshHost when workbench is not running', async () => {
+    mockStartStudioDevServer.mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      server: {config: {server: {port: 3333}}},
+    })
+
+    await devAction(createOptions())
+
+    expect(mockStartStudioDevServer).toHaveBeenCalledWith(
+      expect.objectContaining({reactRefreshHost: undefined}),
+    )
+  })
+
   test('cleans up workbench and re-throws when app/studio startup fails', async () => {
     const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
     mockStartWorkbenchDevServer.mockResolvedValue({

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -18,9 +18,18 @@ export async function devAction(options: DevActionOptions): Promise<{close?: () 
   // Start app/studio dev server: use workbenchPort + 1 if workbench feature is
   // available (reserves the configured port for it), otherwise use the original port
   const desiredAppPort = closeWorkbenchServer === undefined ? workbenchPort : workbenchPort + 1
+
+  // When the workbench is running, point the remote's react-refresh preamble at
+  // the workbench dev server so HMR updates flow through the host.
+  const reactRefreshHost =
+    closeWorkbenchServer === undefined
+      ? undefined
+      : `http://${httpHost || 'localhost'}:${workbenchPort}`
+
   const appOptions: DevActionOptions = {
     ...options,
     flags: {...options.flags, port: String(desiredAppPort)},
+    reactRefreshHost,
     workbenchAvailable,
   }
 

--- a/packages/@sanity/cli/src/actions/dev/startAppDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startAppDevServer.ts
@@ -29,7 +29,12 @@ export async function startAppDevServer(
     output.log('Starting dev server')
 
     const appTitle = cliConfig && 'app' in cliConfig ? cliConfig.app?.title : undefined
-    const {close, server} = await startDevServer({...config, appTitle, isApp: true})
+    const {close, server} = await startDevServer({
+      ...config,
+      appTitle,
+      isApp: true,
+      reactRefreshHost: options.reactRefreshHost,
+    })
 
     const {port} = server.config.server
 

--- a/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
@@ -102,7 +102,10 @@ export async function startStudioDevServer(
   try {
     const startTime = Date.now()
     const spin = spinner('Starting dev server').start()
-    const {close, server} = await startDevServer(config)
+    const {close, server} = await startDevServer({
+      ...config,
+      reactRefreshHost: options.reactRefreshHost,
+    })
 
     const {info: loggerInfo} = server.config.logger
     const {port} = server.config.server

--- a/packages/@sanity/cli/src/actions/dev/types.ts
+++ b/packages/@sanity/cli/src/actions/dev/types.ts
@@ -11,5 +11,6 @@ export interface DevActionOptions {
   output: Output
   workDir: string
 
+  reactRefreshHost?: string
   workbenchAvailable?: boolean
 }

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -25,6 +25,7 @@ export interface DevServerOptions {
   httpHost?: string
   isApp?: boolean
   projectName?: string
+  reactRefreshHost?: string
   schemaExtraction?: CliConfig['schemaExtraction']
   typegen?: CliConfig['typegen']
   vite?: UserViteConfig
@@ -48,6 +49,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     httpPort,
     isApp,
     reactCompiler,
+    reactRefreshHost,
     reactStrictMode,
     schemaExtraction,
     typegen,
@@ -75,6 +77,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     isApp,
     mode: 'development',
     reactCompiler,
+    reactRefreshHost,
     schemaExtraction,
     server: {host: httpHost, port: httpPort},
     typegen,


### PR DESCRIPTION
## Summary

- Passes `reactRefreshHost` to `@vitejs/plugin-react` so federated Studio/App modules connect their react-refresh preamble to the workbench host dev server
- When the workbench is running (federation enabled), `devAction.ts` computes the workbench URL and threads it through `startStudioDevServer`/`startAppDevServer` → `startDevServer` → `getViteConfig` → `viteReact({reactRefreshHost})`
- Enables component-level HMR across the module federation boundary

Closes SDK-1187