### PR TITLE
chore(cli): skip update check for temporary npx downloads

### DIFF
--- a/.changeset/skip-npx-temp-update-check.md
+++ b/.changeset/skip-npx-temp-update-check.md
@@ -2,4 +2,4 @@
 '@sanity/cli': patch
 ---
 
-Skip update check for temporary npx downloads
+Skip update check for throwaway package runner downloads (npx, pnpm dlx, yarn dlx, bunx)

--- a/.changeset/skip-npx-temp-update-check.md
+++ b/.changeset/skip-npx-temp-update-check.md
@@ -2,4 +2,4 @@
 '@sanity/cli': patch
 ---
 
-Skip update check for throwaway package runner downloads (npx, pnpm dlx, yarn dlx, bunx)
+Show a runner-specific update command in the update notification when the CLI is invoked via npx, pnpm dlx, yarn dlx, or bunx

--- a/.changeset/skip-npx-temp-update-check.md
+++ b/.changeset/skip-npx-temp-update-check.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+Skip update check for temporary npx downloads

--- a/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
+++ b/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
@@ -131,7 +131,7 @@ describe('#checkForUpdates', () => {
 
   test.each([
     ['npx', '/home/user/.npm/_npx/abc123/node_modules/.bin/sanity'],
-    ['pnpm dlx', '/home/user/.local/share/pnpm/dlx-abc123/node_modules/.bin/sanity'],
+    ['pnpm dlx', '/home/user/.cache/pnpm/dlx/abc123/node_modules/.bin/sanity'],
     ['yarn dlx', '/tmp/xfs-abc123/dlx-12345/node_modules/.bin/sanity'],
     ['bunx', '/tmp/bunx-1000-sanity@latest/node_modules/.bin/sanity'],
   ])('returns early if running from %s temporary cache', async (_runner, argv1) => {

--- a/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
+++ b/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
@@ -129,22 +129,27 @@ describe('#checkForUpdates', () => {
     expect(mockResolveUpdateTarget).not.toHaveBeenCalled()
   })
 
-  test('returns early if running from temporary npx cache', async () => {
+  test.each([
+    ['npx', '/home/user/.npm/_npx/abc123/node_modules/.bin/sanity'],
+    ['pnpm dlx', '/home/user/.local/share/pnpm/dlx-abc123/node_modules/.bin/sanity'],
+    ['yarn dlx', '/tmp/xfs-abc123/dlx-12345/node_modules/.bin/sanity'],
+    ['bunx', '/tmp/bunx-1000-sanity@latest/node_modules/.bin/sanity'],
+  ])('returns early if running from %s temporary cache', async (_runner, argv1) => {
     const {config} = await getCommandAndConfig('help')
-    process.argv[1] = '/home/user/.npm/_npx/abc123/node_modules/.bin/sanity'
+    process.argv[1] = argv1
 
     await testHook<'init'>(checkForUpdates, {
       config,
     })
 
     expect(mockDebug).toHaveBeenCalledWith(
-      'Running from temporary npx download, skipping update check',
+      'Running from a temporary package runner download, skipping update check',
     )
     expect(mockSpawn).not.toHaveBeenCalled()
     expect(mockResolveUpdateTarget).not.toHaveBeenCalled()
   })
 
-  test('does NOT skip npx when resolving to local install', async () => {
+  test('does NOT skip when resolving to a local install', async () => {
     const {config} = await getCommandAndConfig('help')
     process.argv[1] = '/home/user/project/node_modules/.bin/sanity'
 
@@ -152,9 +157,8 @@ describe('#checkForUpdates', () => {
       config,
     })
 
-    // Should not have been skipped - resolveUpdateTarget should be called
     expect(mockDebug).not.toHaveBeenCalledWith(
-      'Running from temporary npx download, skipping update check',
+      'Running from a temporary package runner download, skipping update check',
     )
     expect(mockResolveUpdateTarget).toHaveBeenCalled()
   })

--- a/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
+++ b/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
@@ -10,6 +10,7 @@ const mockSpawn = vi.hoisted(() => vi.fn())
 const mockIsInstalledGlobally = vi.hoisted(() => ({default: false}))
 const mockIsInstalledUsingYarn = vi.hoisted(() => vi.fn())
 const mockResolveUpdateTarget = vi.hoisted(() => vi.fn())
+const mockResolveRunnerPackage = vi.hoisted(() => vi.fn())
 
 const mockConfigStore = vi.hoisted(() => {
   const store = new Map<string, unknown>()
@@ -48,6 +49,10 @@ vi.mock('../../../util/update/resolveUpdateTarget.js', () => ({
   resolveUpdateTarget: mockResolveUpdateTarget,
 }))
 
+vi.mock('../../../util/update/resolveRunnerPackage.js', () => ({
+  resolveRunnerPackage: mockResolveRunnerPackage,
+}))
+
 const mockIsCi = vi.mocked(isCi)
 const originalIsTTY = process.stdout.isTTY
 const originalArgv1 = process.argv[1]
@@ -75,6 +80,7 @@ describe('#checkForUpdates', () => {
     mockIsInstalledUsingYarn.mockReturnValue(false)
     mockSpawn.mockReturnValue({unref: vi.fn()})
     mockResolveUpdateTarget.mockResolvedValue({installedVersion: '3.60.0', packageName: 'sanity'})
+    mockResolveRunnerPackage.mockResolvedValue('@sanity/cli')
     process.stdout.isTTY = true
     process.argv[1] = originalArgv1
 
@@ -130,26 +136,43 @@ describe('#checkForUpdates', () => {
   })
 
   test.each([
-    ['npx', '/home/user/.npm/_npx/abc123/node_modules/.bin/sanity'],
-    ['pnpm dlx', '/home/user/.cache/pnpm/dlx/abc123/node_modules/.bin/sanity'],
-    ['yarn dlx', '/tmp/xfs-abc123/dlx-12345/node_modules/.bin/sanity'],
-    ['bunx', '/tmp/bunx-1000-sanity@latest/node_modules/.bin/sanity'],
-  ])('returns early if running from %s temporary cache', async (_runner, argv1) => {
-    const {config} = await getCommandAndConfig('help')
-    process.argv[1] = argv1
+    ['npx', '/home/user/.npm/_npx/abc/node_modules/.bin/sanity', 'npx --yes @sanity/cli@latest'],
+    [
+      'pnpm dlx',
+      '/home/user/.cache/pnpm/dlx/abc/node_modules/.bin/sanity',
+      'pnpm dlx @sanity/cli@latest',
+    ],
+    [
+      'yarn dlx',
+      '/tmp/xfs-abc/dlx-123/node_modules/.bin/sanity',
+      'yarn dlx -p @sanity/cli@latest sanity',
+    ],
+    ['bunx', '/tmp/bunx-1000-sanity@latest/node_modules/.bin/sanity', 'bunx @sanity/cli@latest'],
+  ])(
+    'shows runner-specific refresh hint when running from %s with an outdated cache',
+    async (_runner, argv1, expectedCommand) => {
+      const {config} = await getCommandAndConfig('help')
+      process.argv[1] = argv1
 
-    await testHook<'init'>(checkForUpdates, {
-      config,
-    })
+      // Cache is keyed by @sanity/cli when running under a runner — cwd-based
+      // resolution is bypassed.
+      setCachedLatestVersion({
+        key: 'latestVersion:@sanity/cli',
+        latestVersion: '999.0.0',
+      })
 
-    expect(mockDebug).toHaveBeenCalledWith(
-      'Running from a temporary package runner download, skipping update check',
-    )
-    expect(mockSpawn).not.toHaveBeenCalled()
-    expect(mockResolveUpdateTarget).not.toHaveBeenCalled()
-  })
+      const {stderr} = await testHook<'init'>(checkForUpdates, {
+        config,
+      })
 
-  test('does NOT skip when resolving to a local install', async () => {
+      expect(mockResolveUpdateTarget).not.toHaveBeenCalled()
+      expect(stderr).toContain('Update available')
+      expect(stderr).toContain('999.0.0')
+      expect(stderr).toContain(expectedCommand)
+    },
+  )
+
+  test('uses cwd-based resolution when not running from a temporary runner', async () => {
     const {config} = await getCommandAndConfig('help')
     process.argv[1] = '/home/user/project/node_modules/.bin/sanity'
 
@@ -157,9 +180,6 @@ describe('#checkForUpdates', () => {
       config,
     })
 
-    expect(mockDebug).not.toHaveBeenCalledWith(
-      'Running from a temporary package runner download, skipping update check',
-    )
     expect(mockResolveUpdateTarget).toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
+++ b/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
@@ -50,6 +50,7 @@ vi.mock('../../../util/update/resolveUpdateTarget.js', () => ({
 
 const mockIsCi = vi.mocked(isCi)
 const originalIsTTY = process.stdout.isTTY
+const originalArgv1 = process.argv[1]
 
 function setCachedLatestVersion(options: {
   key?: string
@@ -75,6 +76,7 @@ describe('#checkForUpdates', () => {
     mockSpawn.mockReturnValue({unref: vi.fn()})
     mockResolveUpdateTarget.mockResolvedValue({installedVersion: '3.60.0', packageName: 'sanity'})
     process.stdout.isTTY = true
+    process.argv[1] = originalArgv1
 
     mockConfigStore.clear()
   })
@@ -82,6 +84,7 @@ describe('#checkForUpdates', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     process.stdout.isTTY = originalIsTTY
+    process.argv[1] = originalArgv1
   })
 
   test('returns early if running on CI', async () => {
@@ -124,6 +127,36 @@ describe('#checkForUpdates', () => {
 
     expect(mockSpawn).not.toHaveBeenCalled()
     expect(mockResolveUpdateTarget).not.toHaveBeenCalled()
+  })
+
+  test('returns early if running from temporary npx cache', async () => {
+    const {config} = await getCommandAndConfig('help')
+    process.argv[1] = '/home/user/.npm/_npx/abc123/node_modules/.bin/sanity'
+
+    await testHook<'init'>(checkForUpdates, {
+      config,
+    })
+
+    expect(mockDebug).toHaveBeenCalledWith(
+      'Running from temporary npx download, skipping update check',
+    )
+    expect(mockSpawn).not.toHaveBeenCalled()
+    expect(mockResolveUpdateTarget).not.toHaveBeenCalled()
+  })
+
+  test('does NOT skip npx when resolving to local install', async () => {
+    const {config} = await getCommandAndConfig('help')
+    process.argv[1] = '/home/user/project/node_modules/.bin/sanity'
+
+    await testHook<'init'>(checkForUpdates, {
+      config,
+    })
+
+    // Should not have been skipped - resolveUpdateTarget should be called
+    expect(mockDebug).not.toHaveBeenCalledWith(
+      'Running from temporary npx download, skipping update check',
+    )
+    expect(mockResolveUpdateTarget).toHaveBeenCalled()
   })
 
   test('spawns worker when no cached version exists', async () => {

--- a/packages/@sanity/cli/src/util/update/__tests__/getRunnerUpdateCommand.test.ts
+++ b/packages/@sanity/cli/src/util/update/__tests__/getRunnerUpdateCommand.test.ts
@@ -1,0 +1,25 @@
+import {describe, expect, test} from 'vitest'
+
+import {getRunnerUpdateCommand} from '../getRunnerUpdateCommand.js'
+
+describe('getRunnerUpdateCommand', () => {
+  test('builds npx update command', () => {
+    expect(getRunnerUpdateCommand('npx', 'sanity')).toBe('npx --yes sanity@latest')
+    expect(getRunnerUpdateCommand('npx', '@sanity/cli')).toBe('npx --yes @sanity/cli@latest')
+  })
+
+  test('builds pnpm dlx update command', () => {
+    expect(getRunnerUpdateCommand('pnpm-dlx', 'sanity')).toBe('pnpm dlx sanity@latest')
+  })
+
+  test('builds yarn dlx update command with -p and bin name', () => {
+    expect(getRunnerUpdateCommand('yarn-dlx', 'sanity')).toBe('yarn dlx -p sanity@latest sanity')
+    expect(getRunnerUpdateCommand('yarn-dlx', '@sanity/cli')).toBe(
+      'yarn dlx -p @sanity/cli@latest sanity',
+    )
+  })
+
+  test('builds bunx update command', () => {
+    expect(getRunnerUpdateCommand('bunx', 'sanity')).toBe('bunx sanity@latest')
+  })
+})

--- a/packages/@sanity/cli/src/util/update/__tests__/isTemporaryPackageRunner.test.ts
+++ b/packages/@sanity/cli/src/util/update/__tests__/isTemporaryPackageRunner.test.ts
@@ -9,9 +9,17 @@ describe('isTemporaryPackageRunner', () => {
     )
   })
 
-  test('returns true for pnpm dlx paths', () => {
+  test('returns true for pnpm dlx paths (linux cache layout)', () => {
     expect(
-      isTemporaryPackageRunner('/home/user/.local/share/pnpm/dlx-abc123/node_modules/.bin/sanity'),
+      isTemporaryPackageRunner('/home/user/.cache/pnpm/dlx/abc123/node_modules/.bin/sanity'),
+    ).toBe(true)
+  })
+
+  test('returns true for pnpm dlx paths (macOS cache layout)', () => {
+    expect(
+      isTemporaryPackageRunner(
+        '/Users/me/Library/Caches/pnpm/dlx/102cf35740a0642619d8b0b51b83c812f10a8ac02cfe2b4e9d4807dc772486bd/node_modules/.bin/sanity',
+      ),
     ).toBe(true)
   })
 

--- a/packages/@sanity/cli/src/util/update/__tests__/isTemporaryPackageRunner.test.ts
+++ b/packages/@sanity/cli/src/util/update/__tests__/isTemporaryPackageRunner.test.ts
@@ -1,67 +1,52 @@
 import {describe, expect, test} from 'vitest'
 
-import {isTemporaryPackageRunner} from '../isTemporaryPackageRunner.js'
+import {
+  detectTemporaryPackageRunner,
+  isTemporaryPackageRunner,
+} from '../isTemporaryPackageRunner.js'
 
-describe('isTemporaryPackageRunner', () => {
-  test('returns true for npx temporary cache paths', () => {
-    expect(isTemporaryPackageRunner('/home/user/.npm/_npx/abc123/node_modules/.bin/sanity')).toBe(
-      true,
-    )
+describe('detectTemporaryPackageRunner', () => {
+  test.each([
+    ['npx', '/home/user/.npm/_npx/abc123/node_modules/.bin/sanity', 'npx'],
+    ['pnpm dlx (linux)', '/home/user/.cache/pnpm/dlx/abc123/node_modules/.bin/sanity', 'pnpm-dlx'],
+    [
+      'pnpm dlx (macOS)',
+      '/Users/me/Library/Caches/pnpm/dlx/102cf35740a0642619d8b0b51b83c812f10a8ac02cfe2b4e9d4807dc772486bd/node_modules/.bin/sanity',
+      'pnpm-dlx',
+    ],
+    ['yarn dlx', '/tmp/xfs-abc123/dlx-12345/node_modules/.bin/sanity', 'yarn-dlx'],
+    ['bunx', '/tmp/bunx-1000-sanity@latest/node_modules/.bin/sanity', 'bunx'],
+    [
+      'Windows npx',
+      'C:\\Users\\me\\AppData\\Local\\npm-cache\\_npx\\abc123\\node_modules\\.bin\\sanity.cmd',
+      'npx',
+    ],
+  ])('identifies %s', (_label, path, expected) => {
+    expect(detectTemporaryPackageRunner(path)).toBe(expected)
   })
 
-  test('returns true for pnpm dlx paths (linux cache layout)', () => {
-    expect(
-      isTemporaryPackageRunner('/home/user/.cache/pnpm/dlx/abc123/node_modules/.bin/sanity'),
-    ).toBe(true)
-  })
-
-  test('returns true for pnpm dlx paths (macOS cache layout)', () => {
-    expect(
-      isTemporaryPackageRunner(
-        '/Users/me/Library/Caches/pnpm/dlx/102cf35740a0642619d8b0b51b83c812f10a8ac02cfe2b4e9d4807dc772486bd/node_modules/.bin/sanity',
-      ),
-    ).toBe(true)
-  })
-
-  test('returns true for yarn dlx paths', () => {
-    expect(isTemporaryPackageRunner('/tmp/xfs-abc123/dlx-12345/node_modules/.bin/sanity')).toBe(
-      true,
-    )
-  })
-
-  test('returns true for bunx paths', () => {
-    expect(isTemporaryPackageRunner('/tmp/bunx-1000-sanity@latest/node_modules/.bin/sanity')).toBe(
-      true,
-    )
-  })
-
-  test('returns true for Windows npx cache paths', () => {
-    expect(
-      isTemporaryPackageRunner(
-        'C:\\Users\\me\\AppData\\Local\\npm-cache\\_npx\\abc123\\node_modules\\.bin\\sanity.cmd',
-      ),
-    ).toBe(true)
-  })
-
-  test('returns false for local node_modules/.bin paths', () => {
-    expect(isTemporaryPackageRunner('/home/user/project/node_modules/.bin/sanity')).toBe(false)
-  })
-
-  test('returns false for global npm install paths', () => {
-    expect(isTemporaryPackageRunner('/usr/local/lib/node_modules/sanity/bin/sanity')).toBe(false)
-  })
-
-  test('returns false for an empty path', () => {
-    expect(isTemporaryPackageRunner('')).toBe(false)
+  test.each([
+    ['local node_modules/.bin', '/home/user/project/node_modules/.bin/sanity'],
+    ['global install', '/usr/local/lib/node_modules/sanity/bin/sanity'],
+    ['empty path', ''],
+  ])('returns null for %s', (_label, path) => {
+    expect(detectTemporaryPackageRunner(path)).toBeNull()
   })
 
   test('defaults to process.argv[1] when no argument is provided', () => {
     const original = process.argv[1]
     process.argv[1] = '/home/user/.npm/_npx/abc123/node_modules/.bin/sanity'
     try {
-      expect(isTemporaryPackageRunner()).toBe(true)
+      expect(detectTemporaryPackageRunner()).toBe('npx')
     } finally {
       process.argv[1] = original
     }
+  })
+})
+
+describe('isTemporaryPackageRunner', () => {
+  test('is the boolean form of detectTemporaryPackageRunner', () => {
+    expect(isTemporaryPackageRunner('/home/user/.npm/_npx/abc/node_modules/.bin/sanity')).toBe(true)
+    expect(isTemporaryPackageRunner('/home/user/project/node_modules/.bin/sanity')).toBe(false)
   })
 })

--- a/packages/@sanity/cli/src/util/update/__tests__/isTemporaryPackageRunner.test.ts
+++ b/packages/@sanity/cli/src/util/update/__tests__/isTemporaryPackageRunner.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, test} from 'vitest'
+
+import {isTemporaryPackageRunner} from '../isTemporaryPackageRunner.js'
+
+describe('isTemporaryPackageRunner', () => {
+  test('returns true for npx temporary cache paths', () => {
+    expect(isTemporaryPackageRunner('/home/user/.npm/_npx/abc123/node_modules/.bin/sanity')).toBe(
+      true,
+    )
+  })
+
+  test('returns true for pnpm dlx paths', () => {
+    expect(
+      isTemporaryPackageRunner('/home/user/.local/share/pnpm/dlx-abc123/node_modules/.bin/sanity'),
+    ).toBe(true)
+  })
+
+  test('returns true for yarn dlx paths', () => {
+    expect(isTemporaryPackageRunner('/tmp/xfs-abc123/dlx-12345/node_modules/.bin/sanity')).toBe(
+      true,
+    )
+  })
+
+  test('returns true for bunx paths', () => {
+    expect(isTemporaryPackageRunner('/tmp/bunx-1000-sanity@latest/node_modules/.bin/sanity')).toBe(
+      true,
+    )
+  })
+
+  test('returns true for Windows npx cache paths', () => {
+    expect(
+      isTemporaryPackageRunner(
+        'C:\\Users\\me\\AppData\\Local\\npm-cache\\_npx\\abc123\\node_modules\\.bin\\sanity.cmd',
+      ),
+    ).toBe(true)
+  })
+
+  test('returns false for local node_modules/.bin paths', () => {
+    expect(isTemporaryPackageRunner('/home/user/project/node_modules/.bin/sanity')).toBe(false)
+  })
+
+  test('returns false for global npm install paths', () => {
+    expect(isTemporaryPackageRunner('/usr/local/lib/node_modules/sanity/bin/sanity')).toBe(false)
+  })
+
+  test('returns false for an empty path', () => {
+    expect(isTemporaryPackageRunner('')).toBe(false)
+  })
+
+  test('defaults to process.argv[1] when no argument is provided', () => {
+    const original = process.argv[1]
+    process.argv[1] = '/home/user/.npm/_npx/abc123/node_modules/.bin/sanity'
+    try {
+      expect(isTemporaryPackageRunner()).toBe(true)
+    } finally {
+      process.argv[1] = original
+    }
+  })
+})

--- a/packages/@sanity/cli/src/util/update/__tests__/resolveRunnerPackage.test.ts
+++ b/packages/@sanity/cli/src/util/update/__tests__/resolveRunnerPackage.test.ts
@@ -1,0 +1,55 @@
+import {mkdir, mkdtemp, symlink, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {afterEach, beforeEach, describe, expect, test} from 'vitest'
+
+import {resolveRunnerPackage} from '../resolveRunnerPackage.js'
+
+describe('resolveRunnerPackage', () => {
+  let tempRoot: string
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), 'sanity-runner-pkg-test-'))
+  })
+
+  afterEach(async () => {
+    // mkdtemp dirs auto-cleanup isn't guaranteed, but leaving them under
+    // $TMPDIR is harmless for a unit test.
+  })
+
+  async function buildFakeRunnerLayout(pkgName: string): Promise<string> {
+    // Mirror the real layout: <runnerRoot>/node_modules/<pkg>/bin/sanity
+    //                         <runnerRoot>/node_modules/.bin/sanity -> ../<pkg>/bin/sanity
+    const runnerRoot = tempRoot
+    const pkgDir = join(runnerRoot, 'node_modules', pkgName)
+    const binDir = join(runnerRoot, 'node_modules', '.bin')
+    await mkdir(join(pkgDir, 'bin'), {recursive: true})
+    await mkdir(binDir, {recursive: true})
+    await writeFile(join(pkgDir, 'bin', 'sanity'), '#!/usr/bin/env node\n')
+    await writeFile(join(pkgDir, 'package.json'), JSON.stringify({name: pkgName, version: '1.0.0'}))
+    const binLink = join(binDir, 'sanity')
+    await symlink(join(pkgDir, 'bin', 'sanity'), binLink)
+    return binLink
+  }
+
+  test('resolves to `sanity` when invoked from a sanity install', async () => {
+    const binLink = await buildFakeRunnerLayout('sanity')
+    expect(await resolveRunnerPackage(binLink)).toBe('sanity')
+  })
+
+  test('resolves to `@sanity/cli` when invoked from a @sanity/cli install', async () => {
+    const binLink = await buildFakeRunnerLayout('@sanity/cli')
+    expect(await resolveRunnerPackage(binLink)).toBe('@sanity/cli')
+  })
+
+  test('falls back to `@sanity/cli` when the path does not exist', async () => {
+    expect(await resolveRunnerPackage('/does/not/exist/node_modules/.bin/sanity')).toBe(
+      '@sanity/cli',
+    )
+  })
+
+  test('falls back to `@sanity/cli` for an empty path', async () => {
+    expect(await resolveRunnerPackage('')).toBe('@sanity/cli')
+  })
+})

--- a/packages/@sanity/cli/src/util/update/getRunnerUpdateCommand.ts
+++ b/packages/@sanity/cli/src/util/update/getRunnerUpdateCommand.ts
@@ -1,0 +1,27 @@
+import {type SanityPackage} from '../packageManager/installationInfo/types.js'
+import {type TemporaryPackageRunner} from './isTemporaryPackageRunner.js'
+
+export function getRunnerUpdateCommand(
+  runner: TemporaryPackageRunner,
+  packageName: SanityPackage,
+): string {
+  switch (runner) {
+    case 'bunx': {
+      return `bunx ${packageName}@latest`
+    }
+    case 'npx': {
+      return `npx --yes ${packageName}@latest`
+    }
+    case 'pnpm-dlx': {
+      return `pnpm dlx ${packageName}@latest`
+    }
+    case 'yarn-dlx': {
+      // yarn dlx needs `-p` when the package name differs from the bin name
+      return `yarn dlx -p ${packageName}@latest sanity`
+    }
+    default: {
+      const _exhaustive: never = runner
+      throw new Error(`Unknown runner: ${_exhaustive as string}`)
+    }
+  }
+}

--- a/packages/@sanity/cli/src/util/update/isTemporaryPackageRunner.ts
+++ b/packages/@sanity/cli/src/util/update/isTemporaryPackageRunner.ts
@@ -1,0 +1,20 @@
+/**
+ * Returns true when the given binary path looks like it was invoked from a
+ * package runner's temporary download cache (npx, pnpm dlx, yarn dlx, bunx).
+ *
+ * These are throwaway installs where prompting the user to update is pointless:
+ * the download is discarded right after the command completes, so the "update"
+ * would be re-downloaded on the next invocation anyway.
+ *
+ * This does NOT match `npx sanity` / `pnpm exec sanity` when they resolve to a
+ * locally installed binary, because those paths sit inside the project's
+ * `node_modules/.bin/`.
+ */
+export function isTemporaryPackageRunner(binaryPath: string = process.argv[1] ?? ''): boolean {
+  // Normalize Windows separators so a single set of patterns covers both platforms.
+  const normalized = binaryPath.replaceAll('\\', '/')
+
+  return (
+    normalized.includes('/_npx/') || normalized.includes('/dlx-') || normalized.includes('/bunx-')
+  )
+}

--- a/packages/@sanity/cli/src/util/update/isTemporaryPackageRunner.ts
+++ b/packages/@sanity/cli/src/util/update/isTemporaryPackageRunner.ts
@@ -15,6 +15,13 @@ export function isTemporaryPackageRunner(binaryPath: string = process.argv[1] ??
   const normalized = binaryPath.replaceAll('\\', '/')
 
   return (
-    normalized.includes('/_npx/') || normalized.includes('/dlx-') || normalized.includes('/bunx-')
+    // npm: `~/.npm/_npx/<hash>/...`
+    normalized.includes('/_npx/') ||
+    // pnpm: `~/Library/Caches/pnpm/dlx/<hash>/...` (or `~/.cache/pnpm/dlx/<hash>/...`)
+    normalized.includes('/pnpm/dlx/') ||
+    // yarn berry: `$TMPDIR/xfs-<hash>/dlx-<pid>/...`
+    normalized.includes('/dlx-') ||
+    // bun: `$TMPDIR/bunx-<uid>-<pkg>/...`
+    normalized.includes('/bunx-')
   )
 }

--- a/packages/@sanity/cli/src/util/update/isTemporaryPackageRunner.ts
+++ b/packages/@sanity/cli/src/util/update/isTemporaryPackageRunner.ts
@@ -1,27 +1,18 @@
-/**
- * Returns true when the given binary path looks like it was invoked from a
- * package runner's temporary download cache (npx, pnpm dlx, yarn dlx, bunx).
- *
- * These are throwaway installs where prompting the user to update is pointless:
- * the download is discarded right after the command completes, so the "update"
- * would be re-downloaded on the next invocation anyway.
- *
- * This does NOT match `npx sanity` / `pnpm exec sanity` when they resolve to a
- * locally installed binary, because those paths sit inside the project's
- * `node_modules/.bin/`.
- */
-export function isTemporaryPackageRunner(binaryPath: string = process.argv[1] ?? ''): boolean {
-  // Normalize Windows separators so a single set of patterns covers both platforms.
+export type TemporaryPackageRunner = 'bunx' | 'npx' | 'pnpm-dlx' | 'yarn-dlx'
+
+export function detectTemporaryPackageRunner(
+  binaryPath: string = process.argv[1] ?? '',
+): TemporaryPackageRunner | null {
   const normalized = binaryPath.replaceAll('\\', '/')
 
-  return (
-    // npm: `~/.npm/_npx/<hash>/...`
-    normalized.includes('/_npx/') ||
-    // pnpm: `~/Library/Caches/pnpm/dlx/<hash>/...` (or `~/.cache/pnpm/dlx/<hash>/...`)
-    normalized.includes('/pnpm/dlx/') ||
-    // yarn berry: `$TMPDIR/xfs-<hash>/dlx-<pid>/...`
-    normalized.includes('/dlx-') ||
-    // bun: `$TMPDIR/bunx-<uid>-<pkg>/...`
-    normalized.includes('/bunx-')
-  )
+  if (normalized.includes('/_npx/')) return 'npx'
+  if (normalized.includes('/pnpm/dlx/')) return 'pnpm-dlx'
+  if (normalized.includes('/dlx-')) return 'yarn-dlx'
+  if (normalized.includes('/bunx-')) return 'bunx'
+
+  return null
+}
+
+export function isTemporaryPackageRunner(binaryPath: string = process.argv[1] ?? ''): boolean {
+  return detectTemporaryPackageRunner(binaryPath) !== null
 }

--- a/packages/@sanity/cli/src/util/update/resolveRunnerPackage.ts
+++ b/packages/@sanity/cli/src/util/update/resolveRunnerPackage.ts
@@ -1,0 +1,34 @@
+import {realpathSync} from 'node:fs'
+import {readFile} from 'node:fs/promises'
+import {dirname, resolve} from 'node:path'
+
+import {type SanityPackage} from '../packageManager/installationInfo/types.js'
+
+const KNOWN_PACKAGES = new Set<SanityPackage>(['@sanity/cli', 'sanity'])
+
+export async function resolveRunnerPackage(
+  binaryPath: string = process.argv[1] ?? '',
+): Promise<SanityPackage> {
+  try {
+    let dir = dirname(realpathSync(binaryPath))
+    while (dir !== resolve(dir, '..')) {
+      try {
+        const pkg = JSON.parse(await readFile(resolve(dir, 'package.json'), 'utf8'))
+        if (typeof pkg.name === 'string' && isKnownSanityPackage(pkg.name)) {
+          return pkg.name
+        }
+      } catch {
+        // keep walking
+      }
+      dir = dirname(dir)
+    }
+  } catch {
+    // fall through
+  }
+
+  return '@sanity/cli'
+}
+
+function isKnownSanityPackage(name: string): name is SanityPackage {
+  return KNOWN_PACKAGES.has(name as SanityPackage)
+}

--- a/packages/@sanity/cli/src/util/update/showNotificationUpdate.ts
+++ b/packages/@sanity/cli/src/util/update/showNotificationUpdate.ts
@@ -6,8 +6,10 @@ import isInstalledGlobally from 'is-installed-globally'
 
 import {type SanityPackage} from '../packageManager/installationInfo/types.js'
 import {getPackageManagerChoice} from '../packageManager/packageManagerChoice.js'
+import {getRunnerUpdateCommand} from './getRunnerUpdateCommand.js'
 import {getUpdateCommand} from './getUpdateCommand.js'
 import {isInstalledUsingYarn} from './isInstalledUsingYarn.js'
+import {type TemporaryPackageRunner} from './isTemporaryPackageRunner.js'
 
 /**
  * Show a boxed notification about the available update
@@ -16,11 +18,13 @@ export async function showUpdateNotification(
   currentVersion: string,
   latestVersion: string,
   packageName: SanityPackage,
+  runner: TemporaryPackageRunner | null = null,
 ): Promise<void> {
   let command
 
-  // Check if CLI is installed globally
-  if (isInstalledGlobally) {
+  if (runner) {
+    command = getRunnerUpdateCommand(runner, packageName)
+  } else if (isInstalledGlobally) {
     command = isInstalledUsingYarn()
       ? `yarn global add ${packageName}`
       : `npm install -g ${packageName}`

--- a/packages/@sanity/cli/src/util/update/updateChecker.ts
+++ b/packages/@sanity/cli/src/util/update/updateChecker.ts
@@ -4,7 +4,8 @@ import {fileURLToPath} from 'node:url'
 import {getUserConfig, isCi, subdebug} from '@sanity/cli-core'
 import {gt as semverGt} from 'semver'
 
-import {isTemporaryPackageRunner} from './isTemporaryPackageRunner.js'
+import {detectTemporaryPackageRunner} from './isTemporaryPackageRunner.js'
+import {resolveRunnerPackage} from './resolveRunnerPackage.js'
 import {resolveUpdateTarget} from './resolveUpdateTarget.js'
 import {showUpdateNotification} from './showNotificationUpdate.js'
 
@@ -34,18 +35,11 @@ export async function updateChecker(config: {version: string}): Promise<void> {
     return
   }
 
-  // Skip for throwaway installs created by package runners (npx, pnpm dlx,
-  // yarn dlx, bunx). The download is discarded right after, so update prompts
-  // are pointless. Local `node_modules/.bin/` resolutions are not matched.
-  if (isTemporaryPackageRunner()) {
-    debug('Running from a temporary package runner download, skipping update check')
-    return
-  }
-
-  // Resolve which package to check and what's installed locally.
-  // This walks up from cwd reading package.json files - fast, no network.
-  const {installedVersion, packageName} = await resolveUpdateTarget(process.cwd(), config.version)
-  debug('Update target: %s@%s', packageName, installedVersion)
+  const runner = detectTemporaryPackageRunner()
+  const {installedVersion, packageName} = runner
+    ? {installedVersion: config.version, packageName: await resolveRunnerPackage()}
+    : await resolveUpdateTarget(process.cwd(), config.version)
+  debug('Update target: %s@%s%s', packageName, installedVersion, runner ? ` via ${runner}` : '')
 
   const store = getUserConfig()
   const cacheKey = `latestVersion:${packageName}`
@@ -64,7 +58,7 @@ export async function updateChecker(config: {version: string}): Promise<void> {
 
     if (semverGt(latestVersion, installedVersion)) {
       debug('Update is available (%s)', latestVersion)
-      await showUpdateNotification(installedVersion, latestVersion, packageName)
+      await showUpdateNotification(installedVersion, latestVersion, packageName, runner)
     } else {
       debug('No update found')
     }

--- a/packages/@sanity/cli/src/util/update/updateChecker.ts
+++ b/packages/@sanity/cli/src/util/update/updateChecker.ts
@@ -4,6 +4,7 @@ import {fileURLToPath} from 'node:url'
 import {getUserConfig, isCi, subdebug} from '@sanity/cli-core'
 import {gt as semverGt} from 'semver'
 
+import {isTemporaryPackageRunner} from './isTemporaryPackageRunner.js'
 import {resolveUpdateTarget} from './resolveUpdateTarget.js'
 import {showUpdateNotification} from './showNotificationUpdate.js'
 
@@ -33,11 +34,11 @@ export async function updateChecker(config: {version: string}): Promise<void> {
     return
   }
 
-  // Skip for temporary npx downloads (npx @sanity/cli when not locally installed).
-  // This does NOT skip `npx sanity` resolving to a local install (path is in node_modules/.bin/).
-  const binaryPath = process.argv[1] ?? ''
-  if (binaryPath.includes('/_npx/') || binaryPath.includes('\\_npx\\')) {
-    debug('Running from temporary npx download, skipping update check')
+  // Skip for throwaway installs created by package runners (npx, pnpm dlx,
+  // yarn dlx, bunx). The download is discarded right after, so update prompts
+  // are pointless. Local `node_modules/.bin/` resolutions are not matched.
+  if (isTemporaryPackageRunner()) {
+    debug('Running from a temporary package runner download, skipping update check')
     return
   }
 

--- a/packages/@sanity/cli/src/util/update/updateChecker.ts
+++ b/packages/@sanity/cli/src/util/update/updateChecker.ts
@@ -33,6 +33,14 @@ export async function updateChecker(config: {version: string}): Promise<void> {
     return
   }
 
+  // Skip for temporary npx downloads (npx @sanity/cli when not locally installed).
+  // This does NOT skip `npx sanity` resolving to a local install (path is in node_modules/.bin/).
+  const binaryPath = process.argv[1] ?? ''
+  if (binaryPath.includes('/_npx/') || binaryPath.includes('\\_npx\\')) {
+    debug('Running from temporary npx download, skipping update check')
+    return
+  }
+
   // Resolve which package to check and what's installed locally.
   // This walks up from cwd reading package.json files - fast, no network.
   const {installedVersion, packageName} = await resolveUpdateTarget(process.cwd(), config.version)


### PR DESCRIPTION
### Description

Skips the update check when the CLI is running from a temporary npx cache (`/_npx/` in the binary path). These are throwaway downloads that will be discarded immediately, so checking for updates is pointless.

Does **not** skip when `npx sanity` resolves to a locally installed binary (path is in `node_modules/.bin/`).

### What to review

- `updateChecker.ts` — 4-line early return checking `process.argv[1]` for `/_npx/` or `\_npx\`
- `checkForUpdates.test.ts` — 2 new tests: one for temporary npx path (skipped), one for local install path (not skipped)

### Testing

- 2 new test cases covering both the skip and non-skip paths
- All existing tests continue to pass