### PR TITLE
chore: update renovate gitIgnoredAuthors for squiggler-app bot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>sanity-io/renovate-config"],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
-  "gitIgnoredAuthors": ["ecospark[bot]@users.noreply.github.com"],
+  "gitIgnoredAuthors": [
+    "265501495+squiggler-app[bot]@users.noreply.github.com",
+    "squiggler-app[bot]@users.noreply.github.com"
+  ],
   "schedule": ["before 5am"],
   "prConcurrentLimit": 3,
   "automerge": true,


### PR DESCRIPTION
### Description

Replace `ecospark[bot]` with `squiggler-app[bot]` in Renovate's `gitIgnoredAuthors` config so Renovate recognizes changeset commits added by the new bot (see #933).

Both the numbered (`265501495+squiggler-app[bot]@users.noreply.github.com`) and plain (`squiggler-app[bot]@users.noreply.github.com`) email formats are included for safety.

### What to review

- `.github/renovate.json` — verify the new bot emails are correct

### Testing

Config-only change, no automated tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)