### PR TITLE
refactor(cli-core): replace tsx with jiti in getCliConfigSync

### DIFF
--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@inquirer/prompts": "^8.3.0",
     "@oclif/core": "catalog:",
-    "@rexxars/jiti": "^2.6.2",
+    "@rexxars/jiti": "catalog:",
     "@sanity/client": "catalog:",
     "babel-plugin-react-compiler": "^1.0.0",
     "boxen": "^8.0.1",
@@ -79,7 +79,6 @@
     "ora": "catalog:",
     "read-package-up": "catalog:",
     "rxjs": "catalog:",
-    "tsx": "catalog:",
     "vite": "catalog:",
     "vite-node": "^5.3.0",
     "zod": "catalog:"

--- a/packages/@sanity/cli-core/src/config/cli/getCliConfigSync.ts
+++ b/packages/@sanity/cli-core/src/config/cli/getCliConfigSync.ts
@@ -1,8 +1,7 @@
 import {existsSync} from 'node:fs'
-import {createRequire} from 'node:module'
 import {join} from 'node:path'
 
-import {register} from 'tsx/esm/api'
+import {createJiti} from '@rexxars/jiti'
 
 import {NotFoundError} from '../../errors/NotFoundError.js'
 import {tryGetDefaultExport} from '../../util/tryGetDefaultExport.js'
@@ -12,7 +11,7 @@ import {type CliConfig} from './types/cliConfig.js'
 /**
  * Get the CLI config for a project synchronously, given the root path.
  *
- * This loads the CLI config in the main thread using tsx/register for TypeScript support.
+ * This loads the CLI config in the main thread using jiti for TypeScript support.
  * Note: This is a synchronous operation and does not use worker threads like the async version.
  *
  * @param rootPath - Root path for the project, eg where `sanity.cli.(ts|js)` is located.
@@ -33,19 +32,9 @@ export function getCliConfigSync(rootPath: string): CliConfig {
 
   const configPath = configPaths[0]
 
-  // Register tsx for TypeScript support
-  const unregister = register()
-
-  let cliConfig: CliConfig | undefined
-  try {
-    // Use createRequire for synchronous loading in ESM contexts
-    // This works when tsx loader is active
-    const require = createRequire(import.meta.url)
-    const loaded = require(configPath)
-    cliConfig = tryGetDefaultExport(loaded) as CliConfig | undefined
-  } finally {
-    unregister()
-  }
+  const jiti = createJiti(import.meta.url, {tsconfigPaths: true})
+  const loaded = jiti(configPath)
+  const cliConfig = tryGetDefaultExport(loaded) as CliConfig | undefined
 
   const {data, error, success} = cliConfigSchema.safeParse(cliConfig)
   if (!success) {

--- a/packages/@sanity/cli-core/src/util/importModule.ts
+++ b/packages/@sanity/cli-core/src/util/importModule.ts
@@ -22,7 +22,6 @@ const debug = subdebug('importModule')
 
 /**
  * Imports a module using jiti and returns its exports.
- * This is a thin wrapper around tsx to allow swapping out the underlying implementation in the future if needed.
  *
  * @param filePath - Path to the module to import.
  * @param options - Options for the importModule function.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@oclif/plugin-not-found':
       specifier: ^3.2.78
       version: 3.2.78
+    '@rexxars/jiti':
+      specifier: ^2.6.2
+      version: 2.6.2
     '@sanity/codegen':
       specifier: ^6.0.2
       version: 6.0.2
@@ -786,7 +789,7 @@ importers:
         specifier: 'catalog:'
         version: 4.10.3
       '@rexxars/jiti':
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.6.2
       '@sanity/client':
         specifier: ^7.20.0
@@ -827,9 +830,6 @@ importers:
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
-      tsx:
-        specifier: 'catalog:'
-        version: 4.21.0
       vite:
         specifier: 'catalog:'
         version: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ catalog:
   '@oclif/plugin-not-found': ^3.2.78
 
   # Utilities
+  '@rexxars/jiti': ^2.6.2
   debug: ^4.4.3
   jsdom: ^29.0.1
   zod: ^4.3.6


### PR DESCRIPTION
### Description

Replaces `tsx` with `@rexxars/jiti` for synchronous TypeScript config loading in `getCliConfigSync`:

- **`getCliConfigSync.ts`** — replaced the tsx `register()`/`unregister()` + `createRequire()` pattern with a simpler `createJiti()` sync call for loading `sanity.cli.ts` config files
- **`importModule.ts`** — removed stale "wrapper around tsx" doc comment (already uses jiti)
- **`pnpm-workspace.yaml`** — added `@rexxars/jiti` to catalog, updated `cli-core` to use `catalog:` reference

`execScript.ts` was not changed because jiti's register hook doesn't handle CJS/ESM interop with top-level await (`ERR_REQUIRE_ASYNC_MODULE` via `@oclif/core`), so that must stay on tsx.

### What to review

- `packages/@sanity/cli-core/src/config/cli/getCliConfigSync.ts` — sync jiti call replacing tsx register/unregister pattern
- `packages/@sanity/cli-core/package.json` — `@rexxars/jiti` now uses `catalog:` reference
- `pnpm-workspace.yaml` — `@rexxars/jiti` added to catalog

### Testing

Existing tests pass. The `getCliConfigSync` unit tests continue to pass as they mock `existsSync` and don't exercise the actual loader. The `exec` integration tests also pass since `execScript.ts` was not changed.