### PR TITLE
refactor(cli): replace default namespace imports with named imports

### DIFF
--- a/packages/@sanity/cli/src/__tests__/exports.test.ts
+++ b/packages/@sanity/cli/src/__tests__/exports.test.ts
@@ -7,7 +7,16 @@ import {readPackageJson} from '@sanity/cli-core'
 import {getTempPath} from '@sanity/cli-test'
 import gunzipMaybe from 'gunzip-maybe'
 import {extract} from 'tar-fs'
-import ts from 'typescript'
+import {
+  createSourceFile,
+  forEachChild,
+  isExportDeclaration,
+  isInterfaceDeclaration,
+  isNamedExports,
+  isTypeAliasDeclaration,
+  ScriptTarget,
+  SyntaxKind,
+} from 'typescript'
 import {expect, test} from 'vitest'
 
 import * as newExports from '../exports/index.js'
@@ -76,20 +85,20 @@ async function getSanityPackageExports() {
 }
 
 async function extractTypes(typesPath: string) {
-  const sourceFile = ts.createSourceFile(
+  const sourceFile = createSourceFile(
     typesPath,
     await readFile(typesPath, 'utf8'),
-    ts.ScriptTarget.Latest,
+    ScriptTarget.Latest,
     true,
   )
 
   const exportedTypes: string[] = []
 
-  ts.forEachChild(sourceFile, (node) => {
+  forEachChild(sourceFile, (node) => {
     // Handle `export interface Foo { ... }` and `export type Foo = ...`
     if (
-      (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) &&
-      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+      (isInterfaceDeclaration(node) || isTypeAliasDeclaration(node)) &&
+      node.modifiers?.some((m) => m.kind === SyntaxKind.ExportKeyword)
     ) {
       exportedTypes.push(node.name.text)
     }
@@ -97,7 +106,7 @@ async function extractTypes(typesPath: string) {
     // Handle type re-exports: `export type { Foo }` and `export { type Foo }`
     // Note: this only works on source files where the `type` keyword is preserved.
     // In .d.ts files built by api-extractor, `type` is stripped from re-exports.
-    if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
+    if (isExportDeclaration(node) && node.exportClause && isNamedExports(node.exportClause)) {
       if (node.isTypeOnly) {
         // `export type { Foo, Bar }` — all specifiers are types
         for (const specifier of node.exportClause.elements) {

--- a/packages/@sanity/cli/src/actions/build/__tests__/checkStudioDependencyVersions.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/checkStudioDependencyVersions.test.ts
@@ -1,11 +1,21 @@
 import {type Output} from '@sanity/cli-core'
-import semver from 'semver'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {checkStudioDependencyVersions} from '../checkStudioDependencyVersions.js'
 
 const mockReadPackageJson = vi.hoisted(() => vi.fn())
 const mockGetLocalPackageVersion = vi.hoisted(() => vi.fn())
+const mockCoerce = vi.hoisted(() => vi.fn())
+const originalCoerce = vi.hoisted(() => ({fn: null as typeof import('semver').coerce | null}))
+
+vi.mock('semver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('semver')>()
+  originalCoerce.fn = actual.coerce
+  mockCoerce.mockImplementation((...args: Parameters<typeof actual.coerce>) =>
+    actual.coerce(...args),
+  )
+  return {...actual, coerce: (...args: Parameters<typeof actual.coerce>) => mockCoerce(...args)}
+})
 
 vi.mock('../../../util/getLocalPackageVersion.js', () => ({
   getLocalPackageVersion: mockGetLocalPackageVersion,
@@ -25,6 +35,7 @@ describe('checkStudioDependencyVersions', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    mockCoerce.mockImplementation((v: string) => originalCoerce.fn!(v))
   })
 
   function createMockOutput(): Output {
@@ -268,9 +279,8 @@ describe('checkStudioDependencyVersions', () => {
     test('should handle invalid version ranges in upgrade instructions', async () => {
       // Test the edge case where semver.coerce returns null in getUpgradeInstructions,
       // falling back to {version: ''}
-      const originalCoerce = semver.coerce
       let coerceCallCount = 0
-      vi.spyOn(semver, 'coerce').mockImplementation((version) => {
+      mockCoerce.mockImplementation((version: string) => {
         coerceCallCount++
         // Return null for the version range strings in getUpgradeInstructions
         if (
@@ -281,7 +291,7 @@ describe('checkStudioDependencyVersions', () => {
         ) {
           return null
         }
-        return originalCoerce(version)
+        return originalCoerce.fn!(version)
       })
 
       setupMocks({
@@ -415,8 +425,8 @@ describe('checkStudioDependencyVersions', () => {
       })
       mockGetLocalPackageVersion.mockResolvedValue(null)
 
-      // Mock semver.coerce to return null for any input
-      vi.spyOn(semver, 'coerce').mockReturnValue(null)
+      // Mock coerce to return null for any input
+      mockCoerce.mockReturnValue(null)
 
       await checkStudioDependencyVersions(workDir, mockOutput)
 

--- a/packages/@sanity/cli/src/actions/build/__tests__/decorateIndexWithStagingScript.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/decorateIndexWithStagingScript.test.ts
@@ -1,5 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
+import {decorateIndexWithStagingScript} from '../decorateIndexWithStagingScript'
+
 const mockIsStaging = vi.hoisted(() => vi.fn<() => boolean>())
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
@@ -9,8 +11,6 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
     isStaging: mockIsStaging,
   }
 })
-
-import {decorateIndexWithStagingScript} from '../decorateIndexWithStagingScript'
 
 const sampleHtml = '<html><head><script src="app.js"></script></head><body></body></html>'
 

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -4,7 +4,7 @@ import {styleText} from 'node:util'
 
 import {getCliTelemetry, getTimer, isInteractive} from '@sanity/cli-core'
 import {confirm, logSymbols, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
-import semver from 'semver'
+import {parse as semverParse} from 'semver'
 
 import {AppBuildTrace} from '../../telemetry/build.telemetry.js'
 import {getAppId} from '../../util/appId.js'
@@ -49,14 +49,14 @@ export async function buildApp(options: BuildOptions): Promise<void> {
 
   if (autoUpdatesEnabled) {
     // Get the clean version without build metadata: https://semver.org/#spec-item-10
-    const cleanSDKVersion = semver.parse(installedSdkVersion)?.version
+    const cleanSDKVersion = semverParse(installedSdkVersion)?.version
     if (!cleanSDKVersion) {
       output.error(`Failed to parse installed SDK version: ${installedSdkVersion}`, {exit: 1})
       return
     }
 
     // Sanity might not be installed, but if it is, we want to auto update it.
-    const cleanSanityVersion = semver.parse(installedSanityVersion)?.version
+    const cleanSanityVersion = semverParse(installedSanityVersion)?.version
 
     const autoUpdatedPackages = [
       {name: '@sanity/sdk', version: cleanSDKVersion},

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -4,7 +4,7 @@ import {styleText} from 'node:util'
 
 import {getCliTelemetry, getTimer, isInteractive} from '@sanity/cli-core'
 import {confirm, logSymbols, select, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
-import semver from 'semver'
+import {parse as semverParse} from 'semver'
 
 import {StudioBuildTrace} from '../../telemetry/build.telemetry.js'
 import {getAppId} from '../../util/appId.js'
@@ -56,7 +56,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
 
   if (autoUpdatesEnabled) {
     // Get the clean version without build metadata: https://semver.org/#spec-item-10
-    const cleanSanityVersion = semver.parse(installedSanityVersion)?.version
+    const cleanSanityVersion = semverParse(installedSanityVersion)?.version
     if (!cleanSanityVersion) {
       throw new Error(`Failed to parse installed Sanity version: ${installedSanityVersion}`)
     }

--- a/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
+++ b/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import semver from 'semver'
+import {gt, minVersion, rcompare, satisfies} from 'semver'
 import {build} from 'vite'
 
 import {getLocalPackageDir, getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
@@ -124,26 +124,26 @@ export async function buildVendorDependencies({
 
     // Sort version ranges in descending order
     const sortedRanges = Object.keys(ranges).toSorted((range1, range2) => {
-      const min1 = semver.minVersion(range1)
-      const min2 = semver.minVersion(range2)
+      const min1 = minVersion(range1)
+      const min2 = minVersion(range2)
 
       if (!min1) throw new Error(`Could not parse range '${range1}'`)
       if (!min2) throw new Error(`Could not parse range '${range2}'`)
 
       // sort them in reverse so we can rely on array `.find` below
-      return semver.rcompare(min1.version, min2.version)
+      return rcompare(min1.version, min2.version)
     })
 
     // Find the first version range that satisfies the package version
-    const matchedRange = sortedRanges.find((range) => semver.satisfies(version, range))
+    const matchedRange = sortedRanges.find((range) => satisfies(version, range))
 
     if (!matchedRange) {
-      const min = semver.minVersion(sortedRanges.at(-1)!)
+      const min = minVersion(sortedRanges.at(-1)!)
       if (!min) {
         throw new Error(`Could not find a minimum version for package '${packageName}'`)
       }
 
-      if (semver.gt(min.version, version)) {
+      if (gt(min.version, version)) {
         throw new Error(`Package '${packageName}' requires at least ${min.version}.`)
       }
 

--- a/packages/@sanity/cli/src/actions/build/checkRequiredDependencies.ts
+++ b/packages/@sanity/cli/src/actions/build/checkRequiredDependencies.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import {type CliConfig, type Output, type PackageJson, readPackageJson} from '@sanity/cli-core'
 import {oneline} from 'oneline'
-import semver, {type SemVer} from 'semver'
+import {minVersion, satisfies, type SemVer} from 'semver'
 
 import {determineIsApp} from '../../util/determineIsApp.js'
 import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
@@ -88,7 +88,7 @@ export async function checkRequiredDependencies(
   // Theoretically the version specified in package.json could be incorrect, eg `foo`
   let minDeclaredStyledComponentsVersion: SemVer | null = null
   try {
-    minDeclaredStyledComponentsVersion = semver.minVersion(declaredStyledComponentsVersion)
+    minDeclaredStyledComponentsVersion = minVersion(declaredStyledComponentsVersion)
   } catch {
     // Intentional fall-through (variable will be left as null, throwing below)
   }
@@ -113,7 +113,7 @@ export async function checkRequiredDependencies(
   if (
     !isStyledComponentsVersionRangeInCatalog &&
     isComparableRange(declaredStyledComponentsVersion) &&
-    !semver.satisfies(minDeclaredStyledComponentsVersion!, wantedStyledComponentsVersionRange)
+    !satisfies(minDeclaredStyledComponentsVersion!, wantedStyledComponentsVersionRange)
   ) {
     output.warn(oneline`
       Declared version of styled-components (${declaredStyledComponentsVersion})
@@ -136,7 +136,7 @@ export async function checkRequiredDependencies(
 
   // The studio should have an _installed_ version of `styled-components`, and it should
   // be semver compatible with the version specified in `sanity` peer dependencies.
-  if (!semver.satisfies(installedStyledComponentsVersion, wantedStyledComponentsVersionRange)) {
+  if (!satisfies(installedStyledComponentsVersion, wantedStyledComponentsVersionRange)) {
     output.warn(oneline`
       Installed version of styled-components (${installedStyledComponentsVersion})
       is not compatible with the version required by sanity (${wantedStyledComponentsVersionRange}).

--- a/packages/@sanity/cli/src/actions/build/checkStudioDependencyVersions.ts
+++ b/packages/@sanity/cli/src/actions/build/checkStudioDependencyVersions.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import {type Output, readPackageJson} from '@sanity/cli-core'
-import semver, {type SemVer} from 'semver'
+import {coerce, gtr, ltr, rcompare, satisfies, type SemVer} from 'semver'
 
 import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 
@@ -47,7 +47,7 @@ export async function checkStudioDependencyVersions(
     }
 
     const packageVersion = await getLocalPackageVersion(pkg.name, workDir)
-    const installed = semver.coerce(packageVersion ?? dependency.replaceAll(/[\D.]/g, ''))
+    const installed = coerce(packageVersion ?? dependency.replaceAll(/[\D.]/g, ''))
 
     if (!installed) {
       return false
@@ -59,15 +59,15 @@ export async function checkStudioDependencyVersions(
     // before a release, but given that is usually works in a backwards-compatible way, we want
     // to indicate that it's _untested_, not necessarily _unsupported_
     // Ex: Installed is react@20.0.0, but we've only _tested_ with react@^19
-    const isUntested = !semver.satisfies(installed, supported) && semver.gtr(installed, supported)
+    const isUntested = !satisfies(installed, supported) && gtr(installed, supported)
 
     // "Unsupported" in that the installed version is _lower than_ the minimum version
     // Ex: Installed is react@18.0.0, but we require react@^19.2
-    const isUnsupported = !semver.satisfies(installed, supported) && !isUntested
+    const isUnsupported = !satisfies(installed, supported) && !isUntested
 
     // "Deprecated" in that we will stop supporting it at some point in the near future,
     // so users should be prompted to upgrade
-    const isDeprecated = pkg.deprecatedBelow ? semver.ltr(installed, pkg.deprecatedBelow) : false
+    const isDeprecated = pkg.deprecatedBelow ? ltr(installed, pkg.deprecatedBelow) : false
 
     return {
       ...pkg,
@@ -135,8 +135,8 @@ function getUpgradeInstructions(pkgs: PackageInfo[]) {
   const inst = pkgs
     .map((pkg) => {
       const [highestSupported] = pkg.supported
-        .map((version) => (semver.coerce(version) || {version: ''}).version)
-        .toSorted(semver.rcompare)
+        .map((version) => (coerce(version) || {version: ''}).version)
+        .toSorted(rcompare)
 
       return `"${pkg.name}@^${highestSupported}"`
     })
@@ -162,8 +162,8 @@ function getDowngradeInstructions(pkgs: PackageInfo[]) {
   const inst = pkgs
     .map((pkg) => {
       const [highestSupported] = pkg.supported
-        .map((version) => (semver.coerce(version) || {version: ''}).version)
-        .toSorted(semver.rcompare)
+        .map((version) => (coerce(version) || {version: ''}).version)
+        .toSorted(rcompare)
 
       return `"${pkg.name}@^${highestSupported}"`
     })

--- a/packages/@sanity/cli/src/actions/codemods/reactIconsV3.ts
+++ b/packages/@sanity/cli/src/actions/codemods/reactIconsV3.ts
@@ -1,4 +1,4 @@
-import semver from 'semver'
+import {compare} from 'semver'
 
 import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 import {type CodeMod} from './types.js'
@@ -27,7 +27,7 @@ export const reactIconsV3: CodeMod = {
       throw new Error('Could not find react-icons declared as dependency in package.json')
     }
 
-    if (semver.compare(dependencyVersion, '3.0.0') < 0) {
+    if (compare(dependencyVersion, '3.0.0') < 0) {
       throw new Error('react-icons declared in package.json dependencies is lower than 3.0.0')
     }
   },

--- a/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
@@ -2,7 +2,7 @@ import {styleText} from 'node:util'
 
 import {isInteractive} from '@sanity/cli-core'
 import {confirm, logSymbols, spinner} from '@sanity/cli-core/ux'
-import semver from 'semver'
+import {parse as semverParse} from 'semver'
 
 import {startDevServer} from '../../server/devServer.js'
 import {gracefulServerDeath} from '../../server/gracefulServerDeath.js'
@@ -39,7 +39,7 @@ export async function startStudioDevServer(
 
   if (autoUpdatesEnabled) {
     // Get the clean version without build metadata: https://semver.org/#spec-item-10
-    const cleanSanityVersion = semver.parse(installedSanityVersion)?.version
+    const cleanSanityVersion = semverParse(installedSanityVersion)?.version
     if (!cleanSanityVersion) {
       throw new Error(`Failed to parse installed Sanity version: ${installedSanityVersion}`)
     }

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
@@ -2,6 +2,7 @@ import {mkdtemp, readFile, rm} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import path from 'node:path'
 
+import {type Output} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {bootstrapLocalTemplate} from '../bootstrapLocalTemplate.js'
@@ -28,7 +29,7 @@ function makeOutput() {
       start: () => ({fail: vi.fn(), succeed: vi.fn()}),
     })),
     warn: vi.fn(),
-  } as any
+  } as unknown as Output
 }
 
 describe('bootstrapLocalTemplate (app templates)', () => {

--- a/packages/@sanity/cli/src/actions/init/checkNextJsReactCompatibility.ts
+++ b/packages/@sanity/cli/src/actions/init/checkNextJsReactCompatibility.ts
@@ -1,5 +1,5 @@
 import {Output, readPackageJson} from '@sanity/cli-core'
-import semver from 'semver'
+import {coerce} from 'semver'
 
 import {VersionedFramework} from './types.js'
 
@@ -18,8 +18,8 @@ export async function checkNextJsReactCompatibility({
   const reactVersion = packageJson?.dependencies?.react
 
   if (reactVersion) {
-    const isUsingReact19 = semver.coerce(reactVersion)?.major === 19
-    const isUsingNextJs15 = semver.coerce(detectedFramework?.detectedVersion)?.major === 15
+    const isUsingReact19 = coerce(reactVersion)?.major === 19
+    const isUsingNextJs15 = coerce(detectedFramework?.detectedVersion)?.major === 15
 
     if (isUsingNextJs15 && isUsingReact19) {
       output.warn('╭────────────────────────────────────────────────────────────╮')

--- a/packages/@sanity/cli/src/actions/versions/buildPackageArray.ts
+++ b/packages/@sanity/cli/src/actions/versions/buildPackageArray.ts
@@ -1,4 +1,4 @@
-import semver from 'semver'
+import {valid} from 'semver'
 
 import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 import {trimHashFromVersion} from '../../util/trimHashFromVersion.js'
@@ -10,7 +10,7 @@ import {tryFindLatestVersion} from './tryFindLatestVersion.js'
  * @internal
  */
 function isPinnedVersion(version: string): boolean {
-  return !!semver.valid(version)
+  return !!valid(version)
 }
 
 /**

--- a/packages/@sanity/cli/src/actions/versions/findSanityModulesVersions.ts
+++ b/packages/@sanity/cli/src/actions/versions/findSanityModulesVersions.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import {readPackageJson} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import promiseProps from 'promise-props-recursive'
-import semver from 'semver'
+import {compare, minVersion} from 'semver'
 
 import {getCliVersion} from '../../util/getCliVersion.js'
 import {buildPackageArray} from './buildPackageArray.js'
@@ -51,8 +51,8 @@ export async function findSanityModulesVersions(
     versionsDebug('packages:', packages)
 
     return packages.map((mod) => {
-      const current = mod.installed || semver.minVersion(mod.declared)?.toString() || ''
-      const needsUpdate = mod.latest ? semver.compare(current, mod.latest) === -1 : false
+      const current = mod.installed || minVersion(mod.declared)?.toString() || ''
+      const needsUpdate = mod.latest ? compare(current, mod.latest) === -1 : false
 
       return {...mod, needsUpdate}
     })

--- a/packages/@sanity/cli/src/commands/__tests__/debug.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/debug.test.ts
@@ -6,7 +6,7 @@ import {
   tryFindStudioConfigPath,
 } from '@sanity/cli-core'
 import {convertToSystemPath, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECTS_API_VERSION} from '../../services/projects.js'
@@ -75,8 +75,8 @@ const defaultMocks = {
 
 afterEach(() => {
   vi.clearAllMocks()
-  const pending = nock.pendingMocks()
-  nock.cleanAll()
+  const pending = pendingMocks()
+  cleanAll()
   expect(pending, 'pending mocks').toEqual([])
 })
 

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.app.test.ts
@@ -1,6 +1,6 @@
 import {confirm, input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {buildApp} from '../../actions/build/buildApp.js'
@@ -85,8 +85,8 @@ describe('#deploy app', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
@@ -1,7 +1,7 @@
 import {exitCodes, studioWorkerTask} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {buildStudio} from '../../actions/build/buildStudio.js'
@@ -93,8 +93,8 @@ describe('#deploy studio (external)', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
@@ -1,7 +1,7 @@
 import {exitCodes, getCliTelemetry, studioWorkerTask} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {buildStudio} from '../../actions/build/buildStudio.js'
@@ -94,8 +94,8 @@ describe('#deploy studio', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -1,5 +1,5 @@
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
@@ -150,8 +150,8 @@ const defaultMocks = {
 describe('#init: authentication', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -1,5 +1,5 @@
 import {convertToSystemPath, createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
@@ -139,8 +139,8 @@ mocks.createOrAppendEnvVars.mockResolvedValue(undefined)
 describe('#init: bootstrap-app-initialization', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
   test('initializes app without env files', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
@@ -1,6 +1,6 @@
 import * as cliUX from '@sanity/cli-core/ux'
 import {convertToSystemPath, createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {setupMCP} from '../../../actions/mcp/setupMCP.js'
@@ -177,8 +177,8 @@ const defaultMocks = {
 describe('#init: create new project', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
@@ -1,5 +1,5 @@
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
@@ -132,8 +132,8 @@ const defaultMocks = {
 describe('#init: get project details', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 
@@ -975,8 +975,8 @@ describe('#init: get project details', () => {
 describe('#init: promptForAppTemplateSetup', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.nextjs.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.nextjs.test.ts
@@ -5,7 +5,7 @@ import {
   testCommand,
   testFixture,
 } from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {CORS_API_VERSION} from '../../../services/cors.js'
@@ -163,8 +163,8 @@ mocks.getSanityEnv.mockReturnValue('production')
 describe('#init:nextjs-app-initialization', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
   test('initializes nextjs app', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.plan.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.plan.test.ts
@@ -1,5 +1,5 @@
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {INIT_API_VERSION} from '../../../actions/init/constants.js'
@@ -150,8 +150,8 @@ describe('#init: retrieving plan', () => {
   })
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.staging-env.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.staging-env.test.ts
@@ -1,5 +1,5 @@
 import {convertToSystemPath, createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {setupMCP} from '../../../actions/mcp/setupMCP.js'
@@ -161,8 +161,8 @@ mocks.createOrAppendEnvVars.mockResolvedValue(undefined)
 describe('#init: staging env propagation', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -1,7 +1,7 @@
 import http from 'node:http'
 
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import open from 'open'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -113,8 +113,8 @@ function mockSingleProviderLogin(sessionId = 'test-session-id') {
 describe('#login', {timeout: 10_000}, () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -1,6 +1,6 @@
 import {getCliToken, setCliUserConfig} from '@sanity/cli-core'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {AUTH_API_VERSION} from '../../services/auth.js'
@@ -25,8 +25,8 @@ const mockedSetConfig = vi.mocked(setCliUserConfig)
 
 afterEach(() => {
   vi.clearAllMocks()
-  const pending = nock.pendingMocks()
-  nock.cleanAll()
+  const pending = pendingMocks()
+  cleanAll()
   expect(pending, 'pending mocks').toEqual([])
 })
 

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -1,6 +1,6 @@
 import {confirm} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {UndeployCommand} from '../undeploy.js'
@@ -16,8 +16,8 @@ vi.mock('@sanity/cli-core/ux', async () => {
 describe('#undeploy', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/backups/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/disable.test.ts
@@ -1,6 +1,6 @@
 import {select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {BACKUP_API_VERSION} from '../../../actions/backup/constants.js'
@@ -44,8 +44,8 @@ const mockSelect = vi.mocked(select)
 
 describe('#backup:disable', () => {
   afterEach(() => {
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     vi.clearAllMocks()
     expect(pending, 'pending mocks').toEqual([])
   })

--- a/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 import {confirm, input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import nock, {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {BACKUP_API_VERSION} from '../../../actions/backup/constants.js'
@@ -104,8 +104,8 @@ function mockFileDownloads(files: {name: string; type: string; url: string}[]) {
 
 describe('#backup:download', () => {
   afterEach(() => {
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     vi.clearAllMocks()
     expect(pending, 'pending mocks').toEqual([])
   })

--- a/packages/@sanity/cli/src/commands/backups/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/enable.test.ts
@@ -1,6 +1,6 @@
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {BACKUP_API_VERSION} from '../../../actions/backup/constants.js'
@@ -49,8 +49,8 @@ const mockSelect = vi.mocked(select)
 
 describe('#backup:enable', () => {
   afterEach(() => {
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     vi.clearAllMocks()
     expect(pending, 'pending mocks').toEqual([])
   })

--- a/packages/@sanity/cli/src/commands/backups/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/list.test.ts
@@ -1,6 +1,6 @@
 import {select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {BACKUP_API_VERSION} from '../../../actions/backup/constants.js'
@@ -57,8 +57,8 @@ const backupsResponse = {
 
 describe('#backup:list', () => {
   afterEach(() => {
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     vi.clearAllMocks()
     expect(pending, 'pending mocks').toEqual([])
   })

--- a/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 
 import {confirm} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {CORS_API_VERSION} from '../../../services/cors.js'
@@ -58,8 +58,8 @@ describe('#cors:add', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
@@ -1,5 +1,5 @@
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {CORS_API_VERSION, type CorsOrigin} from '../../../services/cors.js'
@@ -51,8 +51,8 @@ vi.mock('@sanity/cli-core/ux', async () => {
 describe('#cors:delete', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/cors/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/list.test.ts
@@ -1,5 +1,5 @@
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {CORS_API_VERSION} from '../../../services/cors.js'
@@ -20,8 +20,8 @@ const defaultMocks = {
 describe('#list', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -1,6 +1,6 @@
 import {input, select} from '@sanity/cli-core/ux'
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {of, throwError} from 'rxjs'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -91,8 +91,8 @@ function createMockDataset(name: string) {
 describe('#dataset:copy', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/create.test.ts
@@ -1,6 +1,6 @@
 import {input, select} from '@sanity/cli-core/ux'
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
@@ -65,8 +65,8 @@ const mockSelect = vi.mocked(select)
 describe('#dataset:create', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/list.test.ts
@@ -1,5 +1,5 @@
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {DATASET_API_VERSION, type DatasetAliasDefinition} from '../../../services/datasets.js'
@@ -58,8 +58,8 @@ const defaultMocks = {
 describe('#dataset:list', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/create.test.ts
@@ -1,5 +1,5 @@
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {DATASET_API_VERSION} from '../../../../services/datasets.js'
@@ -47,8 +47,8 @@ const defaultMocks = {
 describe('#dataset:alias:create', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/delete.test.ts
@@ -1,7 +1,7 @@
 import {NonInteractiveError} from '@sanity/cli-core'
 import {input} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {DATASET_ALIASES_API_VERSION} from '../../../../services/datasetAliases.js'
@@ -36,8 +36,8 @@ const mockInput = vi.mocked(input)
 describe('#dataset:alias:delete', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/link.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/link.test.ts
@@ -1,5 +1,5 @@
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {DATASET_API_VERSION} from '../../../../services/datasets.js'
@@ -46,8 +46,8 @@ const defaultMocks = {
 describe('#dataset:alias:link', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/unlink.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/unlink.test.ts
@@ -1,7 +1,7 @@
 import {NonInteractiveError} from '@sanity/cli-core'
 import {input} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {DATASET_ALIASES_API_VERSION} from '../../../../services/datasetAliases.js'
@@ -36,8 +36,8 @@ const mockInput = vi.mocked(input)
 describe('#dataset:alias:unlink', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -231,7 +231,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
   private async handleCopyMode(
     projectId: string,
     args: {source?: string; target?: string},
-    flags: {'skip-content-releases'?: boolean; 'skip-history'?: boolean; detach?: boolean},
+    flags: {detach?: boolean; 'skip-content-releases'?: boolean; 'skip-history'?: boolean},
   ): Promise<void> {
     copyDatasetDebug('Starting copy mode')
 

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/disable.test.ts
@@ -1,6 +1,6 @@
 import {select} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {DatasetEmbeddingsDisableCommand} from '../disable.js'
@@ -45,8 +45,8 @@ const mockSelect = vi.mocked(select)
 
 describe('#dataset:embeddings:disable', () => {
   afterEach(() => {
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     vi.restoreAllMocks()
     expect(pending, 'pending mocks').toEqual([])
   })

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/enable.test.ts
@@ -1,6 +1,6 @@
 import {select} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {DatasetEmbeddingsEnableCommand} from '../enable.js'
@@ -53,8 +53,8 @@ const mockSelect = vi.mocked(select)
 
 describe('#dataset:embeddings:enable', () => {
   afterEach(() => {
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     vi.restoreAllMocks()
     expect(pending, 'pending mocks').toEqual([])
   })

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/status.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/status.test.ts
@@ -1,6 +1,6 @@
 import {select} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {DatasetEmbeddingsStatusCommand} from '../status.js'
@@ -45,8 +45,8 @@ const mockSelect = vi.mocked(select)
 
 describe('#dataset:embeddings:status', () => {
   afterEach(() => {
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     vi.restoreAllMocks()
     expect(pending, 'pending mocks').toEqual([])
   })

--- a/packages/@sanity/cli/src/commands/docs/__tests__/read.test.ts
+++ b/packages/@sanity/cli/src/commands/docs/__tests__/read.test.ts
@@ -1,5 +1,5 @@
 import {testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import nock, {cleanAll, pendingMocks} from 'nock'
 import open from 'open'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -10,8 +10,8 @@ vi.mock('open')
 const mockOpen = vi.mocked(open)
 
 afterEach(() => {
-  const pending = nock.pendingMocks()
-  nock.cleanAll()
+  const pending = pendingMocks()
+  cleanAll()
   expect(pending, 'pending mocks').toEqual([])
 })
 

--- a/packages/@sanity/cli/src/commands/docs/__tests__/search.test.ts
+++ b/packages/@sanity/cli/src/commands/docs/__tests__/search.test.ts
@@ -1,6 +1,6 @@
 import {select} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import nock, {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {DocsSearchCommand} from '../search.js'
@@ -26,8 +26,8 @@ vi.mock('@sanity/cli-core', async () => {
 const mockedSelect = vi.mocked(select)
 
 afterEach(() => {
-  const pending = nock.pendingMocks()
-  nock.cleanAll()
+  const pending = pendingMocks()
+  cleanAll()
   expect(pending, 'pending mocks').toEqual([])
   vi.resetAllMocks()
 })

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-errors.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-errors.test.ts
@@ -3,7 +3,7 @@ import {join} from 'node:path'
 
 import {getCliConfig} from '@sanity/cli-core'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
-import nock from 'nock'
+import nock, {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 
 import {GRAPHQL_API_VERSION} from '../../../services/graphql.js'
@@ -44,8 +44,8 @@ describe('#graphql:deploy errors', {timeout: 60 * 1000}, () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending).toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-generation.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-generation.test.ts
@@ -1,6 +1,6 @@
 import {getCliConfig} from '@sanity/cli-core'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
-import nock from 'nock'
+import nock, {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 
 import {GRAPHQL_API_VERSION} from '../../../services/graphql.js'
@@ -40,8 +40,8 @@ describe('#graphql:deploy generation', {timeout: 60 * 1000}, () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending).toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/deploy.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/deploy.test.ts
@@ -1,6 +1,6 @@
 import {getCliConfig} from '@sanity/cli-core'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
-import nock from 'nock'
+import nock, {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 
 import {GRAPHQL_API_VERSION} from '../../../services/graphql.js'
@@ -41,8 +41,8 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending).toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/list.test.ts
@@ -1,5 +1,5 @@
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {GRAPHQL_API_VERSION} from '../../../services/graphql.js'
@@ -20,8 +20,8 @@ const defaultMocks = {
 describe('#list', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
@@ -1,6 +1,6 @@
 import {ProjectRootNotFoundError} from '@sanity/cli-core'
 import {convertToSystemPath, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {getGraphQLAPIs} from '../../../actions/graphql/getGraphQLAPIs.js'
@@ -41,8 +41,8 @@ describe('graphql undeploy', () => {
   })
 
   afterEach(() => {
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 
@@ -160,7 +160,7 @@ describe('graphql undeploy', () => {
     mockConfirm.mockResolvedValue(false)
     const {stdout} = await testCommand(Undeploy, [], {mocks: defaultMocks})
     expect(stdout).toBe('Operation cancelled\n')
-    expect(nock.pendingMocks()).toHaveLength(0) // No API call should be made
+    expect(pendingMocks()).toHaveLength(0) // No API call should be made
   })
 
   test('successfully undeploys with --api flag', async () => {

--- a/packages/@sanity/cli/src/commands/hooks/__tests__/attempt.test.ts
+++ b/packages/@sanity/cli/src/commands/hooks/__tests__/attempt.test.ts
@@ -1,5 +1,5 @@
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {HOOK_API_VERSION} from '../../../actions/hook/constants.js'
@@ -21,8 +21,8 @@ const defaultMocks = {
 describe('#attempt', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/hooks/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/hooks/__tests__/delete.test.ts
@@ -1,5 +1,5 @@
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {HOOK_API_VERSION} from '../../../actions/hook/constants.js'
@@ -30,8 +30,8 @@ const mockSelect = vi.mocked(await import('@sanity/cli-core/ux')).select
 describe('#delete', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/hooks/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/hooks/__tests__/list.test.ts
@@ -1,5 +1,5 @@
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {HOOK_API_VERSION} from '../../../actions/hook/constants.js'
@@ -20,8 +20,8 @@ const defaultMocks = {
 describe('#list', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/hooks/__tests__/logs.test.ts
+++ b/packages/@sanity/cli/src/commands/hooks/__tests__/logs.test.ts
@@ -1,6 +1,6 @@
 import {select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {HOOK_API_VERSION} from '../../../actions/hook/constants.js'
@@ -31,8 +31,8 @@ const mockedSelect = vi.mocked(select)
 describe('#hook:logs', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises'
 import {checkbox} from '@sanity/cli-core/ux'
 import {convertToSystemPath, createTestToken, mockApi, testCommand} from '@sanity/cli-test'
 import {execa} from 'execa'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {MCP_API_VERSION} from '../../../services/mcp.js'
@@ -424,8 +424,8 @@ describe('#mcp:configure', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/media/__tests__/delete-aspect.test.ts
+++ b/packages/@sanity/cli/src/commands/media/__tests__/delete-aspect.test.ts
@@ -1,6 +1,6 @@
 import {confirm, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {MEDIA_LIBRARY_API_VERSION} from '../../../services/mediaLibraries.js'
@@ -36,8 +36,8 @@ const defaultMocks = {
 describe('#media:delete-aspect', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/media/__tests__/deploy-aspect.test.ts
+++ b/packages/@sanity/cli/src/commands/media/__tests__/deploy-aspect.test.ts
@@ -7,7 +7,7 @@ import {
   MEDIA_LIBRARY_ASSET_ASPECT_TYPE_NAME,
   type MediaLibraryAssetAspectDocument,
 } from '@sanity/types'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {MEDIA_LIBRARY_API_VERSION} from '../../../services/mediaLibraries.js'
@@ -174,8 +174,8 @@ describe('#media:deploy-aspect', () => {
   afterEach(() => {
     vi.clearAllMocks()
     vi.unstubAllEnvs()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/media/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/media/__tests__/export.test.ts
@@ -4,7 +4,7 @@ import {type CliConfig} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 import {createTestToken, mockApi, testCommand} from '@sanity/cli-test'
 import {exportDataset} from '@sanity/export'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {MEDIA_LIBRARY_API_VERSION} from '../../../services/mediaLibraries.js'
@@ -123,8 +123,8 @@ describe('#media:export', () => {
   afterEach(() => {
     vi.clearAllMocks()
     vi.unstubAllEnvs()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/media/__tests__/import.test.ts
+++ b/packages/@sanity/cli/src/commands/media/__tests__/import.test.ts
@@ -1,6 +1,6 @@
 import {type CliConfig, ProjectRootNotFoundError} from '@sanity/cli-core'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {of, throwError} from 'rxjs'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -45,8 +45,8 @@ const defaultMocks = {
 describe('#media:import', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/openapi/__tests__/get.test.ts
+++ b/packages/@sanity/cli/src/commands/openapi/__tests__/get.test.ts
@@ -1,5 +1,5 @@
 import {testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import nock, {cleanAll, pendingMocks} from 'nock'
 import open from 'open'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -34,8 +34,8 @@ const mockJsonSpec = JSON.stringify({
 describe('#openapi:get', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/openapi/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/openapi/__tests__/list.test.ts
@@ -1,5 +1,5 @@
 import {testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import nock, {cleanAll, pendingMocks} from 'nock'
 import open from 'open'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -21,8 +21,8 @@ const mockSpecs = [
 describe('#openapi:list', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
@@ -1,5 +1,5 @@
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
@@ -77,8 +77,8 @@ const defaultMocks = {
 describe('#projects:create', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/projects/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/list.test.ts
@@ -1,5 +1,5 @@
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test} from 'vitest'
 
 import {PROJECTS_API_VERSION} from '../../../services/projects.js'
@@ -7,8 +7,8 @@ import {List} from '../list.js'
 
 describe('#list', () => {
   afterEach(() => {
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
@@ -1,6 +1,6 @@
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {TOKENS_API_VERSION} from '../../../actions/tokens/constants.js'
@@ -34,8 +34,8 @@ const defaultMocks = {
 describe('#tokens:add', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
@@ -1,5 +1,5 @@
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {TOKENS_API_VERSION} from '../../../actions/tokens/constants.js'
@@ -61,8 +61,8 @@ vi.mock('@sanity/cli-core/ux', async () => {
 describe('#tokens:delete', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/list.test.ts
@@ -1,5 +1,5 @@
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {TOKENS_API_VERSION} from '../../../actions/tokens/constants.js'
@@ -59,8 +59,8 @@ const mockTokens = [
 describe('#tokens:list', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
@@ -1,6 +1,6 @@
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECTS_API_VERSION} from '../../../services/projects.js'
@@ -73,8 +73,8 @@ const mockRoles = [
 describe('#invite', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/commands/users/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/list.test.ts
@@ -1,6 +1,6 @@
 import {getProjectCliClient} from '@sanity/cli-core'
 import {mockApi, testCommand} from '@sanity/cli-test'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECTS_API_VERSION} from '../../../services/projects.js'
@@ -32,8 +32,8 @@ const mockGetProjectCliClient = vi.mocked(getProjectCliClient)
 describe('#list', () => {
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
   })
 

--- a/packages/@sanity/cli/src/hooks/prerun/__tests__/setupTelemetry.test.ts
+++ b/packages/@sanity/cli/src/hooks/prerun/__tests__/setupTelemetry.test.ts
@@ -15,7 +15,7 @@ import {
 } from '@sanity/cli-core'
 import {createTestToken, mockApi, testHook} from '@sanity/cli-test'
 import {type TelemetryEvent} from '@sanity/telemetry'
-import nock from 'nock'
+import {cleanAll, pendingMocks} from 'nock'
 import {glob} from 'tinyglobby'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -156,8 +156,8 @@ describe('setupTelemetry integration test', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = nock.pendingMocks()
-    nock.cleanAll()
+    const pending = pendingMocks()
+    cleanAll()
     expect(pending, 'pending mocks').toEqual([])
 
     // Reset globalThis.cliTelemetry after each test

--- a/packages/@sanity/cli/src/services/datasets.ts
+++ b/packages/@sanity/cli/src/services/datasets.ts
@@ -82,10 +82,11 @@ export async function createDataset({
 
 interface CopyDatasetOptions {
   projectId: string
-  skipContentReleases?: boolean
   skipHistory: boolean
   sourceDataset: string
   targetDataset: string
+
+  skipContentReleases?: boolean
 }
 
 interface CopyDatasetResponse {

--- a/packages/@sanity/cli/src/util/__tests__/compareDependencyVersions.integration.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/compareDependencyVersions.integration.test.ts
@@ -2,7 +2,7 @@ import {mkdtemp, rm, writeFile} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import path from 'node:path'
 
-import semver from 'semver'
+import {gt, valid} from 'semver'
 import {afterAll, beforeAll, describe, expect, it} from 'vitest'
 
 import {compareDependencyVersions} from '../compareDependencyVersions.js'
@@ -39,7 +39,7 @@ describe('compareDependencyVersions (integration)', {timeout: 30_000}, () => {
     const [mismatch] = result.mismatched
     expect(mismatch.pkg).toBe('sanity')
     expect(mismatch.installed).toBe('3.0.0')
-    expect(semver.valid(mismatch.remote)).toBeTruthy()
-    expect(semver.gt(mismatch.remote, '3.0.0')).toBe(true)
+    expect(valid(mismatch.remote)).toBeTruthy()
+    expect(gt(mismatch.remote, '3.0.0')).toBe(true)
   })
 })

--- a/packages/@sanity/cli/src/util/compareDependencyVersions.ts
+++ b/packages/@sanity/cli/src/util/compareDependencyVersions.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import {readPackageJson} from '@sanity/cli-core'
 import {createRequester} from '@sanity/cli-core/request'
-import semver from 'semver'
+import {coerce, eq, prerelease, parse as semverParse} from 'semver'
 
 import {getModuleUrl} from '../actions/build/getAutoUpdatesImportMap.js'
 import {getLocalPackageVersion} from './getLocalPackageVersion.js'
@@ -78,7 +78,7 @@ export async function compareDependencyVersions(
     const resolvedVersion = await getRemoteResolvedVersion(getModuleUrl(pkg, {appId}), requester)
 
     if (resolvedVersion === null) {
-      if (semver.prerelease(pkg.version)) {
+      if (prerelease(pkg.version)) {
         unresolvedPrerelease.push({pkg: pkg.name, version: pkg.version})
         continue
       }
@@ -91,15 +91,13 @@ export async function compareDependencyVersions(
 
     const manifestVersion = dependencies[pkg.name]
 
-    const installed = semver.coerce(
-      packageVersion ? semver.parse(packageVersion) : semver.coerce(manifestVersion),
-    )
+    const installed = coerce(packageVersion ? semverParse(packageVersion) : coerce(manifestVersion))
 
     if (!installed) {
       throw new Error(`Failed to parse installed version for ${pkg.name}`)
     }
 
-    if (!semver.eq(resolvedVersion, installed.version)) {
+    if (!eq(resolvedVersion, installed.version)) {
       mismatched.push({
         installed: installed.version,
         pkg: pkg.name,

--- a/packages/@sanity/cli/src/util/packageManager/installationInfo/analyzeIssues.ts
+++ b/packages/@sanity/cli/src/util/packageManager/installationInfo/analyzeIssues.ts
@@ -1,4 +1,4 @@
-import semver from 'semver'
+import {satisfies, parse as semverParse, subset, valid} from 'semver'
 
 import {
   getGlobalUninstallCommand,
@@ -81,10 +81,10 @@ export function analyzeIssues(
     // Skip @sanity/cli here — global-cli-incompatible (below) handles it with
     // better context by checking against sanity's actual required range.
     if (info.installed && name !== '@sanity/cli') {
-      const localMajor = semver.parse(info.installed.version)?.major
+      const localMajor = semverParse(info.installed.version)?.major
       if (localMajor !== undefined) {
         for (const globalMatch of globals.filter((g) => g.packageName === name)) {
-          const globalMajor = semver.parse(globalMatch.version)?.major
+          const globalMajor = semverParse(globalMatch.version)?.major
           if (globalMajor !== undefined && globalMajor !== localMajor) {
             issues.push({
               message: `${name} version mismatch: global ${globalMatch.version} (${globalMatch.packageManager}) vs local ${info.installed.version}.`,
@@ -118,7 +118,7 @@ export function analyzeIssues(
     if (cliInfo?.declared && !isNonSemverProtocol(cliInfo.declared.versionRange)) {
       const declaredRange = cliInfo.declared.versionRange
       // Only flag as redundant when every version in the declared range also
-      // satisfies the required range. semver.subset('^5.0.0', '^5.33.0') → false,
+      // satisfies the required range. subset('^5.0.0', '^5.33.0') → false,
       // so a too-wide range is correctly classified as conflicting.
       if (safeSubset(declaredRange, expectedCliRange)) {
         issues.push({
@@ -234,7 +234,7 @@ function inferPackageManager(workspace: WorkspaceInfo): LockfileType {
  */
 function safeSatisfies(version: string, range: string): boolean {
   try {
-    return semver.satisfies(version, range, {includePrerelease: true})
+    return satisfies(version, range, {includePrerelease: true})
   } catch {
     return false
   }
@@ -246,7 +246,7 @@ function safeSatisfies(version: string, range: string): boolean {
  */
 function safeSubset(sub: string, sup: string): boolean {
   try {
-    return semver.subset(sub, sup) ?? false
+    return subset(sub, sup) ?? false
   } catch {
     return false
   }
@@ -262,7 +262,7 @@ function toCaretRange(range: string): string {
     return range
   }
   // If it's a plain version like "5.33.0", treat as ^5.33.0
-  if (semver.valid(range)) {
+  if (valid(range)) {
     return `^${range}`
   }
   return range


### PR DESCRIPTION
### Description

Replace default namespace imports with named imports across 76 files to resolve 167 `import-x/no-named-as-default-member` lint warnings and one `@typescript-eslint/no-explicit-any` warning.

Libraries affected:
- **semver** — `semver.parse()` → `import {parse} from 'semver'` (12 source files, 2 test files)
- **nock** — `nock.cleanAll()` / `nock.pendingMocks()` → named imports (50+ test files)
- **typescript** — `ts.createSourceFile()` etc → named imports (1 test file)
- Fixed `as any` → `as unknown as Output` in 1 test file

CJS modules (json5, dotenv, tar-fs, tar-stream) are left unchanged since they don't support named ESM imports at runtime.

### What to review

- Verify named import replacements are correct and no runtime behavior changed
- Check aliased imports (`semverParse`) where name collisions existed

### Testing

- `pnpm check:lint` passes with 6 warnings remaining (all CJS modules, down from 173)
- `pnpm check:types` passes
- `pnpm build:cli` passes
- No behavioral changes — purely mechanical import style fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical import refactors, but it touches version parsing/comparison in build and package-manager diagnostics, so a missed semver API mapping could cause subtle runtime regressions.
> 
> **Overview**
> Refactors `semver` usage across the CLI to replace `import semver from 'semver'` with named imports (e.g. `parse`/`coerce`/`satisfies`/`rcompare`) in build flows (`buildApp`, `buildStudio`, vendor dependency selection, dependency/version checks) and in version reporting/utilities.
> 
> Updates tests to avoid default `nock` namespace usage by importing `pendingMocks`/`cleanAll` directly, and adjusts a `semver.coerce` mock to wrap/restore the real implementation. Also replaces a single `as any` with `as unknown as Output`, and switches the exports test from `ts.*` to named `typescript` AST helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d6435e9666b7ffa1a08e69618cfb3b60f6a89b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->