### PR TITLE
feat(workbench): support only running one workbench instance and finding local apps

### DIFF
--- a/.changeset/clear-dragons-search.md
+++ b/.changeset/clear-dragons-search.md
@@ -2,4 +2,4 @@
 '@sanity/cli-core': minor
 ---
 
-feat: add federation to cli config
+Add federation to CLI config

--- a/.changeset/pr-770.md
+++ b/.changeset/pr-770.md
@@ -2,4 +2,4 @@
 '@sanity/cli': minor
 ---
 
-Add workbench dev server for federated studio and app development
+Enforce single workbench instance with dev-server registry, fix PID-reuse detection and signal cleanup

--- a/.changeset/pr-770.md
+++ b/.changeset/pr-770.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': minor
+---
+
+Add workbench dev server for federated studio and app development

--- a/.changeset/pr-905.md
+++ b/.changeset/pr-905.md
@@ -2,4 +2,4 @@
 '@sanity/cli': minor
 ---
 
-forward CLI config organization id to workbench runtime
+Support passing organization ID to the workbench dev server

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -37,6 +37,7 @@ export {
 export {type Output, type SanityOrgUser} from '../types.js'
 export {doImport} from '../util/doImport.js'
 export * from '../util/environment/mockBrowserEnvironment.js'
+export * from '../util/getSanityConfigDir.js'
 export * from '../util/getSanityEnvVar.js'
 export * from '../util/getSanityUrl.js'
 export * from '../util/importModule.js'

--- a/packages/@sanity/cli-core/src/services/cliUserConfig.ts
+++ b/packages/@sanity/cli-core/src/services/cliUserConfig.ts
@@ -1,10 +1,10 @@
 import {mkdirSync} from 'node:fs'
-import {homedir} from 'node:os'
 import {dirname, join as joinPath} from 'node:path'
 
 import {z} from 'zod/mini'
 
 import {debug} from '../debug.js'
+import {getSanityConfigDir} from '../util/getSanityConfigDir.js'
 import {readJsonFileSync} from '../util/readJsonFileSync.js'
 import {writeJsonFileSync} from '../util/writeJsonFileSync.js'
 import {clearCliTokenCache} from './cliTokenCache.js'
@@ -156,10 +156,5 @@ function readConfig(): Record<string, unknown> {
  * @internal
  */
 function getCliUserConfigPath() {
-  const sanityEnvSuffix = process.env.SANITY_INTERNAL_ENV === 'staging' ? '-staging' : ''
-  const cliConfigPath =
-    process.env.SANITY_CLI_CONFIG_PATH ||
-    joinPath(homedir(), '.config', `sanity${sanityEnvSuffix}`, 'config.json')
-
-  return cliConfigPath
+  return process.env.SANITY_CLI_CONFIG_PATH || joinPath(getSanityConfigDir(), 'config.json')
 }

--- a/packages/@sanity/cli-core/src/util/getSanityConfigDir.ts
+++ b/packages/@sanity/cli-core/src/util/getSanityConfigDir.ts
@@ -1,0 +1,36 @@
+import {homedir} from 'node:os'
+import {join as joinPath} from 'node:path'
+
+import {isStaging} from './isStaging.js'
+
+function envSuffix(): string {
+  return isStaging() ? '-staging' : ''
+}
+
+/**
+ * Returns the base Sanity configuration directory for the current user.
+ * For persistent user settings (auth tokens, preferences, etc.).
+ * Respects `SANITY_INTERNAL_ENV=staging` to isolate staging instances.
+ *
+ * Layout: `~/.config/sanity{-staging}/`
+ *
+ * @returns Absolute path to the config directory
+ * @internal
+ */
+export function getSanityConfigDir(): string {
+  return joinPath(homedir(), '.config', `sanity${envSuffix()}`)
+}
+
+/**
+ * Returns the base Sanity data directory for the current user.
+ * For ephemeral runtime state (dev-server registries, caches, etc.).
+ * Respects `SANITY_INTERNAL_ENV=staging` to isolate staging instances.
+ *
+ * Layout: `~/.sanity{-staging}/`
+ *
+ * @returns Absolute path to the data directory
+ * @internal
+ */
+export function getSanityDataDir(): string {
+  return joinPath(homedir(), `.sanity${envSuffix()}`)
+}

--- a/packages/@sanity/cli/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli/src/actions/build/getViteConfig.ts
@@ -12,7 +12,7 @@ import viteReact from '@vitejs/plugin-react'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import debug from 'debug'
 import {readPackageUp} from 'read-package-up'
-import {type ConfigEnv, type InlineConfig, mergeConfig, PluginOption, type Rollup} from 'vite'
+import {type ConfigEnv, type InlineConfig, mergeConfig, type PluginOption, type Rollup} from 'vite'
 
 import {sanityBuildEntries} from '../../server/vite/plugin-sanity-build-entries.js'
 import {sanityFaviconsPlugin} from '../../server/vite/plugin-sanity-favicons.js'

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -6,6 +6,7 @@ import {devAction} from '../devAction.js'
 const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
 const mockStartAppDevServer = vi.hoisted(() => vi.fn())
 const mockStartStudioDevServer = vi.hoisted(() => vi.fn())
+const mockRegisterDevServer = vi.hoisted(() => vi.fn())
 
 vi.mock('../startWorkbenchDevServer.js', () => ({
   startWorkbenchDevServer: mockStartWorkbenchDevServer,
@@ -15,6 +16,9 @@ vi.mock('../startAppDevServer.js', () => ({
 }))
 vi.mock('../startStudioDevServer.js', () => ({
   startStudioDevServer: mockStartStudioDevServer,
+}))
+vi.mock('../devServerRegistry.js', () => ({
+  registerDevServer: mockRegisterDevServer,
 }))
 
 function createMockOutput(): Output {
@@ -47,11 +51,12 @@ describe('devAction', () => {
   beforeEach(() => {
     // Default: no workbench (federation disabled)
     mockStartWorkbenchDevServer.mockResolvedValue({
-      close: undefined,
+      close: vi.fn().mockResolvedValue(undefined),
       httpHost: 'localhost',
       workbenchAvailable: false,
       workbenchPort: 3333,
     })
+    mockRegisterDevServer.mockReturnValue(vi.fn())
   })
 
   afterEach(() => {
@@ -173,8 +178,72 @@ describe('devAction', () => {
 
     const result = await devAction(createOptions())
 
-    await expect(result.close?.()).resolves.toBeUndefined()
+    await expect(result.close()).resolves.toBeUndefined()
     expect(mockWorkbenchClose).toHaveBeenCalled()
     expect(mockAppClose).toHaveBeenCalled()
+  })
+
+  describe('registry integration', () => {
+    test('registers studio in registry when federation is enabled', async () => {
+      mockStartStudioDevServer.mockResolvedValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        server: {config: {server: {port: 3334}}},
+      })
+
+      await devAction(
+        createOptions({
+          cliConfig: {federation: {enabled: true}},
+        }),
+      )
+
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: 'localhost',
+          port: 3334,
+          type: 'studio',
+        }),
+      )
+    })
+
+    test('registers app type when isApp is true', async () => {
+      mockStartAppDevServer.mockResolvedValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        server: {config: {server: {port: 3334}}},
+      })
+
+      await devAction(
+        createOptions({
+          cliConfig: {federation: {enabled: true}},
+          isApp: true,
+        }),
+      )
+
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({type: 'app'}))
+    })
+
+    test('does not register when federation is disabled', async () => {
+      mockStartStudioDevServer.mockResolvedValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        server: {config: {server: {port: 3333}}},
+      })
+
+      await devAction(createOptions())
+
+      expect(mockRegisterDevServer).not.toHaveBeenCalled()
+    })
+
+    test('calls manifest cleanup on close', async () => {
+      const mockCleanup = vi.fn()
+      mockRegisterDevServer.mockReturnValue(mockCleanup)
+      mockStartStudioDevServer.mockResolvedValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        server: {config: {server: {port: 3334}}},
+      })
+
+      const result = await devAction(createOptions({cliConfig: {federation: {enabled: true}}}))
+
+      await result.close()
+      expect(mockCleanup).toHaveBeenCalled()
+    })
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -218,7 +218,7 @@ describe('devAction', () => {
         }),
       )
 
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({type: 'app'}))
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({type: 'coreApp'}))
     })
 
     test('does not register when federation is disabled', async () => {
@@ -244,6 +244,23 @@ describe('devAction', () => {
 
       await result.close()
       expect(mockCleanup).toHaveBeenCalled()
+    })
+
+    test('close removes signal handlers to prevent listener leaks', async () => {
+      const offSpy = vi.spyOn(process, 'off')
+      mockRegisterDevServer.mockReturnValue(vi.fn())
+      mockStartStudioDevServer.mockResolvedValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        server: {config: {server: {port: 3334}}},
+      })
+
+      const result = await devAction(createOptions({cliConfig: {federation: {enabled: true}}}))
+      await result.close()
+
+      expect(offSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function))
+      expect(offSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function))
+
+      offSpy.mockRestore()
     })
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
@@ -1,0 +1,221 @@
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {
+  acquireWorkbenchLock,
+  type DevServerManifest,
+  readWorkbenchLock,
+  registerDevServer,
+  watchRegistry,
+} from '../devServerRegistry.js'
+
+// Mock homedir to use a temp directory per test
+let testRegistryDir: string
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return {
+    ...actual,
+    homedir: () => testRegistryDir,
+  }
+})
+
+/** Derives the registry path the same way the module does internally. */
+function registryDir() {
+  return join(testRegistryDir, '.sanity', 'dev-servers')
+}
+
+beforeEach(() => {
+  testRegistryDir = join(tmpdir(), `sanity-registry-test-${process.pid}-${Date.now()}`)
+  mkdirSync(testRegistryDir, {recursive: true})
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.unstubAllEnvs()
+})
+
+describe('registerDevServer', () => {
+  test('writes a manifest file and returns a cleanup function', () => {
+    const cleanup = registerDevServer({
+      host: 'localhost',
+      port: 3334,
+      type: 'studio',
+      workDir: '/tmp/project',
+    })
+
+    const filePath = join(registryDir(), `${process.pid}.json`)
+    expect(existsSync(filePath)).toBe(true)
+
+    const manifest = JSON.parse(readFileSync(filePath, 'utf8'))
+    expect(manifest.pid).toBe(process.pid)
+    expect(manifest.type).toBe('studio')
+    expect(manifest.port).toBe(3334)
+    expect(manifest.host).toBe('localhost')
+    expect(manifest.workDir).toBe('/tmp/project')
+    expect(manifest.startedAt).toBeDefined()
+
+    cleanup()
+    expect(existsSync(filePath)).toBe(false)
+  })
+
+  test('cleanup does not throw if file already removed', () => {
+    const cleanup = registerDevServer({
+      host: 'localhost',
+      port: 3333,
+      type: 'studio',
+      workDir: '/tmp/project',
+    })
+
+    cleanup()
+    expect(() => cleanup()).not.toThrow()
+  })
+})
+
+describe('acquireWorkbenchLock', () => {
+  test('returns lock object when lock is available', () => {
+    const lock = acquireWorkbenchLock({host: 'localhost', port: 3333})
+    expect(lock).toBeDefined()
+    expect(lock!.release).toBeTypeOf('function')
+    expect(lock!.updatePort).toBeTypeOf('function')
+    lock!.release()
+  })
+
+  test('returns undefined when lock is already held by a live process', () => {
+    const lock = acquireWorkbenchLock({host: 'localhost', port: 3333})
+    expect(lock).toBeDefined()
+
+    const second = acquireWorkbenchLock({host: 'localhost', port: 3333})
+    expect(second).toBeUndefined()
+
+    lock!.release()
+  })
+
+  test('release removes the lock file', () => {
+    const lock = acquireWorkbenchLock({host: 'localhost', port: 3333})
+    lock!.release()
+
+    const second = acquireWorkbenchLock({host: 'localhost', port: 3333})
+    expect(second).toBeDefined()
+    second!.release()
+  })
+
+  test('stores host and port in the lock file', () => {
+    const lock = acquireWorkbenchLock({host: '0.0.0.0', port: 4000})
+
+    const lockPath = join(registryDir(), 'workbench.lock')
+    const data = JSON.parse(readFileSync(lockPath, 'utf8'))
+    expect(data.host).toBe('0.0.0.0')
+    expect(data.port).toBe(4000)
+    expect(data.pid).toBe(process.pid)
+
+    lock!.release()
+  })
+
+  test('updatePort writes the new port to the lock file', () => {
+    const lock = acquireWorkbenchLock({host: 'localhost', port: 3333})
+    lock!.updatePort(3334)
+
+    const lockPath = join(registryDir(), 'workbench.lock')
+    const data = JSON.parse(readFileSync(lockPath, 'utf8'))
+    expect(data.port).toBe(3334)
+
+    lock!.release()
+  })
+
+  test('reclaims stale lock from a dead process', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    writeFileSync(
+      join(dir, 'workbench.lock'),
+      JSON.stringify({host: 'localhost', pid: 99_999_999, port: 3333}),
+      {flag: 'wx'},
+    )
+
+    const lock = acquireWorkbenchLock({host: 'localhost', port: 3333})
+    expect(lock).toBeDefined()
+    lock!.release()
+  })
+})
+
+describe('readWorkbenchLock', () => {
+  test('returns undefined when no lock file exists', () => {
+    expect(readWorkbenchLock()).toBeUndefined()
+  })
+
+  test('returns lock data when lock is held by a live process', () => {
+    const lock = acquireWorkbenchLock({host: '0.0.0.0', port: 4000})
+
+    const data = readWorkbenchLock()
+    expect(data).toBeDefined()
+    expect(data!.host).toBe('0.0.0.0')
+    expect(data!.port).toBe(4000)
+    expect(data!.pid).toBe(process.pid)
+
+    lock!.release()
+  })
+
+  test('prunes stale lock and returns undefined', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    const lockPath = join(dir, 'workbench.lock')
+    writeFileSync(lockPath, JSON.stringify({host: 'localhost', pid: 99_999_999, port: 3333}))
+
+    expect(readWorkbenchLock()).toBeUndefined()
+    expect(existsSync(lockPath)).toBe(false)
+  })
+})
+
+describe('watchRegistry', () => {
+  test('invokes callback when a manifest file is added', async () => {
+    const callback = vi.fn()
+    const watcher = watchRegistry(callback)
+
+    const dir = registryDir()
+    const manifest: DevServerManifest = {
+      host: 'localhost',
+      pid: process.pid,
+      port: 5555,
+      startedAt: new Date().toISOString(),
+      type: 'studio',
+      workDir: '/tmp/watch-test',
+    }
+    writeFileSync(join(dir, `${process.pid}.json`), JSON.stringify(manifest))
+
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    expect(callback).toHaveBeenCalled()
+    const servers = callback.mock.calls.at(-1)![0]
+    expect(servers.some((s: DevServerManifest) => s.port === 5555)).toBe(true)
+
+    watcher.close()
+  })
+
+  test('close stops notifications', async () => {
+    const callback = vi.fn()
+    const watcher = watchRegistry(callback)
+    watcher.close()
+
+    const dir = registryDir()
+    writeFileSync(
+      join(dir, 'after-close.json'),
+      JSON.stringify({
+        host: 'localhost',
+        pid: process.pid,
+        port: 6666,
+        startedAt: new Date().toISOString(),
+        type: 'studio',
+        workDir: '/tmp/closed',
+      }),
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+})

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
@@ -7,30 +7,39 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 import {
   acquireWorkbenchLock,
   type DevServerManifest,
+  getRegisteredServers,
   readWorkbenchLock,
   registerDevServer,
   watchRegistry,
 } from '../devServerRegistry.js'
 
-// Mock homedir to use a temp directory per test
-let testRegistryDir: string
+const mockExecSync = vi.hoisted(() => vi.fn())
 
-vi.mock('node:os', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:os')>()
+vi.mock('node:child_process', () => ({
+  execSync: mockExecSync,
+}))
+
+// Mock getSanityConfigDir to use a temp directory per test
+let testDataDir: string
+
+vi.mock('@sanity/cli-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/cli-core')>()
   return {
     ...actual,
-    homedir: () => testRegistryDir,
+    getSanityDataDir: () => testDataDir,
   }
 })
 
 /** Derives the registry path the same way the module does internally. */
 function registryDir() {
-  return join(testRegistryDir, '.sanity', 'dev-servers')
+  return join(testDataDir, 'dev-servers')
 }
 
 beforeEach(() => {
-  testRegistryDir = join(tmpdir(), `sanity-registry-test-${process.pid}-${Date.now()}`)
-  mkdirSync(testRegistryDir, {recursive: true})
+  testDataDir = join(tmpdir(), `sanity-registry-test-${process.pid}-${Date.now()}`)
+  mkdirSync(testDataDir, {recursive: true})
+  // By default, return a start time matching "now" so our own PID passes isOurProcess
+  mockExecSync.mockReturnValue(new Date().toString())
 })
 
 afterEach(() => {
@@ -57,6 +66,7 @@ describe('registerDevServer', () => {
     expect(manifest.host).toBe('localhost')
     expect(manifest.workDir).toBe('/tmp/project')
     expect(manifest.startedAt).toBeDefined()
+    expect(manifest.version).toBe(1)
 
     cleanup()
     expect(existsSync(filePath)).toBe(false)
@@ -103,7 +113,7 @@ describe('acquireWorkbenchLock', () => {
     second!.release()
   })
 
-  test('stores host and port in the lock file', () => {
+  test('stores host, port, startedAt and version in the lock file', () => {
     const lock = acquireWorkbenchLock({host: '0.0.0.0', port: 4000})
 
     const lockPath = join(registryDir(), 'workbench.lock')
@@ -111,6 +121,8 @@ describe('acquireWorkbenchLock', () => {
     expect(data.host).toBe('0.0.0.0')
     expect(data.port).toBe(4000)
     expect(data.pid).toBe(process.pid)
+    expect(data.startedAt).toBeDefined()
+    expect(data.version).toBe(1)
 
     lock!.release()
   })
@@ -132,13 +144,32 @@ describe('acquireWorkbenchLock', () => {
 
     writeFileSync(
       join(dir, 'workbench.lock'),
-      JSON.stringify({host: 'localhost', pid: 99_999_999, port: 3333}),
+      JSON.stringify({
+        host: 'localhost',
+        pid: 99_999_999,
+        port: 3333,
+        startedAt: new Date().toISOString(),
+        version: 1,
+      }),
       {flag: 'wx'},
     )
 
     const lock = acquireWorkbenchLock({host: 'localhost', port: 3333})
     expect(lock).toBeDefined()
     lock!.release()
+  })
+
+  test('returns undefined after exhausting retries', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    // Write a lock that will fail schema validation (missing required fields),
+    // causing readWorkbenchLock to return undefined without pruning the file.
+    // With retries=0, the function should not recurse.
+    writeFileSync(join(dir, 'workbench.lock'), JSON.stringify({host: 'localhost', pid: 1, port: 1}))
+
+    const lock = acquireWorkbenchLock({host: 'localhost', port: 3333}, 0)
+    expect(lock).toBeUndefined()
   })
 })
 
@@ -164,7 +195,112 @@ describe('readWorkbenchLock', () => {
     mkdirSync(dir, {recursive: true})
 
     const lockPath = join(dir, 'workbench.lock')
-    writeFileSync(lockPath, JSON.stringify({host: 'localhost', pid: 99_999_999, port: 3333}))
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        host: 'localhost',
+        pid: 99_999_999,
+        port: 3333,
+        startedAt: new Date().toISOString(),
+        version: 1,
+      }),
+    )
+
+    expect(readWorkbenchLock()).toBeUndefined()
+    expect(existsSync(lockPath)).toBe(false)
+  })
+})
+
+describe('PID-reuse detection', () => {
+  test('prunes manifest when PID is alive but start time does not match', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    // Write a manifest for the current PID but with a startedAt far in the past
+    const staleManifest: DevServerManifest = {
+      host: 'localhost',
+      pid: process.pid,
+      port: 9999,
+      startedAt: new Date('2020-01-01T00:00:00Z').toISOString(),
+      type: 'studio',
+      version: 1,
+      workDir: '/tmp/stale-project',
+    }
+    writeFileSync(join(dir, `${process.pid}.json`), JSON.stringify(staleManifest))
+
+    // Mock ps to return a different (current) start time
+    mockExecSync.mockReturnValue(new Date().toString())
+
+    const servers = getRegisteredServers()
+    expect(servers).toHaveLength(0)
+    expect(existsSync(join(dir, `${process.pid}.json`))).toBe(false)
+  })
+
+  test('keeps manifest when PID is alive and start time matches', () => {
+    const now = new Date()
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    const manifest: DevServerManifest = {
+      host: 'localhost',
+      pid: process.pid,
+      port: 9999,
+      startedAt: now.toISOString(),
+      type: 'studio',
+      version: 1,
+      workDir: '/tmp/valid-project',
+    }
+    writeFileSync(join(dir, `${process.pid}.json`), JSON.stringify(manifest))
+
+    // Mock ps to return matching start time
+    mockExecSync.mockReturnValue(now.toString())
+
+    const servers = getRegisteredServers()
+    expect(servers).toHaveLength(1)
+    expect(servers[0].port).toBe(9999)
+  })
+
+  test('falls back to alive-check when start time cannot be retrieved', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    const manifest: DevServerManifest = {
+      host: 'localhost',
+      pid: process.pid,
+      port: 9999,
+      startedAt: new Date().toISOString(),
+      type: 'studio',
+      version: 1,
+      workDir: '/tmp/fallback-project',
+    }
+    writeFileSync(join(dir, `${process.pid}.json`), JSON.stringify(manifest))
+
+    // ps fails — should fall back to isProcessAlive (which will be true for our PID)
+    mockExecSync.mockImplementation(() => {
+      throw new Error('ps not available')
+    })
+
+    const servers = getRegisteredServers()
+    expect(servers).toHaveLength(1)
+  })
+
+  test('prunes workbench lock when PID is reused', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    const lockPath = join(dir, 'workbench.lock')
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        host: 'localhost',
+        pid: process.pid,
+        port: 4000,
+        startedAt: new Date('2020-01-01T00:00:00Z').toISOString(),
+        version: 1,
+      }),
+    )
+
+    mockExecSync.mockReturnValue(new Date().toString())
 
     expect(readWorkbenchLock()).toBeUndefined()
     expect(existsSync(lockPath)).toBe(false)
@@ -183,6 +319,7 @@ describe('watchRegistry', () => {
       port: 5555,
       startedAt: new Date().toISOString(),
       type: 'studio',
+      version: 1,
       workDir: '/tmp/watch-test',
     }
     writeFileSync(join(dir, `${process.pid}.json`), JSON.stringify(manifest))
@@ -210,6 +347,7 @@ describe('watchRegistry', () => {
         port: 6666,
         startedAt: new Date().toISOString(),
         type: 'studio',
+        version: 1,
         workDir: '/tmp/closed',
       }),
     )

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -46,9 +46,9 @@ function createMockServer(port = 3333) {
   return {
     close: vi.fn().mockResolvedValue(undefined),
     config: {server: {port}},
-    hot: {on: vi.fn(), send: vi.fn()},
     httpServer: {address: vi.fn().mockReturnValue({address: '127.0.0.1', family: 'IPv4', port})},
     listen: vi.fn().mockResolvedValue(undefined),
+    ws: {on: vi.fn(), send: vi.fn()},
   }
 }
 
@@ -177,9 +177,11 @@ describe('startWorkbenchDevServer', () => {
       })
       mockCreateServer.mockResolvedValue(mockServer)
 
-      const result = await startWorkbenchDevServer(createOptions())
+      const result = await startWorkbenchDevServer(
+        createOptions({cliConfig: {federation: {enabled: true}}}),
+      )
 
-      expect(result.workbenchPort).toBe(3333)
+      expect(result.workbenchPort).toBe(3334)
     })
 
     test('passes workDir to writeWorkbenchRuntime', async () => {
@@ -376,7 +378,7 @@ describe('startWorkbenchDevServer', () => {
         {host: 'localhost', pid: 3, port: 3335, type: 'app'},
       ])
 
-      expect(mockServer.hot.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
+      expect(mockServer.ws.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
         applications: [
           {host: 'localhost', port: 3334, type: 'studio'},
           {host: 'localhost', port: 3335, type: 'app'},
@@ -395,7 +397,7 @@ describe('startWorkbenchDevServer', () => {
       await startWorkbenchDevServer(createOptions({cliConfig: federationConfig}))
 
       // Find the handler registered for the request event
-      const onCall = mockServer.hot.on.mock.calls.find(
+      const onCall = mockServer.ws.on.mock.calls.find(
         (args: unknown[]) => args[0] === 'sanity:workbench:get-local-applications',
       )
       expect(onCall).toBeDefined()

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -7,6 +7,10 @@ const mockResolveLocalPackage = vi.hoisted(() => vi.fn())
 const mockCreateServer = vi.hoisted(() => vi.fn())
 const mockGetSharedServerConfig = vi.hoisted(() => vi.fn())
 const mockWriteWorkbenchRuntime = vi.hoisted(() => vi.fn())
+const mockAcquireWorkbenchLock = vi.hoisted(() => vi.fn())
+const mockGetRegisteredServers = vi.hoisted(() => vi.fn())
+const mockReadWorkbenchLock = vi.hoisted(() => vi.fn())
+const mockWatchRegistry = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
@@ -23,6 +27,12 @@ vi.mock('../../../util/getSharedServerConfig.js', () => ({
 vi.mock('../writeWorkbenchRuntime.js', () => ({
   writeWorkbenchRuntime: mockWriteWorkbenchRuntime,
 }))
+vi.mock('../devServerRegistry.js', () => ({
+  acquireWorkbenchLock: mockAcquireWorkbenchLock,
+  getRegisteredServers: mockGetRegisteredServers,
+  readWorkbenchLock: mockReadWorkbenchLock,
+  watchRegistry: mockWatchRegistry,
+}))
 
 function createMockOutput(): Output {
   return {
@@ -36,6 +46,7 @@ function createMockServer(port = 3333) {
   return {
     close: vi.fn().mockResolvedValue(undefined),
     config: {server: {port}},
+    hot: {on: vi.fn(), send: vi.fn()},
     httpServer: {address: vi.fn().mockReturnValue({address: '127.0.0.1', family: 'IPv4', port})},
     listen: vi.fn().mockResolvedValue(undefined),
   }
@@ -63,6 +74,10 @@ describe('startWorkbenchDevServer', () => {
   beforeEach(() => {
     mockGetSharedServerConfig.mockReturnValue({httpHost: 'localhost', httpPort: 3333})
     mockWriteWorkbenchRuntime.mockResolvedValue('/tmp/sanity-project/.sanity/workbench')
+    mockAcquireWorkbenchLock.mockReturnValue({release: vi.fn(), updatePort: vi.fn()})
+    mockGetRegisteredServers.mockReturnValue([])
+    mockReadWorkbenchLock.mockReturnValue(undefined)
+    mockWatchRegistry.mockReturnValue({close: vi.fn()})
   })
 
   afterEach(() => {
@@ -75,7 +90,7 @@ describe('startWorkbenchDevServer', () => {
       const result = await startWorkbenchDevServer(createOptions())
 
       expect(result.workbenchAvailable).toBe(false)
-      expect(result.close).toBeUndefined()
+      expect(result.close).toBeTypeOf('function')
       expect(mockResolveLocalPackage).not.toHaveBeenCalled()
       expect(mockCreateServer).not.toHaveBeenCalled()
     })
@@ -86,7 +101,7 @@ describe('startWorkbenchDevServer', () => {
       )
 
       expect(result.workbenchAvailable).toBe(false)
-      expect(result.close).toBeUndefined()
+      expect(result.close).toBeTypeOf('function')
       expect(mockResolveLocalPackage).not.toHaveBeenCalled()
     })
 
@@ -109,7 +124,7 @@ describe('startWorkbenchDevServer', () => {
       )
 
       expect(result.workbenchAvailable).toBe(false)
-      expect(result.close).toBeUndefined()
+      expect(result.close).toBeTypeOf('function')
       expect(mockCreateServer).not.toHaveBeenCalled()
     })
 
@@ -278,7 +293,7 @@ describe('startWorkbenchDevServer', () => {
       )
 
       expect(result.workbenchAvailable).toBe(false)
-      expect(result.close).toBeUndefined()
+      expect(result.close).toBeTypeOf('function')
       expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('Port already in use'))
     })
 
@@ -291,6 +306,135 @@ describe('startWorkbenchDevServer', () => {
       await startWorkbenchDevServer(createOptions({cliConfig: federationConfig}))
 
       expect(mockServer.close).toHaveBeenCalled()
+    })
+  })
+
+  describe('singleton detection', () => {
+    const federationConfig = {federation: {enabled: true}} as const
+
+    test('skips starting server when lock is held by another process', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockAcquireWorkbenchLock.mockReturnValue(undefined)
+      mockReadWorkbenchLock.mockReturnValue({host: '0.0.0.0', pid: 12_345, port: 4000})
+
+      const result = await startWorkbenchDevServer(createOptions({cliConfig: federationConfig}))
+
+      expect(result.workbenchAvailable).toBe(true)
+      expect(result.workbenchPort).toBe(4000)
+      expect(result.httpHost).toBe('0.0.0.0')
+      expect(result.close).toBeTypeOf('function')
+      expect(mockCreateServer).not.toHaveBeenCalled()
+    })
+
+    test('falls back to configured host/port when lock is held but lock file unreadable', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockAcquireWorkbenchLock.mockReturnValue(undefined)
+      mockReadWorkbenchLock.mockReturnValue(undefined)
+
+      const result = await startWorkbenchDevServer(createOptions({cliConfig: federationConfig}))
+
+      expect(result.workbenchAvailable).toBe(true)
+      expect(result.workbenchPort).toBe(3333)
+      expect(result.httpHost).toBe('localhost')
+      expect(mockCreateServer).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('registry integration', () => {
+    const federationConfig = {federation: {enabled: true}} as const
+
+    test('updates lock with actual port after successful startup', async () => {
+      const mockUpdatePort = vi.fn()
+      mockAcquireWorkbenchLock.mockReturnValue({release: vi.fn(), updatePort: mockUpdatePort})
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer(3334))
+
+      await startWorkbenchDevServer(createOptions({cliConfig: federationConfig}))
+
+      expect(mockUpdatePort).toHaveBeenCalledWith(3334)
+    })
+
+    test('starts watching registry after successful startup', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+
+      await startWorkbenchDevServer(createOptions({cliConfig: federationConfig}))
+
+      expect(mockWatchRegistry).toHaveBeenCalledWith(expect.any(Function))
+    })
+
+    test('watcher callback broadcasts applications via server.hot.send', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      const mockServer = createMockServer()
+      mockCreateServer.mockResolvedValue(mockServer)
+
+      await startWorkbenchDevServer(createOptions({cliConfig: federationConfig}))
+
+      const watchCallback = mockWatchRegistry.mock.calls[0][0]
+      watchCallback([
+        {host: 'localhost', pid: 2, port: 3334, type: 'studio'},
+        {host: 'localhost', pid: 3, port: 3335, type: 'app'},
+      ])
+
+      expect(mockServer.hot.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
+        applications: [
+          {host: 'localhost', port: 3334, type: 'studio'},
+          {host: 'localhost', port: 3335, type: 'app'},
+        ],
+      })
+    })
+
+    test('responds to client request with current applications', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      const mockServer = createMockServer()
+      mockCreateServer.mockResolvedValue(mockServer)
+      mockGetRegisteredServers.mockReturnValue([
+        {host: 'localhost', pid: 2, port: 3334, type: 'studio'},
+      ])
+
+      await startWorkbenchDevServer(createOptions({cliConfig: federationConfig}))
+
+      // Find the handler registered for the request event
+      const onCall = mockServer.hot.on.mock.calls.find(
+        (args: unknown[]) => args[0] === 'sanity:workbench:get-local-applications',
+      )
+      expect(onCall).toBeDefined()
+
+      const mockClient = {send: vi.fn()}
+      const handler = onCall![1] as (data: unknown, client: typeof mockClient) => void
+      handler(undefined, mockClient)
+
+      expect(mockClient.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
+        applications: [{host: 'localhost', port: 3334, type: 'studio'}],
+      })
+    })
+
+    test('close stops watcher and releases lock', async () => {
+      const mockReleaseLock = vi.fn()
+      const mockWatcherClose = vi.fn()
+      mockAcquireWorkbenchLock.mockReturnValue({release: mockReleaseLock, updatePort: vi.fn()})
+      mockWatchRegistry.mockReturnValue({close: mockWatcherClose})
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+
+      const result = await startWorkbenchDevServer(createOptions({cliConfig: federationConfig}))
+      await result.close()
+
+      expect(mockWatcherClose).toHaveBeenCalled()
+      expect(mockReleaseLock).toHaveBeenCalled()
+    })
+
+    test('releases lock when server startup fails', async () => {
+      const mockReleaseLock = vi.fn()
+      mockAcquireWorkbenchLock.mockReturnValue({release: mockReleaseLock, updatePort: vi.fn()})
+      mockResolveLocalPackage.mockResolvedValue({})
+      const mockServer = createMockServer()
+      mockServer.listen.mockRejectedValue(new Error('Port already in use'))
+      mockCreateServer.mockResolvedValue(mockServer)
+
+      await startWorkbenchDevServer(createOptions({cliConfig: federationConfig}))
+
+      expect(mockReleaseLock).toHaveBeenCalled()
     })
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -57,21 +57,26 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
 
   // Register the studio/app dev server in the registry (federated projects only)
   let cleanupManifest: () => void = syncNoop
+  let onSignal: (() => void) | undefined
   if (options.cliConfig?.federation?.enabled) {
     const addr = server.httpServer?.address()
     const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
     cleanupManifest = registerDevServer({
       host: httpHost || 'localhost',
       port: appPort,
-      type: options.isApp ? 'app' : 'studio',
+      type: options.isApp ? 'coreApp' : 'studio',
       workDir: options.workDir,
     })
 
-    // Ensure manifest is cleaned up on abrupt shutdown
-    const onSignal = () => {
+    // Ensure manifest and workbench lock are cleaned up on abrupt shutdown.
+    // closeWorkbenchServer() starts with synchronous calls (watcher.close,
+    // lock.release) that complete before the process exits; the trailing
+    // async server.close() is best-effort.
+    onSignal = () => {
       cleanupManifest()
-      process.off('SIGINT', onSignal)
-      process.off('SIGTERM', onSignal)
+      closeWorkbenchServer()
+      process.off('SIGINT', onSignal!)
+      process.off('SIGTERM', onSignal!)
     }
     process.on('SIGINT', onSignal)
     process.on('SIGTERM', onSignal)
@@ -88,6 +93,11 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
 
   return {
     close: async () => {
+      // Remove signal handlers to prevent double-cleanup and listener leaks
+      if (onSignal) {
+        process.off('SIGINT', onSignal)
+        process.off('SIGTERM', onSignal)
+      }
       cleanupManifest()
       // Run both closes independently — a failing workbench close must not prevent
       // the primary server from shutting down

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -1,11 +1,15 @@
 import {styleText} from 'node:util'
 
+import {registerDevServer} from './devServerRegistry.js'
 import {startAppDevServer} from './startAppDevServer.js'
 import {startStudioDevServer} from './startStudioDevServer.js'
 import {startWorkbenchDevServer} from './startWorkbenchDevServer.js'
 import {type DevActionOptions} from './types.js'
 
-export async function devAction(options: DevActionOptions): Promise<{close?: () => Promise<void>}> {
+const noop = async () => {}
+const syncNoop = () => {}
+
+export async function devAction(options: DevActionOptions): Promise<{close: () => Promise<void>}> {
   const {output} = options
 
   const {
@@ -17,14 +21,13 @@ export async function devAction(options: DevActionOptions): Promise<{close?: () 
 
   // Start app/studio dev server: use workbenchPort + 1 if workbench feature is
   // available (reserves the configured port for it), otherwise use the original port
-  const desiredAppPort = closeWorkbenchServer === undefined ? workbenchPort : workbenchPort + 1
+  const desiredAppPort = workbenchAvailable ? workbenchPort + 1 : workbenchPort
 
   // When the workbench is running, point the remote's react-refresh preamble at
   // the workbench dev server so HMR updates flow through the host.
-  const reactRefreshHost =
-    closeWorkbenchServer === undefined
-      ? undefined
-      : `http://${httpHost || 'localhost'}:${workbenchPort}`
+  const reactRefreshHost = workbenchAvailable
+    ? `http://${httpHost || 'localhost'}:${workbenchPort}`
+    : undefined
 
   const appOptions: DevActionOptions = {
     ...options,
@@ -33,31 +36,50 @@ export async function devAction(options: DevActionOptions): Promise<{close?: () 
     workbenchAvailable,
   }
 
-  let closeAppDevServer: (() => Promise<void>) | undefined
+  let closeAppDevServer: () => Promise<void> = noop
   let server
   try {
     const result = options.isApp
       ? await startAppDevServer(appOptions)
       : await startStudioDevServer(appOptions)
-    closeAppDevServer = result.close
+    closeAppDevServer = result.close ?? noop
     server = result.server
   } catch (err) {
-    await closeWorkbenchServer?.()
+    await closeWorkbenchServer()
     throw err
   }
 
   // server is undefined only when startAppDevServer exits early (e.g. missing orgId);
   // in that case the process is already exiting so no workbench needed.
   if (!server) {
-    return {
-      close: async () => {
-        await closeWorkbenchServer?.()
-      },
-    }
+    return {close: closeWorkbenchServer}
   }
 
-  if (closeWorkbenchServer !== undefined) {
-    const appPort = server.config.server.port
+  // Register the studio/app dev server in the registry (federated projects only)
+  let cleanupManifest: () => void = syncNoop
+  if (options.cliConfig?.federation?.enabled) {
+    const addr = server.httpServer?.address()
+    const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
+    cleanupManifest = registerDevServer({
+      host: httpHost || 'localhost',
+      port: appPort,
+      type: options.isApp ? 'app' : 'studio',
+      workDir: options.workDir,
+    })
+
+    // Ensure manifest is cleaned up on abrupt shutdown
+    const onSignal = () => {
+      cleanupManifest()
+      process.off('SIGINT', onSignal)
+      process.off('SIGTERM', onSignal)
+    }
+    process.on('SIGINT', onSignal)
+    process.on('SIGTERM', onSignal)
+  }
+
+  if (workbenchAvailable) {
+    const addr = server.httpServer?.address()
+    const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
     const workbenchUrl = `http://${httpHost || 'localhost'}:${workbenchPort}`
     output.log(
       `Workbench dev server started at ${styleText(['blue', 'underline'], workbenchUrl)} (app on port ${appPort})`,
@@ -66,9 +88,10 @@ export async function devAction(options: DevActionOptions): Promise<{close?: () 
 
   return {
     close: async () => {
+      cleanupManifest()
       // Run both closes independently — a failing workbench close must not prevent
       // the primary server from shutting down
-      await Promise.allSettled([closeWorkbenchServer?.(), closeAppDevServer?.()])
+      await Promise.allSettled([closeWorkbenchServer(), closeAppDevServer()])
     },
   }
 }

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -1,0 +1,265 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+  watch,
+  writeFileSync,
+} from 'node:fs'
+import {homedir} from 'node:os'
+import {join} from 'node:path'
+
+import {z} from 'zod/mini'
+
+import {devDebug} from './devDebug.js'
+
+const workbenchLockSchema = z.object({
+  host: z.string(),
+  pid: z.number(),
+  port: z.number(),
+})
+
+const devServerManifestSchema = z.extend(workbenchLockSchema, {
+  startedAt: z.string(),
+  type: z.enum(['app', 'studio']),
+  workDir: z.string(),
+})
+/**
+ * A manifest describing a running dev server process (studio or app).
+ * Stored as `~/.sanity/dev-servers/<pid>.json`.
+ *
+ * Workbench state is tracked separately via the lock file — see
+ * {@link acquireWorkbenchLock} and {@link readWorkbenchLock}.
+ */
+export type DevServerManifest = z.infer<typeof devServerManifestSchema>
+
+/**
+ * Returns the path to the dev server registry directory.
+ * Respects `SANITY_INTERNAL_ENV=staging` to isolate staging instances.
+ */
+function getRegistryDir(): string {
+  const suffix = process.env.SANITY_INTERNAL_ENV === 'staging' ? '-staging' : ''
+  return join(homedir(), `.sanity${suffix}`, 'dev-servers')
+}
+
+/**
+ * Check whether a process is still alive.
+ * Sends signal 0 which doesn't kill anything — just checks existence.
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err: unknown) {
+    // EPERM means the process exists but we lack permission to signal it
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'EPERM') {
+      return true
+    }
+    return false
+  }
+}
+
+/**
+ * Write a manifest file for the current process and return a cleanup function
+ * that removes it. Uses synchronous I/O so the file exists before any signal
+ * handler could fire.
+ */
+export function registerDevServer(
+  manifest: Omit<DevServerManifest, 'pid' | 'startedAt'>,
+): () => void {
+  const registryDir = getRegistryDir()
+  mkdirSync(registryDir, {recursive: true})
+
+  const fullManifest: DevServerManifest = {
+    ...manifest,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+  }
+
+  const filePath = join(registryDir, `${process.pid}.json`)
+  writeFileSync(filePath, JSON.stringify(fullManifest, null, 2))
+
+  return () => {
+    try {
+      unlinkSync(filePath)
+    } catch {
+      // ENOENT is fine — already cleaned up
+    }
+  }
+}
+
+/**
+ * Read all manifest files from the registry, prune stale entries (dead PIDs),
+ * and return the live ones.
+ */
+export function getRegisteredServers(): DevServerManifest[] {
+  const registryDir = getRegistryDir()
+
+  if (!existsSync(registryDir)) {
+    return []
+  }
+
+  const files = readdirSync(registryDir).filter((f) => f.endsWith('.json'))
+  const servers: DevServerManifest[] = []
+
+  for (const file of files) {
+    const filePath = join(registryDir, file)
+    let raw: unknown
+    try {
+      raw = JSON.parse(readFileSync(filePath, 'utf8'))
+    } catch {
+      continue
+    }
+
+    const {data, success} = devServerManifestSchema.safeParse(raw)
+    if (!success) continue
+
+    if (isProcessAlive(data.pid)) {
+      servers.push(data)
+    } else {
+      // Prune stale manifest
+      try {
+        unlinkSync(filePath)
+      } catch {
+        // Ignore — another process may have already cleaned it up
+      }
+    }
+  }
+
+  return servers
+}
+
+/**
+ * Read the workbench lock file and return its contents if the holding
+ * process is still alive. Prunes stale locks from crashed processes.
+ */
+export function readWorkbenchLock(): z.infer<typeof workbenchLockSchema> | undefined {
+  const lockPath = join(getRegistryDir(), 'workbench.lock')
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(lockPath, 'utf8'))
+  } catch {
+    return undefined
+  }
+
+  const {data, success} = workbenchLockSchema.safeParse(raw)
+
+  devDebug('Read workbench lock: %o', data)
+
+  if (success && isProcessAlive(data.pid)) {
+    devDebug('Workbench process is alive at pid %d on port %d', data.pid, data.port)
+    return data
+  }
+
+  // Stale lock — prune it
+  try {
+    devDebug('Removing stale workbench lock')
+    unlinkSync(lockPath)
+    devDebug('Stale workbench lock removed')
+  } catch {
+    // Another process may have already cleaned it up
+  }
+  return undefined
+}
+
+interface WorkbenchLock {
+  /** Release the lock file. */
+  release: () => void
+  /** Update the lock with the actual port after the server starts listening. */
+  updatePort: (port: number) => void
+}
+
+/**
+ * Attempt to acquire an exclusive lock for the workbench process.
+ * Uses `O_EXCL` (the `wx` flag) which is atomic at the OS level — only one
+ * process can create the file.
+ *
+ * The lock stores `{pid, host, port}` so other processes can find the
+ * running workbench. Call `updatePort` after the Vite server starts to
+ * write the actual port (Vite may pick a different one).
+ *
+ * @returns A {@link WorkbenchLock} if acquired, or `undefined` if another
+ *          live process already holds it.
+ */
+export function acquireWorkbenchLock(info: {
+  host: string
+  port: number
+}): WorkbenchLock | undefined {
+  const registryDir = getRegistryDir()
+  mkdirSync(registryDir, {recursive: true})
+
+  const lockPath = join(registryDir, 'workbench.lock')
+  const lockData = {host: info.host, pid: process.pid, port: info.port}
+
+  devDebug('Acquiring workbench lock at %s', lockPath)
+
+  try {
+    writeFileSync(lockPath, JSON.stringify(lockData), {flag: 'wx'})
+    devDebug('Workbench lock acquired')
+    return {
+      release() {
+        try {
+          unlinkSync(lockPath)
+        } catch {
+          // Already cleaned up
+        }
+      },
+      updatePort(port: number) {
+        writeFileSync(lockPath, JSON.stringify({...lockData, port}))
+      },
+    }
+  } catch (err: unknown) {
+    devDebug(
+      'Failed to acquire workbench lock: %s',
+      err instanceof Error ? err.message : String(err),
+    )
+    if (!isNodeError(err) || err.code !== 'EEXIST') return undefined
+
+    // Lock exists — check if the holder is still alive
+    const existing = readWorkbenchLock()
+    if (existing) return undefined
+
+    // Stale lock was pruned by readWorkbenchLock — retry
+    return acquireWorkbenchLock(info)
+  }
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && 'code' in err
+}
+
+interface RegistryWatcher {
+  close(): void
+}
+
+/**
+ * Watch the registry directory for changes and invoke the callback with the
+ * current list of live servers whenever a change is detected.
+ *
+ * Uses `fs.watch` with a debounce to coalesce rapid file changes (e.g. a
+ * server starting and writing its manifest triggers multiple FS events).
+ */
+export function watchRegistry(callback: (servers: DevServerManifest[]) => void): RegistryWatcher {
+  const registryDir = getRegistryDir()
+  mkdirSync(registryDir, {recursive: true})
+
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined
+
+  const notify = () => {
+    clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      callback(getRegisteredServers())
+    }, 50)
+  }
+
+  const watcher = watch(registryDir, notify)
+
+  return {
+    close() {
+      clearTimeout(debounceTimer)
+      watcher.close()
+    },
+  }
+}

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -1,3 +1,4 @@
+import {execSync} from 'node:child_process'
 import {
   existsSync,
   mkdirSync,
@@ -7,22 +8,27 @@ import {
   watch,
   writeFileSync,
 } from 'node:fs'
-import {homedir} from 'node:os'
 import {join} from 'node:path'
 
+import {getSanityDataDir} from '@sanity/cli-core'
 import {z} from 'zod/mini'
 
 import {devDebug} from './devDebug.js'
+
+/** Bump when the manifest/lock shape changes in a breaking way. */
+const REGISTRY_VERSION = 1
 
 const workbenchLockSchema = z.object({
   host: z.string(),
   pid: z.number(),
   port: z.number(),
+  startedAt: z.string(),
+  version: z.literal(REGISTRY_VERSION),
 })
 
 const devServerManifestSchema = z.extend(workbenchLockSchema, {
   startedAt: z.string(),
-  type: z.enum(['app', 'studio']),
+  type: z.enum(['coreApp', 'studio']),
   workDir: z.string(),
 })
 /**
@@ -36,11 +42,10 @@ export type DevServerManifest = z.infer<typeof devServerManifestSchema>
 
 /**
  * Returns the path to the dev server registry directory.
- * Respects `SANITY_INTERNAL_ENV=staging` to isolate staging instances.
+ * Uses the shared Sanity config directory to stay consistent with other CLI paths.
  */
 function getRegistryDir(): string {
-  const suffix = process.env.SANITY_INTERNAL_ENV === 'staging' ? '-staging' : ''
-  return join(homedir(), `.sanity${suffix}`, 'dev-servers')
+  return join(getSanityDataDir(), 'dev-servers')
 }
 
 /**
@@ -60,13 +65,56 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+/** Tolerance in ms when comparing stored vs OS-reported process start times. */
+const START_TIME_TOLERANCE_MS = 2000
+
+/**
+ * Retrieve the OS-reported start time for a process.
+ * Uses `ps -o lstart=` which works on both macOS and Linux.
+ * Returns `undefined` if the process doesn't exist or the command fails.
+ */
+function getProcessStartTime(pid: number): Date | undefined {
+  try {
+    const output = execSync(`ps -o lstart= -p ${pid}`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1000,
+    }).trim()
+    if (!output) return undefined
+    const date = new Date(output)
+    return Number.isNaN(date.getTime()) ? undefined : date
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Check whether a process is alive **and** is the same process that wrote
+ * the manifest/lock (not a PID that was reused by the OS after a crash).
+ *
+ * Compares the stored `startedAt` timestamp against the OS-reported process
+ * start time. Falls back to a plain alive-check when the start time cannot
+ * be retrieved (unsupported platform, permissions, etc.).
+ */
+function isOurProcess(pid: number, startedAt: string): boolean {
+  if (!isProcessAlive(pid)) return false
+
+  const osStart = getProcessStartTime(pid)
+  if (!osStart) return true // can't verify — assume alive is good enough
+
+  const storedStart = new Date(startedAt)
+  if (Number.isNaN(storedStart.getTime())) return true // bad stored value — fall back
+
+  return Math.abs(osStart.getTime() - storedStart.getTime()) <= START_TIME_TOLERANCE_MS
+}
+
 /**
  * Write a manifest file for the current process and return a cleanup function
  * that removes it. Uses synchronous I/O so the file exists before any signal
  * handler could fire.
  */
 export function registerDevServer(
-  manifest: Omit<DevServerManifest, 'pid' | 'startedAt'>,
+  manifest: Omit<DevServerManifest, 'pid' | 'startedAt' | 'version'>,
 ): () => void {
   const registryDir = getRegistryDir()
   mkdirSync(registryDir, {recursive: true})
@@ -75,6 +123,7 @@ export function registerDevServer(
     ...manifest,
     pid: process.pid,
     startedAt: new Date().toISOString(),
+    version: REGISTRY_VERSION,
   }
 
   const filePath = join(registryDir, `${process.pid}.json`)
@@ -115,7 +164,7 @@ export function getRegisteredServers(): DevServerManifest[] {
     const {data, success} = devServerManifestSchema.safeParse(raw)
     if (!success) continue
 
-    if (isProcessAlive(data.pid)) {
+    if (isOurProcess(data.pid, data.startedAt)) {
       servers.push(data)
     } else {
       // Prune stale manifest
@@ -148,7 +197,7 @@ export function readWorkbenchLock(): z.infer<typeof workbenchLockSchema> | undef
 
   devDebug('Read workbench lock: %o', data)
 
-  if (success && isProcessAlive(data.pid)) {
+  if (success && isOurProcess(data.pid, data.startedAt)) {
     devDebug('Workbench process is alive at pid %d on port %d', data.pid, data.port)
     return data
   }
@@ -183,15 +232,22 @@ interface WorkbenchLock {
  * @returns A {@link WorkbenchLock} if acquired, or `undefined` if another
  *          live process already holds it.
  */
-export function acquireWorkbenchLock(info: {
-  host: string
-  port: number
-}): WorkbenchLock | undefined {
+export function acquireWorkbenchLock(
+  info: {host: string; port: number},
+  retries = 1,
+): WorkbenchLock | undefined {
   const registryDir = getRegistryDir()
   mkdirSync(registryDir, {recursive: true})
 
   const lockPath = join(registryDir, 'workbench.lock')
-  const lockData = {host: info.host, pid: process.pid, port: info.port}
+  const startedAt = new Date().toISOString()
+  const lockData = {
+    host: info.host,
+    pid: process.pid,
+    port: info.port,
+    startedAt,
+    version: REGISTRY_VERSION,
+  }
 
   devDebug('Acquiring workbench lock at %s', lockPath)
 
@@ -221,8 +277,9 @@ export function acquireWorkbenchLock(info: {
     const existing = readWorkbenchLock()
     if (existing) return undefined
 
-    // Stale lock was pruned by readWorkbenchLock — retry
-    return acquireWorkbenchLock(info)
+    // Stale lock was pruned by readWorkbenchLock — retry (with guard against infinite recursion)
+    if (retries <= 0) return undefined
+    return acquireWorkbenchLock(info, retries - 1)
   }
 }
 

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -4,15 +4,27 @@ import {createServer, type InlineConfig} from 'vite'
 
 import {getSharedServerConfig} from '../../util/getSharedServerConfig.js'
 import {devDebug} from './devDebug.js'
+import {
+  acquireWorkbenchLock,
+  type DevServerManifest,
+  getRegisteredServers,
+  readWorkbenchLock,
+  watchRegistry,
+} from './devServerRegistry.js'
 import {type DevActionOptions} from './types.js'
 import {writeWorkbenchRuntime} from './writeWorkbenchRuntime.js'
 
+const noop = async () => {}
+
+const toApplicationsPayload = (servers: DevServerManifest[]) => ({
+  applications: servers.map(({host, port, type}) => ({host, port, type})),
+})
+
 interface WorkbenchDevServerResult {
+  close: () => Promise<void>
   httpHost: string | undefined
   workbenchAvailable: boolean
   workbenchPort: number
-
-  close?: () => Promise<void>
 }
 
 export async function startWorkbenchDevServer(
@@ -28,7 +40,7 @@ export async function startWorkbenchDevServer(
 
   if (!cliConfig?.federation?.enabled) {
     devDebug('Federation not enabled, skipping workbench dev server')
-    return {httpHost, workbenchAvailable: false, workbenchPort}
+    return {close: noop, httpHost, workbenchAvailable: false, workbenchPort}
   }
 
   const reactStrictMode = process.env.SANITY_STUDIO_REACT_STRICT_MODE
@@ -52,7 +64,26 @@ export async function startWorkbenchDevServer(
   }
 
   if (!workbenchAvailable) {
-    return {httpHost, workbenchAvailable, workbenchPort}
+    return {close: noop, httpHost, workbenchAvailable, workbenchPort}
+  }
+
+  // Acquire an exclusive lock — only one workbench per machine.
+  // Uses O_EXCL which is atomic at the OS level, preventing races when
+  // multiple `sanity dev` processes start simultaneously (e.g. via turbo).
+  const workbenchLock = acquireWorkbenchLock({host: httpHost || 'localhost', port: workbenchPort})
+  if (!workbenchLock) {
+    const existing = readWorkbenchLock()
+    devDebug(
+      'Workbench already running at pid %d on port %d, skipping',
+      existing?.pid,
+      existing?.port,
+    )
+    return {
+      close: noop,
+      httpHost: existing?.host ?? httpHost,
+      workbenchAvailable: true,
+      workbenchPort: existing?.port ?? workbenchPort,
+    }
   }
 
   devDebug('Writing workbench runtime files')
@@ -65,12 +96,15 @@ export async function startWorkbenchDevServer(
   let remoteUrl: string | undefined = undefined
 
   try {
-    remoteUrl = URL.parse(process.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL || '')?.toString()
+    remoteUrl = new URL(process.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL || '').toString()
   } catch {
     // Ignore parsing errors, the variable might not be set or might be an invalid URL, in which case we just won't use it
   }
 
   const viteConfig: InlineConfig = {
+    // Define a custom cache directory so that sanity's vite cache
+    // does not conflict with any potential local vite projects
+    cacheDir: 'node_modules/.sanity/vite',
     configFile: false,
     define: {
       'import.meta.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL': JSON.stringify(remoteUrl),
@@ -96,18 +130,39 @@ export async function startWorkbenchDevServer(
     await server.listen()
   } catch (err) {
     await server.close()
+    workbenchLock.release()
     output.warn(
       `Workbench dev server failed to start: ${err instanceof Error ? err.message : String(err)}`,
     )
-    return {httpHost, workbenchAvailable: false, workbenchPort}
+    return {close: noop, httpHost, workbenchAvailable: false, workbenchPort}
   }
 
   // Vite may have picked a different port if the desired one was occupied
   const addr = server.httpServer?.address()
   const actualPort = typeof addr === 'object' && addr ? addr.port : workbenchPort
 
+  // Update the lock file with the actual port so other processes can find us
+  workbenchLock.updatePort(actualPort)
+
+  // Respond to client requests for the current application list
+  server.ws.on('sanity:workbench:get-local-applications', (_, client) => {
+    client.send(
+      'sanity:workbench:local-applications',
+      toApplicationsPayload(getRegisteredServers()),
+    )
+  })
+
+  // Watch the registry and broadcast updates to all connected clients
+  const registryWatcher = watchRegistry((servers) => {
+    server.ws.send('sanity:workbench:local-applications', toApplicationsPayload(servers))
+  })
+
   return {
-    close: () => server.close(),
+    close: async () => {
+      registryWatcher.close()
+      workbenchLock.release()
+      await server.close()
+    },
     httpHost,
     workbenchAvailable,
     workbenchPort: actualPort,

--- a/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
@@ -49,7 +49,7 @@ vi.mock('../../actions/dev/startWorkbenchDevServer.js', () => ({
       workDir: options.workDir,
     })
 
-    return {httpHost, workbenchAvailable: false, workbenchPort: httpPort}
+    return {close: async () => {}, httpHost, workbenchAvailable: false, workbenchPort: httpPort}
   }),
 }))
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

* creates dev-server manifests at the root of the user's machine to coordinate which processes are running for which apps
* creates a lock file so there can only be one workbench instance at a time
* uses the HotClient API to forward the list of applications to the user's client app only on the workbench dev-server

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

* I've opted for this over something like bonjour since it can largely be done natively, and we dont need to know whats going on in the network per say we just want to know whats happening on the local machine – does that make more sense? I think so?