### PR TITLE
feat(cli): expand MCP editor detection and refactor for testability

### DIFF
--- a/.changeset/mcp-editor-detection-refactor.md
+++ b/.changeset/mcp-editor-detection-refactor.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': minor
+---
+
+Added MCP auto-configuration support for Antigravity, Cline CLI, Codex CLI, GitHub Copilot CLI, and MCPorter. Refactored editor detection to use dependency injection for improved testability and cross-platform reliability.

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -52,8 +52,6 @@ const baseConfig = {
         'src/**/*.worker.ts',
         'package.config.ts',
       ],
-      // Claude, Codex, and OpenCode are not dependencies of the CLI, but they are used in MCP configuration
-      ignoreBinaries: ['claude', 'codex', 'opencode'],
       oclif: {
         config: ['oclif.config.js'],
       },

--- a/packages/@sanity/cli/README.md
+++ b/packages/@sanity/cli/README.md
@@ -2467,14 +2467,14 @@ EXAMPLES
 
 ## `sanity mcp configure`
 
-Configure Sanity MCP server for AI editors (Claude Code, Codex CLI, Cursor, Gemini CLI, GitHub Copilot CLI, VS Code)
+Configure Sanity MCP server for AI editors (Antigravity, Claude Code, Cline, Cline CLI, Codex CLI, Cursor, Gemini CLI, GitHub Copilot CLI, MCPorter, OpenCode, VS Code, VS Code Insiders, Zed)
 
 ```
 USAGE
   $ sanity mcp configure
 
 DESCRIPTION
-  Configure Sanity MCP server for AI editors (Claude Code, Codex CLI, Cursor, Gemini CLI, GitHub Copilot CLI, VS Code)
+  Configure Sanity MCP server for AI editors (Antigravity, Claude Code, Cline, Cline CLI, Codex CLI, Cursor, Gemini CLI, GitHub Copilot CLI, MCPorter, OpenCode, VS Code, VS Code Insiders, Zed)
 
 EXAMPLES
   Configure Sanity MCP server for detected AI editors

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
@@ -1,6 +1,44 @@
+import path from 'node:path'
+
 import {describe, expect, test} from 'vitest'
 
-import {EDITOR_CONFIGS} from '../editorConfigs.js'
+import {type DetectionEnv, EDITOR_CONFIGS, getVSCodeUserDir} from '../editorConfigs.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Creates an isolated DetectionEnv with safe defaults (nothing detected). */
+function createMockEnv(overrides?: Partial<DetectionEnv>): DetectionEnv {
+  return {
+    env: {},
+    execCommand: () => Promise.reject(new Error('not installed')),
+    existsSync: () => false,
+    homedir: '/home/testuser',
+    platform: 'darwin',
+    ...overrides,
+  }
+}
+
+/** Normalize a path to forward slashes for cross-platform comparison. */
+function normalize(p: string): string {
+  return p.replaceAll('\\', '/')
+}
+
+/** Assert that a detected path ends with the expected suffix (cross-platform). */
+function expectPath(actual: string | null, expectedSuffix: string): void {
+  expect(actual).not.toBeNull()
+  expect(normalize(actual!)).toContain(expectedSuffix)
+}
+
+/** Returns an existsSync mock that matches any of the given path suffixes (cross-platform). */
+function existsForSuffixes(...suffixes: string[]): (p: string) => boolean {
+  return (p: string) => suffixes.some((s) => normalize(p).endsWith(s))
+}
+
+// ---------------------------------------------------------------------------
+// readToken (existing tests, kept as-is)
+// ---------------------------------------------------------------------------
 
 describe('readToken', () => {
   const validServerConfig = {
@@ -54,10 +92,14 @@ describe('readToken', () => {
 
   test('all editors with headers-based auth extract tokens consistently', () => {
     const headersEditors = [
+      'Antigravity',
       'Claude Code',
+      'Cline',
+      'Cline CLI',
       'Cursor',
       'Gemini CLI',
       'GitHub Copilot CLI',
+      'MCPorter',
       'OpenCode',
       'VS Code',
       'VS Code Insiders',
@@ -73,5 +115,356 @@ describe('readToken', () => {
   test('Codex CLI does NOT extract from headers (uses http_headers)', () => {
     const token = EDITOR_CONFIGS['Codex CLI'].readToken(validServerConfig)
     expect(token).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getVSCodeUserDir
+// ---------------------------------------------------------------------------
+
+describe('getVSCodeUserDir', () => {
+  test('returns macOS path for stable', () => {
+    const ctx = createMockEnv({platform: 'darwin'})
+    expect(getVSCodeUserDir(ctx)).toBe(
+      path.join('/home/testuser', 'Library/Application Support/Code/User'),
+    )
+  })
+
+  test('returns macOS path for insiders', () => {
+    const ctx = createMockEnv({platform: 'darwin'})
+    expect(getVSCodeUserDir(ctx, 'insiders')).toBe(
+      path.join('/home/testuser', 'Library/Application Support/Code - Insiders/User'),
+    )
+  })
+
+  test('returns Windows path using APPDATA', () => {
+    const ctx = createMockEnv({
+      env: {APPDATA: 'C:\\Users\\test\\AppData\\Roaming'},
+      platform: 'win32',
+    })
+    expect(getVSCodeUserDir(ctx)).toBe(path.join('C:\\Users\\test\\AppData\\Roaming', 'Code/User'))
+  })
+
+  test('returns null on Windows without APPDATA', () => {
+    const ctx = createMockEnv({platform: 'win32'})
+    expect(getVSCodeUserDir(ctx)).toBeNull()
+  })
+
+  test('returns Linux path for stable', () => {
+    const ctx = createMockEnv({platform: 'linux'})
+    expect(getVSCodeUserDir(ctx)).toBe(path.join('/home/testuser', '.config/Code/User'))
+  })
+
+  test('returns Linux path for insiders', () => {
+    const ctx = createMockEnv({platform: 'linux'})
+    expect(getVSCodeUserDir(ctx, 'insiders')).toBe(
+      path.join('/home/testuser', '.config/Code - Insiders/User'),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detect functions — each tested with its own isolated DetectionEnv
+// ---------------------------------------------------------------------------
+
+describe('detect', () => {
+  // -- Directory-based editors --
+
+  describe('Cursor', () => {
+    test('returns config path when .cursor dir exists', async () => {
+      const ctx = createMockEnv({existsSync: existsForSuffixes('.cursor')})
+      const result = await EDITOR_CONFIGS.Cursor.detect(ctx)
+      expectPath(result, '.cursor/mcp.json')
+    })
+
+    test('returns null when .cursor dir does not exist', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS.Cursor.detect(ctx)).toBeNull()
+    })
+  })
+
+  describe('Antigravity', () => {
+    test('returns config path when .gemini/antigravity dir exists', async () => {
+      const ctx = createMockEnv({existsSync: existsForSuffixes('.gemini/antigravity')})
+      const result = await EDITOR_CONFIGS.Antigravity.detect(ctx)
+      expectPath(result, '.gemini/antigravity/mcp_config.json')
+    })
+
+    test('returns null when dir does not exist', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS.Antigravity.detect(ctx)).toBeNull()
+    })
+  })
+
+  describe('Gemini CLI', () => {
+    test('returns settings.json when it exists', async () => {
+      const ctx = createMockEnv({existsSync: existsForSuffixes('.gemini/settings.json')})
+      const result = await EDITOR_CONFIGS['Gemini CLI'].detect(ctx)
+      expectPath(result, '.gemini/settings.json')
+    })
+
+    test('returns null when settings.json does not exist', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS['Gemini CLI'].detect(ctx)).toBeNull()
+    })
+
+    test('does NOT detect when only antigravity subdir exists', async () => {
+      const ctx = createMockEnv({existsSync: existsForSuffixes('.gemini/antigravity')})
+      expect(await EDITOR_CONFIGS['Gemini CLI'].detect(ctx)).toBeNull()
+    })
+  })
+
+  describe('GitHub Copilot CLI', () => {
+    test('returns config path when .copilot dir exists', async () => {
+      const ctx = createMockEnv({existsSync: existsForSuffixes('.copilot')})
+      const result = await EDITOR_CONFIGS['GitHub Copilot CLI'].detect(ctx)
+      expectPath(result, '.copilot/mcp-config.json')
+    })
+
+    test('uses XDG_CONFIG_HOME on Linux', async () => {
+      const ctx = createMockEnv({
+        env: {XDG_CONFIG_HOME: '/custom/config'},
+        existsSync: existsForSuffixes('config/copilot'),
+        platform: 'linux',
+      })
+      const result = await EDITOR_CONFIGS['GitHub Copilot CLI'].detect(ctx)
+      expectPath(result, 'copilot/mcp-config.json')
+    })
+
+    test('ignores XDG_CONFIG_HOME on non-Linux', async () => {
+      const ctx = createMockEnv({
+        env: {XDG_CONFIG_HOME: '/custom/config'},
+        existsSync: existsForSuffixes('.copilot'),
+        platform: 'darwin',
+      })
+      const result = await EDITOR_CONFIGS['GitHub Copilot CLI'].detect(ctx)
+      expectPath(result, '.copilot/mcp-config.json')
+    })
+
+    test('returns null when dir does not exist', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS['GitHub Copilot CLI'].detect(ctx)).toBeNull()
+    })
+  })
+
+  // -- VS Code family --
+
+  describe('VS Code', () => {
+    test('returns config path on macOS when dir exists', async () => {
+      const ctx = createMockEnv({
+        existsSync: existsForSuffixes('Code/User'),
+        platform: 'darwin',
+      })
+      const result = await EDITOR_CONFIGS['VS Code'].detect(ctx)
+      expectPath(result, 'Library/Application Support/Code/User/mcp.json')
+    })
+
+    test('returns config path on Linux when dir exists', async () => {
+      const ctx = createMockEnv({
+        existsSync: existsForSuffixes('Code/User'),
+        platform: 'linux',
+      })
+      const result = await EDITOR_CONFIGS['VS Code'].detect(ctx)
+      expectPath(result, '.config/Code/User/mcp.json')
+    })
+
+    test('returns null when dir does not exist', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS['VS Code'].detect(ctx)).toBeNull()
+    })
+
+    test('returns null on Windows without APPDATA', async () => {
+      const ctx = createMockEnv({platform: 'win32'})
+      expect(await EDITOR_CONFIGS['VS Code'].detect(ctx)).toBeNull()
+    })
+  })
+
+  describe('VS Code Insiders', () => {
+    test('returns config path on macOS when dir exists', async () => {
+      const ctx = createMockEnv({
+        existsSync: existsForSuffixes('Code - Insiders/User'),
+        platform: 'darwin',
+      })
+      const result = await EDITOR_CONFIGS['VS Code Insiders'].detect(ctx)
+      expectPath(result, 'Library/Application Support/Code - Insiders/User/mcp.json')
+    })
+
+    test('returns null when dir does not exist', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS['VS Code Insiders'].detect(ctx)).toBeNull()
+    })
+  })
+
+  // -- Cline (VS Code extension) — the key isolation test --
+
+  describe('Cline', () => {
+    test('returns config path when Cline extension dir exists inside VS Code', async () => {
+      const ctx = createMockEnv({
+        existsSync: existsForSuffixes('globalStorage/saoudrizwan.claude-dev/settings'),
+        platform: 'darwin',
+      })
+      const result = await EDITOR_CONFIGS.Cline.detect(ctx)
+      expectPath(result, 'cline_mcp_settings.json')
+    })
+
+    test('returns null when only VS Code dir exists (Cline not installed)', async () => {
+      // This is the exact collision case that previously broke the integration test.
+      // Only the VS Code User dir exists, not the nested Cline extension dir.
+      const ctx = createMockEnv({
+        existsSync: existsForSuffixes('Code/User'),
+        platform: 'darwin',
+      })
+      expect(await EDITOR_CONFIGS.Cline.detect(ctx)).toBeNull()
+    })
+
+    test('returns null on Windows without APPDATA', async () => {
+      const ctx = createMockEnv({platform: 'win32'})
+      expect(await EDITOR_CONFIGS.Cline.detect(ctx)).toBeNull()
+    })
+  })
+
+  // -- Cline CLI --
+
+  describe('Cline CLI', () => {
+    test('returns config path when .cline dir exists', async () => {
+      const ctx = createMockEnv({existsSync: existsForSuffixes('.cline')})
+      const result = await EDITOR_CONFIGS['Cline CLI'].detect(ctx)
+      expectPath(result, '.cline/data/settings/cline_mcp_settings.json')
+    })
+
+    test('uses CLINE_DIR env var when set', async () => {
+      const ctx = createMockEnv({
+        env: {CLINE_DIR: '/custom/cline'},
+        existsSync: existsForSuffixes('/custom/cline'),
+      })
+      const result = await EDITOR_CONFIGS['Cline CLI'].detect(ctx)
+      expectPath(result, 'custom/cline/data/settings/cline_mcp_settings.json')
+    })
+
+    test('returns null when .cline dir does not exist', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS['Cline CLI'].detect(ctx)).toBeNull()
+    })
+  })
+
+  // -- CLI-based editors --
+
+  describe('Claude Code', () => {
+    test('returns config path when CLI is available', async () => {
+      const ctx = createMockEnv({execCommand: () => Promise.resolve()})
+      const result = await EDITOR_CONFIGS['Claude Code'].detect(ctx)
+      expectPath(result, '.claude.json')
+    })
+
+    test('returns null when CLI is not installed', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS['Claude Code'].detect(ctx)).toBeNull()
+    })
+  })
+
+  describe('Codex CLI', () => {
+    test('returns config path when CLI is available', async () => {
+      const ctx = createMockEnv({execCommand: () => Promise.resolve()})
+      const result = await EDITOR_CONFIGS['Codex CLI'].detect(ctx)
+      expectPath(result, '.codex/config.toml')
+    })
+
+    test('uses CODEX_HOME env var when set', async () => {
+      const ctx = createMockEnv({
+        env: {CODEX_HOME: '/custom/codex'},
+        execCommand: () => Promise.resolve(),
+      })
+      const result = await EDITOR_CONFIGS['Codex CLI'].detect(ctx)
+      expectPath(result, 'custom/codex/config.toml')
+    })
+
+    test('returns null when CLI is not installed', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS['Codex CLI'].detect(ctx)).toBeNull()
+    })
+  })
+
+  describe('OpenCode', () => {
+    test('returns config path when CLI is available', async () => {
+      const ctx = createMockEnv({execCommand: () => Promise.resolve()})
+      const result = await EDITOR_CONFIGS.OpenCode.detect(ctx)
+      expectPath(result, '.config/opencode/opencode.json')
+    })
+
+    test('returns null when CLI is not installed', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS.OpenCode.detect(ctx)).toBeNull()
+    })
+  })
+
+  // -- Zed --
+
+  describe('Zed', () => {
+    test('returns config path on macOS when dir exists', async () => {
+      const ctx = createMockEnv({
+        existsSync: existsForSuffixes('.config/zed'),
+        platform: 'darwin',
+      })
+      const result = await EDITOR_CONFIGS.Zed.detect(ctx)
+      expectPath(result, '.config/zed/settings.json')
+    })
+
+    test('returns config path on Windows using APPDATA', async () => {
+      const ctx = createMockEnv({
+        env: {APPDATA: 'C:\\Users\\test\\AppData\\Roaming'},
+        existsSync: existsForSuffixes('Zed'),
+        platform: 'win32',
+      })
+      const result = await EDITOR_CONFIGS.Zed.detect(ctx)
+      expectPath(result, 'Zed/settings.json')
+    })
+
+    test('returns null on Windows without APPDATA', async () => {
+      const ctx = createMockEnv({platform: 'win32'})
+      expect(await EDITOR_CONFIGS.Zed.detect(ctx)).toBeNull()
+    })
+
+    test('returns null when dir does not exist', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS.Zed.detect(ctx)).toBeNull()
+    })
+  })
+
+  // -- MCPorter --
+
+  describe('MCPorter', () => {
+    test('returns .json path when both dir and .json exist', async () => {
+      const ctx = createMockEnv({
+        existsSync: existsForSuffixes('.mcporter', '.mcporter/mcporter.json'),
+      })
+      const result = await EDITOR_CONFIGS.MCPorter.detect(ctx)
+      expectPath(result, '.mcporter/mcporter.json')
+    })
+
+    test('returns .jsonc path when dir and .jsonc exist but .json does not', async () => {
+      const ctx = createMockEnv({
+        existsSync: existsForSuffixes('.mcporter', '.mcporter/mcporter.jsonc'),
+      })
+      const result = await EDITOR_CONFIGS.MCPorter.detect(ctx)
+      expectPath(result, '.mcporter/mcporter.jsonc')
+    })
+
+    test('falls back to .json path when dir exists but neither file does', async () => {
+      const ctx = createMockEnv({
+        existsSync: (p: string) => {
+          const n = normalize(p)
+          if (n.endsWith('.mcporter/mcporter.json')) return false
+          if (n.endsWith('.mcporter/mcporter.jsonc')) return false
+          return n.endsWith('.mcporter')
+        },
+      })
+      const result = await EDITOR_CONFIGS.MCPorter.detect(ctx)
+      expectPath(result, '.mcporter/mcporter.json')
+    })
+
+    test('returns null when .mcporter dir does not exist', async () => {
+      const ctx = createMockEnv()
+      expect(await EDITOR_CONFIGS.MCPorter.detect(ctx)).toBeNull()
+    })
   })
 })

--- a/packages/@sanity/cli/src/actions/mcp/detectAvailableEditors.ts
+++ b/packages/@sanity/cli/src/actions/mcp/detectAvailableEditors.ts
@@ -5,7 +5,12 @@ import {subdebug} from '@sanity/cli-core'
 import {type ParseError, parse as parseJsonc} from 'jsonc-parser'
 import {parse as parseToml} from 'smol-toml'
 
-import {EDITOR_CONFIGS, type EditorName} from './editorConfigs.js'
+import {
+  createDetectionEnv,
+  type DetectionEnv,
+  EDITOR_CONFIGS,
+  type EditorName,
+} from './editorConfigs.js'
 import {type Editor} from './types.js'
 
 const debug = subdebug('mcp:detectAvailableEditors')
@@ -90,15 +95,20 @@ async function checkEditorConfig(name: EditorName, configPath: string): Promise<
 /**
  * Detect which editors are installed and have parseable configs.
  * Editors with unparseable configs are skipped to avoid data loss.
+ *
+ * Accepts an optional `DetectionEnv` for testability. When omitted,
+ * uses the real process/OS environment.
  */
-export async function detectAvailableEditors(): Promise<Editor[]> {
+export async function detectAvailableEditors(env?: DetectionEnv): Promise<Editor[]> {
+  const ctx = env ?? createDetectionEnv()
+
   // Detect all editors in parallel to avoid stacking timeouts —
   // CLI-based editors (Claude Code, Codex CLI, OpenCode) each have a
   // 5s execa timeout, so sequential detection can add ~15s on machines
   // where none are installed.
   const results = await Promise.all(
     Object.entries(EDITOR_CONFIGS).map(async ([name, config]) => {
-      const configPath = await config.detect()
+      const configPath = await config.detect(ctx)
       if (!configPath) return null
       return checkEditorConfig(name as EditorName, configPath)
     }),

--- a/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
+++ b/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
@@ -6,11 +6,37 @@ import {execa} from 'execa'
 
 import {MCP_SERVER_URL} from '../../services/mcp.js'
 
+/**
+ * Environment abstraction for editor detection.
+ *
+ * Detect functions receive this instead of using module-level imports, making
+ * each function independently testable without global mocks.
+ */
+export interface DetectionEnv {
+  env: Record<string, string | undefined>
+  /** Run a CLI command to check if a tool is installed. Rejects on failure. */
+  execCommand: (cmd: string, args: string[]) => Promise<void>
+  existsSync: (p: string) => boolean
+  homedir: string
+  platform: NodeJS.Platform
+}
+
+/** Create the real detection environment backed by process/OS globals. */
+export function createDetectionEnv(): DetectionEnv {
+  return {
+    env: process.env,
+    execCommand: (cmd, args) => execa(cmd, args, {stdio: 'pipe', timeout: 5000}).then(() => {}),
+    existsSync,
+    homedir: os.homedir(),
+    platform: process.platform,
+  }
+}
+
 interface EditorConfig {
   buildServerConfig: (token: string) => Record<string, unknown>
   configKey: string
   /** Returns the config file path if editor is detected, null otherwise */
-  detect: () => Promise<string | null>
+  detect: (env: DetectionEnv) => Promise<string | null>
   format: 'jsonc' | 'toml'
   /** Extracts the auth token from a parsed Sanity server config block */
   readToken: (serverConfig: Record<string, unknown>) => string | undefined
@@ -22,110 +48,140 @@ const defaultHttpConfig = (token: string) => ({
   url: MCP_SERVER_URL,
 })
 
-const homeDir = os.homedir()
-
 // -- Detect functions --
 
-async function detectClaudeCode(): Promise<string | null> {
+async function detectClaudeCode(ctx: DetectionEnv): Promise<string | null> {
   try {
-    await execa('claude', ['--version'], {stdio: 'pipe', timeout: 5000})
-    return path.join(homeDir, '.claude.json')
+    await ctx.execCommand('claude', ['--version'])
+    return path.join(ctx.homedir, '.claude.json')
   } catch {
     return null
   }
 }
 
-async function detectCodexCli(): Promise<string | null> {
+async function detectAntigravity(ctx: DetectionEnv): Promise<string | null> {
+  const antigravityDir = path.join(ctx.homedir, '.gemini/antigravity')
+  return ctx.existsSync(antigravityDir) ? path.join(antigravityDir, 'mcp_config.json') : null
+}
+
+export function getVSCodeUserDir(
+  ctx: DetectionEnv,
+  variant: 'insiders' | 'stable' = 'stable',
+): string | null {
+  switch (ctx.platform) {
+    case 'darwin': {
+      return path.join(
+        ctx.homedir,
+        variant === 'insiders'
+          ? 'Library/Application Support/Code - Insiders/User'
+          : 'Library/Application Support/Code/User',
+      )
+    }
+    case 'win32': {
+      if (!ctx.env.APPDATA) return null
+      return path.join(
+        ctx.env.APPDATA,
+        variant === 'insiders' ? 'Code - Insiders/User' : 'Code/User',
+      )
+    }
+    default: {
+      return path.join(
+        ctx.homedir,
+        variant === 'insiders' ? '.config/Code - Insiders/User' : '.config/Code/User',
+      )
+    }
+  }
+}
+
+async function detectCline(ctx: DetectionEnv): Promise<string | null> {
+  const vscodeUserDir = getVSCodeUserDir(ctx)
+  if (!vscodeUserDir) return null
+  const clineConfigDir = path.join(vscodeUserDir, 'globalStorage/saoudrizwan.claude-dev/settings')
+  return ctx.existsSync(clineConfigDir)
+    ? path.join(clineConfigDir, 'cline_mcp_settings.json')
+    : null
+}
+
+async function detectClineCli(ctx: DetectionEnv): Promise<string | null> {
+  const clineHome = ctx.env.CLINE_DIR || path.join(ctx.homedir, '.cline')
+  if (!ctx.existsSync(clineHome)) return null
+  return path.join(clineHome, 'data/settings/cline_mcp_settings.json')
+}
+
+async function detectCodexCli(ctx: DetectionEnv): Promise<string | null> {
   try {
-    await execa('codex', ['--version'], {stdio: 'pipe', timeout: 5000})
-    const codexHome = process.env.CODEX_HOME || path.join(homeDir, '.codex')
+    await ctx.execCommand('codex', ['--version'])
+    const codexHome = ctx.env.CODEX_HOME || path.join(ctx.homedir, '.codex')
     return path.join(codexHome, 'config.toml')
   } catch {
     return null
   }
 }
 
-async function detectCursor(): Promise<string | null> {
-  const cursorDir = path.join(homeDir, '.cursor')
-  return existsSync(cursorDir) ? path.join(cursorDir, 'mcp.json') : null
+async function detectCursor(ctx: DetectionEnv): Promise<string | null> {
+  const cursorDir = path.join(ctx.homedir, '.cursor')
+  return ctx.existsSync(cursorDir) ? path.join(cursorDir, 'mcp.json') : null
 }
 
-async function detectGeminiCli(): Promise<string | null> {
-  const geminiDir = path.join(homeDir, '.gemini')
-  return existsSync(geminiDir) ? path.join(geminiDir, 'settings.json') : null
+async function detectGeminiCli(ctx: DetectionEnv): Promise<string | null> {
+  // Antigravity stores its config under ~/.gemini/antigravity, so checking
+  // only the parent ~/.gemini directory causes false Gemini CLI detection.
+  const settingsPath = path.join(ctx.homedir, '.gemini/settings.json')
+  return ctx.existsSync(settingsPath) ? settingsPath : null
 }
 
-async function detectGitHubCopilotCli(): Promise<string | null> {
+async function detectGitHubCopilotCli(ctx: DetectionEnv): Promise<string | null> {
   const copilotDir =
-    process.platform === 'linux' && process.env.XDG_CONFIG_HOME
-      ? path.join(process.env.XDG_CONFIG_HOME, 'copilot')
-      : path.join(homeDir, '.copilot')
-  return existsSync(copilotDir) ? path.join(copilotDir, 'mcp-config.json') : null
+    ctx.platform === 'linux' && ctx.env.XDG_CONFIG_HOME
+      ? path.join(ctx.env.XDG_CONFIG_HOME, 'copilot')
+      : path.join(ctx.homedir, '.copilot')
+  return ctx.existsSync(copilotDir) ? path.join(copilotDir, 'mcp-config.json') : null
 }
 
-async function detectOpenCode(): Promise<string | null> {
+async function detectOpenCode(ctx: DetectionEnv): Promise<string | null> {
   try {
-    await execa('opencode', ['--version'], {stdio: 'pipe', timeout: 5000})
-    return path.join(homeDir, '.config/opencode/opencode.json')
+    await ctx.execCommand('opencode', ['--version'])
+    return path.join(ctx.homedir, '.config/opencode/opencode.json')
   } catch {
     return null
   }
 }
 
-async function detectVSCode(): Promise<string | null> {
-  let configDir: string | null = null
-  switch (process.platform) {
-    case 'darwin': {
-      configDir = path.join(homeDir, 'Library/Application Support/Code/User')
-      break
-    }
-    case 'win32': {
-      if (process.env.APPDATA) {
-        configDir = path.join(process.env.APPDATA, 'Code/User')
-      }
-      break
-    }
-    default: {
-      configDir = path.join(homeDir, '.config/Code/User')
-    }
-  }
-  return configDir && existsSync(configDir) ? path.join(configDir, 'mcp.json') : null
+async function detectVSCode(ctx: DetectionEnv): Promise<string | null> {
+  const configDir = getVSCodeUserDir(ctx)
+  return configDir && ctx.existsSync(configDir) ? path.join(configDir, 'mcp.json') : null
 }
 
-async function detectVSCodeInsiders(): Promise<string | null> {
-  let configDir: string | null = null
-  switch (process.platform) {
-    case 'darwin': {
-      configDir = path.join(homeDir, 'Library/Application Support/Code - Insiders/User')
-      break
-    }
-    case 'win32': {
-      if (process.env.APPDATA) {
-        configDir = path.join(process.env.APPDATA, 'Code - Insiders/User')
-      }
-      break
-    }
-    default: {
-      configDir = path.join(homeDir, '.config/Code - Insiders/User')
-    }
-  }
-  return configDir && existsSync(configDir) ? path.join(configDir, 'mcp.json') : null
+async function detectVSCodeInsiders(ctx: DetectionEnv): Promise<string | null> {
+  const configDir = getVSCodeUserDir(ctx, 'insiders')
+  return configDir && ctx.existsSync(configDir) ? path.join(configDir, 'mcp.json') : null
 }
 
-async function detectZed(): Promise<string | null> {
+async function detectZed(ctx: DetectionEnv): Promise<string | null> {
   let configDir: string | null = null
-  switch (process.platform) {
+  switch (ctx.platform) {
     case 'win32': {
-      if (process.env.APPDATA) {
-        configDir = path.join(process.env.APPDATA, 'Zed')
+      if (ctx.env.APPDATA) {
+        configDir = path.join(ctx.env.APPDATA, 'Zed')
       }
       break
     }
     default: {
-      configDir = path.join(homeDir, '.config/zed')
+      configDir = path.join(ctx.homedir, '.config/zed')
     }
   }
-  return configDir && existsSync(configDir) ? path.join(configDir, 'settings.json') : null
+  return configDir && ctx.existsSync(configDir) ? path.join(configDir, 'settings.json') : null
+}
+
+async function detectMCPorter(ctx: DetectionEnv): Promise<string | null> {
+  const mcporterDir = path.join(ctx.homedir, '.mcporter')
+  if (!ctx.existsSync(mcporterDir)) return null
+
+  const jsonPath = path.join(mcporterDir, 'mcporter.json')
+  const jsoncPath = path.join(mcporterDir, 'mcporter.jsonc')
+  if (ctx.existsSync(jsonPath)) return jsonPath
+  if (ctx.existsSync(jsoncPath)) return jsoncPath
+  return jsonPath
 }
 
 // -- Read token helpers --
@@ -150,10 +206,30 @@ function readTokenFromHttpHeaders(serverConfig: Record<string, unknown>): string
   return extractBearerToken(serverConfig.http_headers)
 }
 
-// -- Build server config functions --
+// -- Defaults & build server config functions --
 
-function buildClaudeCodeServerConfig(token: string): Record<string, unknown> {
-  return defaultHttpConfig(token)
+/** Most editors share these values — entries only need to declare `detect` + any overrides. */
+const EDITOR_DEFAULTS = {
+  buildServerConfig: defaultHttpConfig,
+  configKey: 'mcpServers',
+  format: 'jsonc' as const,
+  readToken: readTokenFromHeaders,
+}
+
+function buildAntigravityServerConfig(token: string): Record<string, unknown> {
+  return {
+    headers: {Authorization: `Bearer ${token}`},
+    serverUrl: MCP_SERVER_URL,
+  }
+}
+
+function buildClineServerConfig(token: string): Record<string, unknown> {
+  return {
+    disabled: false,
+    headers: {Authorization: `Bearer ${token}`},
+    type: 'streamableHttp',
+    url: MCP_SERVER_URL,
+  }
 }
 
 function buildCodexCliServerConfig(token: string): Record<string, unknown> {
@@ -162,14 +238,6 @@ function buildCodexCliServerConfig(token: string): Record<string, unknown> {
     type: 'http',
     url: MCP_SERVER_URL,
   }
-}
-
-function buildCursorServerConfig(token: string): Record<string, unknown> {
-  return defaultHttpConfig(token)
-}
-
-function buildGeminiCliServerConfig(token: string): Record<string, unknown> {
-  return defaultHttpConfig(token)
 }
 
 function buildGitHubCopilotCliServerConfig(token: string): Record<string, unknown> {
@@ -189,14 +257,6 @@ function buildOpenCodeServerConfig(token: string): Record<string, unknown> {
   }
 }
 
-function buildVSCodeServerConfig(token: string): Record<string, unknown> {
-  return defaultHttpConfig(token)
-}
-
-function buildVSCodeInsidersServerConfig(token: string): Record<string, unknown> {
-  return defaultHttpConfig(token)
-}
-
 function buildZedServerConfig(token: string): Record<string, unknown> {
   return {
     headers: {Authorization: `Bearer ${token}`},
@@ -207,71 +267,79 @@ function buildZedServerConfig(token: string): Record<string, unknown> {
 
 /**
  * Centralized editor configuration including detection logic.
- * To add a new editor: add an entry here - EditorName type is derived automatically.
+ * To add a new editor: add an entry here — EditorName type is derived automatically.
+ *
+ * Each entry includes a doc URL pointing to the source of truth for its
+ * config path and format. When updating a path, verify against the linked
+ * documentation first.
  */
 export const EDITOR_CONFIGS = {
-  'Claude Code': {
-    buildServerConfig: buildClaudeCodeServerConfig,
-    configKey: 'mcpServers',
-    detect: detectClaudeCode,
-    format: 'jsonc',
-    readToken: readTokenFromHeaders,
+  // Doc: https://support.google.com/gemini/answer/16255176 (Antigravity / Project Mariner)
+  Antigravity: {
+    ...EDITOR_DEFAULTS,
+    buildServerConfig: buildAntigravityServerConfig,
+    detect: detectAntigravity,
   },
+  // Doc: https://docs.anthropic.com/en/docs/claude-code/mcp
+  // Path: ~/.claude.json  Key: mcpServers
+  'Claude Code': {...EDITOR_DEFAULTS, detect: detectClaudeCode},
+  // Doc: https://github.com/cline/cline — VS Code extension (saoudrizwan.claude-dev)
+  // Path: <VS Code User>/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json
+  Cline: {...EDITOR_DEFAULTS, buildServerConfig: buildClineServerConfig, detect: detectCline},
+  // Doc: https://github.com/cline/cline — standalone CLI mode
+  // Path: $CLINE_DIR || ~/.cline/data/settings/cline_mcp_settings.json
+  'Cline CLI': {
+    ...EDITOR_DEFAULTS,
+    buildServerConfig: buildClineServerConfig,
+    detect: detectClineCli,
+  },
+  // Doc: https://platform.openai.com/docs/guides/tools-remote-mcp#codex-cli
+  // Path: $CODEX_HOME || ~/.codex/config.toml  Key: mcp_servers  Format: TOML
   'Codex CLI': {
+    ...EDITOR_DEFAULTS,
     buildServerConfig: buildCodexCliServerConfig,
     configKey: 'mcp_servers',
     detect: detectCodexCli,
-    format: 'toml',
+    format: 'toml' as const,
     readToken: readTokenFromHttpHeaders,
   },
-  Cursor: {
-    buildServerConfig: buildCursorServerConfig,
-    configKey: 'mcpServers',
-    detect: detectCursor,
-    format: 'jsonc',
-    readToken: readTokenFromHeaders,
-  },
-  'Gemini CLI': {
-    buildServerConfig: buildGeminiCliServerConfig,
-    configKey: 'mcpServers',
-    detect: detectGeminiCli,
-    format: 'jsonc',
-    readToken: readTokenFromHeaders,
-  },
+  // Doc: https://docs.cursor.com/context/model-context-protocol
+  // Path: ~/.cursor/mcp.json  Key: mcpServers
+  Cursor: {...EDITOR_DEFAULTS, detect: detectCursor},
+  // Doc: https://googlegemini.wiki/gemini-cli/mcp-servers
+  // Path: ~/.gemini/settings.json  Key: mcpServers
+  'Gemini CLI': {...EDITOR_DEFAULTS, detect: detectGeminiCli},
+  // Doc: https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-coding-agent-with-mcp
+  // Path: ~/.copilot/mcp-config.json (or $XDG_CONFIG_HOME/copilot on Linux)  Key: mcpServers
   'GitHub Copilot CLI': {
+    ...EDITOR_DEFAULTS,
     buildServerConfig: buildGitHubCopilotCliServerConfig,
-    configKey: 'mcpServers',
     detect: detectGitHubCopilotCli,
-    format: 'jsonc',
-    readToken: readTokenFromHeaders,
   },
+  // Doc: https://github.com/nicobailon/mcporter
+  // Path: ~/.mcporter/mcporter.{json,jsonc}  Key: mcpServers
+  MCPorter: {...EDITOR_DEFAULTS, detect: detectMCPorter},
+  // Doc: https://opencode.ai/docs/config
+  // Path: ~/.config/opencode/opencode.json  Key: mcp
   OpenCode: {
+    ...EDITOR_DEFAULTS,
     buildServerConfig: buildOpenCodeServerConfig,
     configKey: 'mcp',
     detect: detectOpenCode,
-    format: 'jsonc',
-    readToken: readTokenFromHeaders,
   },
-  'VS Code': {
-    buildServerConfig: buildVSCodeServerConfig,
-    configKey: 'servers',
-    detect: detectVSCode,
-    format: 'jsonc',
-    readToken: readTokenFromHeaders,
-  },
-  'VS Code Insiders': {
-    buildServerConfig: buildVSCodeInsidersServerConfig,
-    configKey: 'servers',
-    detect: detectVSCodeInsiders,
-    format: 'jsonc',
-    readToken: readTokenFromHeaders,
-  },
+  // Doc: https://code.visualstudio.com/docs/copilot/chat/mcp-servers
+  // Path: <VS Code User dir>/mcp.json  Key: servers
+  'VS Code': {...EDITOR_DEFAULTS, configKey: 'servers', detect: detectVSCode},
+  // Doc: https://code.visualstudio.com/docs/copilot/chat/mcp-servers
+  // Path: <VS Code Insiders User dir>/mcp.json  Key: servers
+  'VS Code Insiders': {...EDITOR_DEFAULTS, configKey: 'servers', detect: detectVSCodeInsiders},
+  // Doc: https://zed.dev/docs/assistant/model-context-protocol
+  // Path: ~/.config/zed/settings.json (or $APPDATA/Zed on Windows)  Key: context_servers
   Zed: {
+    ...EDITOR_DEFAULTS,
     buildServerConfig: buildZedServerConfig,
     configKey: 'context_servers',
     detect: detectZed,
-    format: 'jsonc',
-    readToken: readTokenFromHeaders,
   },
 } satisfies Record<string, EditorConfig>
 

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -64,6 +64,344 @@ const mockReadFile = vi.mocked(fs.readFile)
 const mockWriteFile = vi.mocked(fs.writeFile)
 const mockExeca = vi.mocked(execa)
 
+// ---------------------------------------------------------------------------
+// Helpers for table-driven per-editor tests
+// ---------------------------------------------------------------------------
+
+interface EditorTestCase {
+  /** How to make this editor detectable */
+  detect: {
+    /** CLI commands that should succeed (e.g. ['codex', 'claude']) */
+    cliCommands?: string[]
+    /** Env vars to set for this test */
+    env?: Record<string, string>
+    /** existsSync predicate — receives the path string */
+    existsSync?: (p: string) => boolean
+    /** Platform to override via Object.defineProperty */
+    overridePlatform?: NodeJS.Platform
+  }
+  /** Substring the written config path must contain */
+  expectedConfigPath: string
+  /** Editor name as it appears in EDITOR_CONFIGS */
+  name: string
+
+  /** Extra substrings the written content must contain (beyond the token) */
+  expectedContentChecks?: string[]
+  /** Only run on this platform (skipped otherwise) */
+  platform?: NodeJS.Platform
+}
+
+const EXECA_SUCCESS = {
+  command: 'test --version',
+  exitCode: 0,
+  failed: false,
+  killed: false,
+  signal: undefined,
+  stderr: '',
+  stdout: '1.0.0',
+  timedOut: false,
+} as never
+
+/** Shared helper: sets up mocks, runs command, asserts outputs for a single editor. */
+async function runEditorTest(tc: EditorTestCase): Promise<void> {
+  const originalPlatform = process.platform
+  const envBackups: Record<string, string | undefined> = {}
+
+  try {
+    // Platform override
+    if (tc.detect.overridePlatform) {
+      Object.defineProperty(process, 'platform', {value: tc.detect.overridePlatform})
+    }
+
+    // Env var overrides
+    if (tc.detect.env) {
+      for (const [key, value] of Object.entries(tc.detect.env)) {
+        envBackups[key] = process.env[key]
+        process.env[key] = value
+      }
+    }
+
+    // existsSync mock
+    if (tc.detect.existsSync) {
+      const predicate = tc.detect.existsSync
+      mockExistsSync.mockImplementation((p: PathLike) => predicate(String(p)))
+    }
+
+    // CLI mock — resolve for specific commands, reject for everything else
+    if (tc.detect.cliCommands) {
+      const commands = tc.detect.cliCommands
+      mockExeca.mockImplementation((async (command: string | URL) => {
+        if (commands.includes(String(command))) return EXECA_SUCCESS
+        throw new Error('Not installed')
+      }) as never)
+    }
+
+    mockCheckbox.mockResolvedValue([tc.name])
+
+    const sessionId = `session-${tc.name.toLowerCase().replaceAll(/\s+/g, '-')}`
+    const token = `test-token-${tc.name.toLowerCase().replaceAll(/\s+/g, '-')}`
+
+    mockApi({
+      apiVersion: MCP_API_VERSION,
+      method: 'post',
+      uri: '/auth/session/create',
+    }).reply(200, {id: sessionId, sid: sessionId})
+
+    mockApi({
+      apiVersion: MCP_API_VERSION,
+      method: 'get',
+      query: {sid: sessionId},
+      uri: '/auth/fetch',
+    }).reply(200, {label: 'MCP Token', token})
+
+    const {stdout} = await testCommand(ConfigureMcpCommand, [])
+
+    // Assert config was written to the expected path with the token
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining(convertToSystemPath(tc.expectedConfigPath)),
+      expect.stringContaining(token),
+      'utf8',
+    )
+
+    // Assert extra content checks
+    if (tc.expectedContentChecks) {
+      const writtenContent = mockWriteFile.mock.calls[0]?.[1] as string
+      for (const check of tc.expectedContentChecks) {
+        expect(writtenContent, `written content should contain "${check}"`).toContain(check)
+      }
+    }
+
+    expect(stdout).toContain(`MCP configured for ${tc.name}`)
+  } finally {
+    // Restore platform
+    if (tc.detect.overridePlatform) {
+      Object.defineProperty(process, 'platform', {value: originalPlatform})
+    }
+    // Restore env vars
+    for (const [key, original] of Object.entries(envBackups)) {
+      if (original === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = original
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test cases — one entry per editor/variant
+// ---------------------------------------------------------------------------
+
+const editorTestCases: EditorTestCase[] = [
+  {
+    detect: {existsSync: (p) => p.endsWith('.cursor')},
+    expectedConfigPath: '.cursor/mcp.json',
+    name: 'Cursor',
+  },
+  {
+    detect: {
+      existsSync: (p) => p.endsWith('Code/User'),
+      overridePlatform: 'darwin',
+    },
+    expectedConfigPath: 'Code/User/mcp.json',
+    name: 'VS Code',
+    platform: 'darwin',
+  },
+  {
+    detect: {
+      env: {APPDATA: String.raw`C:\Users\test\AppData\Roaming`},
+      existsSync: (p) => p.includes(String.raw`AppData\Roaming\Code\User`),
+      overridePlatform: 'win32',
+    },
+    expectedConfigPath: String.raw`AppData\Roaming\Code\User\mcp.json`,
+    name: 'VS Code',
+    platform: 'win32',
+  },
+  {
+    detect: {
+      existsSync: (p) => p.endsWith('Code - Insiders/User'),
+      overridePlatform: 'darwin',
+    },
+    expectedConfigPath: 'Code - Insiders/User/mcp.json',
+    name: 'VS Code Insiders',
+    platform: 'darwin',
+  },
+  {
+    detect: {
+      env: {APPDATA: String.raw`C:\Users\test\AppData\Roaming`},
+      existsSync: (p) => p.includes(String.raw`AppData\Roaming\Code - Insiders\User`),
+      overridePlatform: 'win32',
+    },
+    expectedConfigPath: String.raw`AppData\Roaming\Code - Insiders\User\mcp.json`,
+    name: 'VS Code Insiders',
+    platform: 'win32',
+  },
+  {
+    detect: {cliCommands: ['claude']},
+    expectedConfigPath: '.claude.json',
+    name: 'Claude Code',
+  },
+  {
+    detect: {
+      existsSync: (p) => {
+        const n = p.replaceAll('\\', '/')
+        return n.endsWith('/.gemini/antigravity')
+      },
+    },
+    expectedConfigPath: '.gemini/antigravity/mcp_config.json',
+    expectedContentChecks: ['serverUrl'],
+    name: 'Antigravity',
+  },
+  {
+    detect: {
+      existsSync: (p) => {
+        const n = p.replaceAll('\\', '/')
+        return n.endsWith('/Code/User/globalStorage/saoudrizwan.claude-dev/settings')
+      },
+    },
+    expectedConfigPath:
+      'Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json',
+    name: 'Cline',
+  },
+  {
+    detect: {
+      env: {
+        CLINE_DIR:
+          process.platform === 'win32'
+            ? String.raw`C:\tmp\custom-cline-home`
+            : '/tmp/custom-cline-home',
+      },
+      existsSync: (p) => {
+        const n = p.replaceAll('\\', '/')
+        return n.endsWith('/tmp/custom-cline-home')
+      },
+    },
+    expectedConfigPath: convertToSystemPath(
+      '/tmp/custom-cline-home/data/settings/cline_mcp_settings.json',
+    ),
+    name: 'Cline CLI',
+  },
+  {
+    detect: {
+      existsSync: (p) => {
+        const n = p.replaceAll('\\', '/')
+        return n.endsWith('/.gemini/settings.json')
+      },
+    },
+    expectedConfigPath: '.gemini/settings.json',
+    name: 'Gemini CLI',
+  },
+  {
+    detect: {
+      existsSync: (p) => {
+        const n = p.replaceAll('\\', '/')
+        return /\/.?copilot(?:\/|$)/.test(n)
+      },
+    },
+    expectedConfigPath: 'mcp-config.json',
+    expectedContentChecks: ['"tools"'],
+    name: 'GitHub Copilot CLI',
+  },
+  {
+    detect: {
+      env: {XDG_CONFIG_HOME: '/home/user/.config'},
+      existsSync: (p) => p.includes('/home/user/.config/copilot'),
+    },
+    expectedConfigPath: '/home/user/.config/copilot/mcp-config.json',
+    name: 'GitHub Copilot CLI',
+    platform: 'linux',
+  },
+  {
+    detect: {cliCommands: ['opencode'], overridePlatform: 'darwin'},
+    expectedConfigPath: '.config/opencode/opencode.json',
+    name: 'OpenCode',
+    platform: 'darwin',
+  },
+  {
+    detect: {cliCommands: ['codex']},
+    expectedConfigPath: '.codex/config.toml',
+    expectedContentChecks: ['[mcp_servers.Sanity]', '[mcp_servers.Sanity.http_headers]'],
+    name: 'Codex CLI',
+  },
+  {
+    detect: {
+      cliCommands: ['codex'],
+      env: {
+        CODEX_HOME:
+          process.platform === 'win32'
+            ? String.raw`C:\tmp\custom-codex-home`
+            : '/tmp/custom-codex-home',
+      },
+    },
+    expectedConfigPath: convertToSystemPath('/tmp/custom-codex-home/config.toml'),
+    name: 'Codex CLI',
+  },
+  {
+    detect: {
+      existsSync: (p) => p.includes('.config/zed'),
+      overridePlatform: 'darwin',
+    },
+    expectedConfigPath: '.config/zed/settings.json',
+    name: 'Zed',
+    platform: 'darwin',
+  },
+  {
+    detect: {
+      env: {APPDATA: String.raw`C:\Users\test\AppData\Roaming`},
+      existsSync: (p) => p.includes(String.raw`AppData\Roaming\Zed`),
+      overridePlatform: 'win32',
+    },
+    expectedConfigPath: String.raw`AppData\Roaming\Zed\settings.json`,
+    name: 'Zed',
+    platform: 'win32',
+  },
+]
+
+// MCPorter has three variants for file format detection
+const mcporterTestCases: Array<{
+  existsSync: (p: string) => boolean
+  expectedConfigPath: string
+  label: string
+}> = [
+  {
+    existsSync: (p) => {
+      const n = p.replaceAll('\\', '/')
+      if (n.endsWith('/.mcporter')) return true
+      if (n.endsWith('/.mcporter/mcporter.json')) return false
+      if (n.endsWith('/.mcporter/mcporter.jsonc')) return true
+      return false
+    },
+    expectedConfigPath: '.mcporter/mcporter.jsonc',
+    label: 'existing jsonc config',
+  },
+  {
+    existsSync: (p) => {
+      const n = p.replaceAll('\\', '/')
+      if (n.endsWith('/.mcporter')) return true
+      if (n.endsWith('/.mcporter/mcporter.json')) return true
+      if (n.endsWith('/.mcporter/mcporter.jsonc')) return false
+      return false
+    },
+    expectedConfigPath: '.mcporter/mcporter.json',
+    label: 'existing json config',
+  },
+  {
+    existsSync: (p) => {
+      const n = p.replaceAll('\\', '/')
+      if (n.endsWith('/.mcporter')) return true
+      if (n.endsWith('/.mcporter/mcporter.json')) return false
+      if (n.endsWith('/.mcporter/mcporter.jsonc')) return false
+      return false
+    },
+    expectedConfigPath: '.mcporter/mcporter.json',
+    label: 'fresh install (defaults to json)',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Main test suite
+// ---------------------------------------------------------------------------
+
 describe('#mcp:configure', () => {
   beforeEach(async () => {
     mockEnsureAuthenticated.mockResolvedValue({
@@ -86,545 +424,37 @@ describe('#mcp:configure', () => {
     expect(pending, 'pending mocks').toEqual([])
   })
 
-  test('shows warning when no editors are detected', async () => {
-    // No editors detected (all checks fail)
-    mockExistsSync.mockReturnValue(false)
-    mockExeca.mockRejectedValue(new Error('Not installed'))
-
-    const {error, stderr} = await testCommand(ConfigureMcpCommand, [])
-
-    if (error) throw error
-
-    expect(stderr).toContain("Couldn't auto-configure Sanity MCP server for your editor")
-    expect(stderr).toContain('https://mcp.sanity.io')
-  })
-
-  test('detects Cursor and configures it', async () => {
-    mockExistsSync.mockImplementation((path: PathLike) => {
-      return String(path).includes('.cursor')
-    })
-
-    mockCheckbox.mockResolvedValue(['Cursor'])
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-123', sid: 'session-123'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-123'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'test-token-123'})
-
-    const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-    expect(mockCheckbox).toHaveBeenCalledWith({
-      choices: [
-        {
-          checked: true,
-          name: 'Cursor',
-          value: 'Cursor',
-        },
-      ],
-      message: 'Configure Sanity MCP server?',
-    })
-
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining(convertToSystemPath('.cursor/mcp.json')),
-      expect.stringContaining('test-token-123'),
-      'utf8',
-    )
-
-    expect(stdout).toContain('MCP configured for Cursor')
-  })
-
-  test.runIf(process.platform === 'darwin')(
-    'detects VS Code on macOS and configures it',
-    async () => {
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', {
-        value: 'darwin',
-      })
-
-      mockExistsSync.mockImplementation((path: PathLike) => {
-        return String(path).includes('Library/Application Support/Code/User')
-      })
-
-      mockCheckbox.mockResolvedValue(['VS Code'])
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'post',
-        uri: '/auth/session/create',
-      }).reply(200, {id: 'session-456', sid: 'session-456'})
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'get',
-        query: {sid: 'session-456'},
-        uri: '/auth/fetch',
-      }).reply(200, {label: 'MCP Token', token: 'test-token-456'})
-
-      const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-      expect(mockCheckbox).toHaveBeenCalledWith({
-        choices: [
-          {
-            checked: true,
-            name: 'VS Code',
-            value: 'VS Code',
-          },
-        ],
-        message: 'Configure Sanity MCP server?',
-      })
-
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining('Code/User/mcp.json'),
-        expect.stringContaining('test-token-456'),
-        'utf8',
-      )
-
-      expect(stdout).toContain('MCP configured for VS Code')
-
-      Object.defineProperty(process, 'platform', {
-        value: originalPlatform,
-      })
-    },
-  )
-
-  test.runIf(process.platform === 'win32')(
-    'detects VS Code on Windows and configures it',
-    async () => {
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', {
-        value: 'win32',
-      })
-
-      mockExistsSync.mockImplementation((path: PathLike) => {
-        return String(path).includes(String.raw`AppData\Roaming\Code\User`)
-      })
-
-      mockCheckbox.mockResolvedValue(['VS Code'])
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'post',
-        uri: '/auth/session/create',
-      }).reply(200, {id: 'session-456', sid: 'session-456'})
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'get',
-        query: {sid: 'session-456'},
-        uri: '/auth/fetch',
-      }).reply(200, {label: 'MCP Token', token: 'test-token-456'})
-
-      const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-      expect(mockCheckbox).toHaveBeenCalledWith({
-        choices: [
-          {
-            checked: true,
-            name: 'VS Code',
-            value: 'VS Code',
-          },
-        ],
-        message: 'Configure Sanity MCP server?',
-      })
-
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining(String.raw`AppData\Roaming\Code\User\mcp.json`),
-        expect.stringContaining('test-token-456'),
-        'utf8',
-      )
-
-      expect(stdout).toContain('MCP configured for VS Code')
-
-      Object.defineProperty(process, 'platform', {
-        value: originalPlatform,
-      })
-    },
-  )
-
-  test('detects Claude Code via CLI and configures it', async () => {
-    mockExeca.mockResolvedValue({
-      command: 'claude --version',
-      exitCode: 0,
-      failed: false,
-      killed: false,
-      signal: undefined,
-      stderr: '',
-      stdout: '1.0.0',
-      timedOut: false,
-    } as never)
-
-    mockCheckbox.mockResolvedValue(['Claude Code'])
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-789', sid: 'session-789'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-789'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'test-token-789'})
-
-    const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-    expect(mockExeca).toHaveBeenCalledWith('claude', ['--version'], {
-      stdio: 'pipe',
-      timeout: 5000,
-    })
-
-    expect(mockCheckbox).toHaveBeenCalledWith({
-      choices: expect.arrayContaining([
-        {
-          checked: true,
-          name: 'Claude Code',
-          value: 'Claude Code',
-        },
-      ]),
-      message: 'Configure Sanity MCP server?',
-    })
-
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining('.claude.json'),
-      expect.stringContaining('test-token-789'),
-      'utf8',
-    )
-
-    expect(stdout).toContain('MCP configured for Claude Code')
-  })
-
-  test('detects Gemini CLI and configures it', async () => {
-    mockExistsSync.mockImplementation((path: PathLike) => {
-      return String(path).includes('.gemini')
-    })
-
-    mockCheckbox.mockResolvedValue(['Gemini CLI'])
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-gemini', sid: 'session-gemini'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-gemini'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'test-token-gemini'})
-
-    const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-    expect(mockCheckbox).toHaveBeenCalledWith({
-      choices: [
-        {
-          checked: true,
-          name: 'Gemini CLI',
-          value: 'Gemini CLI',
-        },
-      ],
-      message: 'Configure Sanity MCP server?',
-    })
-
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining(convertToSystemPath('.gemini/settings.json')),
-      expect.stringContaining('test-token-gemini'),
-      'utf8',
-    )
-
-    expect(stdout).toContain('MCP configured for Gemini CLI')
-  })
-
-  test('detects GitHub Copilot CLI and configures it with tools field', async () => {
-    // Match both ~/.copilot and $XDG_CONFIG_HOME/copilot across platforms
-    mockExistsSync.mockImplementation((p: PathLike) => {
-      const normalizedPath = String(p).replaceAll('\\', '/')
-      return /\/.?copilot(?:\/|$)/.test(normalizedPath)
-    })
-
-    mockCheckbox.mockResolvedValue(['GitHub Copilot CLI'])
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-copilot', sid: 'session-copilot'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-copilot'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'test-token-copilot'})
-
-    const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-    expect(mockCheckbox).toHaveBeenCalledWith({
-      choices: [
-        {
-          checked: true,
-          name: 'GitHub Copilot CLI',
-          value: 'GitHub Copilot CLI',
-        },
-      ],
-      message: 'Configure Sanity MCP server?',
-    })
-
-    const writtenContent = mockWriteFile.mock.calls[0]?.[1] as string
-    expect(writtenContent).toContain('test-token-copilot')
-    expect(writtenContent).toContain('"tools"')
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining('mcp-config.json'),
-      expect.any(String),
-      'utf8',
-    )
-
-    expect(stdout).toContain('MCP configured for GitHub Copilot CLI')
-  })
-
-  test.runIf(process.platform === 'linux')(
-    'detects GitHub Copilot CLI via XDG_CONFIG_HOME on Linux',
-    async () => {
-      const originalXdg = process.env.XDG_CONFIG_HOME
-      process.env.XDG_CONFIG_HOME = '/home/user/.config'
-
-      mockExistsSync.mockImplementation((p: PathLike) => {
-        return String(p).includes('/home/user/.config/copilot')
-      })
-
-      mockCheckbox.mockResolvedValue(['GitHub Copilot CLI'])
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'post',
-        uri: '/auth/session/create',
-      }).reply(200, {id: 'session-copilot-xdg', sid: 'session-copilot-xdg'})
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'get',
-        query: {sid: 'session-copilot-xdg'},
-        uri: '/auth/fetch',
-      }).reply(200, {label: 'MCP Token', token: 'test-token-copilot-xdg'})
-
-      const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining('/home/user/.config/copilot/mcp-config.json'),
-        expect.stringContaining('test-token-copilot-xdg'),
-        'utf8',
-      )
-
-      expect(stdout).toContain('MCP configured for GitHub Copilot CLI')
-
-      process.env.XDG_CONFIG_HOME = originalXdg
-    },
-  )
-
-  test.runIf(process.platform === 'darwin')(
-    'detects OpenCode via CLI on macOS and configures it',
-    async () => {
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', {
-        value: 'darwin',
-      })
-
-      mockExeca.mockResolvedValue({
-        command: 'opencode --version',
-        exitCode: 0,
-        failed: false,
-        killed: false,
-        signal: undefined,
-        stderr: '',
-        stdout: '1.0.0',
-        timedOut: false,
-      } as never)
-
-      mockCheckbox.mockResolvedValue(['OpenCode'])
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'post',
-        uri: '/auth/session/create',
-      }).reply(200, {id: 'session-opencode', sid: 'session-opencode'})
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'get',
-        query: {sid: 'session-opencode'},
-        uri: '/auth/fetch',
-      }).reply(200, {label: 'MCP Token', token: 'test-token-opencode'})
-
-      const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-      expect(mockExeca).toHaveBeenCalledWith('opencode', ['--version'], {
-        stdio: 'pipe',
-        timeout: 5000,
-      })
-
-      expect(mockCheckbox).toHaveBeenCalledWith({
-        choices: expect.arrayContaining([
-          {
-            checked: true,
-            name: 'OpenCode',
-            value: 'OpenCode',
-          },
-        ]),
-        message: 'Configure Sanity MCP server?',
-      })
-
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining('.config/opencode/opencode.json'),
-        expect.stringContaining('test-token-opencode'),
-        'utf8',
-      )
-
-      expect(stdout).toContain('MCP configured for OpenCode')
-
-      Object.defineProperty(process, 'platform', {
-        value: originalPlatform,
-      })
-    },
-  )
-
-  test('detects Codex CLI via CLI and configures TOML with headers', async () => {
-    mockExeca.mockImplementation((async (command: string | URL) => {
-      if (command === 'codex') {
-        return {
-          command: 'codex --version',
-          exitCode: 0,
-          failed: false,
-          killed: false,
-          signal: undefined,
-          stderr: '',
-          stdout: '1.0.0',
-          timedOut: false,
-        } as never
-      }
-
-      throw new Error('Not installed')
-    }) as never)
-
-    mockCheckbox.mockResolvedValue(['Codex CLI'])
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-codex', sid: 'session-codex'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-codex'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'test-token-codex'})
-
-    const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-    expect(mockExeca).toHaveBeenCalledWith('codex', ['--version'], {
-      stdio: 'pipe',
-      timeout: 5000,
-    })
-
-    expect(mockCheckbox).toHaveBeenCalledWith({
-      choices: [
-        {
-          checked: true,
-          name: 'Codex CLI',
-          value: 'Codex CLI',
-        },
-      ],
-      message: 'Configure Sanity MCP server?',
-    })
-
-    const writtenContent = mockWriteFile.mock.calls[0]?.[1] as string
-    expect(writtenContent).toContain('[mcp_servers.Sanity]')
-    expect(writtenContent).toContain('[mcp_servers.Sanity.http_headers]')
-    expect(writtenContent).toContain('Authorization = "Bearer test-token-codex"')
-
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining(convertToSystemPath('.codex/config.toml')),
-      expect.any(String),
-      'utf8',
-    )
-
-    expect(stdout).toContain('MCP configured for Codex CLI')
-  })
-
-  test('uses CODEX_HOME when configuring Codex CLI', async () => {
-    const originalCodexHome = process.env.CODEX_HOME
-    process.env.CODEX_HOME = '/tmp/custom-codex-home'
-    try {
-      mockExeca.mockImplementation((async (command: string | URL) => {
-        if (command === 'codex') {
-          return {
-            command: 'codex --version',
-            exitCode: 0,
-            failed: false,
-            killed: false,
-            signal: undefined,
-            stderr: '',
-            stdout: '1.0.0',
-            timedOut: false,
-          } as never
-        }
-
-        throw new Error('Not installed')
-      }) as never)
-
-      mockCheckbox.mockResolvedValue(['Codex CLI'])
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'post',
-        uri: '/auth/session/create',
-      }).reply(200, {id: 'session-codex-home', sid: 'session-codex-home'})
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'get',
-        query: {sid: 'session-codex-home'},
-        uri: '/auth/fetch',
-      }).reply(200, {label: 'MCP Token', token: 'test-token-codex-home'})
-
-      const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-      const writtenPath = mockWriteFile.mock.calls[0]?.[0] as string
-      expect(writtenPath.replaceAll('\\', '/')).toMatch(/\/tmp\/custom-codex-home\/config\.toml$/)
-      expect(mockWriteFile).toHaveBeenCalledWith(expect.any(String), expect.any(String), 'utf8')
-
-      expect(stdout).toContain('MCP configured for Codex CLI')
-    } finally {
-      process.env.CODEX_HOME = originalCodexHome
+  // -------------------------------------------------------------------------
+  // Per-editor detection (table-driven)
+  // -------------------------------------------------------------------------
+
+  describe('editor detection and configuration', () => {
+    for (const tc of editorTestCases) {
+      const suffix = tc.platform ? ` on ${tc.platform}` : ''
+      const envNote = tc.detect.env ? ` (${Object.keys(tc.detect.env).join(', ')})` : ''
+      const label = `detects ${tc.name}${suffix}${envNote} and configures it`
+
+      test.runIf(!tc.platform || process.platform === tc.platform)(label, () => runEditorTest(tc))
+    }
+
+    // MCPorter file-format variants
+    for (const mc of mcporterTestCases) {
+      test(`detects MCPorter with ${mc.label} and configures it`, () =>
+        runEditorTest({
+          detect: {existsSync: mc.existsSync},
+          expectedConfigPath: mc.expectedConfigPath,
+          name: 'MCPorter',
+        }))
     }
   })
 
+  // -------------------------------------------------------------------------
+  // Codex CLI: unparseable TOML skips editor
+  // -------------------------------------------------------------------------
+
   test('skips Codex CLI when existing TOML config is unparseable', async () => {
     mockExeca.mockImplementation((async (command: string | URL) => {
-      if (command === 'codex') {
-        return {
-          command: 'codex --version',
-          exitCode: 0,
-          failed: false,
-          killed: false,
-          signal: undefined,
-          stderr: '',
-          stdout: '1.0.0',
-          timedOut: false,
-        } as never
-      }
-
+      if (command === 'codex') return EXECA_SUCCESS
       throw new Error('Not installed')
     }) as never)
 
@@ -641,215 +471,25 @@ describe('#mcp:configure', () => {
     expect(mockWriteFile).not.toHaveBeenCalled()
   })
 
-  test.runIf(process.platform === 'darwin')(
-    'detects VS Code Insiders on macOS and configures it',
-    async () => {
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', {
-        value: 'darwin',
-      })
+  // -------------------------------------------------------------------------
+  // Edge cases and no-editor scenario
+  // -------------------------------------------------------------------------
 
-      mockExistsSync.mockImplementation((path: PathLike) => {
-        return String(path).includes('Library/Application Support/Code - Insiders/User')
-      })
+  test('shows warning when no editors are detected', async () => {
+    mockExistsSync.mockReturnValue(false)
+    mockExeca.mockRejectedValue(new Error('Not installed'))
 
-      mockCheckbox.mockResolvedValue(['VS Code Insiders'])
+    const {error, stderr} = await testCommand(ConfigureMcpCommand, [])
 
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'post',
-        uri: '/auth/session/create',
-      }).reply(200, {id: 'session-insiders', sid: 'session-insiders'})
+    if (error) throw error
 
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'get',
-        query: {sid: 'session-insiders'},
-        uri: '/auth/fetch',
-      }).reply(200, {label: 'MCP Token', token: 'test-token-insiders'})
-
-      const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-      expect(mockCheckbox).toHaveBeenCalledWith({
-        choices: [
-          {
-            checked: true,
-            name: 'VS Code Insiders',
-            value: 'VS Code Insiders',
-          },
-        ],
-        message: 'Configure Sanity MCP server?',
-      })
-
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining('Code - Insiders/User/mcp.json'),
-        expect.stringContaining('test-token-insiders'),
-        'utf8',
-      )
-
-      expect(stdout).toContain('MCP configured for VS Code Insiders')
-
-      Object.defineProperty(process, 'platform', {
-        value: originalPlatform,
-      })
-    },
-  )
-
-  test.runIf(process.platform === 'win32')(
-    'detects VS Code Insiders on Windows and configures it',
-    async () => {
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', {
-        value: 'win32',
-      })
-
-      mockExistsSync.mockImplementation((path: PathLike) => {
-        return String(path).includes(String.raw`AppData\Roaming\Code - Insiders\User`)
-      })
-
-      mockCheckbox.mockResolvedValue(['VS Code Insiders'])
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'post',
-        uri: '/auth/session/create',
-      }).reply(200, {id: 'session-insiders', sid: 'session-insiders'})
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'get',
-        query: {sid: 'session-insiders'},
-        uri: '/auth/fetch',
-      }).reply(200, {label: 'MCP Token', token: 'test-token-insiders'})
-
-      const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-      expect(mockCheckbox).toHaveBeenCalledWith({
-        choices: [
-          {
-            checked: true,
-            name: 'VS Code Insiders',
-            value: 'VS Code Insiders',
-          },
-        ],
-        message: 'Configure Sanity MCP server?',
-      })
-
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining(String.raw`AppData\Roaming\Code - Insiders\User\mcp.json`),
-        expect.stringContaining('test-token-insiders'),
-        'utf8',
-      )
-
-      expect(stdout).toContain('MCP configured for VS Code Insiders')
-
-      Object.defineProperty(process, 'platform', {
-        value: originalPlatform,
-      })
-    },
-  )
-
-  test.runIf(process.platform === 'darwin')('detects Zed on macOS and configures it', async () => {
-    const originalPlatform = process.platform
-    Object.defineProperty(process, 'platform', {
-      value: 'darwin',
-    })
-
-    mockExistsSync.mockImplementation((path: PathLike) => {
-      return String(path).includes('.config/zed')
-    })
-
-    mockCheckbox.mockResolvedValue(['Zed'])
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-zed', sid: 'session-zed'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-zed'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'test-token-zed'})
-
-    const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-    expect(mockCheckbox).toHaveBeenCalledWith({
-      choices: [
-        {
-          checked: true,
-          name: 'Zed',
-          value: 'Zed',
-        },
-      ],
-      message: 'Configure Sanity MCP server?',
-    })
-
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining('.config/zed/settings.json'),
-      expect.stringContaining('test-token-zed'),
-      'utf8',
-    )
-
-    expect(stdout).toContain('MCP configured for Zed')
-
-    Object.defineProperty(process, 'platform', {
-      value: originalPlatform,
-    })
+    expect(stderr).toContain("Couldn't auto-configure Sanity MCP server for your editor")
+    expect(stderr).toContain('https://mcp.sanity.io')
   })
 
-  test.runIf(process.platform === 'win32')('detects Zed on Windows and configures it', async () => {
-    const originalPlatform = process.platform
-    Object.defineProperty(process, 'platform', {
-      value: 'win32',
-    })
-
-    mockExistsSync.mockImplementation((path: PathLike) => {
-      return String(path).includes(String.raw`AppData\Roaming\Zed`)
-    })
-
-    mockCheckbox.mockResolvedValue(['Zed'])
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-zed', sid: 'session-zed'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-zed'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'test-token-zed'})
-
-    const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-    expect(mockCheckbox).toHaveBeenCalledWith({
-      choices: [
-        {
-          checked: true,
-          name: 'Zed',
-          value: 'Zed',
-        },
-      ],
-      message: 'Configure Sanity MCP server?',
-    })
-
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining(String.raw`AppData\Roaming\Zed\settings.json`),
-      expect.stringContaining('test-token-zed'),
-      'utf8',
-    )
-
-    expect(stdout).toContain('MCP configured for Zed')
-
-    Object.defineProperty(process, 'platform', {
-      value: originalPlatform,
-    })
-  })
+  // -------------------------------------------------------------------------
+  // Token lifecycle
+  // -------------------------------------------------------------------------
 
   test('skips prompt when all configured editors have valid auth', async () => {
     mockExistsSync.mockImplementation((path: PathLike) => {
@@ -942,8 +582,8 @@ describe('#mcp:configure', () => {
   test('reuses valid token from another editor instead of creating new one', async () => {
     // Detect both Cursor (configured with valid token) and Gemini (unconfigured)
     mockExistsSync.mockImplementation((path: PathLike) => {
-      const p = String(path)
-      return p.includes('.cursor') || p.includes('.gemini')
+      const normalized = String(path).replaceAll('\\', '/')
+      return normalized.includes('/.cursor') || normalized.endsWith('/.gemini/settings.json')
     })
 
     // Cursor has existing config with valid token, Gemini has empty config
@@ -985,6 +625,10 @@ describe('#mcp:configure', () => {
     expect(stdout).toContain('MCP configured for Gemini CLI')
   })
 
+  // -------------------------------------------------------------------------
+  // User interaction
+  // -------------------------------------------------------------------------
+
   test('exits gracefully when user deselects all editors', async () => {
     mockExistsSync.mockImplementation((path: PathLike) => {
       return String(path).includes('.cursor')
@@ -997,6 +641,65 @@ describe('#mcp:configure', () => {
     expect(stdout).toContain('MCP configuration skipped')
     expect(mockWriteFile).not.toHaveBeenCalled()
   })
+
+  test('configures multiple editors when selected', async () => {
+    mockExistsSync.mockReturnValue(true)
+
+    mockCheckbox.mockResolvedValue(['Cursor', 'VS Code'])
+
+    mockApi({
+      apiVersion: MCP_API_VERSION,
+      method: 'post',
+      uri: '/auth/session/create',
+    }).reply(200, {id: 'session-multi', sid: 'session-multi'})
+
+    mockApi({
+      apiVersion: MCP_API_VERSION,
+      method: 'get',
+      query: {sid: 'session-multi'},
+      uri: '/auth/fetch',
+    }).reply(200, {label: 'MCP Token', token: 'multi-token-123'})
+
+    const {stdout} = await testCommand(ConfigureMcpCommand, [])
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(2)
+    expect(stdout).toContain('MCP configured for Cursor, VS Code')
+  })
+
+  test('auto-selects all editors in non-interactive mode without prompting', async () => {
+    mockIsInteractive.mockReturnValue(false)
+
+    mockExistsSync.mockImplementation((path: PathLike) => {
+      return String(path).includes('.cursor')
+    })
+
+    mockApi({
+      apiVersion: MCP_API_VERSION,
+      method: 'post',
+      uri: '/auth/session/create',
+    }).reply(200, {id: 'session-ci', sid: 'session-ci'})
+
+    mockApi({
+      apiVersion: MCP_API_VERSION,
+      method: 'get',
+      query: {sid: 'session-ci'},
+      uri: '/auth/fetch',
+    }).reply(200, {label: 'MCP Token', token: 'test-token-ci'})
+
+    const {stdout} = await testCommand(ConfigureMcpCommand, [])
+
+    expect(mockCheckbox).not.toHaveBeenCalled()
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining(convertToSystemPath('.cursor/mcp.json')),
+      expect.stringContaining('test-token-ci'),
+      'utf8',
+    )
+    expect(stdout).toContain('MCP configured for Cursor')
+  })
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
 
   test('handles token creation error gracefully', async () => {
     mockExistsSync.mockImplementation((path: PathLike) => {
@@ -1046,30 +749,6 @@ describe('#mcp:configure', () => {
     expect(stderr).toContain('https://mcp.sanity.io')
   })
 
-  test('configures multiple editors when selected', async () => {
-    mockExistsSync.mockReturnValue(true)
-
-    mockCheckbox.mockResolvedValue(['Cursor', 'VS Code'])
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-multi', sid: 'session-multi'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-multi'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'multi-token-123'})
-
-    const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-    expect(mockWriteFile).toHaveBeenCalledTimes(2)
-    expect(stdout).toContain('MCP configured for Cursor, VS Code')
-  })
-
   test('suggests login when login fails', async () => {
     const {LoginError} = await import('../../../errors/LoginError.js')
     mockEnsureAuthenticated.mockRejectedValue(new LoginError('No authentication providers found'))
@@ -1092,6 +771,10 @@ describe('#mcp:configure', () => {
     expect(error?.message).not.toContain('sanity login')
     expect(error?.oclif?.exit).toBe(1)
   })
+
+  // -------------------------------------------------------------------------
+  // Config merging
+  // -------------------------------------------------------------------------
 
   test('merges with existing config file', async () => {
     mockExistsSync.mockReturnValue(true)
@@ -1133,36 +816,5 @@ describe('#mcp:configure', () => {
       expect.stringContaining('Sanity'),
       'utf8',
     )
-  })
-
-  test('auto-selects all editors in non-interactive mode without prompting', async () => {
-    mockIsInteractive.mockReturnValue(false)
-
-    mockExistsSync.mockImplementation((path: PathLike) => {
-      return String(path).includes('.cursor')
-    })
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-ci', sid: 'session-ci'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-ci'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'test-token-ci'})
-
-    const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-    expect(mockCheckbox).not.toHaveBeenCalled()
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining(convertToSystemPath('.cursor/mcp.json')),
-      expect.stringContaining('test-token-ci'),
-      'utf8',
-    )
-    expect(stdout).toContain('MCP configured for Cursor')
   })
 })

--- a/packages/@sanity/cli/src/commands/mcp/configure.ts
+++ b/packages/@sanity/cli/src/commands/mcp/configure.ts
@@ -10,7 +10,7 @@ const debug = subdebug('mcp:configure')
 
 export class ConfigureMcpCommand extends SanityCommand<typeof ConfigureMcpCommand> {
   static override description =
-    'Configure Sanity MCP server for AI editors (Claude Code, Codex CLI, Cursor, Gemini CLI, GitHub Copilot CLI, VS Code)'
+    'Configure Sanity MCP server for AI editors (Antigravity, Claude Code, Cline, Cline CLI, Codex CLI, Cursor, Gemini CLI, GitHub Copilot CLI, MCPorter, OpenCode, VS Code, VS Code Insiders, Zed)'
 
   static override examples = [
     {


### PR DESCRIPTION
### Description

Adds MCP auto-configuration support for 5 new editors and refactors the detection architecture to eliminate a class of test fragility caused by global mock collisions.

**New editors:** Antigravity, Cline CLI, Codex CLI, GitHub Copilot CLI, MCPorter

**Problem:** Detection functions used module-level imports (`existsSync`, `execa`, `process.platform`), so the only way to test them was through global mocks in a 1,400-line integration test. Editors with overlapping filesystem paths (e.g., Cline's config lives inside VS Code's directory) caused mock collisions — a test for editor A would accidentally trigger editor B's detection. Adding new editors kept breaking existing tests.

**Solution:** Introduce a `DetectionEnv` interface that each detect function receives as a parameter instead of importing side-effectful modules directly. This makes every detect function independently testable with its own isolated context, and eliminates cross-editor mock interference.

### What to review

**Production code** (minimal surface area):
- `editorConfigs.ts` — `DetectionEnv` type, `createDetectionEnv()` factory, all 13 detect functions updated to accept the env parameter, doc URLs added for every editor config path
- `detectAvailableEditors.ts` — accepts optional `DetectionEnv`, passes it through to each `config.detect(ctx)` call
- `knip.config.ts` — removed `ignoreBinaries` (no longer needed since `execa` calls go through the `execCommand` abstraction)

**Test code** (bulk of the diff):
- `editorConfigs.test.ts` — 44 new unit tests covering all 13 detect functions with isolated `DetectionEnv` contexts, including the exact Cline/VS Code collision case
- `configure.test.ts` — replaced 21 hand-written per-editor integration tests with a table-driven approach (1,411 → 820 lines). Behavioral edge-case tests (token reuse, auth expiry, config merging, etc.) are unchanged.

### Testing

- 44 new unit tests for detect functions (each using isolated `DetectionEnv` — no global mock collisions)
- Table-driven integration tests covering all 13 editors + MCPorter file-format variants
- 12 behavioral edge-case tests preserved unchanged
- All 172 affected tests pass locally (macOS), all 43 CI checks pass (Ubuntu + Windows, Node 20/22/24)
- Type check, lint, dep check, and build all clean