### PR TITLE
fix(cli): resolve correct package for update checker notifications

### DIFF
--- a/.changeset/fix-update-checker-correct-command.md
+++ b/.changeset/fix-update-checker-correct-command.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+Show the correct update command based on whether the project depends on `sanity` or `@sanity/cli`

--- a/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
+++ b/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
@@ -257,7 +257,7 @@ describe('#checkForUpdates', () => {
     expect(mockDebug).toHaveBeenCalledWith('Update is available (%s)', '999.0.0')
     expect(stderr).toContain('Update available')
     expect(stderr).toContain('999.0.0')
-    expect(stderr).toContain('pnpm')
+    expect(stderr).toContain('pnpm update sanity')
   })
 
   test('does not show notification when cache is hit', async () => {

--- a/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
+++ b/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
@@ -9,6 +9,7 @@ const mockDebug = vi.hoisted(() => vi.fn())
 const mockGetLatestVersion = vi.hoisted(() => vi.fn())
 const mockIsInstalledGlobally = vi.hoisted(() => ({default: false}))
 const mockIsInstalledUsingYarn = vi.hoisted(() => vi.fn())
+const mockResolveUpdateTarget = vi.hoisted(() => vi.fn())
 
 const mockConfigStore = vi.hoisted(() => {
   const store = new Map<string, unknown>()
@@ -39,6 +40,10 @@ vi.mock('../../../util/update/isInstalledUsingYarn.js', () => ({
   isInstalledUsingYarn: mockIsInstalledUsingYarn,
 }))
 
+vi.mock('../../../util/update/resolveUpdateTarget.js', () => ({
+  resolveUpdateTarget: mockResolveUpdateTarget,
+}))
+
 const mockIsCi = vi.mocked(isCi)
 const originalIsTTY = process.stdout.isTTY
 
@@ -49,6 +54,7 @@ describe('#checkForUpdates', () => {
     mockIsCi.mockReturnValue(false)
     mockIsInstalledGlobally.default = false
     mockIsInstalledUsingYarn.mockReturnValue(false)
+    mockResolveUpdateTarget.mockResolvedValue({installedVersion: '3.60.0', packageName: 'sanity'})
     process.stdout.isTTY = true
 
     mockConfigStore.clear()
@@ -71,6 +77,7 @@ describe('#checkForUpdates', () => {
       'Running on CI, or explicitly disabled, skipping update check',
     )
     expect(mockGetLatestVersion).not.toHaveBeenCalled()
+    expect(mockResolveUpdateTarget).not.toHaveBeenCalled()
   })
 
   test('returns early if NO_UPDATE_NOTIFIER env variable is present', async () => {
@@ -85,6 +92,7 @@ describe('#checkForUpdates', () => {
       'Running on CI, or explicitly disabled, skipping update check',
     )
     expect(mockGetLatestVersion).not.toHaveBeenCalled()
+    expect(mockResolveUpdateTarget).not.toHaveBeenCalled()
   })
 
   test('returns early if not TTY', async () => {
@@ -96,6 +104,7 @@ describe('#checkForUpdates', () => {
     })
 
     expect(mockGetLatestVersion).not.toHaveBeenCalled()
+    expect(mockResolveUpdateTarget).not.toHaveBeenCalled()
   })
 
   test('skips latest update check if checked within last 12 hours', async () => {
@@ -104,7 +113,7 @@ describe('#checkForUpdates', () => {
     const recentTimestamp = now - 1000 * 60 * 60 * 6 // 6 hours ago
 
     const userConfig = getUserConfig()
-    userConfig.set('cliLatestRemoteVersion', {
+    userConfig.set('latestVersion:sanity', {
       updatedAt: recentTimestamp,
       value: '1.0.0',
     })
@@ -128,12 +137,12 @@ describe('#checkForUpdates', () => {
       config,
     })
 
-    expect(mockDebug).toHaveBeenCalledWith('Checking for latest remote version')
-    expect(mockGetLatestVersion).toHaveBeenCalledWith('@sanity/cli')
+    expect(mockDebug).toHaveBeenCalledWith('Checking for latest remote version of %s', 'sanity')
+    expect(mockGetLatestVersion).toHaveBeenCalledWith('sanity')
     expect(mockDebug).toHaveBeenCalledWith('Latest remote version is %s', '1.1.0')
 
     const userConfig = getUserConfig()
-    const cachedVersion = userConfig.get('cliLatestRemoteVersion')
+    const cachedVersion = userConfig.get('latestVersion:sanity')
     expect(cachedVersion).toMatchObject({
       updatedAt: expect.any(Number),
       value: '1.1.0',
@@ -151,14 +160,14 @@ describe('#checkForUpdates', () => {
       config,
     })
 
-    expect(mockDebug).toHaveBeenCalledWith('Checking for latest remote version')
+    expect(mockDebug).toHaveBeenCalledWith('Checking for latest remote version of %s', 'sanity')
     expect(mockGetLatestVersion).toHaveBeenCalled()
     expect(mockDebug).toHaveBeenCalledWith(
       expect.stringContaining('Max time 300 reached waiting for latest version info'),
     )
 
     const userConfig = getUserConfig()
-    const cachedVersion = userConfig.get('cliLatestRemoteVersion')
+    const cachedVersion = userConfig.get('latestVersion:sanity')
     expect(cachedVersion).toBeUndefined()
   })
 
@@ -172,14 +181,14 @@ describe('#checkForUpdates', () => {
       config,
     })
 
-    expect(mockDebug).toHaveBeenCalledWith('Checking for latest remote version')
+    expect(mockDebug).toHaveBeenCalledWith('Checking for latest remote version of %s', 'sanity')
     expect(mockGetLatestVersion).toHaveBeenCalled()
     expect(mockDebug).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to fetch latest version of @sanity/cli from npm:'),
+      expect.stringContaining('Failed to fetch latest version of sanity from npm:'),
     )
 
     const userConfig = getUserConfig()
-    const cachedVersion = userConfig.get('cliLatestRemoteVersion')
+    const cachedVersion = userConfig.get('latestVersion:sanity')
     expect(cachedVersion).toBeUndefined()
   })
 
@@ -202,7 +211,7 @@ describe('#checkForUpdates', () => {
     const recentTimestamp = now - 1000 * 60 * 60 * 6 // 6 hours ago
 
     const userConfig = getUserConfig()
-    userConfig.set('cliLatestRemoteVersion', {
+    userConfig.set('latestVersion:sanity', {
       updatedAt: recentTimestamp,
       value: '1.0.0', // older than current
     })
@@ -220,9 +229,9 @@ describe('#checkForUpdates', () => {
     const recentTimestamp = now - 1000 * 60 * 60 * 6 // 6 hours ago
 
     const userConfig = getUserConfig()
-    userConfig.set('cliLatestRemoteVersion', {
+    userConfig.set('latestVersion:sanity', {
       updatedAt: recentTimestamp,
-      value: config.version, // same as current
+      value: '3.60.0', // same as installedVersion from mock
     })
 
     await testHook<'init'>(checkForUpdates, {
@@ -257,7 +266,7 @@ describe('#checkForUpdates', () => {
     const recentTimestamp = now - 1000 * 60 * 60 * 6 // 6 hours ago
 
     const userConfig = getUserConfig()
-    userConfig.set('cliLatestRemoteVersion', {
+    userConfig.set('latestVersion:sanity', {
       updatedAt: recentTimestamp,
       value: '999.0.0', // newer than current
     })
@@ -290,5 +299,56 @@ describe('#checkForUpdates', () => {
     expect(stderr).toContain('Update available')
     expect(stderr).toContain('999.0.0')
     expect(stderr).toContain('yarn global add sanity')
+  })
+
+  test('uses @sanity/cli package when sanity is not a project dependency', async () => {
+    mockResolveUpdateTarget.mockResolvedValue({
+      installedVersion: '6.3.1',
+      packageName: '@sanity/cli',
+    })
+
+    const {config} = await getCommandAndConfig('help')
+    mockGetLatestVersion.mockResolvedValueOnce('6.4.0')
+
+    const {stderr} = await testHook<'init'>(checkForUpdates, {
+      config,
+    })
+
+    expect(mockGetLatestVersion).toHaveBeenCalledWith('@sanity/cli')
+    expect(mockDebug).toHaveBeenCalledWith('Update is available (%s)', '6.4.0')
+    expect(stderr).toContain('Update available')
+    expect(stderr).toContain('6.4.0')
+
+    const userConfig = getUserConfig()
+    const cachedVersion = userConfig.get('latestVersion:@sanity/cli')
+    expect(cachedVersion).toMatchObject({
+      updatedAt: expect.any(Number),
+      value: '6.4.0',
+    })
+  })
+
+  test('uses correct cache key per resolved package', async () => {
+    mockResolveUpdateTarget.mockResolvedValue({
+      installedVersion: '6.3.0',
+      packageName: '@sanity/cli',
+    })
+
+    const {config} = await getCommandAndConfig('help')
+
+    // Cache has entry for sanity (from another project) but not @sanity/cli
+    const userConfig = getUserConfig()
+    userConfig.set('latestVersion:sanity', {
+      updatedAt: Date.now(),
+      value: '999.0.0',
+    })
+
+    mockGetLatestVersion.mockResolvedValueOnce('6.4.0')
+
+    await testHook<'init'>(checkForUpdates, {
+      config,
+    })
+
+    // Should fetch @sanity/cli, not read the sanity cache
+    expect(mockGetLatestVersion).toHaveBeenCalledWith('@sanity/cli')
   })
 })

--- a/packages/@sanity/cli/src/util/packageManager/installationInfo/__tests__/detectPackages.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/installationInfo/__tests__/detectPackages.test.ts
@@ -75,6 +75,23 @@ describe('findPackageDeclaration', () => {
     expect(result).toBeNull()
   })
 
+  test('finds sanity declaration without workspaceInfo', async () => {
+    const cwd = path.join(fixturesDir, 'standalone-npm')
+    const result = await findPackageDeclaration('sanity', cwd)
+    if (!result) throw new Error('Expected result to be non-null')
+    expect(result.packageJsonPath).toBe(path.join(cwd, 'package.json'))
+    expect(result.dependencyType).toBe('dependencies')
+  })
+
+  test('returns raw declared range when no workspaceInfo provided', async () => {
+    const workspaceRoot = path.join(fixturesDir, 'pnpm-workspace-with-catalog')
+    const cwd = path.join(workspaceRoot, 'packages', 'studio')
+    const result = await findPackageDeclaration('sanity', cwd)
+    if (!result) throw new Error('Expected result to be non-null')
+    expect(result.declaredVersionRange).toBe('catalog:')
+    expect(result.versionRange).toBe('catalog:')
+  })
+
   test('resolves catalog: version in pnpm workspace', async () => {
     const workspaceRoot = path.join(fixturesDir, 'pnpm-workspace-with-catalog')
     const cwd = path.join(workspaceRoot, 'packages', 'studio')
@@ -212,6 +229,13 @@ describe('findInstalledPackage', () => {
     // In pnpm, @sanity/cli is a sibling to sanity in the .pnpm/.../node_modules folder
     const expectedSuffix = path.join('.pnpm', 'sanity@5.4.0', 'node_modules', '@sanity', 'cli')
     expect(result?.path).toContain(expectedSuffix)
+  })
+
+  test('finds sanity without explicit workspaceRoot', async () => {
+    const cwd = pnpmFixture
+    const result = await findInstalledPackage('sanity', cwd)
+    if (!result) throw new Error('Expected result to be non-null')
+    expect(result.version).toBe('5.4.0')
   })
 
   test('returns null when @sanity/cli is not found within workspace root', async () => {

--- a/packages/@sanity/cli/src/util/packageManager/installationInfo/detectPackages.ts
+++ b/packages/@sanity/cli/src/util/packageManager/installationInfo/detectPackages.ts
@@ -29,17 +29,20 @@ interface PackageJson {
 
 /**
  * Finds where a package is declared in the workspace, walking up from startDir.
- * Resolves catalog: protocol if used.
+ * Resolves catalog: protocol if used (requires workspaceInfo).
+ *
+ * When workspaceInfo is omitted, walks to the filesystem root instead of stopping
+ * at the workspace root, and returns the raw declared range without catalog resolution.
  */
 export async function findPackageDeclaration(
   packageName: SanityPackage,
   startDir: string,
-  workspaceInfo: WorkspaceInfo,
+  workspaceInfo?: WorkspaceInfo,
 ): Promise<PackageDeclaration | null> {
   let currentDir = path.resolve(startDir)
   const fsRoot = path.parse(currentDir).root
 
-  // Walk up until we pass the workspace root
+  // Walk up until we pass the workspace root (or filesystem root if no workspace info)
   while (currentDir !== fsRoot) {
     const packageJsonPath = path.join(currentDir, 'package.json')
     const packageJson = await readJsonFile<PackageJson>(packageJsonPath)
@@ -54,11 +57,9 @@ export async function findPackageDeclaration(
         const deps = packageJson[depType]
         if (deps && packageName in deps) {
           const declaredVersionRange = deps[packageName]
-          const versionRange = await resolveVersionRange(
-            declaredVersionRange,
-            packageName,
-            workspaceInfo,
-          )
+          const versionRange = workspaceInfo
+            ? await resolveVersionRange(declaredVersionRange, packageName, workspaceInfo)
+            : declaredVersionRange
 
           return {
             declaredVersionRange,
@@ -70,8 +71,8 @@ export async function findPackageDeclaration(
       }
     }
 
-    // Stop at workspace root
-    if (currentDir === workspaceInfo.root) {
+    // Stop at workspace root if provided, otherwise continue to filesystem root
+    if (workspaceInfo && currentDir === workspaceInfo.root) {
       break
     }
 
@@ -131,11 +132,14 @@ export async function findPackageOverride(
  * Also extracts \@sanity/cli dependency range from sanity package if applicable.
  *
  * Handles both hoisted (npm/yarn) and nested (pnpm) node_modules structures.
+ *
+ * When workspaceRoot is omitted, walks to the filesystem root instead of stopping
+ * at the workspace root.
  */
 export async function findInstalledPackage(
   packageName: SanityPackage,
   startDir: string,
-  workspaceRoot: string,
+  workspaceRoot?: string,
 ): Promise<InstalledPackage | null> {
   let currentDir = path.resolve(startDir)
   const fsRoot = path.parse(currentDir).root
@@ -162,8 +166,8 @@ export async function findInstalledPackage(
       }
     }
 
-    // Stop at workspace root
-    if (currentDir === workspaceRoot) {
+    // Stop at workspace root if provided, otherwise continue to filesystem root
+    if (workspaceRoot && currentDir === workspaceRoot) {
       break
     }
 

--- a/packages/@sanity/cli/src/util/update/__tests__/getUpdateCommand.test.ts
+++ b/packages/@sanity/cli/src/util/update/__tests__/getUpdateCommand.test.ts
@@ -12,39 +12,43 @@ describe('getUpdateCommand', () => {
     vi.clearAllMocks()
   })
 
-  test('returns npm update command', () => {
-    expect(getUpdateCommand('npm')).toBe('npm update sanity')
+  test('returns npm update command for sanity', () => {
+    expect(getUpdateCommand('npm', 'sanity')).toBe('npm update sanity')
+  })
+
+  test('returns npm update command for @sanity/cli', () => {
+    expect(getUpdateCommand('npm', '@sanity/cli')).toBe('npm update @sanity/cli')
   })
 
   test('returns pnpm update command', () => {
-    expect(getUpdateCommand('pnpm')).toBe('pnpm update sanity')
+    expect(getUpdateCommand('pnpm', 'sanity')).toBe('pnpm update sanity')
   })
 
   test('returns bun update command', () => {
-    expect(getUpdateCommand('bun')).toBe('bun update sanity')
+    expect(getUpdateCommand('bun', 'sanity')).toBe('bun update sanity')
   })
 
   test('returns npm update for manual', () => {
-    expect(getUpdateCommand('manual')).toBe('npm update sanity')
+    expect(getUpdateCommand('manual', 'sanity')).toBe('npm update sanity')
   })
 
   test('returns yarn upgrade for yarn v1', () => {
     mockGetYarnMajorVersion.mockReturnValue(1)
-    expect(getUpdateCommand('yarn')).toBe('yarn upgrade sanity')
+    expect(getUpdateCommand('yarn', 'sanity')).toBe('yarn upgrade sanity')
   })
 
   test('returns yarn up for yarn v2+', () => {
     mockGetYarnMajorVersion.mockReturnValue(2)
-    expect(getUpdateCommand('yarn')).toBe('yarn up sanity')
+    expect(getUpdateCommand('yarn', 'sanity')).toBe('yarn up sanity')
   })
 
   test('returns yarn up for yarn v4', () => {
     mockGetYarnMajorVersion.mockReturnValue(4)
-    expect(getUpdateCommand('yarn')).toBe('yarn up sanity')
+    expect(getUpdateCommand('yarn', 'sanity')).toBe('yarn up sanity')
   })
 
   test('returns yarn upgrade when yarn version is undefined', () => {
     mockGetYarnMajorVersion.mockReturnValue(undefined)
-    expect(getUpdateCommand('yarn')).toBe('yarn upgrade sanity')
+    expect(getUpdateCommand('yarn', 'sanity')).toBe('yarn upgrade sanity')
   })
 })

--- a/packages/@sanity/cli/src/util/update/__tests__/resolveUpdateTarget.test.ts
+++ b/packages/@sanity/cli/src/util/update/__tests__/resolveUpdateTarget.test.ts
@@ -1,0 +1,76 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {
+  type InstalledPackage,
+  type PackageDeclaration,
+} from '../../packageManager/installationInfo/types.js'
+import {resolveUpdateTarget} from '../resolveUpdateTarget.js'
+
+const mockFindInstalledPackage = vi.hoisted(() => vi.fn())
+const mockFindPackageDeclaration = vi.hoisted(() => vi.fn())
+
+vi.mock('../../packageManager/installationInfo/detectPackages.js', () => ({
+  findInstalledPackage: mockFindInstalledPackage,
+  findPackageDeclaration: mockFindPackageDeclaration,
+}))
+
+describe('resolveUpdateTarget', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns sanity when sanity is declared and installed', async () => {
+    const declaration: PackageDeclaration = {
+      declaredVersionRange: '^5.4.0',
+      dependencyType: 'dependencies',
+      packageJsonPath: '/fake/project/package.json',
+      versionRange: '^5.4.0',
+    }
+    const installed: InstalledPackage = {
+      cliDependencyRange: '5.4.0',
+      path: '/fake/project/node_modules/.pnpm/sanity@5.4.0/node_modules/sanity',
+      version: '5.4.0',
+    }
+
+    mockFindPackageDeclaration.mockResolvedValue(declaration)
+    mockFindInstalledPackage.mockResolvedValue(installed)
+
+    const result = await resolveUpdateTarget('/fake/project', '6.3.1')
+
+    expect(result.packageName).toBe('sanity')
+    expect(result.installedVersion).toBe('5.4.0')
+    expect(mockFindPackageDeclaration).toHaveBeenCalledWith('sanity', '/fake/project')
+    expect(mockFindInstalledPackage).toHaveBeenCalledWith('sanity', '/fake/project')
+  })
+
+  test('falls back to @sanity/cli when sanity is declared but not installed', async () => {
+    const declaration: PackageDeclaration = {
+      declaredVersionRange: '^3.67.0',
+      dependencyType: 'dependencies',
+      packageJsonPath: '/fake/project/package.json',
+      versionRange: '^3.67.0',
+    }
+
+    mockFindPackageDeclaration.mockResolvedValue(declaration)
+    mockFindInstalledPackage.mockResolvedValue(null)
+
+    const result = await resolveUpdateTarget('/fake/project', '6.3.1')
+
+    expect(result.packageName).toBe('@sanity/cli')
+    expect(result.installedVersion).toBe('6.3.1')
+    expect(mockFindPackageDeclaration).toHaveBeenCalledWith('sanity', '/fake/project')
+    expect(mockFindInstalledPackage).toHaveBeenCalledWith('sanity', '/fake/project')
+  })
+
+  test('falls back to @sanity/cli when sanity is not declared', async () => {
+    mockFindPackageDeclaration.mockResolvedValue(null)
+
+    const result = await resolveUpdateTarget('/fake/project', '6.3.1')
+
+    expect(result.packageName).toBe('@sanity/cli')
+    expect(result.installedVersion).toBe('6.3.1')
+    expect(mockFindPackageDeclaration).toHaveBeenCalledWith('sanity', '/fake/project')
+    // Should not attempt to find installed package when not declared
+    expect(mockFindInstalledPackage).not.toHaveBeenCalled()
+  })
+})

--- a/packages/@sanity/cli/src/util/update/getUpdateCommand.ts
+++ b/packages/@sanity/cli/src/util/update/getUpdateCommand.ts
@@ -1,24 +1,23 @@
 import {getYarnMajorVersion} from '@sanity/cli-core/package-manager'
 
+import {type SanityPackage} from '../packageManager/installationInfo/types.js'
 import {type PackageManager} from '../packageManager/packageManagerChoice.js'
-
-export const cliPkgName = 'sanity'
 
 /**
  * Get the appropriate update command for the package manager
  */
-export function getUpdateCommand(pm: PackageManager): string {
+export function getUpdateCommand(pm: PackageManager, packageName: SanityPackage): string {
   if (pm === 'yarn') {
     const yarnMajor = getYarnMajorVersion()
     const cmd = yarnMajor !== undefined && yarnMajor >= 2 ? 'up' : 'upgrade'
-    return `yarn ${cmd} ${cliPkgName}`
+    return `yarn ${cmd} ${packageName}`
   }
 
   const localCommands: Record<Exclude<PackageManager, 'yarn'>, string> = {
-    bun: `bun update ${cliPkgName}`,
-    manual: `npm update ${cliPkgName}`,
-    npm: `npm update ${cliPkgName}`,
-    pnpm: `pnpm update ${cliPkgName}`,
+    bun: `bun update ${packageName}`,
+    manual: `npm update ${packageName}`,
+    npm: `npm update ${packageName}`,
+    pnpm: `pnpm update ${packageName}`,
   }
   return localCommands[pm]
 }

--- a/packages/@sanity/cli/src/util/update/resolveUpdateTarget.ts
+++ b/packages/@sanity/cli/src/util/update/resolveUpdateTarget.ts
@@ -1,0 +1,40 @@
+import {subdebug} from '@sanity/cli-core'
+
+import {
+  findInstalledPackage,
+  findPackageDeclaration,
+} from '../packageManager/installationInfo/detectPackages.js'
+import {type SanityPackage} from '../packageManager/installationInfo/types.js'
+
+const debug = subdebug('updateChecker')
+
+interface UpdateTarget {
+  installedVersion: string
+  packageName: SanityPackage
+}
+
+/**
+ * Determine which package to check for updates and what version is currently installed.
+ *
+ * If the user's project declares `sanity` as a dependency and it's installed,
+ * we check `sanity` (since that's what the user manages). Otherwise, we fall back
+ * to `@sanity/cli` (the currently running CLI binary).
+ */
+export async function resolveUpdateTarget(cwd: string, cliVersion: string): Promise<UpdateTarget> {
+  // Check if `sanity` is a dependency in the local project
+  const sanityDeclaration = await findPackageDeclaration('sanity', cwd)
+
+  if (sanityDeclaration) {
+    debug('Project declares sanity as a dependency, checking installed version')
+    const sanityInstalled = await findInstalledPackage('sanity', cwd)
+
+    if (sanityInstalled) {
+      debug('Installed sanity version: %s', sanityInstalled.version)
+      return {installedVersion: sanityInstalled.version, packageName: 'sanity'}
+    }
+
+    debug('sanity is declared but not installed, falling back to @sanity/cli')
+  }
+
+  return {installedVersion: cliVersion, packageName: '@sanity/cli'}
+}

--- a/packages/@sanity/cli/src/util/update/showNotificationUpdate.ts
+++ b/packages/@sanity/cli/src/util/update/showNotificationUpdate.ts
@@ -4,8 +4,9 @@ import {ux} from '@oclif/core'
 import {boxen} from '@sanity/cli-core/ux'
 import isInstalledGlobally from 'is-installed-globally'
 
+import {type SanityPackage} from '../packageManager/installationInfo/types.js'
 import {getPackageManagerChoice} from '../packageManager/packageManagerChoice.js'
-import {cliPkgName, getUpdateCommand} from './getUpdateCommand.js'
+import {getUpdateCommand} from './getUpdateCommand.js'
 import {isInstalledUsingYarn} from './isInstalledUsingYarn.js'
 
 /**
@@ -14,17 +15,18 @@ import {isInstalledUsingYarn} from './isInstalledUsingYarn.js'
 export async function showUpdateNotification(
   currentVersion: string,
   latestVersion: string,
+  packageName: SanityPackage,
 ): Promise<void> {
   let command
 
   // Check if CLI is installed globally
   if (isInstalledGlobally) {
     command = isInstalledUsingYarn()
-      ? `yarn global add ${cliPkgName}`
-      : `npm install -g ${cliPkgName}`
+      ? `yarn global add ${packageName}`
+      : `npm install -g ${packageName}`
   } else {
     const {chosen} = await getPackageManagerChoice(process.cwd(), {interactive: false})
-    command = getUpdateCommand(chosen)
+    command = getUpdateCommand(chosen, packageName)
   }
 
   const message = `Update available: ${styleText('dim', currentVersion)} → ${styleText('green', latestVersion)}\n\nRun ${styleText('cyan', command)} to update`

--- a/packages/@sanity/cli/src/util/update/updateChecker.ts
+++ b/packages/@sanity/cli/src/util/update/updateChecker.ts
@@ -17,11 +17,7 @@ const CHECK_TIMEOUT = 300
  *
  * @param config - The CLI config containing version and name
  */
-export async function updateChecker(config: {
-  name: string
-  root: string
-  version: string
-}): Promise<void> {
+export async function updateChecker(config: {version: string}): Promise<void> {
   debug(`Installed CLI version is ${config.version}`)
   // Skip in CI or if disabled
   if (isCi() || process.env.NO_UPDATE_NOTIFIER) {

--- a/packages/@sanity/cli/src/util/update/updateChecker.ts
+++ b/packages/@sanity/cli/src/util/update/updateChecker.ts
@@ -3,6 +3,7 @@ import semver from 'semver'
 
 import {createExpiringConfig} from '../createExpiringConfig.js'
 import {fetchLatestVersion} from './fetchLatestVersion.js'
+import {resolveUpdateTarget} from './resolveUpdateTarget.js'
 import {showUpdateNotification} from './showNotificationUpdate.js'
 
 const debug = subdebug('updateChecker')
@@ -32,19 +33,24 @@ export async function updateChecker(config: {
     return
   }
 
+  // Resolve which package to check and what's installed locally.
+  // If the project depends on `sanity`, check that; otherwise fall back to `@sanity/cli`.
+  const {installedVersion, packageName} = await resolveUpdateTarget(process.cwd(), config.version)
+  debug('Update target: %s@%s', packageName, installedVersion)
+
   const store = getUserConfig()
 
   let showNotificationUpdate = true
 
   // Cache for latest version from npm
   const latestVersionCache = createExpiringConfig({
-    fetchValue: async () => fetchLatestVersion(config.name, CHECK_TIMEOUT),
-    key: 'cliLatestRemoteVersion',
+    fetchValue: async () => fetchLatestVersion(packageName, CHECK_TIMEOUT),
+    key: `latestVersion:${packageName}`,
     onCacheHit: () => {
       debug('Less than 12 hours since last check, skipping update check')
       showNotificationUpdate = false
     },
-    onFetch: () => debug('Checking for latest remote version'),
+    onFetch: () => debug('Checking for latest remote version of %s', packageName),
     store,
     ttl: TWELVE_HOURS,
     validateValue: (value): value is string => typeof value === 'string',
@@ -57,7 +63,7 @@ export async function updateChecker(config: {
     return
   }
 
-  const comparison = semver.compare(latestVersion, config.version)
+  const comparison = semver.compare(latestVersion, installedVersion)
 
   if (comparison < 0) {
     debug('Remote version older than local')
@@ -72,6 +78,6 @@ export async function updateChecker(config: {
   debug('Update is available (%s)', latestVersion)
 
   if (showNotificationUpdate) {
-    await showUpdateNotification(config.version, latestVersion)
+    await showUpdateNotification(installedVersion, latestVersion, packageName)
   }
 }


### PR DESCRIPTION
### Description

The update checker compared `@sanity/cli` versions from npm but told users to run `pnpm update sanity`. Since `@sanity/cli` and `sanity` are separate packages with independent version numbers, this was confusing and sometimes incorrect.

Now resolves which package the project actually depends on (`sanity` vs `@sanity/cli`), fetches the latest version of *that* package, compares against the *installed* version, and shows the matching update command.

Relates to #890 (package resolution only, without the background worker changes).

### What to review

- `resolveUpdateTarget.ts` — new module that determines which package to check (`sanity` if declared+installed, otherwise `@sanity/cli`)
- `updateChecker.ts` — wires in `resolveUpdateTarget` to fetch/compare the correct package, uses per-package cache key (`latestVersion:sanity` vs `latestVersion:@sanity/cli`)
- `getUpdateCommand.ts` / `showNotificationUpdate.ts` — accept `packageName` param instead of hardcoded `cliPkgName`
- `detectPackages.ts` — `workspaceInfo`/`workspaceRoot` params made optional so `resolveUpdateTarget` can call them without full workspace context

### Testing

- 40 tests passing across 4 test files (checkForUpdates, resolveUpdateTarget, getUpdateCommand, detectPackages)
- New tests for `resolveUpdateTarget` covering: sanity declared+installed, sanity declared but not installed, sanity not declared
- New tests for per-package cache key isolation
- New test for `@sanity/cli` fallback path through the full update checker flow

Resolves SDK-1249 and SDK-1250