### PR TITLE
ci: auto-release dist tag for feature branch

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,12 +1,17 @@
 name: Snapshot Release
 
 on:
+  push:
+    branches:
+      # Note: this needs to be removed before the feature branch gets merged to main
+      - feat/workbench
   workflow_dispatch:
     inputs:
       tag:
         description: 'npm dist-tag for the snapshot release'
         required: false
-        default: 'snapshot'
+        # TODO: revert to "snapshot" before the feature branch gets merged to main
+        default: 'workbench'
         type: string
       forceBump:
         description: 'Force a version bump for all packages'


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Automate releasing the CI dist-tag for the feature branch. We will remove it, before the feature branch gets merged to `main`.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
