### PR TITLE
test(cli-test): add --ignore-workspace to fixture pnpm install

### DIFF
--- a/.changeset/pr-976.md
+++ b/.changeset/pr-976.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli-test': patch
----
-
-add --ignore-workspace to fixture pnpm install

--- a/.changeset/pr-976.md
+++ b/.changeset/pr-976.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-test': patch
+---
+
+add --ignore-workspace to fixture pnpm install

--- a/packages/@sanity/cli-e2e/globalSetup.ts
+++ b/packages/@sanity/cli-e2e/globalSetup.ts
@@ -2,14 +2,16 @@ import {mkdtempSync, rmSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
+import {setup as setupFixtures, teardown as teardownFixtures} from '@sanity/cli-test/vitest'
 import {config as loadDotenv} from 'dotenv'
+import {type TestProject} from 'vitest/node'
 
 import {installFromTarball, packCli} from './helpers/packCli.js'
 
 let cleanupDir: string | undefined
 let tarballPath: string | undefined
 
-export async function setup(): Promise<void> {
+export async function setup(project: TestProject): Promise<void> {
   // Load .env file into process.env so tests can read SANITY_E2E_* vars.
   // Existing env vars take precedence (CI sets them directly).
   loadDotenv({quiet: true})
@@ -17,24 +19,27 @@ export async function setup(): Promise<void> {
   // skip pack and use the provided binary.
   if (process.env.E2E_BINARY_PATH) {
     console.log(`Using pre-set E2E_BINARY_PATH: ${process.env.E2E_BINARY_PATH}`)
-    return
+  } else {
+    console.log('Packing @sanity/cli...')
+    const tarball = packCli()
+    tarballPath = tarball
+
+    const tmpDir = mkdtempSync(join(tmpdir(), 'cli-e2e-'))
+    cleanupDir = tmpDir
+
+    console.log(`Installing tarball into ${tmpDir}...`)
+    const binaryPath = installFromTarball(tarball, tmpDir)
+
+    process.env.E2E_BINARY_PATH = binaryPath
+    console.log(`E2E_BINARY_PATH set to ${binaryPath}`)
   }
 
-  console.log('Packing @sanity/cli...')
-  const tarball = packCli()
-  tarballPath = tarball
-
-  const tmpDir = mkdtempSync(join(tmpdir(), 'cli-e2e-'))
-  cleanupDir = tmpDir
-
-  console.log(`Installing tarball into ${tmpDir}...`)
-  const binaryPath = installFromTarball(tarball, tmpDir)
-
-  process.env.E2E_BINARY_PATH = binaryPath
-  console.log(`E2E_BINARY_PATH set to ${binaryPath}`)
+  await setupFixtures(project, {ignoreWorkspace: true})
 }
 
 export async function teardown(): Promise<void> {
+  await teardownFixtures()
+
   if (tarballPath) {
     rmSync(tarballPath, {force: true})
   }

--- a/packages/@sanity/cli-e2e/vitest.config.ts
+++ b/packages/@sanity/cli-e2e/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     globals: false,
     // 1. Pack @sanity/cli into a tarball and extract to tmp/ for realistic E2E testing
     // 2. Initialize test fixtures (copies fixtures, installs deps)
-    globalSetup: ['./globalSetup.ts', '@sanity/cli-test/vitest'],
+    globalSetup: ['./globalSetup.ts'],
     hookTimeout: 120_000,
     // E2E tests spawn real processes and need longer timeouts
     testTimeout: 30_000,

--- a/packages/@sanity/cli-test/src/test/setupFixtures.ts
+++ b/packages/@sanity/cli-test/src/test/setupFixtures.ts
@@ -34,6 +34,14 @@ export interface SetupTestFixturesOptions {
   additionalFixtures?: string[]
 
   /**
+   * When true, passes `--ignore-workspace` to pnpm install so fixtures get
+   * their own node_modules even when the temp directory is inside a pnpm
+   * workspace. Required for E2E tests that spawn the CLI binary against
+   * fixture directories.
+   */
+  ignoreWorkspace?: boolean
+
+  /**
    * Custom temp directory path. Defaults to process.cwd()/tmp
    */
   tempDir?: string
@@ -92,7 +100,7 @@ interface FixtureDetails {
  * ```
  */
 export async function setup(_: TestProject, options: SetupTestFixturesOptions = {}): Promise<void> {
-  const {additionalFixtures, tempDir} = options
+  const {additionalFixtures, ignoreWorkspace, tempDir} = options
 
   const spinner = ora({
     // Without this, the watch mode input is discarded
@@ -142,7 +150,8 @@ export async function setup(_: TestProject, options: SetupTestFixturesOptions = 
 
       // Run pnpm install --no-lockfile in the temp directory
       try {
-        await exec(`pnpm install --prefer-offline --no-lockfile`, {
+        const ignoreWsFlag = ignoreWorkspace ? ' --ignore-workspace' : ''
+        await exec(`pnpm install --prefer-offline --no-lockfile${ignoreWsFlag}`, {
           cwd: toPath,
         })
       } catch (error) {


### PR DESCRIPTION
### Description

Fixes E2E test failures in registry mode (workflow_dispatch) where tests using `testFixture()` fail with "CLI config cannot be loaded".

**Root cause:** `setupTestFixtures` runs `pnpm install --no-lockfile` in fixture temp directories located inside the monorepo workspace (`packages/@sanity/cli-e2e/tmp/`). Pnpm detects the workspace root and runs a workspace-level install instead of installing dependencies in the fixture directory. This means fixtures never get their own `node_modules/sanity`, so the CLI fails when it tries to import `sanity.cli.ts` (which requires `sanity/cli` from `node_modules`).

**Fix:** Add an `ignoreWorkspace` option to `SetupTestFixturesOptions` that passes `--ignore-workspace` to pnpm install. The E2E globalSetup opts in (`ignoreWorkspace: true`), while the main test suite uses the default (`false`) to preserve existing behavior. This avoids the Windows Node 20 open-handle hang that occurs when pnpm installs full dependency trees into all 9 fixture directories.

### What to review

- `packages/@sanity/cli-test/src/test/setupFixtures.ts` — new `ignoreWorkspace` option on `SetupTestFixturesOptions`
- `packages/@sanity/cli-e2e/globalSetup.ts` — consolidated globalSetup that handles CLI pack/install and fixture setup with `ignoreWorkspace: true`
- `packages/@sanity/cli-e2e/vitest.config.ts` — removed separate `@sanity/cli-test/vitest` globalSetup entry (now handled by the consolidated globalSetup)

### Testing

- Reproduced the failure locally by setting up a fixture inside the workspace and running the published CLI against it — confirmed "CLI config cannot be loaded" error
- Verified the fix resolves the issue — CLI successfully loads config after `--ignore-workspace` is added
- Verified that the default path (no `--ignore-workspace`) preserves existing behavior for the main test suite
- Type checking passes for both `@sanity/cli-test` and `@sanity/cli-e2e`