### PR TITLE
ci: split e2e workflow into PR and scheduled runs

### DIFF
--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -1,0 +1,95 @@
+name: E2E Tests (Scheduled)
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+    inputs:
+      cli_version:
+        description: 'npm version/tag to test (e.g., latest, 5.20.0)'
+        required: true
+        default: 'latest'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [20, 22, 24]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install CLI from npm
+        run: |
+          CLI_VERSION="${{ inputs.cli_version || 'latest' }}"
+          INSTALL_DIR=$(mktemp -d)
+          npm install --prefix "$INSTALL_DIR" "sanity@${CLI_VERSION}" "create-sanity@latest"
+          echo "E2E_BINARY_PATH=$INSTALL_DIR/node_modules/.bin/sanity" >> "$GITHUB_ENV"
+          echo "E2E_CREATE_SANITY_BINARY_PATH=$INSTALL_DIR/node_modules/.bin/create-sanity" >> "$GITHUB_ENV"
+          echo "E2E_REGISTRY_MODE=true" >> "$GITHUB_ENV"
+          "$INSTALL_DIR/node_modules/.bin/sanity" --version
+          "$INSTALL_DIR/node_modules/.bin/create-sanity" --help > /dev/null
+
+      - name: Build test infrastructure
+        run: pnpm --filter @sanity/cli-test build
+
+      - name: Run E2E tests
+        env:
+          SANITY_E2E_TOKEN: ${{ secrets.SANITY_E2E_TOKEN }}
+          SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
+          SANITY_E2E_DATASET: ${{ secrets.SANITY_E2E_DATASET }}
+        run: pnpm --filter @sanity/cli-e2e test
+
+  notify-failure:
+    if: failure()
+    needs: [e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook: ${{ secrets.SLACK_E2E_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ${{ toJSON(format('Scheduled E2E failed for sanity@{0}', inputs.cli_version || 'latest')) }},
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":red_circle: *Scheduled E2E failed*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJSON(format('*Package:* `sanity@{0}`', inputs.cli_version || 'latest')) }}
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJSON(format('*Run:* <{0}/{1}/actions/runs/{2}|View logs>', github.server_url, github.repository, github.run_id)) }}
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,12 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      cli_version:
-        description: 'npm version/tag to test (e.g., latest, 5.20.0)'
-        required: true
-        default: 'latest'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,7 +17,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      should_run: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || steps.filter.outputs.cli == 'true' }}
+      should_run: ${{ github.event_name == 'push' || steps.filter.outputs.cli == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
@@ -61,26 +55,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Build CLI (pack mode)
-        if: ${{ !inputs.cli_version }}
+      - name: Build CLI
         run: pnpm build:cli
-
-      - name: Install CLI from npm (registry mode)
-        if: ${{ inputs.cli_version }}
-        env:
-          CLI_VERSION: ${{ inputs.cli_version }}
-        run: |
-          INSTALL_DIR=$(mktemp -d)
-          npm install --prefix "$INSTALL_DIR" "sanity@${CLI_VERSION}" "create-sanity@latest"
-          echo "E2E_BINARY_PATH=$INSTALL_DIR/node_modules/.bin/sanity" >> "$GITHUB_ENV"
-          echo "E2E_CREATE_SANITY_BINARY_PATH=$INSTALL_DIR/node_modules/.bin/create-sanity" >> "$GITHUB_ENV"
-          echo "E2E_REGISTRY_MODE=true" >> "$GITHUB_ENV"
-          "$INSTALL_DIR/node_modules/.bin/sanity" --version
-          "$INSTALL_DIR/node_modules/.bin/create-sanity" --help > /dev/null
-
-      - name: Build test infrastructure (registry mode)
-        if: ${{ inputs.cli_version }}
-        run: pnpm --filter @sanity/cli-test build
 
       - name: Run E2E tests
         env:
@@ -88,44 +64,6 @@ jobs:
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: ${{ secrets.SANITY_E2E_DATASET }}
         run: pnpm --filter @sanity/cli-e2e test
-
-  notify-failure:
-    if: ${{ failure() && inputs.cli_version }}
-    needs: [e2e]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
-        with:
-          webhook: ${{ secrets.SLACK_E2E_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": ${{ toJSON(format('Post-release E2E failed for sanity@{0}', inputs.cli_version)) }},
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":red_circle: *Post-release E2E failed*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ${{ toJSON(format('*Package:* `sanity@{0}`', inputs.cli_version)) }}
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ${{ toJSON(format('*Run:* <{0}/{1}/actions/runs/{2}|View logs>', github.server_url, github.repository, github.run_id)) }}
-                  }
-                }
-              ]
-            }
 
   e2e-status:
     if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PUBLISHED_PACKAGES: ${{ needs.release.outputs.publishedPackages }}
         run: |
-          CLI_VERSION=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | select(.name == "@sanity/cli") | .version')
-          if [ -n "$CLI_VERSION" ]; then
-            echo "Triggering E2E tests for @sanity/cli@$CLI_VERSION"
-            gh workflow run e2e.yml -f cli_version="$CLI_VERSION"
+          HAS_CLI=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | select(.name == "@sanity/cli") | .name')
+          if [ -n "$HAS_CLI" ]; then
+            echo "Triggering E2E tests for latest sanity"
+            gh workflow run e2e-scheduled.yml -f cli_version="latest"
           else
             echo "No @sanity/cli in published packages, skipping E2E"
           fi


### PR DESCRIPTION
### Description

Split the E2E workflow into two separate workflows:

- **`e2e.yml`** — runs on PRs and pushes to main in pack mode (builds from source). Removed `workflow_dispatch` trigger, registry mode steps, and Slack failure notifications.
- **`e2e-scheduled.yml`** — runs hourly via cron and on manual dispatch in registry mode (installs `sanity@latest` from npm). Includes Slack failure notifications.

Updated `release.yml` to dispatch `e2e-scheduled.yml` with `latest` instead of passing the `@sanity/cli` version (which doesn't match the `sanity` package version on npm).

Closes SDK-1294

### What to review

- `e2e-scheduled.yml` — new workflow with hourly cron, `workflow_dispatch`, registry mode, and Slack notifications
- `e2e.yml` — simplified to only handle PR/push in pack mode
- `release.yml` — post-release dispatch updated to target `e2e-scheduled.yml` with `latest`

### Testing

CI workflow changes — will be validated by GitHub Actions on merge. The scheduled workflow can also be tested manually via `gh workflow run e2e-scheduled.yml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to GitHub Actions wiring, though misconfiguration could reduce E2E coverage or alter when failures get reported.
> 
> **Overview**
> **Splits E2E coverage into two workflows.** `e2e.yml` is simplified to only run on PRs/pushes, always building the CLI from source (pack mode), and it removes `workflow_dispatch`, npm/registry install steps, and Slack failure notifications.
> 
> **Adds a new scheduled/manual registry-mode run.** New `e2e-scheduled.yml` runs hourly (and via `workflow_dispatch`) across Node 20/22/24 by installing `sanity@<cli_version>` from npm, building `@sanity/cli-test`, running E2Es, and sending a Slack alert on failures.
> 
> **Adjusts post-release triggering.** `release.yml` now dispatches `e2e-scheduled.yml` with `cli_version=latest` when `@sanity/cli` was published, instead of trying to pass a package version through `e2e.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f60f54f75e811962fc12640b1bb1a33b1fed7254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->