### PR TITLE
chore(cli): improve command description and help text copy

### DIFF
--- a/packages/@sanity/cli/src/commands/backups/disable.ts
+++ b/packages/@sanity/cli/src/commands/backups/disable.ts
@@ -21,7 +21,7 @@ export class DisableBackupCommand extends SanityCommand<typeof DisableBackupComm
     }),
   }
 
-  static override description = 'Disable backup for a dataset.'
+  static override description = 'Disable backup for a dataset'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/backups/download.ts
+++ b/packages/@sanity/cli/src/commands/backups/download.ts
@@ -50,7 +50,7 @@ export class DownloadBackupCommand extends SanityCommand<typeof DownloadBackupCo
     }),
   }
 
-  static override description = 'Download a dataset backup to a local file.'
+  static override description = 'Download a dataset backup to a local file'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/backups/enable.ts
+++ b/packages/@sanity/cli/src/commands/backups/enable.ts
@@ -22,7 +22,7 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
     }),
   }
 
-  static override description = 'Enable backup for a dataset.'
+  static override description = 'Enable backup for a dataset'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/backups/list.ts
+++ b/packages/@sanity/cli/src/commands/backups/list.ts
@@ -32,7 +32,7 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
     }),
   }
 
-  static override description = 'List available backups for a dataset.'
+  static override description = 'List available backups for a dataset'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/build.ts
+++ b/packages/@sanity/cli/src/commands/build.ts
@@ -12,7 +12,7 @@ export class BuildCommand extends SanityCommand<typeof BuildCommand> {
     outputDir: Args.directory({description: 'Output directory'}),
   }
 
-  static override description = 'Builds the Sanity Studio configuration into a static bundle'
+  static override description = 'Build Sanity Studio into a static bundle'
 
   static override examples = [
     '<%= config.bin %> <%= command.id %>',

--- a/packages/@sanity/cli/src/commands/cors/add.ts
+++ b/packages/@sanity/cli/src/commands/cors/add.ts
@@ -22,7 +22,7 @@ export class Add extends SanityCommand<typeof Add> {
     }),
   }
 
-  static override description = 'Allow a new origin to use your project API through CORS'
+  static override description = 'Add a CORS origin to the project'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/cors/delete.ts
+++ b/packages/@sanity/cli/src/commands/cors/delete.ts
@@ -16,7 +16,7 @@ export class Delete extends SanityCommand<typeof Delete> {
     }),
   }
 
-  static override description = 'Delete an existing CORS origin from your project'
+  static override description = 'Delete a CORS origin from the project'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/cors/list.ts
+++ b/packages/@sanity/cli/src/commands/cors/list.ts
@@ -7,11 +7,11 @@ import {getProjectIdFlag} from '../../util/sharedFlags.js'
 const listCorsDebug = subdebug('cors:list')
 
 export class List extends SanityCommand<typeof List> {
-  static override description = 'List all origins allowed to access the API for this project'
+  static override description = 'List CORS origins for the project'
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
-      description: 'List CORS origins for the current project',
+      description: 'List CORS origins for the project',
     },
     {
       command: '<%= config.bin %> <%= command.id %> --project-id abc123',

--- a/packages/@sanity/cli/src/commands/datasets/alias/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/create.ts
@@ -25,7 +25,7 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
     }),
   }
 
-  static override description = 'Create a dataset alias within your project'
+  static override description = 'Create a dataset alias for the project'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
@@ -18,7 +18,7 @@ export class DeleteAliasCommand extends SanityCommand<typeof DeleteAliasCommand>
     }),
   }
 
-  static override description = 'Delete a dataset alias within your project'
+  static override description = 'Delete a dataset alias from the project'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/datasets/alias/link.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/link.ts
@@ -26,7 +26,7 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
     }),
   }
 
-  static override description = 'Link a dataset alias to a dataset within your project'
+  static override description = 'Link a dataset alias to a dataset in the project'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
@@ -19,7 +19,7 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
     }),
   }
 
-  static override description = 'Unlink a dataset alias from its dataset within your project'
+  static override description = 'Unlink a dataset alias from its dataset in the project'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -37,8 +37,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     }),
   }
 
-  static override description =
-    'Manages dataset copying, including starting a new copy job, listing copy jobs and following the progress of a running copy job'
+  static override description = 'Copy a dataset or manage copy jobs'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/datasets/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/create.ts
@@ -21,7 +21,7 @@ export class CreateDatasetCommand extends SanityCommand<typeof CreateDatasetComm
     }),
   }
 
-  static override description = 'Create a new dataset within your project'
+  static override description = 'Create a new dataset for the project'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/datasets/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/delete.ts
@@ -20,7 +20,7 @@ export class DeleteDatasetCommand extends SanityCommand<typeof DeleteDatasetComm
     }),
   }
 
-  static override description = 'Delete a dataset within your project'
+  static override description = 'Delete a dataset from the project'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -31,7 +31,8 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
     }),
   }
 
-  static override description = 'Export a dataset to a local file'
+  static override description =
+    'Export a dataset to a local file. Assets returning 401, 403, or 404 are silently excluded.'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -32,7 +32,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
   }
 
   static override description =
-    'Export a dataset to a local gzipped tarball. Assets returning 401, 403, or 404 are silently excluded.'
+    'Export a dataset to a local gzipped tarball. Assets returning 401, 403, or 404 are excluded from the export.'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -31,8 +31,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
     }),
   }
 
-  static override description =
-    'Export dataset to local filesystem as a gzipped tarball. Assets failing with HTTP status codes 401, 403 and 404 upon download are ignored and excluded from export.'
+  static override description = 'Export a dataset to a local file'
 
   static override examples = [
     {
@@ -65,7 +64,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
     mode: Flags.string({
       default: 'stream',
       description:
-        'Mode to export documents with `cursor` might be more performant for larger datasets, but might not be as accurate if the dataset is being modified during export',
+        "Export mode ('cursor' is faster for large datasets but may miss concurrent changes)",
       options: ['stream', 'cursor'],
     }),
     'no-assets': Flags.boolean({

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -32,7 +32,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
   }
 
   static override description =
-    'Export a dataset to a local file. Assets returning 401, 403, or 404 are silently excluded.'
+    'Export a dataset to a local gzipped tarball. Assets returning 401, 403, or 404 are silently excluded.'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/datasets/list.ts
+++ b/packages/@sanity/cli/src/commands/datasets/list.ts
@@ -7,12 +7,12 @@ import {getProjectIdFlag} from '../../util/sharedFlags.js'
 const listDatasetDebug = subdebug('dataset:list')
 
 export class ListDatasetCommand extends SanityCommand<typeof ListDatasetCommand> {
-  static override description = 'List datasets of your project'
+  static override description = 'List datasets for the project'
 
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
-      description: 'List datasets of your project',
+      description: 'List datasets for the project',
     },
     {
       command: '<%= config.bin %> <%= command.id %> --project-id abc123',

--- a/packages/@sanity/cli/src/commands/debug.ts
+++ b/packages/@sanity/cli/src/commands/debug.ts
@@ -17,7 +17,7 @@ import {type StudioWorkspace, type UserInfo} from '../actions/debug/types.js'
 type ConfigLoadResult<T> = {error: Error; value?: never} | {error?: never; value: T}
 
 export class Debug extends SanityCommand<typeof Debug> {
-  static override description = 'Provides diagnostic info for Sanity Studio troubleshooting'
+  static override description = 'Print diagnostic info for troubleshooting'
 
   static override examples = [
     '<%= config.bin %> <%= command.id %>',

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -48,7 +48,8 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
     build: Flags.boolean({
       allowNo: true,
       default: true,
-      description: 'Skip build, deploy existing `dist/` output',
+      description:
+        'Build the studio before deploying (use --no-build to deploy existing `dist/` output)',
     }),
     external: Flags.boolean({
       default: false,

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -48,8 +48,7 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
     build: Flags.boolean({
       allowNo: true,
       default: true,
-      description:
-        "Don't build the studio prior to deploy, instead deploying the version currently in `dist/`",
+      description: 'Skip build, deploy existing `dist/` output',
     }),
     external: Flags.boolean({
       default: false,
@@ -59,11 +58,11 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
     minify: Flags.boolean({
       allowNo: true,
       default: true,
-      description: 'Skip minifying built JavaScript (speeds up build, increases size of bundle)',
+      description: 'Minify built JavaScript',
     }),
     'schema-required': Flags.boolean({
       default: false,
-      description: 'Fail-fast deployment if schema store fails',
+      description: 'Fail if schema deployment fails',
     }),
     'source-maps': Flags.boolean({
       default: false,

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -59,7 +59,7 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
     minify: Flags.boolean({
       allowNo: true,
       default: true,
-      description: 'Minify built JavaScript',
+      description: 'Minify built JavaScript (use --no-minify to skip for faster builds)',
     }),
     'schema-required': Flags.boolean({
       default: false,

--- a/packages/@sanity/cli/src/commands/dev.ts
+++ b/packages/@sanity/cli/src/commands/dev.ts
@@ -8,8 +8,7 @@ import {devDebug} from '../actions/dev/devDebug.js'
 import {determineIsApp} from '../util/determineIsApp.js'
 
 export class DevCommand extends SanityCommand<typeof DevCommand> {
-  static override description =
-    'Starts a local development server for Sanity Studio with live reloading'
+  static override description = 'Start a local development server with live reloading'
 
   static override examples = [
     '<%= config.bin %> <%= command.id %> --host=0.0.0.0',
@@ -20,17 +19,17 @@ export class DevCommand extends SanityCommand<typeof DevCommand> {
   static override flags = {
     'auto-updates': Flags.boolean({
       allowNo: true,
-      description: 'Automatically update Sanity Studio dependencies.',
+      description: 'Automatically update Sanity Studio dependencies',
     }),
     host: Flags.string({
-      description: '[default: localhost] The local network interface at which to listen.',
+      description: 'Local network interface to listen on (default: localhost)',
     }),
     'load-in-dashboard': Flags.boolean({
       allowNo: true,
-      description: 'Load the app/studio in the Sanity dashboard.',
+      description: 'Load the app/studio in the Sanity dashboard',
     }),
     port: Flags.string({
-      description: '[default: 3333] TCP port to start server on.',
+      description: 'TCP port to start server on (default: 3333)',
     }),
   }
 

--- a/packages/@sanity/cli/src/commands/docs/browse.ts
+++ b/packages/@sanity/cli/src/commands/docs/browse.ts
@@ -3,7 +3,7 @@ import {type FlagInput} from '@oclif/core/interfaces'
 import open from 'open'
 
 export class DocsBrowseCommand extends Command {
-  static override description = 'Open Sanity docs in a web browser'
+  static override description = 'Open Sanity docs in your browser'
   static override flags = {} satisfies FlagInput
 
   public async run(): Promise<void> {

--- a/packages/@sanity/cli/src/commands/documents/delete.ts
+++ b/packages/@sanity/cli/src/commands/documents/delete.ts
@@ -19,7 +19,7 @@ export class DeleteDocumentCommand extends SanityCommand<typeof DeleteDocumentCo
     }),
   }
 
-  static override description = 'Delete one or more documents from the projects configured dataset'
+  static override description = "Delete one or more documents from the project's configured dataset"
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/exec.ts
+++ b/packages/@sanity/cli/src/commands/exec.ts
@@ -39,11 +39,11 @@ export class ExecCommand extends SanityCommand<typeof ExecCommand> {
   static override flags = {
     'mock-browser-env': Flags.boolean({
       default: false,
-      description: 'Mocks a browser-like environment using jsdom',
+      description: 'Mock a browser environment with jsdom',
     }),
     'with-user-token': Flags.boolean({
       default: false,
-      description: 'Prime access token from CLI config into getCliClient()',
+      description: 'Include your auth token in getCliClient()',
     }),
   }
 

--- a/packages/@sanity/cli/src/commands/graphql/deploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/deploy.ts
@@ -68,7 +68,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
 
   static override flags = {
     api: Flags.string({
-      description: 'Only deploy API with this ID. Can be specified multiple times.',
+      description: 'Only deploy API with this ID (can be specified multiple times)',
       multiple: true,
     }),
     ...getDatasetFlag({description: 'Deploy API for the given dataset', semantics: 'specify'}),
@@ -94,8 +94,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
       description: 'Deploy API(s) to given tag (defaults to "default")',
     }),
     'with-union-cache': Flags.boolean({
-      description:
-        'Enable union cache that optimizes schema generation for schemas with many self referencing types',
+      description: 'Cache union types (faster for schemas with many self-references)',
     }),
   }
 

--- a/packages/@sanity/cli/src/commands/graphql/list.ts
+++ b/packages/@sanity/cli/src/commands/graphql/list.ts
@@ -13,11 +13,11 @@ import {getProjectIdFlag} from '../../util/sharedFlags.js'
 const listGraphQLDebug = subdebug('graphql:list')
 
 export class List extends SanityCommand<typeof List> {
-  static override description = 'List all GraphQL endpoints deployed for this project'
+  static override description = 'List deployed GraphQL endpoints for the project'
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
-      description: 'List GraphQL endpoints for the current project',
+      description: 'List GraphQL endpoints for the project',
     },
     {
       command: '<%= config.bin %> <%= command.id %> --project-id abc123',

--- a/packages/@sanity/cli/src/commands/hooks/create.ts
+++ b/packages/@sanity/cli/src/commands/hooks/create.ts
@@ -8,11 +8,11 @@ import {getProjectIdFlag} from '../../util/sharedFlags.js'
 const createHookDebug = subdebug('hook:create')
 
 export class CreateHookCommand extends SanityCommand<typeof CreateHookCommand> {
-  static override description = 'Create a new webhook for the current project'
+  static override description = 'Create a new webhook for the project'
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
-      description: 'Create a new webhook for the current project',
+      description: 'Create a new webhook for the project',
     },
     {
       command: '<%= config.bin %> <%= command.id %> --project-id abc123',

--- a/packages/@sanity/cli/src/commands/hooks/delete.ts
+++ b/packages/@sanity/cli/src/commands/hooks/delete.ts
@@ -12,25 +12,25 @@ const deleteHookDebug = subdebug('hook:delete')
 export class Delete extends SanityCommand<typeof Delete> {
   static override args = {
     name: Args.string({
-      description: 'Name of hook to delete (will prompt if not provided)',
+      description: 'Name of webhook to delete (will prompt if not provided)',
       required: false,
     }),
   }
 
-  static override description = 'Delete a hook within your project'
+  static override description = 'Delete a webhook from the project'
 
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
-      description: 'Interactively select and delete a hook',
+      description: 'Interactively select and delete a webhook',
     },
     {
       command: '<%= config.bin %> <%= command.id %> my-hook',
-      description: 'Delete a specific hook by name',
+      description: 'Delete a specific webhook by name',
     },
     {
       command: '<%= config.bin %> <%= command.id %> --project-id abc123',
-      description: 'Delete a hook from a specific project',
+      description: 'Delete a webhook from a specific project',
     },
   ]
 

--- a/packages/@sanity/cli/src/commands/hooks/list.ts
+++ b/packages/@sanity/cli/src/commands/hooks/list.ts
@@ -8,15 +8,15 @@ import {getProjectIdFlag} from '../../util/sharedFlags.js'
 const listHookDebug = subdebug('hook:list')
 
 export class List extends SanityCommand<typeof List> {
-  static override description = 'List hooks for a given project'
+  static override description = 'List webhooks for the project'
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
-      description: 'List hooks for a given project',
+      description: 'List webhooks for the project',
     },
     {
       command: '<%= config.bin %> <%= command.id %> --project-id abc123',
-      description: 'List hooks for a specific project',
+      description: 'List webhooks for a specific project',
     },
   ]
 

--- a/packages/@sanity/cli/src/commands/hooks/logs.ts
+++ b/packages/@sanity/cli/src/commands/hooks/logs.ts
@@ -25,7 +25,7 @@ export class LogsHookCommand extends SanityCommand<typeof LogsHookCommand> {
     }),
   }
 
-  static override description = 'Show log entries for a webhook'
+  static override description = 'Show log entries for project webhooks'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/hooks/logs.ts
+++ b/packages/@sanity/cli/src/commands/hooks/logs.ts
@@ -30,7 +30,7 @@ export class LogsHookCommand extends SanityCommand<typeof LogsHookCommand> {
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
-      description: 'Show log entries for the project webhooks',
+      description: 'Show log entries for project webhooks',
     },
     {
       command: '<%= config.bin %> <%= command.id %> [NAME]',
@@ -38,7 +38,7 @@ export class LogsHookCommand extends SanityCommand<typeof LogsHookCommand> {
     },
     {
       command: '<%= config.bin %> <%= command.id %> --project-id abc123',
-      description: 'Show webhook logs for a specific project',
+      description: 'Show log entries for a specific project',
     },
   ]
 

--- a/packages/@sanity/cli/src/commands/hooks/logs.ts
+++ b/packages/@sanity/cli/src/commands/hooks/logs.ts
@@ -20,25 +20,25 @@ const logsHookDebug = subdebug('hook:logs')
 export class LogsHookCommand extends SanityCommand<typeof LogsHookCommand> {
   static override args = {
     name: Args.string({
-      description: 'Name of the hook to show logs for',
+      description: 'Name of the webhook to show logs for',
       required: false,
     }),
   }
 
-  static override description = 'List latest log entries for a given hook'
+  static override description = 'Show log entries for a webhook'
 
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
-      description: 'List latest log entries for a given hook',
+      description: 'Show log entries for the project webhooks',
     },
     {
       command: '<%= config.bin %> <%= command.id %> [NAME]',
-      description: 'List latest log entries for a specific hook by name',
+      description: 'Show log entries for a specific webhook by name',
     },
     {
       command: '<%= config.bin %> <%= command.id %> --project-id abc123',
-      description: 'List hook logs for a specific project',
+      description: 'Show webhook logs for a specific project',
     },
   ]
 

--- a/packages/@sanity/cli/src/commands/install.ts
+++ b/packages/@sanity/cli/src/commands/install.ts
@@ -16,7 +16,7 @@ export class Install extends SanityCommand<typeof Install> {
     }),
   }
 
-  static override description = 'Installs dependencies for Sanity Studio project'
+  static override description = 'Install dependencies for the Sanity Studio project'
 
   static override examples = [
     '<%= config.bin %> <%= command.id %>',

--- a/packages/@sanity/cli/src/commands/learn.ts
+++ b/packages/@sanity/cli/src/commands/learn.ts
@@ -3,7 +3,7 @@ import {type FlagInput} from '@oclif/core/interfaces'
 import open from 'open'
 
 export class LearnCommand extends Command {
-  static override description = 'Opens Sanity Learn in your web browser'
+  static override description = 'Open Sanity Learn in your browser'
   static override flags = {} satisfies FlagInput
 
   public async run(): Promise<void> {

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -5,7 +5,7 @@ import {SanityCommand} from '@sanity/cli-core'
 import {login} from '../actions/auth/login/login.js'
 
 export class LoginCommand extends SanityCommand<typeof LoginCommand> {
-  static override description = 'Authenticates the CLI for access to Sanity projects'
+  static override description = 'Log in to your Sanity account'
   static override examples: Array<Command.Example> = [
     {
       command: '<%= config.bin %> <%= command.id %>',

--- a/packages/@sanity/cli/src/commands/logout.ts
+++ b/packages/@sanity/cli/src/commands/logout.ts
@@ -4,7 +4,7 @@ import {isHttpError} from '@sanity/client'
 import {logout} from '../services/auth.js'
 
 export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
-  static override description = 'Logs out the CLI from the current user session'
+  static override description = 'Log out of the current session'
 
   public async run(): Promise<void> {
     await this.parse(LogoutCommand)

--- a/packages/@sanity/cli/src/commands/manage.ts
+++ b/packages/@sanity/cli/src/commands/manage.ts
@@ -5,7 +5,7 @@ import open from 'open'
 import {getManageUrl} from '../actions/projects/getManageUrl.js'
 
 export class ManageCommand extends SanityCommand<typeof ManageCommand> {
-  static override description = 'Opens project management interface in your web browser'
+  static override description = 'Open project settings in your browser'
   static override flags = {} satisfies FlagInput
 
   public async run(): Promise<void> {

--- a/packages/@sanity/cli/src/commands/manifest/extract.ts
+++ b/packages/@sanity/cli/src/commands/manifest/extract.ts
@@ -7,9 +7,9 @@ import {formatSchemaValidation} from '../../actions/schema/formatSchemaValidatio
 import {SchemaExtractionError} from '../../actions/schema/utils/SchemaExtractionError.js'
 
 const description = `
-Extracts the studio configuration as one or more JSON manifest files.
+Extract studio configuration as JSON manifest files.
 
-**Note**: This command is experimental and subject to change. It is currently intended for use with Create only.
+Note: This command is experimental and subject to change. It is currently intended for use with Create only.
 `.trim()
 
 export class ExtractManifestCommand extends SanityCommand<typeof ExtractManifestCommand> {

--- a/packages/@sanity/cli/src/commands/media/delete-aspect.ts
+++ b/packages/@sanity/cli/src/commands/media/delete-aspect.ts
@@ -19,7 +19,7 @@ export class MediaDeleteAspectCommand extends SanityCommand<typeof MediaDeleteAs
     }),
   }
 
-  static override description = 'Undeploy an aspect'
+  static override description = 'Delete an aspect definition'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/media/export.ts
+++ b/packages/@sanity/cli/src/commands/media/export.ts
@@ -24,8 +24,7 @@ export class MediaExportCommand extends SanityCommand<typeof MediaExportCommand>
     }),
   }
 
-  static override description =
-    'Export an archive of all file and image assets including their aspect data from the target media library. Video assets are excluded from the export.'
+  static override description = 'Export file and image assets from a media library (excludes video)'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/preview.ts
+++ b/packages/@sanity/cli/src/commands/preview.ts
@@ -15,7 +15,7 @@ export class PreviewCommand extends SanityCommand<typeof PreviewCommand> {
 
   static override deprecateAliases = true
 
-  static override description = 'Starts a server to preview a production build'
+  static override description = 'Start a local server to preview a production build'
 
   static override examples = [
     '<%= config.bin %> <%= command.id %> --host=0.0.0.0',
@@ -25,10 +25,10 @@ export class PreviewCommand extends SanityCommand<typeof PreviewCommand> {
 
   static override flags = {
     host: Flags.string({
-      description: '[default: localhost] The local network interface at which to listen.',
+      description: 'Local network interface to listen on (default: localhost)',
     }),
     port: Flags.string({
-      description: '[default: 3333] TCP port to start server on.',
+      description: 'TCP port to start server on (default: 3333)',
     }),
   }
   static override hiddenAliases: string[] = ['start']

--- a/packages/@sanity/cli/src/commands/projects/list.ts
+++ b/packages/@sanity/cli/src/commands/projects/list.ts
@@ -12,7 +12,7 @@ const sortFields = ['id', 'members', 'name', 'url', 'created']
 const projectsDebug = subdebug('projects')
 
 export class List extends SanityCommand<typeof List> {
-  static override description = 'Lists projects connected to your user'
+  static override description = 'List your projects'
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
@@ -20,17 +20,19 @@ export class List extends SanityCommand<typeof List> {
     },
     {
       command: '<%= config.bin %> <%= command.id %> --sort=members --order=asc',
-      description: 'List all users of the project, but exclude pending invitations and robots',
+      description: 'List projects sorted by member count, ascending',
     },
   ]
 
   static override flags = {
     order: Flags.string({
       default: 'desc',
+      description: 'Sort direction',
       options: ['asc', 'desc'],
     }),
     sort: Flags.string({
       default: 'created',
+      description: 'Sort field',
       options: sortFields,
     }),
   }

--- a/packages/@sanity/cli/src/commands/schemas/deploy.ts
+++ b/packages/@sanity/cli/src/commands/schemas/deploy.ts
@@ -13,10 +13,9 @@ import {parseTag} from '../../actions/schema/utils/schemaStoreValidation.js'
 const description = `
 Deploy schema documents into workspace datasets.
 
-**Note**: This command is experimental and subject to change.
+Note: This command is experimental and subject to change.
 
-This operation (re-)generates a manifest file describing the sanity config workspace by default.
-To re-use an existing manifest file, use --no-extract-manifest.
+Re-generates a manifest file by default. To re-use an existing manifest, use --no-extract-manifest.
 `.trim()
 
 export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaCommand> {
@@ -37,7 +36,7 @@ export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaComman
     'extract-manifest': Flags.boolean({
       allowNo: true,
       default: true,
-      description: 'Disables manifest generation - the command will fail if no manifest exists',
+      description: 'Re-generate manifest before deploying (use --no-extract-manifest to skip)',
     }),
     'manifest-dir': Flags.directory({
       default: './dist/static',

--- a/packages/@sanity/cli/src/commands/schemas/deploy.ts
+++ b/packages/@sanity/cli/src/commands/schemas/deploy.ts
@@ -15,7 +15,7 @@ Deploy schema documents into workspace datasets.
 
 Note: This command is experimental and subject to change.
 
-Re-generates a manifest file by default. To re-use an existing manifest, use --no-extract-manifest.
+Regenerates a manifest file by default. To re-use an existing manifest, use --no-extract-manifest.
 `.trim()
 
 export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaCommand> {
@@ -36,7 +36,7 @@ export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaComman
     'extract-manifest': Flags.boolean({
       allowNo: true,
       default: true,
-      description: 'Re-generate manifest before deploying (use --no-extract-manifest to skip)',
+      description: 'Regenerate manifest before deploying (use --no-extract-manifest to skip)',
     }),
     'manifest-dir': Flags.directory({
       default: './dist/static',

--- a/packages/@sanity/cli/src/commands/schemas/extract.ts
+++ b/packages/@sanity/cli/src/commands/schemas/extract.ts
@@ -6,9 +6,9 @@ import {getExtractOptions} from '../../actions/schema/getExtractOptions.js'
 import {watchExtractSchema} from '../../actions/schema/watchExtractSchema.js'
 
 const description = `
-Extracts a JSON representation of a Sanity schema within a Studio context.
+Extract a JSON representation of a Sanity schema within a Studio context.
 
-**Note**: This command is experimental and subject to change.
+Note: This command is experimental and subject to change.
 `.trim()
 
 export class ExtractSchemaCommand extends SanityCommand<typeof ExtractSchemaCommand> {
@@ -35,7 +35,7 @@ export class ExtractSchemaCommand extends SanityCommand<typeof ExtractSchemaComm
     }),
     format: Flags.string({
       default: 'groq-type-nodes',
-      description: 'Format the schema as GROQ type nodes. Only available format at the moment.',
+      description: 'Output format (currently only groq-type-nodes)',
       helpValue: '<format>',
     }),
     path: Flags.string({

--- a/packages/@sanity/cli/src/commands/schemas/list.ts
+++ b/packages/@sanity/cli/src/commands/schemas/list.ts
@@ -10,7 +10,7 @@ List all schemas in the current dataset.
 
 Note: This command is experimental and subject to change.
 
-Re-generates a manifest file by default. To re-use an existing manifest, use --no-extract-manifest.
+Regenerates a manifest file by default. To reuse an existing manifest, use --no-extract-manifest.
 `.trim()
 
 export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
@@ -39,7 +39,7 @@ export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
     'extract-manifest': Flags.boolean({
       allowNo: true,
       default: true,
-      description: 'Re-generate manifest before listing (use --no-extract-manifest to skip)',
+      description: 'Regenerate manifest before listing (use --no-extract-manifest to skip)',
       hidden: true,
     }),
     id: Flags.string({

--- a/packages/@sanity/cli/src/commands/schemas/list.ts
+++ b/packages/@sanity/cli/src/commands/schemas/list.ts
@@ -6,12 +6,11 @@ import {schemasListDebug} from '../../actions/schema/utils/debug.js'
 import {parseWorkspaceSchemaId} from '../../actions/schema/utils/schemaStoreValidation.js'
 
 const description = `
-Lists all schemas in the current dataset.
+List all schemas in the current dataset.
 
-**Note**: This command is experimental and subject to change.
+Note: This command is experimental and subject to change.
 
-This operation (re-)generates a manifest file describing the sanity config workspace by default.
-To re-use an existing manifest file, use --no-extract-manifest.
+Re-generates a manifest file by default. To re-use an existing manifest, use --no-extract-manifest.
 `.trim()
 
 export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
@@ -40,7 +39,7 @@ export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
     'extract-manifest': Flags.boolean({
       allowNo: true,
       default: true,
-      description: 'Disables manifest generation - the command will fail if no manifest exists',
+      description: 'Re-generate manifest before listing (use --no-extract-manifest to skip)',
       hidden: true,
     }),
     id: Flags.string({

--- a/packages/@sanity/cli/src/commands/telemetry/disable.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/disable.ts
@@ -6,12 +6,12 @@ import {setConsent} from '../../actions/telemetry/setConsent.js'
 import {telemetryLearnMoreMessage} from '../../actions/telemetry/telemetryLearnMoreMessage.js'
 
 export class Disable extends SanityCommand<typeof Disable> {
-  static override description = 'Disable telemetry for your logged in user'
+  static override description = 'Disable telemetry for your account'
 
   static override examples: Array<Command.Example> = [
     {
       command: '<%= config.bin %> telemetry <%= command.id %>',
-      description: 'Disable telemetry for your logged in user',
+      description: 'Disable telemetry for your account',
     },
   ]
 

--- a/packages/@sanity/cli/src/commands/telemetry/enable.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/enable.ts
@@ -6,12 +6,12 @@ import {setConsent} from '../../actions/telemetry/setConsent.js'
 import {telemetryLearnMoreMessage} from '../../actions/telemetry/telemetryLearnMoreMessage.js'
 
 export class Enable extends SanityCommand<typeof Enable> {
-  static override description = 'Enable telemetry for your logged in user'
+  static override description = 'Enable telemetry for your account'
 
   static override examples: Array<Command.Example> = [
     {
       command: '<%= config.bin %> telemetry <%= command.id %>',
-      description: 'Enable telemetry for your logged in user',
+      description: 'Enable telemetry for your account',
     },
   ]
 

--- a/packages/@sanity/cli/src/commands/telemetry/status.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/status.ts
@@ -7,12 +7,12 @@ import {getStatusMessage} from '../../actions/telemetry/getStatusMessage.js'
 import {resolveConsent} from '../../actions/telemetry/resolveConsent.js'
 
 export class Status extends SanityCommand<typeof Status> {
-  static override description = 'Check telemetry consent status for your logged in user'
+  static override description = 'Check telemetry status for your account'
 
   static override examples: Array<Command.Example> = [
     {
       command: '<%= config.bin %> telemetry <%= command.id %>',
-      description: 'Check telemetry consent status for your logged in user',
+      description: 'Check telemetry status for your account',
     },
   ]
 

--- a/packages/@sanity/cli/src/commands/tokens/add.ts
+++ b/packages/@sanity/cli/src/commands/tokens/add.ts
@@ -17,7 +17,7 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
     }),
   }
 
-  static override description = 'Create a new API token for this project'
+  static override description = 'Create a new API token for the project'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/tokens/delete.ts
+++ b/packages/@sanity/cli/src/commands/tokens/delete.ts
@@ -17,7 +17,7 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
     }),
   }
 
-  static override description = 'Delete an API token from this project'
+  static override description = 'Delete an API token from the project'
 
   static override examples = [
     {

--- a/packages/@sanity/cli/src/commands/tokens/list.ts
+++ b/packages/@sanity/cli/src/commands/tokens/list.ts
@@ -11,11 +11,11 @@ import {getProjectIdFlag} from '../../util/sharedFlags.js'
 const listTokenDebug = subdebug('tokens:list')
 
 export class TokensListCommand extends SanityCommand<typeof TokensListCommand> {
-  static override description = 'List API tokens for the current project'
+  static override description = 'List API tokens for the project'
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
-      description: 'List tokens for the current project',
+      description: 'List tokens for the project',
     },
     {
       command: '<%= config.bin %> <%= command.id %> --json',

--- a/packages/@sanity/cli/src/commands/users/list.ts
+++ b/packages/@sanity/cli/src/commands/users/list.ts
@@ -16,7 +16,7 @@ function dimText(value: string, isDim: boolean): string {
 }
 
 export class List extends SanityCommand<typeof List> {
-  static override description = 'List all users of the project'
+  static override description = 'List project members'
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',

--- a/packages/@sanity/cli/src/commands/versions.ts
+++ b/packages/@sanity/cli/src/commands/versions.ts
@@ -8,7 +8,7 @@ import {getDisplayName, getFormatters} from '../actions/versions/getFormatters.j
 import {versionsDebug} from '../actions/versions/versionsDebug.js'
 
 export class Versions extends SanityCommand<typeof Versions> {
-  static override description = 'Shows installed versions of Sanity Studio and components'
+  static override description = 'Show installed package versions'
   static override examples = ['<%= config.bin %> <%= command.id %>']
 
   public async run(): Promise<void> {


### PR DESCRIPTION
### Description

Audit and standardize CLI command descriptions, flag descriptions, and example text across all 50 command files for consistency and clarity.

Changes include:
- **Verb form consistency**: Normalized ~15 commands from third-person ("Builds", "Opens", "Shows") to imperative mood ("Build", "Open", "Show") per CLI conventions
- **Webhook terminology**: Standardized `hooks/*` commands to consistently use "webhook" in descriptions and examples
- **Trailing punctuation**: Removed trailing periods from `backups/*` descriptions and flag descriptions to match the rest of the codebase
- **Grammar fixes**: Fixed missing apostrophe in `documents/delete`, "logged in" → "account" in `telemetry/*`, broken grammar in `datasets/export` `mode` flag
- **Wordy descriptions**: Tightened verbose descriptions in `datasets/copy`, `datasets/export`, `media/export`, `media/delete-aspect` while preserving important behavioral details (e.g. gzipped tarball format, asset exclusion on 401/403/404)
- **Markdown in terminal**: Replaced `**Note**` markdown bold (doesn't render in terminal) with plain `Note:` in `manifest/extract`, `schemas/deploy`, `schemas/list`, `schemas/extract`
- **Flag clarity**: Improved unclear flag descriptions in `deploy` (documented `--no-build` and `--no-minify` variants), `exec`, `graphql/deploy`, `schemas/*`, `projects/list`
- **Embedded defaults**: Cleaned up `[default: X]` bracket syntax in `dev` and `preview` host/port flags to `(default: X)`
- **Project scoping language**: Standardized "within your project" / "of your project" / "for the current project" / "for this project" to consistent "for the project" / "from the project"
- **Incorrect example**: Fixed `projects/list` example that had a copy-pasted description from `users/list`

### What to review

- Skim the diff to confirm descriptions read well and no meaning was lost
- All changes are to static `description`, `examples`, and flag `description` strings — no runtime behavior changes

### Testing

No new tests needed. All changes are to help text strings (static properties on command classes). Ran the full `@sanity/cli` test suite — 1264 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)