### PR TITLE
feat(dataset copy): add --skip-content-releases option

### DIFF
--- a/.changeset/pr-954.md
+++ b/.changeset/pr-954.md
@@ -1,6 +1,5 @@
-<!-- auto-generated -->
 ---
 '@sanity/cli': minor
 ---
 
-add --skip-content-releases option
+Add `--skip-content-releases` flag to `sanity datasets copy` for excluding content release documents from the target dataset.

--- a/.changeset/pr-954.md
+++ b/.changeset/pr-954.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+Add `--skip-content-releases` flag to `sanity datasets copy` for excluding content release documents from the target dataset.
+

--- a/.changeset/pr-954.md
+++ b/.changeset/pr-954.md
@@ -3,5 +3,4 @@
 '@sanity/cli': minor
 ---
 
-Add `--skip-content-releases` flag to `sanity datasets copy` for excluding content release documents from the target dataset.
-
+add --skip-content-releases option

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -407,17 +407,63 @@ describe('#dataset:copy', () => {
         createMockDataset('production'),
         createMockDataset('staging'),
       ])
+      let capturedBody: Record<string, unknown> | undefined
       mockApi({
         apiVersion: DATASET_API_VERSION,
         method: 'put',
         projectId: testProjectId,
         uri: `/datasets/production/copy`,
-      }).reply(200, {jobId: 'job-skip'})
+      }).reply(200, (_uri, body) => {
+        capturedBody = body as Record<string, unknown>
+        return {jobId: 'job-skip'}
+      })
       mockFollowCopyJobProgress.mockReturnValue(of({progress: 100, type: 'progress'}))
 
-      await testCommand(CopyDatasetCommand, ['production', 'backup', '--skip-history'], {
-        mocks: defaultMocks,
+      const {error} = await testCommand(
+        CopyDatasetCommand,
+        ['production', 'backup', '--skip-history'],
+        {mocks: defaultMocks},
+      )
+
+      if (error) throw error
+      expect(capturedBody).toEqual({
+        skipContentReleases: false,
+        skipHistory: true,
+        targetDataset: 'backup',
       })
+    })
+
+    test('copies dataset with skip-content-releases flag', async () => {
+      mockListDatasets.mockResolvedValue([
+        createMockDataset('production'),
+        createMockDataset('staging'),
+      ])
+      let capturedBody: Record<string, unknown> | undefined
+      mockApi({
+        apiVersion: DATASET_API_VERSION,
+        method: 'put',
+        projectId: testProjectId,
+        uri: `/datasets/production/copy`,
+      }).reply(200, (_uri, body) => {
+        capturedBody = body as Record<string, unknown>
+        return {jobId: 'job-no-releases'}
+      })
+      mockFollowCopyJobProgress.mockReturnValue(of({progress: 100, type: 'progress'}))
+
+      const {error, stdout} = await testCommand(
+        CopyDatasetCommand,
+        ['production', 'backup', '--skip-content-releases'],
+        {mocks: defaultMocks},
+      )
+
+      if (error) throw error
+      expect(capturedBody).toEqual({
+        skipContentReleases: true,
+        skipHistory: false,
+        targetDataset: 'backup',
+      })
+      expect(stdout).toContain('Job job-no-releases started')
+      expect(stdout).toContain('Job job-no-releases completed')
     })
 
     test('copies dataset with detach flag (does not wait for completion)', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -57,6 +57,10 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
       description: 'Copy without preserving document history (faster for large datasets)',
     },
     {
+      command: '<%= config.bin %> <%= command.id %> --skip-content-releases source target',
+      description: 'Copy without content release documents',
+    },
+    {
       command: '<%= config.bin %> <%= command.id %> --detach source target',
       description: 'Start copy job without waiting for completion',
     },
@@ -103,6 +107,11 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     offset: Flags.integer({
       dependsOn: ['list'],
       description: 'Start position in the list of jobs (default 0)',
+      required: false,
+    }),
+    'skip-content-releases': Flags.boolean({
+      description: "Don't copy content release documents to the target dataset",
+      exclusive: ['list', 'attach'],
       required: false,
     }),
     'skip-history': Flags.boolean({
@@ -222,11 +231,12 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
   private async handleCopyMode(
     projectId: string,
     args: {source?: string; target?: string},
-    flags: {detach?: boolean; 'skip-history'?: boolean},
+    flags: {'skip-content-releases'?: boolean; 'skip-history'?: boolean; detach?: boolean},
   ): Promise<void> {
     copyDatasetDebug('Starting copy mode')
 
     const skipHistory = Boolean(flags['skip-history'])
+    const skipContentReleases = Boolean(flags['skip-content-releases'])
 
     // Get and validate source dataset
     let sourceDataset = args.source
@@ -290,6 +300,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
 
       const response = await copyDataset({
         projectId,
+        skipContentReleases,
         skipHistory,
         sourceDataset,
         targetDataset,

--- a/packages/@sanity/cli/src/services/datasets.ts
+++ b/packages/@sanity/cli/src/services/datasets.ts
@@ -82,6 +82,7 @@ export async function createDataset({
 
 interface CopyDatasetOptions {
   projectId: string
+  skipContentReleases?: boolean
   skipHistory: boolean
   sourceDataset: string
   targetDataset: string
@@ -93,6 +94,7 @@ interface CopyDatasetResponse {
 
 export async function copyDataset({
   projectId,
+  skipContentReleases,
   skipHistory,
   sourceDataset,
   targetDataset,
@@ -100,6 +102,7 @@ export async function copyDataset({
   const client = await getDatasetClient(projectId)
   return client.request<CopyDatasetResponse>({
     body: {
+      skipContentReleases,
       skipHistory,
       targetDataset,
     },


### PR DESCRIPTION
### Description

Adds support for skipping content release documents when copying a dataset.

### What to review

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
