### PR TITLE
feat(init): use `workbench` dist-tag for `sanity` package

### DIFF
--- a/.changeset/pr-992.md
+++ b/.changeset/pr-992.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+use `workbench` dist-tag for `sanity` package

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
+import {resolveLatestVersions} from '../../../util/resolveLatestVersions.js'
 import {bootstrapLocalTemplate} from '../bootstrapLocalTemplate.js'
 
 vi.mock('../../../util/resolveLatestVersions.js', () => ({
@@ -87,5 +88,85 @@ describe('bootstrapLocalTemplate (app templates)', () => {
     expect(appTsx).toContain(`dataset: ''`)
     expect(appTsx).not.toContain('%projectId%')
     expect(appTsx).not.toContain('%dataset%')
+  })
+})
+
+describe('bootstrapLocalTemplate (federation)', () => {
+  let tmp: string
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'cli-bootstrap-'))
+  })
+  afterEach(async () => {
+    await rm(tmp, {force: true, recursive: true})
+    vi.clearAllMocks()
+  })
+
+  test('overrides the `sanity` dependency with the `workbench` dist-tag when federation is enabled', async () => {
+    await bootstrapLocalTemplate({
+      output: makeOutput(),
+      outputPath: tmp,
+      packageName: 'my-studio',
+      templateName: 'clean',
+      useTypeScript: true,
+      variables: {
+        autoUpdates: false,
+        dataset: 'production',
+        federation: true,
+        organizationId: 'org1',
+        projectId: 'abc123',
+        projectName: 'my-studio',
+      },
+    })
+
+    expect(resolveLatestVersions).toHaveBeenCalledOnce()
+    const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
+    expect(resolvedDeps.sanity).toBe('workbench')
+
+    const pkgJson = JSON.parse(await readFile(path.join(tmp, 'package.json'), 'utf8'))
+    expect(pkgJson.dependencies.sanity).toBe('1.0.0')
+  })
+
+  test('keeps the `sanity` dependency on the `latest` dist-tag when federation is disabled', async () => {
+    await bootstrapLocalTemplate({
+      output: makeOutput(),
+      outputPath: tmp,
+      packageName: 'my-studio',
+      templateName: 'clean',
+      useTypeScript: true,
+      variables: {
+        autoUpdates: false,
+        dataset: 'production',
+        federation: false,
+        organizationId: 'org1',
+        projectId: 'abc123',
+        projectName: 'my-studio',
+      },
+    })
+
+    expect(resolveLatestVersions).toHaveBeenCalledOnce()
+    const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
+    expect(resolvedDeps.sanity).toBe('latest')
+  })
+
+  test('overrides the `sanity` devDependency for app templates when federation is enabled', async () => {
+    await bootstrapLocalTemplate({
+      output: makeOutput(),
+      outputPath: tmp,
+      packageName: 'my-app',
+      templateName: 'app-quickstart',
+      useTypeScript: true,
+      variables: {
+        autoUpdates: false,
+        dataset: 'production',
+        federation: true,
+        organizationId: 'org1',
+        projectId: 'abc123',
+        projectName: 'my-app',
+      },
+    })
+
+    expect(resolveLatestVersions).toHaveBeenCalledOnce()
+    const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
+    expect(resolvedDeps.sanity).toBe('workbench')
   })
 })

--- a/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
@@ -89,6 +89,7 @@ export async function bootstrapLocalTemplate(
     ...(isAppTemplate ? sdkAppDependencies.devDependencies : studioDependencies.devDependencies),
     ...template.dependencies,
     ...template.devDependencies,
+    ...(variables.federation && {sanity: 'workbench'}),
   })
   spin.succeed()
 

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -231,7 +231,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
   private async handleCopyMode(
     projectId: string,
     args: {source?: string; target?: string},
-    flags: {'skip-content-releases'?: boolean; 'skip-history'?: boolean; detach?: boolean},
+    flags: {detach?: boolean; 'skip-content-releases'?: boolean; 'skip-history'?: boolean},
   ): Promise<void> {
     copyDatasetDebug('Starting copy mode')
 

--- a/packages/@sanity/cli/src/services/datasets.ts
+++ b/packages/@sanity/cli/src/services/datasets.ts
@@ -82,10 +82,11 @@ export async function createDataset({
 
 interface CopyDatasetOptions {
   projectId: string
-  skipContentReleases?: boolean
   skipHistory: boolean
   sourceDataset: string
   targetDataset: string
+
+  skipContentReleases?: boolean
 }
 
 interface CopyDatasetResponse {

--- a/packages/@sanity/cli/src/util/__tests__/resolveLatestVersions.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/resolveLatestVersions.test.ts
@@ -1,0 +1,77 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {resolveLatestVersions} from '../resolveLatestVersions.js'
+
+const mockGetLatestVersion = vi.hoisted(() => vi.fn())
+
+vi.mock('get-latest-version', () => ({
+  getLatestVersion: mockGetLatestVersion,
+}))
+
+describe('resolveLatestVersions', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('passes through valid semver ranges without looking them up', async () => {
+    const result = await resolveLatestVersions({
+      foo: '1.2.3',
+      react: '^19.2.4',
+      typescript: '~5.8',
+    })
+
+    expect(result).toEqual({
+      foo: '1.2.3',
+      react: '^19.2.4',
+      typescript: '~5.8',
+    })
+    expect(mockGetLatestVersion).not.toHaveBeenCalled()
+  })
+
+  test('resolves the `latest` dist-tag and caret-prefixes the version', async () => {
+    mockGetLatestVersion.mockResolvedValueOnce('4.5.6')
+
+    const result = await resolveLatestVersions({sanity: 'latest'})
+
+    expect(mockGetLatestVersion).toHaveBeenCalledWith('sanity', {range: 'latest'})
+    expect(result).toEqual({sanity: '^4.5.6'})
+  })
+
+  test('resolves arbitrary dist-tags such as `workbench`', async () => {
+    mockGetLatestVersion.mockResolvedValueOnce('7.8.9-workbench.0')
+
+    const result = await resolveLatestVersions({sanity: 'workbench'})
+
+    expect(mockGetLatestVersion).toHaveBeenCalledWith('sanity', {range: 'workbench'})
+    expect(result).toEqual({sanity: '^7.8.9-workbench.0'})
+  })
+
+  test('falls back to the original tag when the lookup returns undefined', async () => {
+    mockGetLatestVersion.mockResolvedValueOnce(undefined)
+
+    const result = await resolveLatestVersions({sanity: 'workbench'})
+
+    expect(result).toEqual({sanity: 'workbench'})
+  })
+
+  test('resolves a mix of ranges and dist-tags in a single call', async () => {
+    mockGetLatestVersion.mockImplementation(async (_pkg: string, {range}: {range: string}) => {
+      if (range === 'latest') return '1.0.0'
+      if (range === 'workbench') return '2.0.0-workbench.1'
+      return undefined
+    })
+
+    const result = await resolveLatestVersions({
+      '@sanity/vision': 'latest',
+      react: '^19.2.4',
+      sanity: 'workbench',
+    })
+
+    expect(result).toEqual({
+      '@sanity/vision': '^1.0.0',
+      react: '^19.2.4',
+      sanity: '^2.0.0-workbench.1',
+    })
+    expect(mockGetLatestVersion).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/@sanity/cli/src/util/resolveLatestVersions.ts
+++ b/packages/@sanity/cli/src/util/resolveLatestVersions.ts
@@ -1,5 +1,6 @@
 import {getLatestVersion} from 'get-latest-version'
 import promiseProps from 'promise-props-recursive'
+import semver from 'semver'
 
 /**
  * Resolve the latest versions of given packages within their defined ranges
@@ -12,13 +13,15 @@ export function resolveLatestVersions(
 ): Promise<Record<string, string>> {
   const lookups: Record<string, Promise<string> | string> = {}
   for (const [packageName, range] of Object.entries(pkgs)) {
-    lookups[packageName] =
-      range === 'latest' ? getLatestVersion(packageName, {range}).then(caretify) : range
+    const isDistTag = semver.validRange(range) === null
+    lookups[packageName] = isDistTag
+      ? getLatestVersion(packageName, {range}).then((version) => caretify(version, range))
+      : range
   }
 
   return promiseProps(lookups)
 }
 
-function caretify(version: string | undefined) {
-  return version ? `^${version}` : 'latest'
+function caretify(version: string | undefined, fallback: string) {
+  return version ? `^${version}` : fallback
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Temporary: when running `npm create sanity@latest` and federation enabled, we want to use a version of the `sanity` dependency using the `workbench` dist-tag (which does not exist yet), to mimic the final developer experience for this.

This will be removed again before the feature branch will get merged. 

Needs one succesful run of the workflow in the `sanity` package first: https://github.com/sanity-io/sanity/pull/12511

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency resolution during project scaffolding to potentially install a non-`latest` `sanity` version, which can affect newly generated projects. Logic is gated on `federation`, but relies on dist-tag availability and correct resolution behavior.
> 
> **Overview**
> When bootstrapping templates via `bootstrapLocalTemplate`, enabling *federation* now forces the `sanity` dependency to be resolved from the `workbench` dist-tag.
> 
> `resolveLatestVersions` is updated to treat any non-semver range as a dist-tag (not just `latest`), look it up via `get-latest-version`, and fall back to the original tag if no version is found; new tests cover dist-tag resolution and the federation override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767f3b345e8837c471bb942ef2d2faa0665c5f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->