### PR TITLE
chore(cli): bump @sanity/federation to 0.1.0-alpha.6

### DIFF
--- a/.changeset/bump-federation-alpha-6.md
+++ b/.changeset/bump-federation-alpha-6.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+bump @sanity/federation to 0.1.0-alpha.6

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -80,7 +80,7 @@
     "@sanity/codegen": "catalog:",
     "@sanity/descriptors": "^1.3.0",
     "@sanity/export": "^6.1.0",
-    "@sanity/federation": "0.1.0-alpha.4",
+    "@sanity/federation": "0.1.0-alpha.6",
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/id-utils": "^1.0.0",
     "@sanity/import": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,8 +531,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0
       '@sanity/federation':
-        specifier: 0.1.0-alpha.4
-        version: 0.1.0-alpha.4(debug@4.4.3)(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 0.1.0-alpha.6
+        version: 0.1.0-alpha.6(debug@4.4.3)(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -4354,8 +4354,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@0.1.0-alpha.4':
-    resolution: {integrity: sha512-H6wc4yCQEJHvhZq11n/36rQTEki6+gZfKGgcMU+GPW583lZx78m2zVaDcaQB9BslKOgeUO/bkg0RZh+oDFbTVw==}
+  '@sanity/federation@0.1.0-alpha.6':
+    resolution: {integrity: sha512-erYyczA2V9DZvvd3Aj1RBzDRjKk4/bH57vbnQMbbW2rxZJq5y1uysk4Zw0sii8X/JK69+4nx/UKtPXSlV29vGg==}
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
       vite: ^7.0.0 || ^8.0.0
@@ -13643,7 +13643,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@0.1.0-alpha.4(debug@4.4.3)(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@sanity/federation@0.1.0-alpha.6(debug@4.4.3)(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@module-federation/runtime': 2.3.2
       '@module-federation/vite': 1.14.0(debug@4.4.3)(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))


### PR DESCRIPTION
### Description

Bumps `@sanity/federation` from `0.1.0-alpha.4` to `0.1.0-alpha.6` (two alpha releases behind latest).

### What to review

- `packages/@sanity/cli/package.json` — version bump
- `pnpm-lock.yaml` — regenerated
- `.changeset/bump-federation-alpha-6.md` — patch changeset for `@sanity/cli`