### PR TITLE
fix(dev): disable strict ports for applications

### DIFF
--- a/.changeset/pr-930.md
+++ b/.changeset/pr-930.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+disable strict ports for applications

--- a/.changeset/pr-930.md
+++ b/.changeset/pr-930.md
@@ -1,6 +1,5 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
+## <!-- auto-generated -->
+
+## '@sanity/cli': patch
 
 disable strict ports for applications

--- a/.changeset/pr-930.md
+++ b/.changeset/pr-930.md
@@ -1,5 +1,5 @@
-## <!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
 
-## '@sanity/cli': patch
-
-disable strict ports for applications
+Prevent dev server from failing to start when the default port is already in use

--- a/packages/@sanity/cli/src/actions/build/__tests__/decorateIndexWithStagingScript.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/decorateIndexWithStagingScript.test.ts
@@ -1,5 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
+import {decorateIndexWithStagingScript} from '../decorateIndexWithStagingScript'
+
 const mockIsStaging = vi.hoisted(() => vi.fn<() => boolean>())
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
@@ -9,8 +11,6 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
     isStaging: mockIsStaging,
   }
 })
-
-import {decorateIndexWithStagingScript} from '../decorateIndexWithStagingScript'
 
 const sampleHtml = '<html><head><script src="app.js"></script></head><body></body></html>'
 

--- a/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
@@ -137,7 +137,7 @@ describe('#getViteConfig', () => {
       server: {
         host: undefined,
         port: 3333,
-        strictPort: true,
+        strictPort: false,
       },
     })
 
@@ -262,7 +262,7 @@ describe('#getViteConfig', () => {
     expect(config.server).toMatchObject({
       host: '0.0.0.0',
       port: 8080,
-      strictPort: true,
+      strictPort: false,
     })
   })
 

--- a/packages/@sanity/cli/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli/src/actions/build/getViteConfig.ts
@@ -226,9 +226,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     server: {
       host: server?.host,
       port: server?.port || 3333,
-      // Only enable strict port for studio,
-      // since apps can run on any port
-      strictPort: isApp ? false : true,
+      strictPort: false,
 
       /**
        * Significantly speed up startup time,

--- a/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
@@ -383,24 +383,24 @@ describe('#dev', {timeout: (platform() === 'win32' ? 60 : 30) * 1000}, () => {
     })
   })
 
-  test('should throw an error if port is already in use', async () => {
+  test('should start on next available port when requested port is in use', async () => {
     const cwd = await testFixture('basic-studio')
     process.cwd = () => cwd
 
+    // Studios use strictPort: false, so Vite auto-selects the next available port
     const server1 = createServer()
     await new Promise<void>((resolve) => server1.listen(5337, 'localhost', resolve))
 
     try {
-      const {error, result} = await testCommand(DevCommand, ['--port', '5337'], {
+      const {error, result, stdout} = await testCommand(DevCommand, ['--port', '5337'], {
         config: {root: cwd},
         mocks: {isInteractive: true},
       })
 
+      if (error) throw error
+      expect(stdout).toMatch(/running at http:\/\/localhost:\d{4}/)
+      expect(stdout).not.toContain('running at http://localhost:5337')
       await tryCloseServer(result)
-
-      expect(error).toBeDefined()
-      expect(error?.message).toContain('is already in use')
-      expect(error?.oclif?.exit).toBe(1)
     } finally {
       await closeServer(server1)
     }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

While https://github.com/sanity-io/cli/pull/830 disabled strict ports for the _workbench_ dev-server, running `dev` often times still fails, because applications had `strictPort` set to true and therefore fail, if another application is already running on that port.
