### PR TITLE
revert: prevent redundant workflow runs on changeset commits

### DIFF
--- a/.github/scripts/generate-changeset.mjs
+++ b/.github/scripts/generate-changeset.mjs
@@ -35,7 +35,7 @@ function removeChangeset() {
   if (existsSync(CHANGESET_FILE)) {
     ensureGitConfigured()
     git('rm', CHANGESET_FILE)
-    git('commit', '-m', `chore: remove auto-generated changeset for PR #${PR_NUMBER} [skip ci]`)
+    git('commit', '-m', `chore: remove auto-generated changeset for PR #${PR_NUMBER}`)
     git('push', '--force-with-lease')
   }
 }
@@ -195,5 +195,5 @@ if (status !== 1) {
   process.exit(status ?? 1)
 }
 
-git('commit', '-m', `chore: update auto-generated changeset for PR #${PR_NUMBER} [skip ci]`)
+git('commit', '-m', `chore: update auto-generated changeset for PR #${PR_NUMBER}`)
 git('push', '--force-with-lease')

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,16 +1,16 @@
 name: Claude Code Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 jobs:
   claude-review:
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'skip-review') &&
-      github.event.pull_request.user.login != 'squiggler[bot]' &&
-      github.event.pull_request.user.login != 'squiggler-app[bot]' &&
-      (github.event.pull_request.user.login != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, '⚠️ major'))
+      github.actor != 'squiggler[bot]' &&
+      github.actor != 'squiggler-app[bot]' &&
+      (github.actor != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, '⚠️ major'))
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
### Description

Reverts #946.

The `[skip ci]` marker added to changeset bot commits prevents GitHub from running _any_ `pull_request`-triggered workflows on the HEAD commit. Because required status checks (Test, Build, Lint, Depcheck) never report, PRs are blocked from merging (e.g. #949).

This revert restores CI runs on changeset bot pushes so required checks pass again. A follow-up PR will implement a better solution using the **gate job pattern** — skipping expensive work at the workflow level while still reporting success for required checks.

### What to review

- Confirm the revert is clean and matches the inverse of #946
- Two files changed: `generate-changeset.mjs` (removes `[skip ci]` from commit messages) and `claude-code-review.yml` (reverts trigger back to `pull_request`)

### Testing

No automated tests — this is a CI configuration change. Verified by checking that PRs created after this change will have all required checks run and report status.