### PR TITLE
fix: use sanity v5 compatible dependencies in shopify templates

### DIFF
--- a/.changeset/pr-977.md
+++ b/.changeset/pr-977.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+use sanity v5 compatible dependencies in shopify templates

--- a/packages/@sanity/cli/src/actions/init/templates/shopify.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/shopify.ts
@@ -59,14 +59,14 @@ export default defineConfig({
 const shopifyTemplate: ProjectTemplate = {
   configTemplate,
   dependencies: {
-    '@sanity/asset-utils': '^1.3.0',
-    '@sanity/color-input': '^3.0.2',
-    '@sanity/icons': '^2.11.0',
-    '@sanity/ui': '^2.0.0',
+    '@sanity/asset-utils': '^2.3.0',
+    '@sanity/color-input': '^6.0.4',
+    '@sanity/icons': '^3.7.4',
+    '@sanity/ui': '^3.1.14',
     'lodash.get': '^4.4.2',
     'pluralize-esm': '^9.0.2',
-    'sanity-plugin-hotspot-array': '^1.0.1',
-    'sanity-plugin-media': '^2.0.5',
+    'sanity-plugin-hotspot-array': '^3.0.2',
+    'sanity-plugin-media': '^4.1.1',
     slug: '^8.2.2',
   },
   devDependencies: {

--- a/packages/@sanity/cli/src/actions/init/templates/shopifyOnline.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/shopifyOnline.ts
@@ -38,8 +38,8 @@ const shopifyTemplate: ProjectTemplate = {
   configTemplate,
   dependencies: {
     '@portabletext/toolkit': '^2.0.1',
-    '@sanity/icons': '^2.11.0',
-    '@sanity/ui': '^2.0.0',
+    '@sanity/icons': '^3.7.4',
+    '@sanity/ui': '^3.1.14',
     '@types/lodash.get': '^4.4.7',
     'lodash.get': '^4.4.2',
     'pluralize-esm': '^9.0.4',

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/hotspot/imageWithProductHotspotsType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/hotspot/imageWithProductHotspotsType.ts
@@ -38,7 +38,7 @@ export const imageWithProductHotspotsType = defineField({
       return {
         media: image,
         subtitle:
-          showHotspots && hotspots.length > 0
+          showHotspots && hotspots && hotspots.length > 0
             ? `${pluralize('hotspot', hotspots.length, true)}`
             : undefined,
         title: fileName,


### PR DESCRIPTION
### Description

Updates the declared dependencies in the `shopify` and `shopify-online-storefront` init templates so new projects scaffold against Sanity Studio v5 compatible plugin versions. Also adds a small guard to the product hotspots schema's `prepare` so it doesn't throw when `hotspots` is undefined during the preview.

Template version bumps (only for already-declared deps where the existing range was older):

- `@sanity/asset-utils`: ^1.3.0 -> ^2.3.0
- `@sanity/color-input`: ^3.0.2 -> ^6.0.4
- `@sanity/icons`: ^2.11.0 -> ^3.7.4
- `@sanity/ui`: ^2.0.0 -> ^3.1.14
- `sanity-plugin-hotspot-array`: ^1.0.1 -> ^3.0.2
- `sanity-plugin-media`: ^2.0.5 -> ^4.1.1

### What to review

- `packages/@sanity/cli/src/actions/init/templates/shopify.ts` and `shopifyOnline.ts` for the version bumps.
- `packages/@sanity/cli/templates/shopify/schemaTypes/objects/hotspot/imageWithProductHotspotsType.ts` for the added `hotspots &&` truthiness check before reading `.length`.

### Testing

Ran `pnpm check:types` locally. No runtime behavior changes in the CLI itself; templates are installed at `sanity init` time against npm, so end-to-end validation is by initializing a fresh project with the shopify template.