### PR TITLE
chore(ci): detect manual changesets from PR files instead of filesystem

### DIFF
--- a/.github/scripts/generate-changeset.mjs
+++ b/.github/scripts/generate-changeset.mjs
@@ -114,6 +114,10 @@ function getWorkspacePackages() {
 // --- Main ---
 
 // 0. Check for existing changesets using marker-based logic
+// Only consider changesets that are part of this PR's changed files,
+// not pre-existing ones inherited from the base branch.
+const prChangedFiles = await getChangedFiles()
+
 if (existsSync(CHANGESET_FILE)) {
   const content = readFileSync(CHANGESET_FILE, 'utf8')
   if (!content.startsWith(AUTO_GENERATED_MARKER)) {
@@ -122,15 +126,17 @@ if (existsSync(CHANGESET_FILE)) {
   }
   // Marker present — bot still owns the file, will overwrite below
 } else {
-  const changesetDir = resolve('.changeset')
-  if (existsSync(changesetDir)) {
-    const otherChangesets = readdirSync(changesetDir).filter(
-      (f) => f.endsWith('.md') && f !== 'README.md',
-    )
-    if (otherChangesets.length > 0) {
-      console.log(`Skipping: found manual changeset(s): ${otherChangesets.join(', ')}`)
-      process.exit(0)
-    }
+  const manualChangesets = prChangedFiles.filter(
+    (f) =>
+      f.startsWith('.changeset/') &&
+      f.endsWith('.md') &&
+      f !== '.changeset/README.md' &&
+      f !== CHANGESET_FILE,
+  )
+  if (manualChangesets.length > 0) {
+    const names = manualChangesets.map((f) => f.replace('.changeset/', ''))
+    console.log(`Skipping: found manual changeset(s) in PR: ${names.join(', ')}`)
+    process.exit(0)
   }
 }
 
@@ -154,11 +160,10 @@ if (!bump) {
 const releaseNotes = PR_TITLE.replace(/^[a-z]+(\([^)]*\))?!?:\s*/, '')
 
 // 4. Detect affected packages
-const changedFiles = await getChangedFiles()
 const pkgMap = getWorkspacePackages()
 const affected = new Set()
 
-for (const file of changedFiles) {
+for (const file of prChangedFiles) {
   for (const [prefix, name] of pkgMap) {
     if (file.startsWith(prefix)) {
       affected.add(name)


### PR DESCRIPTION
### Description

The `generate-changeset.mjs` script was scanning the local `.changeset/` directory for existing `.md` files to determine if a manual changeset already existed. This included files inherited from the base branch (e.g. `fix-init-nested-folder-count.md`, `pr-902.md` on `main`), causing the script to incorrectly skip changeset generation for unrelated PRs.

Example from [PR #923's CI run](https://github.com/sanity-io/cli/actions/runs/24258487592/job/70836033464):
```
Skipping: found manual changeset(s): fix-init-nested-folder-count.md, pr-902.md
```

Now uses the PR's changed files list from the GitHub API instead of the filesystem, so only changesets actually added by the PR are treated as manual.

### What to review

- `.github/scripts/generate-changeset.mjs` — the manual changeset detection logic (step 0) now filters the PR's changed files instead of doing `readdirSync` on `.changeset/`
- The `getChangedFiles()` call was hoisted to the top so it can be reused for both manual changeset detection and affected package detection (step 4)

### Testing

Verified that `fix-init-nested-folder-count.md` and `pr-902.md` exist on both `main` and the PR branch (`claude/slack-session-Yc3G2`), confirming these are base-branch changesets that were incorrectly triggering the skip logic.