### PR TITLE
test(ci): fix E2E workflow registry mode failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,13 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       cli_version:
-        description: 'npm version/tag to test (e.g., latest, 3.82.0)'
+        description: 'npm version/tag to test (e.g., latest, 5.20.0)'
         required: true
         default: 'latest'
-      cli_package:
-        description: 'Package to install — must provide the "sanity" binary (e.g., @sanity/cli, sanity)'
-        required: false
-        default: '@sanity/cli'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -73,12 +69,15 @@ jobs:
         if: ${{ inputs.cli_version }}
         env:
           CLI_VERSION: ${{ inputs.cli_version }}
-          CLI_PACKAGE: ${{ inputs.cli_package || '@sanity/cli' }}
         run: |
           INSTALL_DIR=$(mktemp -d)
-          npm install --prefix "$INSTALL_DIR" "${CLI_PACKAGE}@${CLI_VERSION}"
+          npm install --prefix "$INSTALL_DIR" "sanity@${CLI_VERSION}"
           echo "E2E_BINARY_PATH=$INSTALL_DIR/node_modules/.bin/sanity" >> "$GITHUB_ENV"
           "$INSTALL_DIR/node_modules/.bin/sanity" --version
+
+      - name: Build test infrastructure (registry mode)
+        if: ${{ inputs.cli_version }}
+        run: pnpm --filter @sanity/cli-test build
 
       - name: Run E2E tests
         env:
@@ -99,7 +98,7 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "text": ${{ toJSON(format('Post-release E2E failed for {0}@{1}', inputs.cli_package || '@sanity/cli', inputs.cli_version)) }},
+              "text": ${{ toJSON(format('Post-release E2E failed for sanity@{0}', inputs.cli_version)) }},
               "blocks": [
                 {
                   "type": "section",
@@ -112,7 +111,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ${{ toJSON(format('*Package:* `{0}@{1}`', inputs.cli_package || '@sanity/cli', inputs.cli_version)) }}
+                    "text": ${{ toJSON(format('*Package:* `sanity@{0}`', inputs.cli_version)) }}
                   }
                 },
                 {


### PR DESCRIPTION
### Description

The E2E `workflow_dispatch` (registry mode) was failing on all Node versions (20, 22, 24) with:

```
Error: Failed to load url .../packages/@sanity/cli-e2e/@sanity/cli-test/vitest
```

**Root cause:** In registry mode, `pnpm build:cli` is skipped (since we test the published npm package), but the E2E vitest config still references `@sanity/cli-test/vitest` as a globalSetup. Since `@sanity/cli-test` was never built, `dist/vitest.js` doesn't exist and vitest fails with `ERR_LOAD_URL`.

**Additional fix:** Registry mode now installs the `sanity` package (what real users install) instead of `@sanity/cli` directly. The `cli_package` input was removed since there's no reason to test arbitrary packages.

Fixes: https://github.com/sanity-io/cli/actions/runs/24575200510

### What to review

- `.github/workflows/e2e.yml` — the only file changed
- New `Build test infrastructure` step in registry mode
- `sanity` package used instead of `@sanity/cli`
- Slack notification updated to match

### Testing

Trigger a `workflow_dispatch` run with `cli_version: latest` to verify registry mode passes.