### PR TITLE
fix(workbench): require `sanity/workbench` rather than `@sanity/workbench`

### DIFF
--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -35,11 +35,18 @@ export async function startWorkbenchDevServer(
     : Boolean(cliConfig?.reactStrictMode)
 
   let workbenchAvailable = false
+
+  /**
+   * Check whether the `sanity` package has the `workbench` export available. If not,
+   * it means an incompatible version of `sanity` is installed and workbench will not
+   * be able to start, because the runtime requires the `renderWorkbench` function from
+   * that export.
+   */
   try {
-    await resolveLocalPackage('@sanity/workbench', workDir)
+    await resolveLocalPackage('sanity/workbench', workDir)
     workbenchAvailable = true
   } catch {
-    // @sanity/workbench not available in this version — skip workbench server
+    // sanity/workbench not available in this version — skip workbench server
   }
 
   if (!workbenchAvailable) {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fixes a regression that prevents the workbench dev-server from starting.
