### PR TITLE
ci: prevent redundant workflow runs on changeset commits

### DIFF
--- a/.github/scripts/generate-changeset.mjs
+++ b/.github/scripts/generate-changeset.mjs
@@ -35,7 +35,7 @@ function removeChangeset() {
   if (existsSync(CHANGESET_FILE)) {
     ensureGitConfigured()
     git('rm', CHANGESET_FILE)
-    git('commit', '-m', `chore: remove auto-generated changeset for PR #${PR_NUMBER}`)
+    git('commit', '-m', `chore: remove auto-generated changeset for PR #${PR_NUMBER} [skip ci]`)
     git('push', '--force-with-lease')
   }
 }
@@ -195,5 +195,5 @@ if (status !== 1) {
   process.exit(status ?? 1)
 }
 
-git('commit', '-m', `chore: update auto-generated changeset for PR #${PR_NUMBER}`)
+git('commit', '-m', `chore: update auto-generated changeset for PR #${PR_NUMBER} [skip ci]`)
 git('push', '--force-with-lease')

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,16 +1,16 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:
   claude-review:
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'skip-review') &&
-      github.actor != 'squiggler[bot]' &&
-      github.actor != 'squiggler-app[bot]' &&
-      (github.actor != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, '⚠️ major'))
+      github.event.pull_request.user.login != 'squiggler[bot]' &&
+      github.event.pull_request.user.login != 'squiggler-app[bot]' &&
+      (github.event.pull_request.user.login != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, '⚠️ major'))
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
### Description

When the changeset bot pushes an auto-generated changeset commit to a PR, the `synchronize` event causes all `pull_request`-triggered workflows (test, build, lint, depcheck) to cancel their in-progress runs and restart. This wastes CI minutes and delays feedback.

This PR fixes the issue by:
1. Adding `[skip ci]` to changeset commit messages — prevents `pull_request`-triggered workflows from re-running on the bot's push
2. Moving `claude-code-review` from `pull_request` to `pull_request_target` — unaffected by `[skip ci]`, so the review still triggers after the changeset commit
3. Switching the actor condition from `github.actor` to `github.event.pull_request.user.login` — ensures the review runs when the bot pushes to a human's PR, while still skipping bot-owned PRs

### What to review

- `[skip ci]` only suppresses `push` and `pull_request` events, not `pull_request_target` — verify this matches expectations
- The `pull_request_target` change for code review is safe because the workflow only reads a static prompt from the base branch and the Claude action reviews the diff via the GitHub API (no untrusted PR code is executed with elevated permissions)
- The code review will run twice on PRs (once on the original push, once after the changeset push) since there is no concurrency group — this is intentional because `cancel-in-progress` doesn't cleanly terminate Claude sessions

### Testing

Tested by opening a PR and verifying:
- [ ] `[skip ci]` prevents test/build/lint/depcheck from re-running on changeset commits
- [ ] Claude code review still triggers after the changeset commit
- [ ] Review is skipped for bot-owned PRs (squiggler, renovate without major label)