### PR TITLE
fix(cli): default to "production" dataset in unattended mode

### DIFF
--- a/.changeset/fix-init-unattended-dataset-default.md
+++ b/.changeset/fix-init-unattended-dataset-default.md
@@ -2,4 +2,4 @@
 '@sanity/cli': patch
 ---
 
-Default to the "production" dataset in unattended mode when `--dataset` is not specified
+Default to the "production" dataset in unattended mode

--- a/.changeset/fix-init-unattended-dataset-default.md
+++ b/.changeset/fix-init-unattended-dataset-default.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+Default to the "production" dataset in unattended mode when `--dataset` is not specified

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
@@ -592,6 +592,49 @@ describe('#init: get project details', () => {
     expect(stdout).toContain('Dataset created successfully')
   })
 
+  test('respects --visibility=private flag in unattended mode when project supports private datasets', async () => {
+    mocks.listProjects.mockResolvedValueOnce([
+      {
+        createdAt: '2024-01-01T00:00:00Z',
+        displayName: 'Test Project',
+        id: 'test-project-123',
+      },
+    ])
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [])
+
+    mocks.listDatasets.mockResolvedValueOnce([])
+
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      uri: '/features',
+    }).reply(200, ['privateDataset'])
+
+    mocks.createDataset.mockResolvedValueOnce(undefined)
+
+    setupInitSuccessMocks('test-project-123')
+
+    const {error, stdout} = await testCommand(
+      InitCommand,
+      ['--yes', '--project=test-project-123', '--output-path=/tmp/test', '--visibility=private'],
+      {
+        mocks: {...defaultMocks},
+      },
+    )
+
+    if (error) throw error
+
+    expect(mocks.createDataset).toHaveBeenCalledWith(
+      'production',
+      expect.objectContaining({aclMode: 'private'}),
+    )
+    expect(stdout).toContain('Dataset created successfully')
+  })
+
   test('uses existing "production" dataset in unattended mode without creating a new one', async () => {
     mocks.listProjects.mockResolvedValueOnce([
       {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
@@ -635,6 +635,49 @@ describe('#init: get project details', () => {
     expect(stdout).toContain('Dataset created successfully')
   })
 
+  test('falls back to public dataset in unattended mode when --visibility=private but project lacks privateDataset feature', async () => {
+    mocks.listProjects.mockResolvedValueOnce([
+      {
+        createdAt: '2024-01-01T00:00:00Z',
+        displayName: 'Test Project',
+        id: 'test-project-123',
+      },
+    ])
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [])
+
+    mocks.listDatasets.mockResolvedValueOnce([])
+
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      uri: '/features',
+    }).reply(200, [])
+
+    mocks.createDataset.mockResolvedValueOnce(undefined)
+
+    setupInitSuccessMocks('test-project-123')
+
+    const {error, stderr} = await testCommand(
+      InitCommand,
+      ['--yes', '--project=test-project-123', '--output-path=/tmp/test', '--visibility=private'],
+      {
+        mocks: {...defaultMocks},
+      },
+    )
+
+    if (error) throw error
+
+    expect(mocks.createDataset).toHaveBeenCalledWith(
+      'production',
+      expect.objectContaining({aclMode: 'public'}),
+    )
+    expect(stderr).toContain('Warning: Private datasets are not available for this project.')
+  })
+
   test('uses existing "production" dataset in unattended mode without creating a new one', async () => {
     mocks.listProjects.mockResolvedValueOnce([
       {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
@@ -549,6 +549,86 @@ describe('#init: get project details', () => {
     if (error) throw error
   })
 
+  test('defaults to "production" dataset in unattended mode when no dataset flag is provided', async () => {
+    mocks.listProjects.mockResolvedValueOnce([
+      {
+        createdAt: '2024-01-01T00:00:00Z',
+        displayName: 'Test Project',
+        id: 'test-project-123',
+      },
+    ])
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [])
+
+    mocks.listDatasets.mockResolvedValueOnce([])
+
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      uri: '/features',
+    }).reply(200, [])
+
+    mocks.createDataset.mockResolvedValueOnce(undefined)
+
+    setupInitSuccessMocks('test-project-123')
+
+    const {error, stdout} = await testCommand(
+      InitCommand,
+      ['--yes', '--project=test-project-123', '--output-path=/tmp/test'],
+      {
+        mocks: {...defaultMocks},
+      },
+    )
+
+    if (error) throw error
+
+    expect(mocks.createDataset).toHaveBeenCalledWith(
+      'production',
+      expect.objectContaining({aclMode: 'public'}),
+    )
+    expect(stdout).toContain('Dataset created successfully')
+  })
+
+  test('uses existing "production" dataset in unattended mode without creating a new one', async () => {
+    mocks.listProjects.mockResolvedValueOnce([
+      {
+        createdAt: '2024-01-01T00:00:00Z',
+        displayName: 'Test Project',
+        id: 'test-project-123',
+      },
+    ])
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [])
+
+    mocks.listDatasets.mockResolvedValueOnce([{aclMode: 'public', name: 'production'}])
+
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      uri: '/features',
+    }).reply(200, [])
+
+    setupInitSuccessMocks('test-project-123')
+
+    const {error} = await testCommand(
+      InitCommand,
+      ['--yes', '--project=test-project-123', '--output-path=/tmp/test'],
+      {
+        mocks: {...defaultMocks},
+      },
+    )
+
+    if (error) throw error
+
+    expect(mocks.createDataset).not.toHaveBeenCalled()
+  })
+
   test('throws warn if visibility flag is provided but not available as a project feature', async () => {
     mocks.listProjects.mockResolvedValueOnce([
       {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -188,7 +188,6 @@ describe('#init: oclif command setup', () => {
 
     // Should not throw a --dataset validation error
     expect(error?.message ?? '').not.toContain('--dataset')
-    expect(error?.oclif?.exit).toBeUndefined()
   })
 
   test('throws error when `output-path` is not used in unattended mode with non-nextjs project', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -175,30 +175,30 @@ describe('#init: oclif command setup', () => {
     expect(error?.oclif?.exit).toBe(1)
   })
 
-  test('throws error when in unattended mode and `dataset` is not set', async () => {
-    const {error} = await testCommand(InitCommand, ['--yes'], {
+  test('does not require --dataset in unattended mode', async () => {
+    // Mock no framework or a non-Next.js framework
+    mocks.detectFrameworkRecord.mockResolvedValueOnce(null)
+
+    // Use --bare to bypass the --output-path requirement, omit --dataset
+    const {error} = await testCommand(InitCommand, ['--yes', '--bare', '--project=test-project'], {
       mocks: {
         ...defaultMocks,
       },
     })
 
-    expect(error?.message).toContain('`--dataset` must be specified in unattended mode')
-    expect(error?.oclif?.exit).toBe(1)
+    // Should not throw a --dataset validation error
+    expect(error?.message ?? '').not.toContain('--dataset')
   })
 
   test('throws error when `output-path` is not used in unattended mode with non-nextjs project', async () => {
     // Mock no framework or a non-Next.js framework
     mocks.detectFrameworkRecord.mockResolvedValueOnce(null)
 
-    const {error} = await testCommand(
-      InitCommand,
-      ['--yes', '--dataset=production', '--project=test-project'],
-      {
-        mocks: {
-          ...defaultMocks,
-        },
+    const {error} = await testCommand(InitCommand, ['--yes', '--project=test-project'], {
+      mocks: {
+        ...defaultMocks,
       },
-    )
+    })
 
     // Should throw output-path error for non-Next.js projects
     expect(error?.message).toContain('`--output-path` must be specified in unattended mode')

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -188,6 +188,7 @@ describe('#init: oclif command setup', () => {
 
     // Should not throw a --dataset validation error
     expect(error?.message ?? '').not.toContain('--dataset')
+    expect(error?.oclif?.exit).toBeUndefined()
   })
 
   test('throws error when `output-path` is not used in unattended mode with non-nextjs project', async () => {

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -907,6 +907,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
         await createDataset({
           datasetName,
           forcePublic: !visibility,
+          isUnattended: true,
           output: this.output,
           projectFeatures,
           projectId: opts.projectId,

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -906,7 +906,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       if (!existing) {
         await createDataset({
           datasetName,
-          forcePublic: !visibility,
+          forcePublic: visibility === undefined,
           isUnattended: true,
           output: this.output,
           projectFeatures,

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -752,12 +752,6 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       return
     }
 
-    if (!this.flags['dataset']) {
-      this.error(`\`--dataset\` must be specified in unattended mode`, {
-        exit: 1,
-      })
-    }
-
     // output-path is required in unattended mode when not using nextjs or bare
     if (!isNextJs && !this.flags.bare && !this.flags['output-path']) {
       this.error(`\`--output-path\` must be specified in unattended mode`, {
@@ -901,6 +895,25 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       }
 
       return {datasetName: dataset, userAction: 'none'}
+    }
+
+    // In unattended mode without --dataset, default to "production" with public visibility
+    // (same behavior as --dataset-default)
+    if (this.isUnattended()) {
+      debug('Unattended mode without --dataset, defaulting to "production" dataset')
+      const datasetName = 'production'
+      const existing = datasets.find((ds) => ds.name === datasetName)
+      if (!existing) {
+        await createDataset({
+          datasetName,
+          forcePublic: !visibility,
+          output: this.output,
+          projectFeatures,
+          projectId: opts.projectId,
+          visibility,
+        })
+      }
+      return {datasetName, userAction: existing ? 'none' : 'create'}
     }
 
     if (datasets.length === 0) {


### PR DESCRIPTION
## Summary

- **Removes** the requirement for `--dataset` in unattended mode (`--yes`), which previously caused `sanity init --yes` to fail with _"`--dataset` must be specified in unattended mode"_
- **Defaults** to the `"production"` dataset with public visibility when `--yes` is used without `--dataset`, matching the documented behavior of `--dataset-default`
- **Respects** an explicit `--visibility` flag when provided (e.g., `--visibility=private` is not silently overridden)
- **Updates** tests to reflect the new default behavior, including coverage for when the "production" dataset already exists

Fixes SDK-1235

## Context

The `--yes` flag description says _"Unattended mode, answers 'yes' to any 'yes/no' prompt and **otherwise uses defaults**"_. However, running `sanity init --yes` (or `--mcp --yes`) would error out requiring `--dataset` to be explicitly specified. The expected behavior is that it should default to a public `"production"` dataset — the same as `--dataset-default`.