### PR TITLE
fix(workbench): propagate staging env to workbench dev server

### DIFF
--- a/.changeset/pr-964.md
+++ b/.changeset/pr-964.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+propagate staging env to workbench dev server

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -107,6 +107,7 @@ export async function startWorkbenchDevServer(
     cacheDir: 'node_modules/.sanity/vite',
     configFile: false,
     define: {
+      __SANITY_STAGING__: process.env.SANITY_INTERNAL_ENV === 'staging',
       'import.meta.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL': JSON.stringify(remoteUrl),
     },
     logLevel: 'warn',


### PR DESCRIPTION
### Description

The workbench dev server was missing the `__SANITY_STAGING__` Vite `define` that the app/studio dev servers receive via `getViteConfig`. This meant setting `SANITY_INTERNAL_ENV=staging` had no effect on the workbench client bundle.

Adds `__SANITY_STAGING__: process.env.SANITY_INTERNAL_ENV === 'staging'` to the workbench Vite config to match the existing behavior in `getViteConfig.ts`.

### What to review

One-line addition in `startWorkbenchDevServer.ts` — confirm the define matches `getViteConfig.ts:172`.