### PR TITLE
fix(cli): replace preferred-pm with local implementation

### DIFF
--- a/.changeset/replace-preferred-pm.md
+++ b/.changeset/replace-preferred-pm.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+Fix package manager detection failing with yarn v1 on Node 20.

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -120,7 +120,6 @@
     "peek-stream": "^1.1.3",
     "picomatch": "^4.0.4",
     "pluralize-esm": "^9.0.5",
-    "preferred-pm": "^5.0.0",
     "pretty-ms": "^9.3.0",
     "promise-props-recursive": "^2.0.2",
     "react": "^19.2.4",

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
@@ -136,6 +136,17 @@ describe('preferredPm', () => {
       expect(preferredPm(targetDir)).toBe('yarn')
     })
 
+    it('skips malformed package.json and continues walk-up', () => {
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({workspaces: ['apps/*']}))
+      fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '')
+
+      const appDir = path.join(tmpDir, 'apps', 'myapp')
+      fs.mkdirSync(appDir, {recursive: true})
+      fs.writeFileSync(path.join(appDir, 'package.json'), '{invalid json!!!}')
+
+      expect(preferredPm(appDir)).toBe('yarn')
+    })
+
     it('detects workspace PM from a subdirectory within a package', () => {
       fs.writeFileSync(
         path.join(tmpDir, 'package.json'),

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
@@ -55,9 +55,16 @@ describe('preferredPm', () => {
     })
   })
 
-  describe('parent directory pnpm-lock.yaml walk-up', () => {
+  describe('parent directory pnpm walk-up', () => {
     it('finds pnpm-lock.yaml in a parent directory', () => {
       fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+      const childDir = path.join(tmpDir, 'packages', 'child')
+      fs.mkdirSync(childDir, {recursive: true})
+      expect(preferredPm(childDir)).toBe('pnpm')
+    })
+
+    it('finds pnpm-workspace.yaml in a parent directory', () => {
+      fs.writeFileSync(path.join(tmpDir, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n")
       const childDir = path.join(tmpDir, 'packages', 'child')
       fs.mkdirSync(childDir, {recursive: true})
       expect(preferredPm(childDir)).toBe('pnpm')

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
@@ -1,0 +1,187 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+
+import {preferredPm} from '../preferredPm'
+
+describe('preferredPm', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preferred-pm-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, {force: true, recursive: true})
+  })
+
+  describe('lock file detection', () => {
+    it('returns npm for package-lock.json', () => {
+      fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
+      expect(preferredPm(tmpDir)).toBe('npm')
+    })
+
+    it('returns yarn for yarn.lock', () => {
+      fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '')
+      expect(preferredPm(tmpDir)).toBe('yarn')
+    })
+
+    it('returns pnpm for pnpm-lock.yaml', () => {
+      fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('returns pnpm for shrinkwrap.yaml', () => {
+      fs.writeFileSync(path.join(tmpDir, 'shrinkwrap.yaml'), '')
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('returns bun for bun.lockb', () => {
+      fs.writeFileSync(path.join(tmpDir, 'bun.lockb'), '')
+      expect(preferredPm(tmpDir)).toBe('bun')
+    })
+
+    it('returns bun for bun.lock', () => {
+      fs.writeFileSync(path.join(tmpDir, 'bun.lock'), '')
+      expect(preferredPm(tmpDir)).toBe('bun')
+    })
+
+    it('prioritizes package-lock.json over yarn.lock', () => {
+      fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
+      fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '')
+      expect(preferredPm(tmpDir)).toBe('npm')
+    })
+  })
+
+  describe('parent directory pnpm-lock.yaml walk-up', () => {
+    it('finds pnpm-lock.yaml in a parent directory', () => {
+      fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+      const childDir = path.join(tmpDir, 'packages', 'child')
+      fs.mkdirSync(childDir, {recursive: true})
+      expect(preferredPm(childDir)).toBe('pnpm')
+    })
+  })
+
+  describe('workspace root detection', () => {
+    it('returns yarn for yarn workspaces', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({workspaces: ['packages/*']}),
+      )
+      const childDir = path.join(tmpDir, 'packages', 'child')
+      fs.mkdirSync(childDir, {recursive: true})
+      fs.writeFileSync(path.join(childDir, 'package.json'), JSON.stringify({name: 'child'}))
+      expect(preferredPm(childDir)).toBe('yarn')
+    })
+
+    it('returns npm for workspace root with package-lock.json', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({workspaces: ['packages/*']}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
+      const childDir = path.join(tmpDir, 'packages', 'child')
+      fs.mkdirSync(childDir, {recursive: true})
+      fs.writeFileSync(path.join(childDir, 'package.json'), JSON.stringify({name: 'child'}))
+      expect(preferredPm(childDir)).toBe('npm')
+    })
+
+    it('returns null for path not matching workspace globs', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({workspaces: ['packages/*']}),
+      )
+      const outsideDir = path.join(tmpDir, 'other', 'child')
+      fs.mkdirSync(outsideDir, {recursive: true})
+      expect(preferredPm(outsideDir)).toBeNull()
+    })
+
+    it('handles workspaces.packages object format', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({workspaces: {packages: ['packages/*']}}),
+      )
+      const childDir = path.join(tmpDir, 'packages', 'child')
+      fs.mkdirSync(childDir, {recursive: true})
+      expect(preferredPm(childDir)).toBe('yarn')
+    })
+
+    it('detects workspace PM from a subdirectory within a package', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({workspaces: ['packages/*']}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '')
+      const childDir = path.join(tmpDir, 'packages', 'child')
+      fs.mkdirSync(childDir, {recursive: true})
+      fs.writeFileSync(path.join(childDir, 'package.json'), JSON.stringify({name: 'child'}))
+      const deepDir = path.join(childDir, 'src', 'utils')
+      fs.mkdirSync(deepDir, {recursive: true})
+      expect(preferredPm(deepDir)).toBe('yarn')
+    })
+  })
+
+  describe('node_modules marker detection', () => {
+    it('returns yarn when .yarn-integrity exists', () => {
+      const nmDir = path.join(tmpDir, 'node_modules')
+      fs.mkdirSync(nmDir, {recursive: true})
+      fs.writeFileSync(path.join(nmDir, '.yarn-integrity'), '')
+      expect(preferredPm(tmpDir)).toBe('yarn')
+    })
+
+    it('returns pnpm when .modules.yaml contains pnpm (YAML format)', () => {
+      const nmDir = path.join(tmpDir, 'node_modules')
+      fs.mkdirSync(nmDir, {recursive: true})
+      fs.writeFileSync(path.join(nmDir, '.modules.yaml'), "packageManager: 'pnpm@9.0.0'\n")
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('returns pnpm when .modules.yaml uses JSON format with quoted keys', () => {
+      const nmDir = path.join(tmpDir, 'node_modules')
+      fs.mkdirSync(nmDir, {recursive: true})
+      fs.writeFileSync(
+        path.join(nmDir, '.modules.yaml'),
+        '{\n  "packageManager": "pnpm@10.30.3",\n}\n',
+      )
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('returns npm when node_modules exists with no markers', () => {
+      const nmDir = path.join(tmpDir, 'node_modules')
+      fs.mkdirSync(nmDir, {recursive: true})
+      expect(preferredPm(tmpDir)).toBe('npm')
+    })
+  })
+
+  describe('workspace root lock file detection', () => {
+    it('returns bun for workspace root with bun.lock', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({workspaces: ['packages/*']}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'bun.lock'), '')
+      const childDir = path.join(tmpDir, 'packages', 'child')
+      fs.mkdirSync(childDir, {recursive: true})
+      expect(preferredPm(childDir)).toBe('bun')
+    })
+
+    it('returns pnpm for workspace root with pnpm-lock.yaml', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({workspaces: ['packages/*']}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+      const childDir = path.join(tmpDir, 'packages', 'child')
+      fs.mkdirSync(childDir, {recursive: true})
+      expect(preferredPm(childDir)).toBe('pnpm')
+    })
+  })
+
+  describe('no detection', () => {
+    it('returns null for empty directory', () => {
+      expect(preferredPm(tmpDir)).toBeNull()
+    })
+  })
+})

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
@@ -208,16 +208,20 @@ describe('preferredPm', () => {
   })
 
   describe('error handling', () => {
-    it('swallows permission errors when reading .modules.yaml', () => {
-      const nmDir = path.join(tmpDir, 'node_modules')
-      fs.mkdirSync(nmDir, {recursive: true})
-      const yamlPath = path.join(nmDir, '.modules.yaml')
-      fs.writeFileSync(yamlPath, "packageManager: 'pnpm@9.0.0'\n")
-      fs.chmodSync(yamlPath, 0o000)
-      // Should not throw — falls through to npm detection (node_modules exists)
-      expect(preferredPm(tmpDir)).toBe('npm')
-      fs.chmodSync(yamlPath, 0o644)
-    })
+    // chmod doesn't enforce read permissions on Windows
+    it.skipIf(process.platform === 'win32')(
+      'swallows permission errors when reading .modules.yaml',
+      () => {
+        const nmDir = path.join(tmpDir, 'node_modules')
+        fs.mkdirSync(nmDir, {recursive: true})
+        const yamlPath = path.join(nmDir, '.modules.yaml')
+        fs.writeFileSync(yamlPath, "packageManager: 'pnpm@9.0.0'\n")
+        fs.chmodSync(yamlPath, 0o000)
+        // Should not throw — falls through to npm detection (node_modules exists)
+        expect(preferredPm(tmpDir)).toBe('npm')
+        fs.chmodSync(yamlPath, 0o644)
+      },
+    )
   })
 
   describe('no detection', () => {

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
@@ -116,6 +116,26 @@ describe('preferredPm', () => {
       expect(preferredPm(childDir)).toBe('yarn')
     })
 
+    it('continues to parent workspace when inner workspace does not match', () => {
+      // Outer workspace root owns apps/*
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({workspaces: ['apps/*']}))
+      fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '')
+
+      // Inner workspace root owns packages/* — does NOT own src/
+      const innerDir = path.join(tmpDir, 'apps', 'myapp')
+      fs.mkdirSync(innerDir, {recursive: true})
+      fs.writeFileSync(
+        path.join(innerDir, 'package.json'),
+        JSON.stringify({workspaces: ['packages/*']}),
+      )
+
+      // Target is inside inner workspace root but not matching its globs
+      const targetDir = path.join(innerDir, 'src')
+      fs.mkdirSync(targetDir, {recursive: true})
+      // Should traverse past inner workspace root and find outer one
+      expect(preferredPm(targetDir)).toBe('yarn')
+    })
+
     it('detects workspace PM from a subdirectory within a package', () => {
       fs.writeFileSync(
         path.join(tmpDir, 'package.json'),
@@ -184,6 +204,19 @@ describe('preferredPm', () => {
       const childDir = path.join(tmpDir, 'packages', 'child')
       fs.mkdirSync(childDir, {recursive: true})
       expect(preferredPm(childDir)).toBe('pnpm')
+    })
+  })
+
+  describe('error handling', () => {
+    it('swallows permission errors when reading .modules.yaml', () => {
+      const nmDir = path.join(tmpDir, 'node_modules')
+      fs.mkdirSync(nmDir, {recursive: true})
+      const yamlPath = path.join(nmDir, '.modules.yaml')
+      fs.writeFileSync(yamlPath, "packageManager: 'pnpm@9.0.0'\n")
+      fs.chmodSync(yamlPath, 0o000)
+      // Should not throw — falls through to npm detection (node_modules exists)
+      expect(preferredPm(tmpDir)).toBe('npm')
+      fs.chmodSync(yamlPath, 0o644)
     })
   })
 

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
@@ -105,6 +105,7 @@ describe('preferredPm', () => {
       )
       const childDir = path.join(tmpDir, 'packages', 'child')
       fs.mkdirSync(childDir, {recursive: true})
+      fs.writeFileSync(path.join(childDir, 'package.json'), JSON.stringify({name: 'child'}))
       expect(preferredPm(childDir)).toBe('yarn')
     })
 

--- a/packages/@sanity/cli/src/util/packageManager/packageManagerChoice.ts
+++ b/packages/@sanity/cli/src/util/packageManager/packageManagerChoice.ts
@@ -3,8 +3,9 @@ import path from 'node:path'
 import {isInteractive} from '@sanity/cli-core'
 import {getRunningPackageManager} from '@sanity/cli-core/package-manager'
 import {select} from '@sanity/cli-core/ux'
-import {preferredPM} from 'preferred-pm'
 import which from 'which'
+
+import {preferredPm} from './preferredPm.js'
 
 export type PackageManager = 'bun' | 'manual' | 'npm' | 'pnpm' | 'yarn'
 
@@ -46,7 +47,7 @@ export async function getPackageManagerChoice(
   options: {interactive: boolean},
 ): Promise<{chosen: PackageManager; mostOptimal?: PackageManager}> {
   const rootDir = workDir || process.cwd()
-  const preferred = (await preferredPM(rootDir))?.name
+  const preferred = preferredPm(rootDir) ?? undefined
 
   if (preferred && (await hasCommand(preferred, rootDir))) {
     // There is an optimal/preferred package manager, and the user has it installed!

--- a/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
+++ b/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 
 import picomatch from 'picomatch'
 
+import {toForwardSlashes} from '../toForwardSlashes.js'
 import {type PackageManager} from './packageManagerChoice.js'
 
 type DetectablePackageManager = Exclude<PackageManager, 'manual'>
@@ -78,7 +79,7 @@ function detectFromWorkspaceRoot(pkgPath: string): DetectablePackageManager | nu
 
         if (workspaces) {
           const matchDir = packageDir === dir ? resolvedPkgPath : packageDir
-          const relativePath = path.relative(dir, matchDir)
+          const relativePath = toForwardSlashes(path.relative(dir, matchDir))
           if (relativePath === '' || picomatch.isMatch(relativePath, workspaces)) {
             return detectFromLockFile(dir) ?? 'yarn'
           }

--- a/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
+++ b/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
@@ -83,7 +83,6 @@ function detectFromWorkspaceRoot(pkgPath: string): DetectablePackageManager | nu
           if (relativePath === '' || picomatch.isMatch(relativePath, workspaces)) {
             return detectFromLockFile(dir) ?? 'yarn'
           }
-          continue
         }
       } catch {
         // malformed package.json, skip

--- a/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
+++ b/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
@@ -7,9 +7,8 @@ import path from 'node:path'
 import picomatch from 'picomatch'
 
 import {toForwardSlashes} from '../toForwardSlashes.js'
-import {type PackageManager} from './packageManagerChoice.js'
 
-type DetectablePackageManager = Exclude<PackageManager, 'manual'>
+type DetectablePackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn'
 
 /**
  * Detects the preferred package manager for a project by examining lock files,

--- a/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
+++ b/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
@@ -64,12 +64,12 @@ function findNearestPackageDir(startDir: string): string {
 }
 
 function detectFromWorkspaceRoot(pkgPath: string): DetectablePackageManager | null {
-  const packageDir = findNearestPackageDir(pkgPath)
-  let dir = path.resolve(pkgPath)
+  const resolvedPkgPath = path.resolve(pkgPath)
+  const packageDir = findNearestPackageDir(resolvedPkgPath)
+  let dir = resolvedPkgPath
   const {root} = path.parse(dir)
-  let previous: string | null = null
 
-  while (dir !== previous) {
+  while (true) {
     const manifestPath = path.join(dir, 'package.json')
     if (fs.existsSync(manifestPath)) {
       try {
@@ -77,7 +77,7 @@ function detectFromWorkspaceRoot(pkgPath: string): DetectablePackageManager | nu
         const workspaces = extractWorkspaces(manifest)
 
         if (workspaces) {
-          const matchDir = packageDir === dir ? pkgPath : packageDir
+          const matchDir = packageDir === dir ? resolvedPkgPath : packageDir
           const relativePath = path.relative(dir, matchDir)
           if (relativePath === '' || picomatch.isMatch(relativePath, workspaces)) {
             return detectFromLockFile(dir) ?? 'yarn'
@@ -88,10 +88,8 @@ function detectFromWorkspaceRoot(pkgPath: string): DetectablePackageManager | nu
         // malformed package.json, skip
       }
     }
-    previous = dir
+    if (dir === root) break
     dir = path.dirname(dir)
-    if (dir === root && previous !== root) continue
-    if (dir === root && previous === root) break
   }
 
   return null

--- a/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
+++ b/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
@@ -83,7 +83,7 @@ function detectFromWorkspaceRoot(pkgPath: string): DetectablePackageManager | nu
           if (relativePath === '' || picomatch.isMatch(relativePath, workspaces)) {
             return detectFromLockFile(dir) ?? 'yarn'
           }
-          return null
+          continue
         }
       } catch {
         // malformed package.json, skip
@@ -133,8 +133,8 @@ function detectFromNodeModules(pkgPath: string): DetectablePackageManager | null
         if (name === 'bun') return 'bun'
       }
     }
-  } catch (err: unknown) {
-    if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') throw err
+  } catch {
+    // best-effort detection — swallow all read errors
   }
 
   if (fs.existsSync(modulesPath)) return 'npm'

--- a/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
+++ b/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
@@ -18,8 +18,8 @@ export function preferredPm(pkgPath: string): DetectablePackageManager | null {
   const fromLockFile = detectFromLockFile(pkgPath)
   if (fromLockFile) return fromLockFile
 
-  const fromParentPnpmLock = findUp('pnpm-lock.yaml', pkgPath)
-  if (fromParentPnpmLock) return 'pnpm'
+  const fromParentPnpm = findUp('pnpm-lock.yaml', pkgPath) || findUp('pnpm-workspace.yaml', pkgPath)
+  if (fromParentPnpm) return 'pnpm'
 
   const fromWorkspace = detectFromWorkspaceRoot(pkgPath)
   if (fromWorkspace) return fromWorkspace

--- a/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
+++ b/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
@@ -1,0 +1,144 @@
+// Based on preferred-pm (MIT) by Zoltan Kochan — https://github.com/zkochan/packages
+// Based on which-pm (MIT) by pnpm — https://github.com/pnpm/which-pm
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+import picomatch from 'picomatch'
+
+import {type PackageManager} from './packageManagerChoice.js'
+
+type DetectablePackageManager = Exclude<PackageManager, 'manual'>
+
+/**
+ * Detects the preferred package manager for a project by examining lock files,
+ * workspace configurations, and node_modules markers.
+ */
+export function preferredPm(pkgPath: string): DetectablePackageManager | null {
+  const fromLockFile = detectFromLockFile(pkgPath)
+  if (fromLockFile) return fromLockFile
+
+  const fromParentPnpmLock = findUp('pnpm-lock.yaml', pkgPath)
+  if (fromParentPnpmLock) return 'pnpm'
+
+  const fromWorkspace = detectFromWorkspaceRoot(pkgPath)
+  if (fromWorkspace) return fromWorkspace
+
+  return detectFromNodeModules(pkgPath)
+}
+
+function detectFromLockFile(dir: string): DetectablePackageManager | null {
+  if (fs.existsSync(path.join(dir, 'package-lock.json'))) return 'npm'
+  if (fs.existsSync(path.join(dir, 'yarn.lock'))) return 'yarn'
+  if (fs.existsSync(path.join(dir, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (fs.existsSync(path.join(dir, 'shrinkwrap.yaml'))) return 'pnpm'
+  if (fs.existsSync(path.join(dir, 'bun.lockb')) || fs.existsSync(path.join(dir, 'bun.lock')))
+    return 'bun'
+  return null
+}
+
+function findUp(filename: string, startDir: string): string | undefined {
+  let dir = path.resolve(startDir)
+  const {root} = path.parse(dir)
+
+  while (dir) {
+    const filePath = path.join(dir, filename)
+    if (fs.existsSync(filePath)) return filePath
+    if (dir === root) break
+    dir = path.dirname(dir)
+  }
+
+  return undefined
+}
+
+function findNearestPackageDir(startDir: string): string {
+  let dir = path.resolve(startDir)
+  const {root} = path.parse(dir)
+
+  while (dir !== root) {
+    if (fs.existsSync(path.join(dir, 'package.json'))) return dir
+    dir = path.dirname(dir)
+  }
+
+  return startDir
+}
+
+function detectFromWorkspaceRoot(pkgPath: string): DetectablePackageManager | null {
+  const packageDir = findNearestPackageDir(pkgPath)
+  let dir = path.resolve(pkgPath)
+  const {root} = path.parse(dir)
+  let previous: string | null = null
+
+  while (dir !== previous) {
+    const manifestPath = path.join(dir, 'package.json')
+    if (fs.existsSync(manifestPath)) {
+      try {
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+        const workspaces = extractWorkspaces(manifest)
+
+        if (workspaces) {
+          const matchDir = packageDir === dir ? pkgPath : packageDir
+          const relativePath = path.relative(dir, matchDir)
+          if (relativePath === '' || picomatch.isMatch(relativePath, workspaces)) {
+            return detectFromLockFile(dir) ?? 'yarn'
+          }
+          return null
+        }
+      } catch {
+        // malformed package.json, skip
+      }
+    }
+    previous = dir
+    dir = path.dirname(dir)
+    if (dir === root && previous !== root) continue
+    if (dir === root && previous === root) break
+  }
+
+  return null
+}
+
+function extractWorkspaces(manifest: Record<string, unknown>): string[] | null {
+  const workspaces = manifest?.workspaces
+  if (Array.isArray(workspaces)) return workspaces
+  if (
+    workspaces &&
+    typeof workspaces === 'object' &&
+    'packages' in workspaces &&
+    Array.isArray((workspaces as Record<string, unknown>).packages)
+  ) {
+    return (workspaces as Record<string, unknown>).packages as string[]
+  }
+  return null
+}
+
+function detectFromNodeModules(pkgPath: string): DetectablePackageManager | null {
+  const modulesPath = path.join(pkgPath, 'node_modules')
+
+  if (fs.existsSync(path.join(modulesPath, '.yarn-integrity'))) return 'yarn'
+
+  try {
+    const modulesYaml = fs.readFileSync(path.join(modulesPath, '.modules.yaml'), 'utf8')
+    const pmLine = modulesYaml
+      .split('\n')
+      .find((line) => /^\s*"?packageManager"?\s*[:=]/.test(line))
+    if (pmLine) {
+      const valueMatch = pmLine.match(/[:=]\s*['"]?([^'",\s]+)/)
+      if (valueMatch) {
+        const pmSpec = valueMatch[1]
+        const name = pmSpec.startsWith('@')
+          ? `@${pmSpec.slice(1).split('@')[0]}`
+          : pmSpec.split('@')[0]
+        if (name === 'pnpm') return 'pnpm'
+        if (name === 'yarn') return 'yarn'
+        if (name === 'npm') return 'npm'
+        if (name === 'bun') return 'bun'
+      }
+    }
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') throw err
+  }
+
+  if (fs.existsSync(modulesPath)) return 'npm'
+
+  return null
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,9 +628,6 @@ importers:
       pluralize-esm:
         specifier: ^9.0.5
         version: 9.0.5
-      preferred-pm:
-        specifier: ^5.0.0
-        version: 5.0.0(ts-toolbelt@9.6.0)
       pretty-ms:
         specifier: ^9.3.0
         version: 9.3.0
@@ -2978,9 +2975,6 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
-
-  '@lazy-node/types-path@1.0.3':
-    resolution: {integrity: sha512-5Bnl5s5jh7o14i0oa7gj+Y0fDLIlri3+KVZmv4gk0OFGuOrOEmWBBCI9ky3Syip5g/yPHZdfa+WO5BVJMUpMdw==}
 
   '@lezer/common@1.5.1':
     resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
@@ -6642,9 +6636,6 @@ packages:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
     engines: {node: '>=18'}
 
-  find-yarn-workspace-root2@1.2.53:
-    resolution: {integrity: sha512-0P66/qSVapUMgxLt0BwnKQ2VEg7uR/PIX82y/YuKOf8oHK437uq3OcMUdB4NGDJrCZ2is6jME0yZcV9nAM0RoQ==}
-
   find-yarn-workspace-root@2.0.0:
     resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
 
@@ -7472,10 +7463,6 @@ packages:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
 
-  load-yaml-file@1.0.0:
-    resolution: {integrity: sha512-Xw+A/X4c5R6GWu7ZUQgw1rnbfUr1P/hAZbDTrreo+/fP/YSGgxAKoWe2IcT+bt4RHuyIca6S7SMGcWx+QI3WIw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
@@ -8058,9 +8045,6 @@ packages:
     resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
     engines: {node: '>=14.0.0'}
 
-  path-is-network-drive@1.0.24:
-    resolution: {integrity: sha512-sux7NWiMq/ul8EEQTQbdM1m/zr+Rrq11/P9tEBgxMgTnVHS8f54tQm0kfrTxkvPNg/OVkRjHNgSia5VxnawOZg==}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -8075,9 +8059,6 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
-
-  path-strip-sep@1.0.21:
-    resolution: {integrity: sha512-V5Lvyhx0fE6/wEk/YseTtoRQIaD32cepnzrQ1b3kOzOxxDoSglry8IZ1b6LPObIeIbpC0+i9ygUsBNhkOttQKw==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -8124,10 +8105,6 @@ packages:
     resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
     engines: {node: '>=6'}
 
-  pkg-dir@5.0.0:
-    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
-    engines: {node: '>=10'}
-
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -8163,10 +8140,6 @@ packages:
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
-
-  preferred-pm@5.0.0:
-    resolution: {integrity: sha512-qs9WZBOIW4tXjxoYxUathIb53hcV3cjVpLJl8Y0h3QOiyqnbDzWmw0jvTI5YOw/RAkhDsB/sFVt9pYV+r6NP2A==}
-    engines: {node: '>=22.13'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -8847,10 +8820,6 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
-  strip-bom@5.0.0:
-    resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
-    engines: {node: '>=12'}
-
   strip-dirs@3.0.0:
     resolution: {integrity: sha512-I0sdgcFTfKQlUPZyAqPJmSG3HLO9rWDFnxonnIbskYNM3DwFOeTNB5KzVq3dA1GdRAc/25b5Y7UO2TQfKWw4aQ==}
 
@@ -9068,14 +9037,6 @@ packages:
     peerDependencies:
       typescript: '>=4.0.0'
 
-  ts-toolbelt@9.6.0:
-    resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
-
-  ts-type@3.0.10:
-    resolution: {integrity: sha512-L6r2sL6PjBrXcYd1cvSznkgheqWHCUURLGHP2Kwnd6HABwkcds3N72eKbNcvZPawBlPgs3UDCz3v6P6kkOAYWA==}
-    peerDependencies:
-      ts-toolbelt: ^9.6.0
-
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
@@ -9124,9 +9085,6 @@ packages:
   type-fest@5.4.4:
     resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
     engines: {node: '>=20'}
-
-  typedarray-dts@1.0.0:
-    resolution: {integrity: sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA==}
 
   typeid-js@0.3.0:
     resolution: {integrity: sha512-A1EmvIWG6xwYRfHuYUjPltHqteZ1EiDG+HOmbIYXeHUVztmnGrPIfU9KIK1QC30x59ko0r4JsMlwzsALCyiB3Q==}
@@ -9230,9 +9188,6 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
-
-  upath2@3.1.23:
-    resolution: {integrity: sha512-HQ7CivlKonWnq7m7VZuZHIDXXUCHOoCoIqgVyCk/z/wsuB/agGwGFhFjGSTArGlvBddiejrW4ChW6SwEMhAURQ==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -9485,10 +9440,6 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  which-pm@4.0.0:
-    resolution: {integrity: sha512-kLoLJ/y2o0GnU8ZNgI5/nlCbyjpUlqtaJQjMrzR2sKyQQ3BcJJ61oSOdZWIrfoScunyZS5w9U0wyFb0Bij9cyg==}
-    engines: {node: '>=22.13'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -12161,14 +12112,6 @@ snapshots:
   '@juggle/resize-observer@3.4.0': {}
 
   '@keyv/serialize@1.1.1': {}
-
-  '@lazy-node/types-path@1.0.3(ts-toolbelt@9.6.0)':
-    dependencies:
-      '@types/node': 25.0.10
-      ts-type: 3.0.10(ts-toolbelt@9.6.0)
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - ts-toolbelt
 
   '@lezer/common@1.5.1': {}
 
@@ -16282,15 +16225,6 @@ snapshots:
       semver-regex: 4.0.5
       super-regex: 1.1.0
 
-  find-yarn-workspace-root2@1.2.53(ts-toolbelt@9.6.0):
-    dependencies:
-      micromatch: 4.0.8
-      pkg-dir: 5.0.0
-      tslib: 2.8.1
-      upath2: 3.1.23(ts-toolbelt@9.6.0)
-    transitivePeerDependencies:
-      - ts-toolbelt
-
   find-yarn-workspace-root@2.0.0:
     dependencies:
       micromatch: 4.0.8
@@ -17124,12 +17058,6 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  load-yaml-file@1.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      js-yaml: 4.1.1
-      strip-bom: 5.0.0
-
   locate-path@3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -17761,10 +17689,6 @@ snapshots:
 
   path-expression-matcher@1.2.0: {}
 
-  path-is-network-drive@1.0.24:
-    dependencies:
-      tslib: 2.8.1
-
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -17775,10 +17699,6 @@ snapshots:
     dependencies:
       lru-cache: 11.2.7
       minipass: 7.1.3
-
-  path-strip-sep@1.0.21:
-    dependencies:
-      tslib: 2.8.1
 
   path-to-regexp@6.3.0: {}
 
@@ -17813,10 +17733,6 @@ snapshots:
   pkg-dir@3.0.0:
     dependencies:
       find-up: 3.0.0
-
-  pkg-dir@5.0.0:
-    dependencies:
-      find-up: 5.0.0
 
   pkg-types@1.3.1:
     dependencies:
@@ -17860,14 +17776,6 @@ snapshots:
       source-map-js: 1.2.1
 
   powershell-utils@0.1.0: {}
-
-  preferred-pm@5.0.0(ts-toolbelt@9.6.0):
-    dependencies:
-      find-up-simple: 1.0.1
-      find-yarn-workspace-root2: 1.2.53(ts-toolbelt@9.6.0)
-      which-pm: 4.0.0
-    transitivePeerDependencies:
-      - ts-toolbelt
 
   prelude-ls@1.2.1: {}
 
@@ -18727,8 +18635,6 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-bom@5.0.0: {}
-
   strip-dirs@3.0.0:
     dependencies:
       inspect-with-kind: 1.0.5
@@ -18935,15 +18841,6 @@ snapshots:
       picomatch: 4.0.4
       typescript: 5.9.3
 
-  ts-toolbelt@9.6.0: {}
-
-  ts-type@3.0.10(ts-toolbelt@9.6.0):
-    dependencies:
-      '@types/node': 25.0.10
-      ts-toolbelt: 9.6.0
-      tslib: 2.8.1
-      typedarray-dts: 1.0.0
-
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
@@ -18989,8 +18886,6 @@ snapshots:
   type-fest@5.4.4:
     dependencies:
       tagged-tag: 1.0.0
-
-  typedarray-dts@1.0.0: {}
 
   typeid-js@0.3.0:
     dependencies:
@@ -19100,16 +18995,6 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
-
-  upath2@3.1.23(ts-toolbelt@9.6.0):
-    dependencies:
-      '@lazy-node/types-path': 1.0.3(ts-toolbelt@9.6.0)
-      '@types/node': 25.0.10
-      path-is-network-drive: 1.0.24
-      path-strip-sep: 1.0.21
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - ts-toolbelt
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -19373,10 +19258,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  which-pm@4.0.0:
-    dependencies:
-      load-yaml-file: 1.0.0
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
### Description

Replaces the `preferred-pm` npm dependency with a local implementation to fix compatibility with yarn v1 on Node 20. The `preferred-pm@5.0.0` package requires `node >=22.13`, which breaks yarn v1 Classic since it enforces engine checks by default.

See #983 for context on the yarn v1 + Node 20 incompatibility.

Changes:
- Remove `preferred-pm` dependency from `@sanity/cli`
- Add local `preferredPm` module that detects package managers via lock files, workspace configurations, and `node_modules` markers
- Convert from async to sync detection (no behavioral change — the original library only did sync filesystem checks behind an async API)
- Fix workspace detection for paths nested inside a package (e.g. `packages/child/src`)
- Fix `.modules.yaml` parsing to handle both YAML and JSON formats

### What to review

- `packages/@sanity/cli/src/util/packageManager/preferredPm.ts` — the local implementation
- `packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts` — unit tests (22 cases)
- `packages/@sanity/cli/src/util/packageManager/packageManagerChoice.ts` — updated import and usage

### Testing

Unit tests cover: lock file detection (all 6 lock file types), parent directory pnpm-lock walk-up, workspace root detection (yarn/npm/pnpm/bun workspaces, subdirectory paths, non-matching paths, `workspaces.packages` format), `node_modules` marker detection (YAML and JSON `.modules.yaml` formats), and empty directory fallback.

```
pnpm test packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI package-manager auto-detection logic and removes a third-party dependency, which can affect dependency installation/upgrade flows across different workspace layouts. Risk is mitigated by extensive new unit tests, but behavior differences in edge cases are still possible.
> 
> **Overview**
> Fixes Yarn v1 on Node 20 by **removing the `preferred-pm` dependency** (and its Node 22+ engine requirement) and switching `getPackageManagerChoice` to use a new in-repo `preferredPm` implementation.
> 
> The new detector infers the preferred package manager from lockfiles, pnpm lock/workspace files in parent directories, workspace root `package.json` globs, and `node_modules` markers (including more tolerant `.modules.yaml` parsing), with a comprehensive new `vitest` suite to cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a000164b40671ecf76fcb450d583833961c56e5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->