### PR TITLE
feat(init): add promt for federation

### DIFF
--- a/.changeset/pr-988.md
+++ b/.changeset/pr-988.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+add promt for federation

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapRemoteTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapRemoteTemplate.test.ts
@@ -76,6 +76,7 @@ const baseOpts = {
   variables: {
     autoUpdates: false,
     dataset: 'production',
+    federation: true,
     projectId: 'test-project-id',
   },
 }

--- a/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
@@ -127,11 +127,13 @@ export async function bootstrapLocalTemplate(
   const cliConfig = isAppTemplate
     ? createAppCliConfig({
         entry: template.entry!,
+        federation: variables.federation,
         organizationId: variables.organizationId,
       })
     : createCliConfig({
         autoUpdates: variables.autoUpdates,
         dataset: variables.dataset,
+        federation: variables.federation,
         projectId: variables.projectId,
       })
 

--- a/packages/@sanity/cli/src/actions/init/bootstrapTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapTemplate.ts
@@ -9,6 +9,7 @@ interface BootstrapTemplateOptions {
   autoUpdates: boolean
   bearerToken: string | undefined
   dataset: string
+  federation: boolean
   organizationId: string | undefined
   output: Output
   outputPath: string
@@ -25,6 +26,7 @@ export async function bootstrapTemplate({
   autoUpdates,
   bearerToken,
   dataset,
+  federation,
   organizationId,
   output,
   outputPath,
@@ -39,6 +41,7 @@ export async function bootstrapTemplate({
   const bootstrapVariables: GenerateConfigOptions['variables'] = {
     autoUpdates,
     dataset,
+    federation,
     organizationId,
     projectId,
     projectName,

--- a/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
@@ -8,17 +8,22 @@ export default defineCliConfig({
     organizationId: '%organizationId%',
     entry: '%entry%',
   },
+  federation: {
+    enabled: __BOOL__federation__,
+  },
 })
 `
 
 interface GenerateCliConfigOptions {
   entry: string
+  federation: boolean
 
   organizationId?: string
 }
 
 export function createAppCliConfig(options: GenerateCliConfigOptions): string {
   return processTemplate({
+    includeBooleanTransform: true,
     template: defaultAppTemplate,
     variables: options,
   })

--- a/packages/@sanity/cli/src/actions/init/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createCliConfig.ts
@@ -14,13 +14,17 @@ export default defineCliConfig({
      * Learn more at https://www.sanity.io/docs/studio/latest-version-of-sanity#k47faf43faf56
      */
     autoUpdates: __BOOL__autoUpdates__,
-  }
+  },
+  federation: {
+    enabled: __BOOL__federation__,
+  },
 })
 `
 
 interface GenerateCliConfigOptions {
   autoUpdates: boolean
   dataset: string
+  federation: boolean
   projectId: string
 }
 

--- a/packages/@sanity/cli/src/actions/init/createStudioConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createStudioConfig.ts
@@ -31,6 +31,7 @@ export interface GenerateConfigOptions {
   variables: {
     autoUpdates: boolean
     dataset: string
+    federation: boolean
     organizationId?: string
     projectId: string
     projectName?: string

--- a/packages/@sanity/cli/src/actions/init/initApp.ts
+++ b/packages/@sanity/cli/src/actions/init/initApp.ts
@@ -14,9 +14,10 @@ export async function initApp({
   autoUpdates,
   defaults,
   error,
+  federation,
   git,
-  noGit,
   mcpConfigured,
+  noGit,
   organizationId,
   output,
   outputPath,
@@ -34,9 +35,10 @@ export async function initApp({
   autoUpdates: boolean
   defaults: {projectName: string}
   error: Output['error']
+  federation: boolean
   git?: boolean | string
-  noGit?: boolean
   mcpConfigured: EditorName[]
+  noGit?: boolean
   organizationId: string | undefined
   output: Output
   outputPath: string
@@ -72,6 +74,7 @@ export async function initApp({
     datasetName: '',
     defaults,
     displayName: '',
+    federation,
     git,
     noGit,
     organizationId,

--- a/packages/@sanity/cli/src/actions/init/initStudio.ts
+++ b/packages/@sanity/cli/src/actions/init/initStudio.ts
@@ -28,11 +28,12 @@ export async function initStudio({
   defaults,
   displayName,
   error,
+  federation,
   git,
-  noGit,
   importDataset,
   isFirstProject,
   mcpConfigured,
+  noGit,
   organizationId,
   output,
   outputPath,
@@ -53,11 +54,12 @@ export async function initStudio({
   defaults: {projectName: string}
   displayName: string
   error: Output['error']
+  federation: boolean
   git?: boolean | string
-  noGit?: boolean
   importDataset?: boolean
   isFirstProject: boolean
   mcpConfigured: EditorName[]
+  noGit?: boolean
   organizationId: string | undefined
   output: Output
   outputPath: string
@@ -112,6 +114,7 @@ export async function initStudio({
     datasetName,
     defaults,
     displayName,
+    federation,
     git,
     noGit,
     organizationId,

--- a/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
@@ -96,6 +96,7 @@ export async function scaffoldAndInstall({
   datasetName,
   defaults,
   displayName,
+  federation,
   git,
   noGit,
   organizationId,
@@ -117,6 +118,7 @@ export async function scaffoldAndInstall({
   datasetName: string
   defaults: {projectName: string}
   displayName: string
+  federation: boolean
   git?: boolean | string
   noGit?: boolean
   organizationId: string | undefined
@@ -139,6 +141,7 @@ export async function scaffoldAndInstall({
       autoUpdates,
       bearerToken: templateToken,
       dataset: datasetName,
+      federation,
       organizationId,
       output,
       outputPath,

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -177,6 +177,7 @@ describe('#init: authentication', () => {
         '--output-path=/test/output',
         '--no-overwrite-files',
         '--template=clean',
+        '--federation',
       ],
       {
         mocks: {
@@ -221,6 +222,7 @@ describe('#init: authentication', () => {
         '--output-path=/test/output',
         '--no-overwrite-files',
         '--template=clean',
+        '--federation',
       ],
       {
         mocks: {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -175,6 +175,7 @@ describe('#init: bootstrap-app-initialization', () => {
         '--dataset=test',
         '--package-manager=npm',
         '--typescript',
+        '--federation',
       ],
       {
         mocks: {
@@ -188,6 +189,7 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: 'test',
+      federation: true,
       organizationId: undefined,
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),
@@ -265,6 +267,7 @@ describe('#init: bootstrap-app-initialization', () => {
         '--output-path=/test/output',
         '--package-manager=npm',
         '--typescript',
+        '--federation',
       ],
       {
         mocks: {
@@ -278,6 +281,7 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: '',
+      federation: true,
       organizationId: 'org-1',
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),
@@ -340,6 +344,7 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: '',
+      federation: true,
       organizationId: 'org-1',
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),
@@ -410,6 +415,7 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: '',
+      federation: true,
       organizationId: 'org-1',
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
@@ -519,6 +519,7 @@ describe('#init: create new project', () => {
         '--no-overwrite-files',
         '--template=moviedb',
         '--no-import-dataset',
+        '--federation',
       ],
       {mocks: {...defaultMocks, isInteractive: true}},
     )

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.staging-env.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.staging-env.test.ts
@@ -236,6 +236,7 @@ describe('#init: staging env propagation', () => {
         '--dataset=test',
         '--package-manager=npm',
         '--typescript',
+        '--federation',
       ],
       {
         mocks: {
@@ -273,6 +274,7 @@ describe('#init: staging env propagation', () => {
         '--dataset=test',
         '--package-manager=npm',
         '--typescript',
+        '--federation',
       ],
       {
         mocks: {
@@ -302,6 +304,7 @@ describe('#init: staging env propagation', () => {
         '--dataset=test',
         '--package-manager=npm',
         '--typescript',
+        '--federation',
       ],
       {
         mocks: {

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -37,6 +37,7 @@ import {getOrganizationChoices} from '../actions/organizations/getOrganizationCh
 import {getOrganizationsWithAttachGrantInfo} from '../actions/organizations/getOrganizationsWithAttachGrantInfo.js'
 import {hasProjectAttachGrant} from '../actions/organizations/hasProjectAttachGrant.js'
 import {type OrganizationChoices} from '../actions/organizations/types.js'
+import {promptForFederation} from '../prompts/init/federation.js'
 import {promptForConfigFiles} from '../prompts/init/nextjs.js'
 import {promptForDatasetName} from '../prompts/promptForDatasetName.js'
 import {promptForDefaultConfig} from '../prompts/promptForDefaultConfig.js'
@@ -130,6 +131,11 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
         }
         return input
       },
+    }),
+    federation: Flags.boolean({
+      allowNo: true,
+      default: undefined,
+      description: 'Enable federation for this project',
     }),
     'from-create': Flags.boolean({
       description: 'Internal flag to indicate that the command is run from create-sanity',
@@ -508,13 +514,19 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       this.exit(0)
     }
 
+    let federation = flagOrDefault(this.flags.federation, true)
+    if (shouldPrompt(this.isUnattended(), this.flags.federation)) {
+      federation = await promptForFederation()
+    }
+
     const sharedParams = {
       autoUpdates: this.flags['auto-updates'],
       defaults,
       error: this.error.bind(this) as typeof this.error,
+      federation,
       git: this.flags.git,
-      noGit: this.flags['no-git'],
       mcpConfigured,
+      noGit: this.flags['no-git'],
       organizationId,
       output: this.output,
       outputPath,

--- a/packages/@sanity/cli/src/prompts/init/federation.ts
+++ b/packages/@sanity/cli/src/prompts/init/federation.ts
@@ -1,0 +1,8 @@
+import {confirm} from '@sanity/cli-core/ux'
+
+export function promptForFederation(): Promise<boolean> {
+  return confirm({
+    default: true,
+    message: 'Would you like to enable federation for this project?',
+  })
+}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds a new prompt about whether a user wants to enable federation for a given up, to the sanity init command, that is being triggered when running `npm create sanity@latest`. In unattended mode, it defaults to `true`.

The idea is that users will be able to run `npm create sanity@workbench` once this is merged, to ease getting started with module-federation internally.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Should we stick to copy around "federation" or should we frame it as workbench, since "federation" is the technology, but not the value this promises?
