### PR TITLE
chore: switch changelog format to conventional-commits style

### DIFF
--- a/.changeset/changelog.mjs
+++ b/.changeset/changelog.mjs
@@ -62,7 +62,7 @@ async function getReleaseLine(changeset, _type, options) {
 
   const formatted = `${scopePrefix}${firstLine}${prLink}${commitLink}`
   if (restLines.length > 0) {
-    return `\n- ${formatted}\n${restLines.join('\n')}`
+    return `\n- ${formatted}\n${restLines.map((l) => (l ? '  ' + l : l)).join('\n')}`
   }
   return `\n- ${formatted}`
 }

--- a/.changeset/changelog.mjs
+++ b/.changeset/changelog.mjs
@@ -1,0 +1,88 @@
+const CONVENTIONAL_COMMIT_RE = /^([a-z]+)(?:\(([^)]+)\))?!?:\s*([\s\S]+)/
+
+async function getPullRequestInfo(commit, repo) {
+  const token = process.env.GITHUB_TOKEN
+  if (!token || !commit || !repo) return null
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${repo}/commits/${commit}/pulls`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    )
+    if (!res.ok) return null
+    const pulls = await res.json()
+    return pulls[0] ? {number: pulls[0].number, title: pulls[0].title} : null
+  } catch {
+    return null
+  }
+}
+
+function parsePrNumberFromId(id) {
+  const match = id.match(/^pr-(\d+)$/)
+  return match ? parseInt(match[1], 10) : null
+}
+
+async function getReleaseLine(changeset, _type, options) {
+  const repo = options?.repo
+  const {commit, id, summary} = changeset
+  const trimmedSummary = summary.trim()
+
+  let prNumber = parsePrNumberFromId(id)
+  let prTitle = null
+
+  if (!prNumber && commit && repo) {
+    const pr = await getPullRequestInfo(commit, repo)
+    if (pr) {
+      prNumber = pr.number
+      prTitle = pr.title
+    }
+  }
+
+  const source = trimmedSummary.match(CONVENTIONAL_COMMIT_RE) ? trimmedSummary : prTitle
+  const ccMatch = source?.match(CONVENTIONAL_COMMIT_RE)
+
+  const scope = ccMatch?.[2] || null
+  const description = ccMatch ? ccMatch[3].trim() : trimmedSummary
+
+  const [firstLine, ...restLines] = description.split('\n')
+  const scopePrefix = scope ? `**${scope}:** ` : ''
+  const prLink =
+    prNumber && repo
+      ? ` ([#${prNumber}](https://github.com/${repo}/pull/${prNumber}))`
+      : ''
+  const commitLink =
+    commit && repo
+      ? ` ([${commit.slice(0, 7)}](https://github.com/${repo}/commit/${commit}))`
+      : ''
+
+  const formatted = `${scopePrefix}${firstLine}${prLink}${commitLink}`
+  if (restLines.length > 0) {
+    return `\n- ${formatted}\n${restLines.join('\n')}`
+  }
+  return `\n- ${formatted}`
+}
+
+async function getDependencyReleaseLine(_changesets, dependenciesUpdated, _options) {
+  if (dependenciesUpdated.length === 0) return ''
+
+  const updates = dependenciesUpdated.map(
+    (dep) => `    - ${dep.name} bumped to ${dep.newVersion}`,
+  )
+
+  return [
+    '',
+    '- The following workspace dependencies were updated',
+    '  - dependencies',
+    ...updates,
+  ].join('\n')
+}
+
+export default {
+  getReleaseLine,
+  getDependencyReleaseLine,
+}

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "./.changeset/changelog.mjs",
     {
       "repo": "sanity-io/cli"
     }

--- a/.changeset/postversion.mjs
+++ b/.changeset/postversion.mjs
@@ -66,11 +66,9 @@ function extractDepBlock(section) {
     }
   }
 
-  const depBlock = lines
-    .slice(0, endLine)
-    .join('\n')
-    .trimEnd()
-  const cleaned = section.slice(0, idx) + section.slice(idx + depBlock.length)
+  const rawBlock = lines.slice(0, endLine).join('\n')
+  const depBlock = rawBlock.trimEnd()
+  const cleaned = section.slice(0, idx) + section.slice(idx + rawBlock.length)
 
   return {section: cleaned, depBlock}
 }

--- a/.changeset/postversion.mjs
+++ b/.changeset/postversion.mjs
@@ -1,0 +1,168 @@
+import {existsSync, readFileSync, readdirSync, writeFileSync} from 'node:fs'
+import {join, resolve} from 'node:path'
+
+const REPO = 'sanity-io/cli'
+const REPO_URL = `https://github.com/${REPO}`
+
+const SECTION_MAP = {
+  'Major Changes': '⚠ BREAKING CHANGES',
+  'Minor Changes': 'Features',
+  'Patch Changes': 'Bug Fixes',
+}
+
+function discoverPackages() {
+  const packages = []
+  const packagesDir = resolve('packages')
+
+  if (!existsSync(packagesDir)) return packages
+
+  for (const entry of readdirSync(packagesDir, {withFileTypes: true})) {
+    if (!entry.isDirectory()) continue
+
+    if (entry.name.startsWith('@')) {
+      const scopeDir = join(packagesDir, entry.name)
+      for (const sub of readdirSync(scopeDir, {withFileTypes: true})) {
+        if (!sub.isDirectory()) continue
+        const pkgJsonPath = join(scopeDir, sub.name, 'package.json')
+        if (!existsSync(pkgJsonPath)) continue
+        const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8'))
+        if (!pkg.private) {
+          packages.push({dir: join(scopeDir, sub.name), name: pkg.name, version: pkg.version})
+        }
+      }
+    } else {
+      const pkgJsonPath = join(packagesDir, entry.name, 'package.json')
+      if (!existsSync(pkgJsonPath)) continue
+      const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8'))
+      if (!pkg.private) {
+        packages.push({dir: join(packagesDir, entry.name), name: pkg.name, version: pkg.version})
+      }
+    }
+  }
+
+  return packages
+}
+
+function getTagPrefix(packageName) {
+  if (packageName.startsWith('@')) {
+    return packageName.split('/')[1] + '-v'
+  }
+  return packageName + '-v'
+}
+
+function extractDepBlock(section) {
+  const marker = '- The following workspace dependencies were updated'
+  const idx = section.indexOf(marker)
+  if (idx === -1) return {section, depBlock: null}
+
+  const afterMarker = section.slice(idx)
+  const lines = afterMarker.split('\n')
+  let endLine = 1
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '' || lines[i].match(/^\s{2,}/)) {
+      endLine = i + 1
+    } else {
+      break
+    }
+  }
+
+  const depBlock = lines
+    .slice(0, endLine)
+    .join('\n')
+    .trimEnd()
+  const cleaned = section.slice(0, idx) + section.slice(idx + depBlock.length)
+
+  return {section: cleaned, depBlock}
+}
+
+function removeEmptySections(text) {
+  const parts = text.split(/(^### .*$)/m)
+  const result = []
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i].startsWith('### ')) {
+      const nextContent = parts[i + 1] || ''
+      if (nextContent.trim().length === 0) {
+        i++
+        continue
+      }
+    }
+    result.push(parts[i])
+  }
+  return result.join('')
+}
+
+function transformChangelog(content, packageName, currentVersion) {
+  const tagPrefix = getTagPrefix(packageName)
+  const today = new Date().toISOString().split('T')[0]
+
+  const versionRegex = /^## (\d+\.\d+\.\d+)\s*$/m
+  const match = content.match(versionRegex)
+  if (!match || match[1] !== currentVersion) return content
+
+  const versionStart = match.index
+  const afterHeading = content.slice(versionStart + match[0].length)
+  const nextVersionMatch = afterHeading.match(/^## /m)
+  const sectionEnd = nextVersionMatch
+    ? versionStart + match[0].length + nextVersionMatch.index
+    : content.length
+
+  const before = content.slice(0, versionStart)
+  let section = content.slice(versionStart, sectionEnd)
+  const after = content.slice(sectionEnd)
+
+  let previousVersion = null
+  if (after) {
+    const prevMatch = after.match(/^## \[?(\d+\.\d+\.\d+)/m)
+    if (prevMatch) previousVersion = prevMatch[1]
+  }
+
+  const compareUrl = previousVersion
+    ? `${REPO_URL}/compare/${tagPrefix}${previousVersion}...${tagPrefix}${currentVersion}`
+    : `${REPO_URL}/releases/tag/${tagPrefix}${currentVersion}`
+
+  section = section.replace(
+    `## ${currentVersion}`,
+    `## [${currentVersion}](${compareUrl}) (${today})`,
+  )
+
+  for (const [from, to] of Object.entries(SECTION_MAP)) {
+    section = section.replace(new RegExp(`^### ${from}$`, 'm'), `### ${to}`)
+  }
+
+  const {section: withoutDeps, depBlock} = extractDepBlock(section)
+  section = withoutDeps
+
+  section = removeEmptySections(section)
+
+  // Collapse multiple blank lines
+  section = section.replace(/\n{3,}/g, '\n\n')
+
+  if (depBlock) {
+    section = section.trimEnd() + '\n\n### Dependencies\n\n' + depBlock + '\n\n'
+  }
+
+  return before + section + after
+}
+
+const packages = discoverPackages()
+let transformed = 0
+
+for (const pkg of packages) {
+  const changelogPath = join(pkg.dir, 'CHANGELOG.md')
+  if (!existsSync(changelogPath)) continue
+
+  const content = readFileSync(changelogPath, 'utf8')
+  const result = transformChangelog(content, pkg.name, pkg.version)
+
+  if (result !== content) {
+    writeFileSync(changelogPath, result)
+    console.log(`  ${pkg.name} CHANGELOG.md transformed`)
+    transformed++
+  }
+}
+
+if (transformed === 0) {
+  console.log('No changelogs needed transformation')
+} else {
+  console.log(`\nTransformed ${transformed} changelog(s)`)
+}

--- a/.github/scripts/generate-changeset.mjs
+++ b/.github/scripts/generate-changeset.mjs
@@ -156,8 +156,8 @@ if (!bump) {
   process.exit(0)
 }
 
-// 3. Derive release notes from PR title
-const releaseNotes = PR_TITLE.replace(/^[a-z]+(\([^)]*\))?!?:\s*/, '')
+// 3. Preserve the full conventional commit title so the changelog function can parse type and scope
+const releaseNotes = PR_TITLE
 
 // 4. Detect affected packages
 const pkgMap = getWorkspacePackages()

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -4,9 +4,13 @@ const project = ['src/**/*.{js,jsx,ts,tsx}', '!**/docs/**']
 
 const baseConfig = {
   // For now only care about cli package
+  // Disabled: the changeset plugin can't resolve local file paths in the changelog config
+  changesets: false,
   ignore: [
     // See `helpClass` in `oclif.config.js`
     'packages/@sanity/cli/src/SanityHelp.ts',
+    // Loaded dynamically by @changesets/cli at version time
+    '.changeset/changelog.mjs',
   ],
   workspaces: {
     'fixtures/*': {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:e2e": "pnpm --filter @sanity/cli-e2e test",
     "pretest:watch": "pnpm run build:cli",
     "test:watch": "vitest",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && node .changeset/postversion.mjs",
     "watch:cli": "turbo run watch --filter=@sanity/cli --filter=@sanity/cli*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "watch:cli": "turbo run watch --filter=@sanity/cli --filter=@sanity/cli*"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
     "@commitlint/cli": "^20.4.2",
     "@commitlint/config-conventional": "^20.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
 
   .:
     devDependencies:
-      '@changesets/changelog-github':
-        specifier: ^0.6.0
-        version: 0.6.0
       '@changesets/cli':
         specifier: ^2.30.0
         version: 2.30.0(@types/node@25.0.10)
@@ -1919,9 +1916,6 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/changelog-github@0.6.0':
-    resolution: {integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==}
-
   '@changesets/cli@2.30.0':
     resolution: {integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==}
     hasBin: true
@@ -1934,9 +1928,6 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
-
-  '@changesets/get-github-info@0.8.0':
-    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
 
   '@changesets/get-release-plan@4.0.15':
     resolution: {integrity: sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==}
@@ -6051,9 +6042,6 @@ packages:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  dataloader@1.4.0:
-    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
-
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
 
@@ -6208,10 +6196,6 @@ packages:
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
-
-  dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
 
   dts-resolver@2.1.3:
     resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
@@ -7786,15 +7770,6 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   node-html-parser@7.0.2:
     resolution: {integrity: sha512-DxodLVh7a6JMkYzWyc8nBX9MaF4M0lLFYkJHlWOiu7+9/I6mwNK9u5TbAMC7qfqDJEPX9OIoWA2A9t4C2l1mUQ==}
 
@@ -9008,9 +8983,6 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
@@ -9402,9 +9374,6 @@ packages:
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -9437,9 +9406,6 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -11006,14 +10972,6 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/changelog-github@0.6.0':
-    dependencies:
-      '@changesets/get-github-info': 0.8.0
-      '@changesets/types': 6.1.0
-      dotenv: 8.6.0
-    transitivePeerDependencies:
-      - encoding
-
   '@changesets/cli@2.30.0(@types/node@25.0.10)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
@@ -11066,13 +11024,6 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.4
-
-  '@changesets/get-github-info@0.8.0':
-    dependencies:
-      dataloader: 1.4.0
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
 
   '@changesets/get-release-plan@4.0.15':
     dependencies:
@@ -15591,8 +15542,6 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  dataloader@1.4.0: {}
-
   dataloader@2.2.3: {}
 
   date-fns@4.1.0: {}
@@ -15716,8 +15665,6 @@ snapshots:
       is-obj: 2.0.0
 
   dotenv@17.3.1: {}
-
-  dotenv@8.6.0: {}
 
   dts-resolver@2.1.3(oxc-resolver@11.19.1):
     optionalDependencies:
@@ -17344,10 +17291,6 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   node-html-parser@7.0.2:
     dependencies:
       css-select: 5.2.2
@@ -18818,8 +18761,6 @@ snapshots:
     dependencies:
       tldts: 7.0.19
 
-  tr46@0.0.3: {}
-
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
@@ -19222,8 +19163,6 @@ snapshots:
 
   web-worker@1.5.0: {}
 
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@7.0.0: {}
 
   webidl-conversions@8.0.1: {}
@@ -19253,11 +19192,6 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
### Description

Switch the changeset changelog output from the `@changesets/changelog-github` format to the conventional-commits/release-please style used in v6.3.0 and earlier.

**Before** (v6.3.1+ format):
```
## 6.3.1

### Patch Changes

- [#851](url) [`0cf739e`](url) Thanks [@binoy14](url)! - deps: bump sanity-tooling
```

**After** (conventional-commits format):
```
## [6.3.1](https://github.com/sanity-io/cli/compare/cli-v6.3.0...cli-v6.3.1) (2026-04-10)

### Bug Fixes

- **deps:** bump sanity-tooling ([#851](url)) ([0cf739e](url))
```

#### Changes

- **`.changeset/changelog.mjs`** — Custom changelog function that parses conventional commit type/scope from changeset summaries (or PR titles via GitHub API), extracts PR numbers from auto-generated changeset IDs, and formats entries as `- **scope:** description ([#PR](url)) ([hash](url))`
- **`.changeset/postversion.mjs`** — Post-processing script that renames section headers (`Minor Changes` → `Features`, `Patch Changes` → `Bug Fixes`), adds compare URLs and dates to version headers, and extracts dependency updates into a separate `Dependencies` section
- **`.changeset/config.json`** — Points changelog to the custom function
- **`package.json`** — Runs postversion script after `changeset version`
- **`.github/scripts/generate-changeset.mjs`** — Preserves full conventional commit PR title in changeset summaries instead of stripping the prefix

### What to review

- Verify the changelog function output format matches the conventional-commits style from v6.3.0
- Verify the postversion script correctly transforms section headers and version headings
- Check edge cases: multiline summaries, manual changesets without conventional commit prefix, missing GitHub token

### Testing

Tested the changelog function and postversion script with multiple scenarios:
- Auto-generated changesets with `pr-{number}` IDs and conventional commit summaries
- Manual changesets without conventional commit prefix
- Multiline summaries
- Dependency release lines
- Empty section removal after extracting dependency blocks
- Section header transformation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it replaces the Changesets changelog generator and adds a post-version rewrite step, which can affect release notes formatting/links and the release pipeline if edge cases are missed.
> 
> **Overview**
> Switches Changesets from `@changesets/changelog-github` to a custom `.changeset/changelog.mjs` that formats entries in *conventional-commits/release-please* style, including scope prefixes and PR/commit links (with PR lookup via GitHub API when needed).
> 
> Adds a `postversion` step (`.changeset/postversion.mjs`) run after `changeset version` to rewrite generated `CHANGELOG.md` sections (rename headers, add compare links + date to version headings, move dependency bumps into a dedicated **Dependencies** section, and drop empty sections). Updates the changeset generation GitHub script to keep the full conventional-commit PR title in changeset summaries, and adjusts `knip` config for the new local changelog script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07314a6b393b74b16e649514fa62b8e0af3cef62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->