### PR TITLE
feat(dev): extract manifests for local applications

### DIFF
--- a/.changeset/pr-997.md
+++ b/.changeset/pr-997.md
@@ -3,4 +3,4 @@
 '@sanity/cli': minor
 ---
 
-extract studio manifest and pass it for local applications
+extract manifests for local applications

--- a/.changeset/pr-997.md
+++ b/.changeset/pr-997.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+extract studio manifest and pass it for local applications

--- a/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
+++ b/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
@@ -195,7 +195,7 @@ export async function buildVendorDependencies({
     },
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
-    cacheDir: path.join(SANITY_CACHE_DIR, 'vite-vendor'),
+    cacheDir: `${SANITY_CACHE_DIR}/vite-vendor`,
     configFile: false,
     define: {'process.env.NODE_ENV': JSON.stringify('production')},
     logLevel: 'silent',

--- a/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
+++ b/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import semver from 'semver'
 import {build} from 'vite'
 
+import {SANITY_CACHE_DIR} from '../../constants.js'
 import {getLocalPackageDir, getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 import {createExternalFromImportMap} from './createExternalFromImportMap.js'
 
@@ -194,7 +195,7 @@ export async function buildVendorDependencies({
     },
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
-    cacheDir: 'node_modules/.sanity/vite-vendor',
+    cacheDir: path.join(SANITY_CACHE_DIR, 'vite-vendor'),
     configFile: false,
     define: {'process.env.NODE_ENV': JSON.stringify('production')},
     logLevel: 'silent',

--- a/packages/@sanity/cli/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli/src/actions/build/getViteConfig.ts
@@ -166,7 +166,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     },
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
-    cacheDir: path.join(SANITY_CACHE_DIR, 'vite'),
+    cacheDir: `${SANITY_CACHE_DIR}/vite`,
     configFile: false,
     define: {
       __SANITY_BUILD_TIMESTAMP__: JSON.stringify(Date.now()),

--- a/packages/@sanity/cli/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli/src/actions/build/getViteConfig.ts
@@ -14,6 +14,7 @@ import debug from 'debug'
 import {readPackageUp} from 'read-package-up'
 import {type ConfigEnv, type InlineConfig, mergeConfig, type PluginOption, type Rollup} from 'vite'
 
+import {SANITY_CACHE_DIR} from '../../constants.js'
 import {sanityBuildEntries} from '../../server/vite/plugin-sanity-build-entries.js'
 import {sanityFaviconsPlugin} from '../../server/vite/plugin-sanity-favicons.js'
 import {sanityRuntimeRewritePlugin} from '../../server/vite/plugin-sanity-runtime-rewrite.js'
@@ -165,7 +166,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     },
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
-    cacheDir: 'node_modules/.sanity/vite',
+    cacheDir: path.join(SANITY_CACHE_DIR, 'vite'),
     configFile: false,
     define: {
       __SANITY_BUILD_TIMESTAMP__: JSON.stringify(Date.now()),

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -14,7 +14,7 @@ import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 import {buildApp} from '../build/buildApp.js'
 import {shouldAutoUpdate} from '../build/shouldAutoUpdate.js'
 import {extractAppManifest} from '../manifest/extractAppManifest.js'
-import {type AppManifest} from '../manifest/types.js'
+import {type CoreAppManifest} from '../manifest/types.js'
 import {checkDir} from './checkDir.js'
 import {createUserApplicationForApp} from './createUserApplicationForApp.js'
 import {deployDebug} from './deployDebug.js'
@@ -99,7 +99,7 @@ export async function deployApp(options: DeployAppOptions) {
     const parentDir = dirname(sourceDir)
     const base = basename(sourceDir)
     const tarball = pack(parentDir, {entries: [base]}).pipe(createGzip())
-    let manifest: AppManifest | undefined
+    let manifest: CoreAppManifest | undefined
     try {
       manifest = await extractAppManifest({workDir})
     } catch (err) {

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -13,7 +13,7 @@ import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 import {buildApp} from '../build/buildApp.js'
 import {shouldAutoUpdate} from '../build/shouldAutoUpdate.js'
-import {extractAppManifest} from '../manifest/extractAppManifest.js'
+import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
 import {type CoreAppManifest} from '../manifest/types.js'
 import {checkDir} from './checkDir.js'
 import {createUserApplicationForApp} from './createUserApplicationForApp.js'
@@ -101,7 +101,7 @@ export async function deployApp(options: DeployAppOptions) {
     const tarball = pack(parentDir, {entries: [base]}).pipe(createGzip())
     let manifest: CoreAppManifest | undefined
     try {
-      manifest = await extractAppManifest({workDir})
+      manifest = await extractCoreAppManifest({workDir})
     } catch (err) {
       deployDebug('Error extracting app manifest', err)
       const message = getErrorMessage(err)

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -27,8 +27,10 @@ vi.mock('../startDevManifestWatcher.js', () => ({
   startDevManifestWatcher: mockStartDevManifestWatcher,
 }))
 vi.mock('../extractDevServerManifest.js', () => ({
-  extractCoreAppManifest: mockExtractCoreAppManifest,
   extractStudioManifest: mockExtractStudioManifest,
+}))
+vi.mock('../../manifest/extractCoreAppManifest.js', () => ({
+  extractCoreAppManifest: mockExtractCoreAppManifest,
 }))
 
 /** Create a mock Vite dev server config shape — `server.config.server.host`

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -9,7 +9,6 @@ const mockStartStudioDevServer = vi.hoisted(() => vi.fn())
 const mockRegisterDevServer = vi.hoisted(() => vi.fn())
 const mockStartDevManifestWatcher = vi.hoisted(() => vi.fn())
 const mockExtractCoreAppManifest = vi.hoisted(() => vi.fn())
-const mockExtractStudioManifest = vi.hoisted(() => vi.fn())
 
 vi.mock('../startWorkbenchDevServer.js', () => ({
   startWorkbenchDevServer: mockStartWorkbenchDevServer,
@@ -25,9 +24,6 @@ vi.mock('../devServerRegistry.js', () => ({
 }))
 vi.mock('../startDevManifestWatcher.js', () => ({
   startDevManifestWatcher: mockStartDevManifestWatcher,
-}))
-vi.mock('../extractDevServerManifest.js', () => ({
-  extractStudioManifest: mockExtractStudioManifest,
 }))
 vi.mock('../../manifest/extractCoreAppManifest.js', () => ({
   extractCoreAppManifest: mockExtractCoreAppManifest,
@@ -54,7 +50,6 @@ describe('devAction', () => {
     mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
     mockStartDevManifestWatcher.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
     mockExtractCoreAppManifest.mockResolvedValue(undefined)
-    mockExtractStudioManifest.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -398,54 +393,17 @@ describe('devAction', () => {
       expect(mockExtractCoreAppManifest).not.toHaveBeenCalled()
     })
 
-    test('registers the studio immediately with no manifest — startup is not blocked on extraction', async () => {
+    test('registers the studio immediately with no manifest — the watcher owns extraction', async () => {
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-      mockExtractStudioManifest.mockReturnValue(new Promise(() => {}))
 
       await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
 
       expect(mockRegisterDevServer).toHaveBeenCalledWith(
         expect.not.objectContaining({manifest: expect.anything()}),
       )
-    })
-
-    test('patches the registry with the studio manifest once extraction completes', async () => {
-      const studioManifest = {createdAt: '2026-01-01', version: 3, workspaces: []}
-      const mockUpdate = vi.fn()
-      mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: mockUpdate})
-      mockExtractStudioManifest.mockResolvedValue(studioManifest)
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
-
-      await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled())
-      expect(mockExtractStudioManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
-      expect(mockUpdate).toHaveBeenCalledWith({
-        manifest: studioManifest,
-        manifestUpdatedAt: expect.any(String),
-      })
-    })
-
-    test('warns and does not patch the registry when studio extraction fails', async () => {
-      mockExtractStudioManifest.mockRejectedValue(new Error('bad schema'))
-      const mockUpdate = vi.fn()
-      mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: mockUpdate})
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-      const output = createMockOutput()
-
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, output}))
-
-      await vi.waitFor(() => expect(output.warn).toHaveBeenCalled())
-      expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('bad schema'))
-      expect(mockUpdate).not.toHaveBeenCalled()
-    })
-
-    test('does not extract the studio manifest for core apps', async () => {
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true}))
-
-      expect(mockExtractStudioManifest).not.toHaveBeenCalled()
+      expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
+        expect.objectContaining({update: expect.any(Function), workDir: '/tmp/sanity-project'}),
+      )
     })
 
     test('calls manifest cleanup on close', async () => {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -345,45 +345,49 @@ describe('devAction', () => {
       expect(mockStartDevManifestWatcher).not.toHaveBeenCalled()
     })
 
-    test('extracts the core-app manifest at startup and inlines it into registerDevServer', async () => {
-      const appManifest = {icon: '<svg><path d="M0 0"/></svg>', title: 'My App', version: '1'}
-      mockExtractCoreAppManifest.mockResolvedValue(appManifest)
+    test('registers the core-app immediately with no manifest — startup is not blocked on extraction', async () => {
       mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
+      // Never resolves — simulates a slow extraction. devAction must still return.
+      mockExtractCoreAppManifest.mockReturnValue(new Promise(() => {}))
 
-      await devAction(
-        createDevOptions({
-          cliConfig: {federation: {enabled: true}},
-          isApp: true,
-        }),
-      )
+      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true}))
 
-      expect(mockExtractCoreAppManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
       expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({
-          manifest: appManifest,
-          manifestUpdatedAt: expect.any(String),
-          type: 'coreApp',
-        }),
+        expect.not.objectContaining({manifest: expect.anything()}),
       )
     })
 
-    test('warns and registers without a manifest when core-app extraction fails', async () => {
+    test('patches the registry with the core-app manifest once extraction completes', async () => {
+      const appManifest = {icon: '<svg><path d="M0 0"/></svg>', title: 'My App', version: '1'}
+      const mockUpdate = vi.fn()
+      mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: mockUpdate})
+      mockExtractCoreAppManifest.mockResolvedValue(appManifest)
+      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true}))
+
+      await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+      expect(mockExtractCoreAppManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
+      expect(mockUpdate).toHaveBeenCalledWith({
+        manifest: appManifest,
+        manifestUpdatedAt: expect.any(String),
+      })
+    })
+
+    test('warns and does not patch the registry when core-app extraction fails', async () => {
       mockExtractCoreAppManifest.mockRejectedValue(new Error('bad config'))
+      const mockUpdate = vi.fn()
+      mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: mockUpdate})
       mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
       const output = createMockOutput()
 
       await devAction(
-        createDevOptions({
-          cliConfig: {federation: {enabled: true}},
-          isApp: true,
-          output,
-        }),
+        createDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true, output}),
       )
 
+      await vi.waitFor(() => expect(output.warn).toHaveBeenCalled())
       expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('bad config'))
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({manifest: undefined, manifestUpdatedAt: undefined}),
-      )
+      expect(mockUpdate).not.toHaveBeenCalled()
     })
 
     test('does not extract the core-app manifest for studios', async () => {
@@ -394,34 +398,46 @@ describe('devAction', () => {
       expect(mockExtractCoreAppManifest).not.toHaveBeenCalled()
     })
 
-    test('extracts the studio manifest at startup and inlines it into registerDevServer', async () => {
+    test('registers the studio immediately with no manifest — startup is not blocked on extraction', async () => {
+      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+      mockExtractStudioManifest.mockReturnValue(new Promise(() => {}))
+
+      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
+
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(
+        expect.not.objectContaining({manifest: expect.anything()}),
+      )
+    })
+
+    test('patches the registry with the studio manifest once extraction completes', async () => {
       const studioManifest = {createdAt: '2026-01-01', version: 3, workspaces: []}
+      const mockUpdate = vi.fn()
+      mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: mockUpdate})
       mockExtractStudioManifest.mockResolvedValue(studioManifest)
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
 
+      await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled())
       expect(mockExtractStudioManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({
-          manifest: studioManifest,
-          manifestUpdatedAt: expect.any(String),
-          type: 'studio',
-        }),
-      )
+      expect(mockUpdate).toHaveBeenCalledWith({
+        manifest: studioManifest,
+        manifestUpdatedAt: expect.any(String),
+      })
     })
 
-    test('warns and registers without a manifest when studio extraction fails', async () => {
+    test('warns and does not patch the registry when studio extraction fails', async () => {
       mockExtractStudioManifest.mockRejectedValue(new Error('bad schema'))
+      const mockUpdate = vi.fn()
+      mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: mockUpdate})
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
       const output = createMockOutput()
 
       await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, output}))
 
+      await vi.waitFor(() => expect(output.warn).toHaveBeenCalled())
       expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('bad schema'))
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({manifest: undefined, manifestUpdatedAt: undefined}),
-      )
+      expect(mockUpdate).not.toHaveBeenCalled()
     })
 
     test('does not extract the studio manifest for core apps', async () => {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -8,6 +8,7 @@ const mockStartAppDevServer = vi.hoisted(() => vi.fn())
 const mockStartStudioDevServer = vi.hoisted(() => vi.fn())
 const mockRegisterDevServer = vi.hoisted(() => vi.fn())
 const mockReadIconFromPath = vi.hoisted(() => vi.fn())
+const mockStartDevManifestWatcher = vi.hoisted(() => vi.fn())
 
 vi.mock('../startWorkbenchDevServer.js', () => ({
   startWorkbenchDevServer: mockStartWorkbenchDevServer,
@@ -20,6 +21,9 @@ vi.mock('../startStudioDevServer.js', () => ({
 }))
 vi.mock('../devServerRegistry.js', () => ({
   registerDevServer: mockRegisterDevServer,
+}))
+vi.mock('../startDevManifestWatcher.js', () => ({
+  startDevManifestWatcher: mockStartDevManifestWatcher,
 }))
 vi.mock('../../manifest/extractAppManifest.js', () => ({
   readIconFromPath: mockReadIconFromPath,
@@ -43,7 +47,8 @@ describe('devAction', () => {
       workbenchAvailable: false,
       workbenchPort: 3333,
     })
-    mockRegisterDevServer.mockReturnValue(vi.fn())
+    mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
+    mockStartDevManifestWatcher.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
   })
 
   afterEach(() => {
@@ -390,9 +395,41 @@ describe('devAction', () => {
       expect(mockRegisterDevServer).not.toHaveBeenCalled()
     })
 
+    test('does not start the manifest watcher when federation is disabled', async () => {
+      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
+
+      await devAction(createDevOptions())
+
+      expect(mockStartDevManifestWatcher).not.toHaveBeenCalled()
+    })
+
+    test('does not start the manifest watcher for apps even when federation is enabled', async () => {
+      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+      await devAction(
+        createDevOptions({
+          cliConfig: {federation: {enabled: true}},
+          isApp: true,
+        }),
+      )
+
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({type: 'coreApp'}))
+      expect(mockStartDevManifestWatcher).not.toHaveBeenCalled()
+    })
+
+    test('starts the manifest watcher for studios when federation is enabled', async () => {
+      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
+
+      expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
+        expect.objectContaining({workDir: '/tmp/sanity-project'}),
+      )
+    })
+
     test('calls manifest cleanup on close', async () => {
       const mockCleanup = vi.fn()
-      mockRegisterDevServer.mockReturnValue(mockCleanup)
+      mockRegisterDevServer.mockReturnValue({release: mockCleanup, update: vi.fn()})
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       const result = await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
@@ -403,7 +440,7 @@ describe('devAction', () => {
 
     test('close removes signal handlers to prevent listener leaks', async () => {
       const offSpy = vi.spyOn(process, 'off')
-      mockRegisterDevServer.mockReturnValue(vi.fn())
+      mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       const result = await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
@@ -418,7 +455,7 @@ describe('devAction', () => {
     test('SIGINT handler cleans up manifest and workbench, and removes itself', async () => {
       const mockCleanup = vi.fn()
       const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
-      mockRegisterDevServer.mockReturnValue(mockCleanup)
+      mockRegisterDevServer.mockReturnValue({release: mockCleanup, update: vi.fn()})
       mockStartWorkbenchDevServer.mockResolvedValue({
         close: mockWorkbenchClose,
         httpHost: 'localhost',

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -431,9 +431,10 @@ describe('devAction', () => {
       offSpy.mockRestore()
     })
 
-    test('SIGINT handler cleans up manifest and workbench, and removes itself', async () => {
+    test('SIGINT handler cleans up manifest, workbench, and the manifest watcher, and removes itself', async () => {
       const mockCleanup = vi.fn()
       const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
+      const mockWatcherClose = vi.fn().mockResolvedValue(undefined)
       mockRegisterDevServer.mockReturnValue({release: mockCleanup, update: vi.fn()})
       mockStartWorkbenchDevServer.mockResolvedValue({
         close: mockWorkbenchClose,
@@ -441,6 +442,7 @@ describe('devAction', () => {
         workbenchAvailable: true,
         workbenchPort: 3333,
       })
+      mockStartDevManifestWatcher.mockResolvedValue({close: mockWatcherClose})
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       const onSpy = vi.spyOn(process, 'on')
@@ -457,6 +459,7 @@ describe('devAction', () => {
       handler()
 
       expect(mockCleanup).toHaveBeenCalled()
+      expect(mockWatcherClose).toHaveBeenCalled()
       expect(mockWorkbenchClose).toHaveBeenCalled()
       expect(offSpy).toHaveBeenCalledWith('SIGINT', handler)
       expect(offSpy).toHaveBeenCalledWith('SIGTERM', handler)

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -7,8 +7,9 @@ const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
 const mockStartAppDevServer = vi.hoisted(() => vi.fn())
 const mockStartStudioDevServer = vi.hoisted(() => vi.fn())
 const mockRegisterDevServer = vi.hoisted(() => vi.fn())
-const mockReadIconFromPath = vi.hoisted(() => vi.fn())
 const mockStartDevManifestWatcher = vi.hoisted(() => vi.fn())
+const mockExtractCoreAppManifest = vi.hoisted(() => vi.fn())
+const mockExtractStudioManifest = vi.hoisted(() => vi.fn())
 
 vi.mock('../startWorkbenchDevServer.js', () => ({
   startWorkbenchDevServer: mockStartWorkbenchDevServer,
@@ -25,8 +26,9 @@ vi.mock('../devServerRegistry.js', () => ({
 vi.mock('../startDevManifestWatcher.js', () => ({
   startDevManifestWatcher: mockStartDevManifestWatcher,
 }))
-vi.mock('../../manifest/extractAppManifest.js', () => ({
-  readIconFromPath: mockReadIconFromPath,
+vi.mock('../extractDevServerManifest.js', () => ({
+  extractCoreAppManifest: mockExtractCoreAppManifest,
+  extractStudioManifest: mockExtractStudioManifest,
 }))
 
 /** Create a mock Vite dev server config shape — `server.config.server.host`
@@ -49,6 +51,8 @@ describe('devAction', () => {
     })
     mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
     mockStartDevManifestWatcher.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
+    mockExtractCoreAppManifest.mockResolvedValue(undefined)
+    mockExtractStudioManifest.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -231,103 +235,15 @@ describe('devAction', () => {
       )
     })
 
-    test('inlines app.icon via readIconFromPath and passes app.title to registerDevServer for SDK apps', async () => {
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
-      mockReadIconFromPath.mockResolvedValue('<svg><path d="M0 0"/></svg>')
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {
-            app: {icon: 'public/logo.svg', title: 'My App'},
-            federation: {enabled: true},
-          },
-          isApp: true,
-        }),
-      )
-
-      expect(mockReadIconFromPath).toHaveBeenCalledWith('/tmp/sanity-project', 'public/logo.svg')
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({
-          icon: '<svg><path d="M0 0"/></svg>',
-          title: 'My App',
-        }),
-      )
-    })
-
-    test('omits title for studios even when app.title is configured', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-      mockReadIconFromPath.mockResolvedValue('<svg><path d="M0 0"/></svg>')
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {
-            app: {icon: 'public/logo.svg', title: 'My App'},
-            federation: {enabled: true},
-          },
-        }),
-      )
-
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({
-          icon: '<svg><path d="M0 0"/></svg>',
-          title: undefined,
-        }),
-      )
-    })
-
-    test('warns and registers without icon when readIconFromPath fails', async () => {
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
-      mockReadIconFromPath.mockRejectedValue(new Error('ENOENT'))
-      const output = createMockOutput()
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {
-            app: {icon: 'public/missing.svg', title: 'My App'},
-            federation: {enabled: true},
-          },
-          isApp: true,
-          output,
-        }),
-      )
-
-      expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('ENOENT'))
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({icon: undefined, title: 'My App'}),
-      )
-    })
-
-    test('does not call readIconFromPath when app.icon is not configured', async () => {
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {
-            app: {title: 'My App'},
-            federation: {enabled: true},
-          },
-          isApp: true,
-        }),
-      )
-
-      expect(mockReadIconFromPath).not.toHaveBeenCalled()
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({icon: undefined, title: 'My App'}),
-      )
-    })
-
-    test('registers with undefined app metadata when nothing is configured', async () => {
+    test('registers without icon/title — they are derived from the inlined manifest', async () => {
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
 
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({
-          icon: undefined,
-          id: undefined,
-          title: undefined,
-        }),
-      )
+      const [registerArg] = mockRegisterDevServer.mock.calls[0]
+      expect(registerArg).not.toHaveProperty('icon')
+      expect(registerArg).not.toHaveProperty('title')
+      expect(registerArg.id).toBeUndefined()
     })
 
     test('registers app under the host applied by the vite dev server', async () => {
@@ -403,7 +319,17 @@ describe('devAction', () => {
       expect(mockStartDevManifestWatcher).not.toHaveBeenCalled()
     })
 
-    test('does not start the manifest watcher for apps even when federation is enabled', async () => {
+    test('starts the manifest watcher for studios when federation is enabled', async () => {
+      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
+
+      expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
+        expect.objectContaining({workDir: '/tmp/sanity-project'}),
+      )
+    })
+
+    test('does not start the manifest watcher for core apps — they have no schema to keep in sync', async () => {
       mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       await devAction(
@@ -417,14 +343,91 @@ describe('devAction', () => {
       expect(mockStartDevManifestWatcher).not.toHaveBeenCalled()
     })
 
-    test('starts the manifest watcher for studios when federation is enabled', async () => {
+    test('extracts the core-app manifest at startup and inlines it into registerDevServer', async () => {
+      const appManifest = {icon: '<svg><path d="M0 0"/></svg>', title: 'My App', version: '1'}
+      mockExtractCoreAppManifest.mockResolvedValue(appManifest)
+      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+      await devAction(
+        createDevOptions({
+          cliConfig: {federation: {enabled: true}},
+          isApp: true,
+        }),
+      )
+
+      expect(mockExtractCoreAppManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          manifest: appManifest,
+          manifestUpdatedAt: expect.any(String),
+          type: 'coreApp',
+        }),
+      )
+    })
+
+    test('warns and registers without a manifest when core-app extraction fails', async () => {
+      mockExtractCoreAppManifest.mockRejectedValue(new Error('bad config'))
+      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
+      const output = createMockOutput()
+
+      await devAction(
+        createDevOptions({
+          cliConfig: {federation: {enabled: true}},
+          isApp: true,
+          output,
+        }),
+      )
+
+      expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('bad config'))
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({manifest: undefined, manifestUpdatedAt: undefined}),
+      )
+    })
+
+    test('does not extract the core-app manifest for studios', async () => {
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
 
-      expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
-        expect.objectContaining({workDir: '/tmp/sanity-project'}),
+      expect(mockExtractCoreAppManifest).not.toHaveBeenCalled()
+    })
+
+    test('extracts the studio manifest at startup and inlines it into registerDevServer', async () => {
+      const studioManifest = {createdAt: '2026-01-01', version: 3, workspaces: []}
+      mockExtractStudioManifest.mockResolvedValue(studioManifest)
+      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
+
+      expect(mockExtractStudioManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          manifest: studioManifest,
+          manifestUpdatedAt: expect.any(String),
+          type: 'studio',
+        }),
       )
+    })
+
+    test('warns and registers without a manifest when studio extraction fails', async () => {
+      mockExtractStudioManifest.mockRejectedValue(new Error('bad schema'))
+      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+      const output = createMockOutput()
+
+      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, output}))
+
+      expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('bad schema'))
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({manifest: undefined, manifestUpdatedAt: undefined}),
+      )
+    })
+
+    test('does not extract the studio manifest for core apps', async () => {
+      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true}))
+
+      expect(mockExtractStudioManifest).not.toHaveBeenCalled()
     })
 
     test('calls manifest cleanup on close', async () => {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
@@ -72,26 +72,22 @@ describe('registerDevServer', () => {
     expect(existsSync(filePath)).toBe(false)
   })
 
-  test('persists app metadata in the manifest when provided', () => {
+  test('persists id in the manifest when provided', () => {
     const {release: cleanup} = registerDevServer({
       host: 'localhost',
-      icon: '<svg>inline</svg>',
       id: 'app-abc',
       port: 3334,
-      title: 'My App',
       type: 'coreApp',
       workDir: '/tmp/project',
     })
 
     const manifest = JSON.parse(readFileSync(join(registryDir(), `${process.pid}.json`), 'utf8'))
-    expect(manifest.icon).toBe('<svg>inline</svg>')
     expect(manifest.id).toBe('app-abc')
-    expect(manifest.title).toBe('My App')
 
     cleanup()
   })
 
-  test('omits app metadata when not provided and retains manifest through getRegisteredServers', () => {
+  test('omits optional metadata when not provided and retains manifest through getRegisteredServers', () => {
     const {release: cleanup} = registerDevServer({
       host: 'localhost',
       port: 3334,
@@ -100,15 +96,31 @@ describe('registerDevServer', () => {
     })
 
     const manifest = JSON.parse(readFileSync(join(registryDir(), `${process.pid}.json`), 'utf8'))
-    expect(manifest.icon).toBeUndefined()
     expect(manifest.id).toBeUndefined()
-    expect(manifest.title).toBeUndefined()
+    expect(manifest.manifest).toBeUndefined()
 
     const servers = getRegisteredServers()
     expect(servers).toHaveLength(1)
-    expect(servers[0].icon).toBeUndefined()
     expect(servers[0].id).toBeUndefined()
-    expect(servers[0].title).toBeUndefined()
+    expect(servers[0].manifest).toBeUndefined()
+
+    cleanup()
+  })
+
+  test('update inlines the extracted manifest into the registry entry', () => {
+    const {release: cleanup, update} = registerDevServer({
+      host: 'localhost',
+      port: 3334,
+      type: 'studio',
+      workDir: '/tmp/project',
+    })
+
+    const inlined = {createdAt: '2026-01-01T00:00:00.000Z', version: 3, workspaces: []}
+    update({manifest: inlined, manifestUpdatedAt: '2026-01-01T00:00:00.000Z'})
+
+    const servers = getRegisteredServers()
+    expect(servers[0].manifest).toEqual(inlined)
+    expect(servers[0].manifestUpdatedAt).toBe('2026-01-01T00:00:00.000Z')
 
     cleanup()
   })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
@@ -49,7 +49,7 @@ afterEach(() => {
 
 describe('registerDevServer', () => {
   test('writes a manifest file and returns a cleanup function', () => {
-    const cleanup = registerDevServer({
+    const {release: cleanup} = registerDevServer({
       host: 'localhost',
       port: 3334,
       type: 'studio',
@@ -73,7 +73,7 @@ describe('registerDevServer', () => {
   })
 
   test('persists app metadata in the manifest when provided', () => {
-    const cleanup = registerDevServer({
+    const {release: cleanup} = registerDevServer({
       host: 'localhost',
       icon: '<svg>inline</svg>',
       id: 'app-abc',
@@ -92,7 +92,7 @@ describe('registerDevServer', () => {
   })
 
   test('omits app metadata when not provided and retains manifest through getRegisteredServers', () => {
-    const cleanup = registerDevServer({
+    const {release: cleanup} = registerDevServer({
       host: 'localhost',
       port: 3334,
       type: 'studio',
@@ -114,7 +114,7 @@ describe('registerDevServer', () => {
   })
 
   test('cleanup does not throw if file already removed', () => {
-    const cleanup = registerDevServer({
+    const {release: cleanup} = registerDevServer({
       host: 'localhost',
       port: 3333,
       type: 'studio',
@@ -360,7 +360,7 @@ describe('startedAt uses OS-reported process start time', () => {
     const osStart = new Date('2026-04-17T11:38:10.000Z')
     mockExecSync.mockReturnValue(osStart.toString())
 
-    const cleanup = registerDevServer({
+    const {release: cleanup} = registerDevServer({
       host: 'localhost',
       port: 3334,
       type: 'studio',
@@ -384,7 +384,7 @@ describe('startedAt uses OS-reported process start time', () => {
     const osStart = new Date(Date.now() - 5000)
     mockExecSync.mockReturnValue(osStart.toString())
 
-    const cleanup = registerDevServer({
+    const {release: cleanup} = registerDevServer({
       host: 'localhost',
       port: 3334,
       type: 'studio',
@@ -434,7 +434,7 @@ describe('startedAt uses OS-reported process start time', () => {
     })
 
     const before = Date.now()
-    const cleanup = registerDevServer({
+    const {release: cleanup} = registerDevServer({
       host: 'localhost',
       port: 3334,
       type: 'studio',

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
@@ -136,6 +136,27 @@ describe('registerDevServer', () => {
     cleanup()
     expect(() => cleanup()).not.toThrow()
   })
+
+  test('update after release is a no-op — late background extractions do not re-create the file', () => {
+    const {release: cleanup, update} = registerDevServer({
+      host: 'localhost',
+      port: 3334,
+      type: 'studio',
+      workDir: '/tmp/project',
+    })
+
+    const filePath = join(registryDir(), `${process.pid}.json`)
+    cleanup()
+    expect(existsSync(filePath)).toBe(false)
+
+    // Simulate a background extraction completing after release.
+    update({
+      manifest: {createdAt: '2026-01-01T00:00:00.000Z', version: 3, workspaces: []},
+      manifestUpdatedAt: '2026-01-01T00:00:00.000Z',
+    })
+
+    expect(existsSync(filePath)).toBe(false)
+  })
 })
 
 describe('acquireWorkbenchLock', () => {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -1,0 +1,184 @@
+import {EventEmitter} from 'node:events'
+
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {startDevManifestWatcher} from '../startDevManifestWatcher.js'
+import {createMockOutput} from './testHelpers.js'
+
+const mockExtractManifest = vi.hoisted(() => vi.fn())
+const mockFindProjectRoot = vi.hoisted(() => vi.fn())
+const mockFsWatch = vi.hoisted(() => vi.fn())
+
+vi.mock('../../manifest/extractManifest.js', () => ({
+  extractManifest: mockExtractManifest,
+}))
+
+vi.mock('@sanity/cli-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/cli-core')>()
+  return {
+    ...actual,
+    findProjectRoot: mockFindProjectRoot,
+  }
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    watch: mockFsWatch,
+  }
+})
+
+/** Fake FSWatcher that exposes helpers for simulating events in tests. */
+// eslint-disable-next-line unicorn/prefer-event-target -- mirrors node's FSWatcher which extends EventEmitter
+class FakeFsWatcher extends EventEmitter {
+  public closed = false
+  public handler: ((event: string, filename: string | null) => void) | undefined
+
+  close() {
+    this.closed = true
+  }
+
+  emitChange(filename: string | null) {
+    this.handler?.('change', filename)
+  }
+}
+
+const WORK_DIR = '/tmp/studio'
+const CONFIG_PATH = '/tmp/studio/sanity.config.ts'
+
+describe('startDevManifestWatcher', () => {
+  let fakeWatcher: FakeFsWatcher
+
+  beforeEach(() => {
+    fakeWatcher = new FakeFsWatcher()
+    mockFindProjectRoot.mockResolvedValue({
+      directory: WORK_DIR,
+      path: CONFIG_PATH,
+      type: 'studio',
+    })
+    mockExtractManifest.mockResolvedValue(undefined)
+    mockFsWatch.mockImplementation((_dir: string, listener: FakeFsWatcher['handler']) => {
+      fakeWatcher.handler = listener
+      return fakeWatcher
+    })
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  test('performs an initial extraction and updates registry with manifestPath', async () => {
+    const update = vi.fn()
+
+    const watcher = await startDevManifestWatcher({
+      output: createMockOutput(),
+      update,
+      workDir: WORK_DIR,
+    })
+
+    expect(mockExtractManifest).toHaveBeenCalledWith({
+      outPath: `${WORK_DIR}/node_modules/.sanity/manifest`,
+      path: CONFIG_PATH,
+      workDir: WORK_DIR,
+    })
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manifestPath: `${WORK_DIR}/node_modules/.sanity/manifest/create-manifest.json`,
+        manifestUpdatedAt: expect.any(String),
+      }),
+    )
+
+    await watcher.close()
+  })
+
+  test('re-extracts after a debounced config file change', async () => {
+    const update = vi.fn()
+    const watcher = await startDevManifestWatcher({
+      output: createMockOutput(),
+      update,
+      workDir: WORK_DIR,
+    })
+
+    expect(mockExtractManifest).toHaveBeenCalledTimes(1)
+
+    // Fire multiple rapid "change" events — should coalesce into a single
+    // regeneration after the debounce window.
+    fakeWatcher.emitChange('sanity.config.ts')
+    fakeWatcher.emitChange('sanity.config.ts')
+    fakeWatcher.emitChange('sanity.config.ts')
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(mockExtractManifest).toHaveBeenCalledTimes(2)
+    expect(update).toHaveBeenCalledTimes(2)
+
+    await watcher.close()
+  })
+
+  test('ignores changes to other files in the config directory', async () => {
+    const update = vi.fn()
+    const watcher = await startDevManifestWatcher({
+      output: createMockOutput(),
+      update,
+      workDir: WORK_DIR,
+    })
+
+    expect(mockExtractManifest).toHaveBeenCalledTimes(1)
+
+    fakeWatcher.emitChange('unrelated.ts')
+    fakeWatcher.emitChange('package.json')
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(mockExtractManifest).toHaveBeenCalledTimes(1)
+
+    await watcher.close()
+  })
+
+  test('logs a warning and keeps running when extraction fails', async () => {
+    const output = createMockOutput()
+    const update = vi.fn()
+    mockExtractManifest
+      .mockRejectedValueOnce(new Error('bad schema'))
+      .mockResolvedValueOnce(undefined)
+
+    const watcher = await startDevManifestWatcher({output, update, workDir: WORK_DIR})
+
+    expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('bad schema'))
+    // Failed extraction must not call update — we only touch the registry
+    // when a manifest actually exists at the expected path.
+    expect(update).not.toHaveBeenCalled()
+
+    // A subsequent change triggers a successful regeneration that updates the
+    // registry as normal.
+    fakeWatcher.emitChange('sanity.config.ts')
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(update).toHaveBeenCalledTimes(1)
+
+    await watcher.close()
+  })
+
+  test('stops regenerating after close', async () => {
+    const update = vi.fn()
+    const watcher = await startDevManifestWatcher({
+      output: createMockOutput(),
+      update,
+      workDir: WORK_DIR,
+    })
+
+    expect(mockExtractManifest).toHaveBeenCalledTimes(1)
+
+    await watcher.close()
+
+    expect(fakeWatcher.closed).toBe(true)
+
+    fakeWatcher.emitChange('sanity.config.ts')
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(mockExtractManifest).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -85,7 +85,10 @@ describe('startDevManifestWatcher', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
-    expect(mockExtractStudioManifest).toHaveBeenCalledWith({workDir: WORK_DIR})
+    expect(mockExtractStudioManifest).toHaveBeenCalledWith({
+      configPath: STUDIO_CONFIG_PATH,
+      workDir: WORK_DIR,
+    })
     expect(update).toHaveBeenCalledWith({
       manifest: studioManifest,
       manifestUpdatedAt: expect.any(String),

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -71,7 +71,7 @@ describe('startDevManifestWatcher', () => {
     vi.clearAllMocks()
   })
 
-  test('does not extract on startup — initial extraction happens in devAction', async () => {
+  test('runs an initial extraction on startup and inlines it into update', async () => {
     const update = vi.fn()
 
     const watcher = await startDevManifestWatcher({
@@ -80,8 +80,54 @@ describe('startDevManifestWatcher', () => {
       workDir: WORK_DIR,
     })
 
-    expect(mockExtractStudioManifest).not.toHaveBeenCalled()
-    expect(update).not.toHaveBeenCalled()
+    // Flush the fire-and-forget microtask chain so the initial extraction
+    // has time to resolve and patch the registry.
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+    expect(mockExtractStudioManifest).toHaveBeenCalledWith({workDir: WORK_DIR})
+    expect(update).toHaveBeenCalledWith({
+      manifest: studioManifest,
+      manifestUpdatedAt: expect.any(String),
+    })
+
+    await watcher.close()
+  })
+
+  test('coalesces a config-file change that fires during the initial extraction', async () => {
+    // Block the first extraction until we say otherwise. This simulates the
+    // user editing sanity.config.ts while the worker is still producing the
+    // initial manifest — the watcher must not run a parallel extraction.
+    let resolveFirst: ((value: typeof studioManifest) => void) | undefined
+    mockExtractStudioManifest
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve
+        }),
+      )
+      .mockResolvedValueOnce(studioManifest)
+
+    const update = vi.fn()
+    const watcher = await startDevManifestWatcher({
+      output: createMockOutput(),
+      update,
+      workDir: WORK_DIR,
+    })
+
+    // Fire a change event while the initial extraction is still in-flight.
+    fakeWatcher.emitChange('sanity.config.ts')
+    await vi.advanceTimersByTimeAsync(300)
+
+    // Only the initial extraction is running — the config change is pending.
+    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+
+    // Release the initial extraction; the pending change-triggered run now
+    // starts, serialized behind it.
+    resolveFirst!(studioManifest)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(2)
+    expect(update).toHaveBeenCalledTimes(2)
 
     await watcher.close()
   })
@@ -94,6 +140,11 @@ describe('startDevManifestWatcher', () => {
       workDir: WORK_DIR,
     })
 
+    // Wait for the initial extraction to complete before exercising the
+    // file-change path.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+
     // Fire multiple rapid "change" events — should coalesce into a single
     // regeneration after the debounce window.
     fakeWatcher.emitChange('sanity.config.ts')
@@ -102,12 +153,8 @@ describe('startDevManifestWatcher', () => {
 
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
-    expect(mockExtractStudioManifest).toHaveBeenCalledWith({workDir: WORK_DIR})
-    expect(update).toHaveBeenCalledWith({
-      manifest: studioManifest,
-      manifestUpdatedAt: expect.any(String),
-    })
+    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(2)
+    expect(update).toHaveBeenCalledTimes(2)
 
     await watcher.close()
   })
@@ -120,12 +167,15 @@ describe('startDevManifestWatcher', () => {
       workDir: WORK_DIR,
     })
 
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+
     fakeWatcher.emitChange('unrelated.ts')
     fakeWatcher.emitChange('package.json')
 
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(mockExtractStudioManifest).not.toHaveBeenCalled()
+    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
 
     await watcher.close()
   })
@@ -139,13 +189,12 @@ describe('startDevManifestWatcher', () => {
 
     const watcher = await startDevManifestWatcher({output, update, workDir: WORK_DIR})
 
-    // First change fails
-    fakeWatcher.emitChange('sanity.config.ts')
-    await vi.advanceTimersByTimeAsync(300)
+    // The initial extraction fails.
+    await vi.advanceTimersByTimeAsync(0)
     expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('bad schema'))
     expect(update).not.toHaveBeenCalled()
 
-    // Second change recovers and updates as normal
+    // A subsequent change recovers and updates as normal.
     fakeWatcher.emitChange('sanity.config.ts')
     await vi.advanceTimersByTimeAsync(300)
     expect(update).toHaveBeenCalledTimes(1)
@@ -161,13 +210,15 @@ describe('startDevManifestWatcher', () => {
       workDir: WORK_DIR,
     })
 
-    await watcher.close()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
 
+    await watcher.close()
     expect(fakeWatcher.closed).toBe(true)
 
     fakeWatcher.emitChange('sanity.config.ts')
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(mockExtractStudioManifest).not.toHaveBeenCalled()
+    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -5,12 +5,12 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 import {startDevManifestWatcher} from '../startDevManifestWatcher.js'
 import {createMockOutput} from './testHelpers.js'
 
-const mockExtractManifest = vi.hoisted(() => vi.fn())
+const mockExtractStudioManifest = vi.hoisted(() => vi.fn())
 const mockFindProjectRoot = vi.hoisted(() => vi.fn())
 const mockFsWatch = vi.hoisted(() => vi.fn())
 
-vi.mock('../../manifest/extractManifest.js', () => ({
-  extractManifest: mockExtractManifest,
+vi.mock('../extractDevServerManifest.js', () => ({
+  extractStudioManifest: mockExtractStudioManifest,
 }))
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
@@ -45,19 +45,20 @@ class FakeFsWatcher extends EventEmitter {
 }
 
 const WORK_DIR = '/tmp/studio'
-const CONFIG_PATH = '/tmp/studio/sanity.config.ts'
+const STUDIO_CONFIG_PATH = '/tmp/studio/sanity.config.ts'
 
 describe('startDevManifestWatcher', () => {
   let fakeWatcher: FakeFsWatcher
+  const studioManifest = {createdAt: '2026-01-01', version: 3, workspaces: []}
 
   beforeEach(() => {
     fakeWatcher = new FakeFsWatcher()
     mockFindProjectRoot.mockResolvedValue({
       directory: WORK_DIR,
-      path: CONFIG_PATH,
+      path: STUDIO_CONFIG_PATH,
       type: 'studio',
     })
-    mockExtractManifest.mockResolvedValue(undefined)
+    mockExtractStudioManifest.mockResolvedValue(studioManifest)
     mockFsWatch.mockImplementation((_dir: string, listener: FakeFsWatcher['handler']) => {
       fakeWatcher.handler = listener
       return fakeWatcher
@@ -70,7 +71,7 @@ describe('startDevManifestWatcher', () => {
     vi.clearAllMocks()
   })
 
-  test('performs an initial extraction and updates registry with manifestPath', async () => {
+  test('does not extract on startup — initial extraction happens in devAction', async () => {
     const update = vi.fn()
 
     const watcher = await startDevManifestWatcher({
@@ -79,30 +80,19 @@ describe('startDevManifestWatcher', () => {
       workDir: WORK_DIR,
     })
 
-    expect(mockExtractManifest).toHaveBeenCalledWith({
-      outPath: `${WORK_DIR}/node_modules/.sanity/manifest`,
-      path: CONFIG_PATH,
-      workDir: WORK_DIR,
-    })
-    expect(update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        manifestPath: `${WORK_DIR}/node_modules/.sanity/manifest/create-manifest.json`,
-        manifestUpdatedAt: expect.any(String),
-      }),
-    )
+    expect(mockExtractStudioManifest).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
 
     await watcher.close()
   })
 
-  test('re-extracts after a debounced config file change', async () => {
+  test('re-extracts and inlines the new manifest after a debounced config file change', async () => {
     const update = vi.fn()
     const watcher = await startDevManifestWatcher({
       output: createMockOutput(),
       update,
       workDir: WORK_DIR,
     })
-
-    expect(mockExtractManifest).toHaveBeenCalledTimes(1)
 
     // Fire multiple rapid "change" events — should coalesce into a single
     // regeneration after the debounce window.
@@ -112,8 +102,12 @@ describe('startDevManifestWatcher', () => {
 
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(mockExtractManifest).toHaveBeenCalledTimes(2)
-    expect(update).toHaveBeenCalledTimes(2)
+    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+    expect(mockExtractStudioManifest).toHaveBeenCalledWith({workDir: WORK_DIR})
+    expect(update).toHaveBeenCalledWith({
+      manifest: studioManifest,
+      manifestUpdatedAt: expect.any(String),
+    })
 
     await watcher.close()
   })
@@ -126,14 +120,12 @@ describe('startDevManifestWatcher', () => {
       workDir: WORK_DIR,
     })
 
-    expect(mockExtractManifest).toHaveBeenCalledTimes(1)
-
     fakeWatcher.emitChange('unrelated.ts')
     fakeWatcher.emitChange('package.json')
 
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(mockExtractManifest).toHaveBeenCalledTimes(1)
+    expect(mockExtractStudioManifest).not.toHaveBeenCalled()
 
     await watcher.close()
   })
@@ -141,22 +133,21 @@ describe('startDevManifestWatcher', () => {
   test('logs a warning and keeps running when extraction fails', async () => {
     const output = createMockOutput()
     const update = vi.fn()
-    mockExtractManifest
+    mockExtractStudioManifest
       .mockRejectedValueOnce(new Error('bad schema'))
-      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(studioManifest)
 
     const watcher = await startDevManifestWatcher({output, update, workDir: WORK_DIR})
 
-    expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('bad schema'))
-    // Failed extraction must not call update — we only touch the registry
-    // when a manifest actually exists at the expected path.
-    expect(update).not.toHaveBeenCalled()
-
-    // A subsequent change triggers a successful regeneration that updates the
-    // registry as normal.
+    // First change fails
     fakeWatcher.emitChange('sanity.config.ts')
     await vi.advanceTimersByTimeAsync(300)
+    expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('bad schema'))
+    expect(update).not.toHaveBeenCalled()
 
+    // Second change recovers and updates as normal
+    fakeWatcher.emitChange('sanity.config.ts')
+    await vi.advanceTimersByTimeAsync(300)
     expect(update).toHaveBeenCalledTimes(1)
 
     await watcher.close()
@@ -170,8 +161,6 @@ describe('startDevManifestWatcher', () => {
       workDir: WORK_DIR,
     })
 
-    expect(mockExtractManifest).toHaveBeenCalledTimes(1)
-
     await watcher.close()
 
     expect(fakeWatcher.closed).toBe(true)
@@ -179,6 +168,6 @@ describe('startDevManifestWatcher', () => {
     fakeWatcher.emitChange('sanity.config.ts')
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(mockExtractManifest).toHaveBeenCalledTimes(1)
+    expect(mockExtractStudioManifest).not.toHaveBeenCalled()
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -420,63 +420,57 @@ describe('startWorkbenchDevServer', () => {
       expect(mockWatchRegistry).toHaveBeenCalledWith(expect.any(Function))
     })
 
-    test('watcher callback broadcasts applications via server.hot.send', async () => {
+    test('watcher callback broadcasts applications via server.ws.send with inlined manifests', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
       const mockServer = createMockServer()
       mockCreateServer.mockResolvedValue(mockServer)
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
+      const studioManifest = {createdAt: '2026-01-01T00:00:00.000Z', version: 3, workspaces: []}
+      const appManifest = {icon: '<svg>two</svg>', title: 'App Two', version: '1'}
+
       const watchCallback = mockWatchRegistry.mock.calls[0][0]
       watchCallback([
         {
           host: 'localhost',
-          icon: '<svg>one</svg>',
           id: 'app-1',
+          manifest: studioManifest,
           pid: 2,
           port: 3334,
           type: 'studio',
         },
         {
           host: 'localhost',
-          icon: '<svg>two</svg>',
           id: 'app-2',
+          manifest: appManifest,
           pid: 3,
           port: 3335,
-          title: 'App Two',
           type: 'coreApp',
         },
       ])
-
-      // Payload build is async (reads optional manifest files from disk) —
-      // wait until the broadcast actually happens.
-      await vi.waitFor(() => expect(mockServer.ws.send).toHaveBeenCalled())
 
       expect(mockServer.ws.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
         applications: [
           {
             host: 'localhost',
-            icon: '<svg>one</svg>',
             id: 'app-1',
-            manifest: undefined,
+            manifest: studioManifest,
             port: 3334,
-            title: undefined,
             type: 'studio',
           },
           {
             host: 'localhost',
-            icon: '<svg>two</svg>',
             id: 'app-2',
-            manifest: undefined,
+            manifest: appManifest,
             port: 3335,
-            title: 'App Two',
             type: 'coreApp',
           },
         ],
       })
     })
 
-    test('includes undefined app metadata when a registered server has none', async () => {
+    test('includes undefined manifest when a registered server has not yet extracted one', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
       const mockServer = createMockServer()
       mockCreateServer.mockResolvedValue(mockServer)
@@ -486,17 +480,13 @@ describe('startWorkbenchDevServer', () => {
       const watchCallback = mockWatchRegistry.mock.calls[0][0]
       watchCallback([{host: 'localhost', pid: 2, port: 3334, type: 'studio'}])
 
-      await vi.waitFor(() => expect(mockServer.ws.send).toHaveBeenCalled())
-
       expect(mockServer.ws.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
         applications: [
           {
             host: 'localhost',
-            icon: undefined,
             id: undefined,
             manifest: undefined,
             port: 3334,
-            title: undefined,
             type: 'studio',
           },
         ],
@@ -507,20 +497,20 @@ describe('startWorkbenchDevServer', () => {
       mockResolveLocalPackage.mockResolvedValue({})
       const mockServer = createMockServer()
       mockCreateServer.mockResolvedValue(mockServer)
+      const inlined = {icon: '<svg>inline</svg>', title: 'Title', version: '1'}
       mockGetRegisteredServers.mockReturnValue([
         {
           host: 'localhost',
-          icon: '<svg>inline</svg>',
           id: 'app-1',
+          manifest: inlined,
           pid: 2,
           port: 3334,
-          type: 'studio',
+          type: 'coreApp',
         },
       ])
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
-      // Find the handler registered for the request event
       const onCall = mockServer.ws.on.mock.calls.find(
         (args: unknown[]) => args[0] === 'sanity:workbench:get-local-applications',
       )
@@ -530,103 +520,17 @@ describe('startWorkbenchDevServer', () => {
       const handler = onCall![1] as (data: unknown, client: typeof mockClient) => void
       handler(undefined, mockClient)
 
-      await vi.waitFor(() => expect(mockClient.send).toHaveBeenCalled())
-
       expect(mockClient.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
         applications: [
           {
             host: 'localhost',
-            icon: '<svg>inline</svg>',
             id: 'app-1',
-            manifest: undefined,
+            manifest: inlined,
             port: 3334,
-            title: undefined,
-            type: 'studio',
+            type: 'coreApp',
           },
         ],
       })
-    })
-
-    test('inlines manifest contents from manifestPath for studio entries', async () => {
-      const {mkdtempSync, writeFileSync} = await import('node:fs')
-      const {tmpdir} = await import('node:os')
-      const {join} = await import('node:path')
-      const dir = mkdtempSync(join(tmpdir(), 'workbench-manifest-'))
-      const manifestPath = join(dir, 'create-manifest.json')
-      const manifestContents = {createdAt: '2026-01-01T00:00:00.000Z', version: 3, workspaces: []}
-      writeFileSync(manifestPath, JSON.stringify(manifestContents))
-
-      mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
-      mockCreateServer.mockResolvedValue(mockServer)
-
-      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
-
-      const watchCallback = mockWatchRegistry.mock.calls[0][0]
-      watchCallback([
-        {
-          host: 'localhost',
-          manifestPath,
-          manifestUpdatedAt: '2026-01-01T00:00:00.000Z',
-          pid: 2,
-          port: 3334,
-          type: 'studio',
-        },
-      ])
-
-      await vi.waitFor(() => expect(mockServer.ws.send).toHaveBeenCalled())
-
-      const [, payload] = mockServer.ws.send.mock.calls[0]
-      expect(payload.applications[0].manifest).toEqual(manifestContents)
-    })
-
-    test('omits manifest when the file at manifestPath is missing or invalid', async () => {
-      mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
-      mockCreateServer.mockResolvedValue(mockServer)
-
-      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
-
-      const watchCallback = mockWatchRegistry.mock.calls[0][0]
-      watchCallback([
-        {
-          host: 'localhost',
-          manifestPath: '/definitely/does/not/exist/create-manifest.json',
-          pid: 2,
-          port: 3334,
-          type: 'studio',
-        },
-      ])
-
-      await vi.waitFor(() => expect(mockServer.ws.send).toHaveBeenCalled())
-
-      const [, payload] = mockServer.ws.send.mock.calls[0]
-      expect(payload.applications[0].manifest).toBeUndefined()
-    })
-
-    test('does not read manifestPath for non-studio entries', async () => {
-      mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
-      mockCreateServer.mockResolvedValue(mockServer)
-
-      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
-
-      const watchCallback = mockWatchRegistry.mock.calls[0][0]
-      watchCallback([
-        {
-          host: 'localhost',
-          // Even if set (shouldn't be in practice), coreApps don't ship a manifest
-          manifestPath: '/tmp/nope.json',
-          pid: 2,
-          port: 3335,
-          type: 'coreApp',
-        },
-      ])
-
-      await vi.waitFor(() => expect(mockServer.ws.send).toHaveBeenCalled())
-
-      const [, payload] = mockServer.ws.send.mock.calls[0]
-      expect(payload.applications[0].manifest).toBeUndefined()
     })
 
     test('close stops watcher and releases lock', async () => {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -448,12 +448,17 @@ describe('startWorkbenchDevServer', () => {
         },
       ])
 
+      // Payload build is async (reads optional manifest files from disk) —
+      // wait until the broadcast actually happens.
+      await vi.waitFor(() => expect(mockServer.ws.send).toHaveBeenCalled())
+
       expect(mockServer.ws.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
         applications: [
           {
             host: 'localhost',
             icon: '<svg>one</svg>',
             id: 'app-1',
+            manifest: undefined,
             port: 3334,
             title: undefined,
             type: 'studio',
@@ -462,6 +467,7 @@ describe('startWorkbenchDevServer', () => {
             host: 'localhost',
             icon: '<svg>two</svg>',
             id: 'app-2',
+            manifest: undefined,
             port: 3335,
             title: 'App Two',
             type: 'coreApp',
@@ -480,12 +486,15 @@ describe('startWorkbenchDevServer', () => {
       const watchCallback = mockWatchRegistry.mock.calls[0][0]
       watchCallback([{host: 'localhost', pid: 2, port: 3334, type: 'studio'}])
 
+      await vi.waitFor(() => expect(mockServer.ws.send).toHaveBeenCalled())
+
       expect(mockServer.ws.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
         applications: [
           {
             host: 'localhost',
             icon: undefined,
             id: undefined,
+            manifest: undefined,
             port: 3334,
             title: undefined,
             type: 'studio',
@@ -521,18 +530,103 @@ describe('startWorkbenchDevServer', () => {
       const handler = onCall![1] as (data: unknown, client: typeof mockClient) => void
       handler(undefined, mockClient)
 
+      await vi.waitFor(() => expect(mockClient.send).toHaveBeenCalled())
+
       expect(mockClient.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
         applications: [
           {
             host: 'localhost',
             icon: '<svg>inline</svg>',
             id: 'app-1',
+            manifest: undefined,
             port: 3334,
             title: undefined,
             type: 'studio',
           },
         ],
       })
+    })
+
+    test('inlines manifest contents from manifestPath for studio entries', async () => {
+      const {mkdtempSync, writeFileSync} = await import('node:fs')
+      const {tmpdir} = await import('node:os')
+      const {join} = await import('node:path')
+      const dir = mkdtempSync(join(tmpdir(), 'workbench-manifest-'))
+      const manifestPath = join(dir, 'create-manifest.json')
+      const manifestContents = {createdAt: '2026-01-01T00:00:00.000Z', version: 3, workspaces: []}
+      writeFileSync(manifestPath, JSON.stringify(manifestContents))
+
+      mockResolveLocalPackage.mockResolvedValue({})
+      const mockServer = createMockServer()
+      mockCreateServer.mockResolvedValue(mockServer)
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+
+      const watchCallback = mockWatchRegistry.mock.calls[0][0]
+      watchCallback([
+        {
+          host: 'localhost',
+          manifestPath,
+          manifestUpdatedAt: '2026-01-01T00:00:00.000Z',
+          pid: 2,
+          port: 3334,
+          type: 'studio',
+        },
+      ])
+
+      await vi.waitFor(() => expect(mockServer.ws.send).toHaveBeenCalled())
+
+      const [, payload] = mockServer.ws.send.mock.calls[0]
+      expect(payload.applications[0].manifest).toEqual(manifestContents)
+    })
+
+    test('omits manifest when the file at manifestPath is missing or invalid', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      const mockServer = createMockServer()
+      mockCreateServer.mockResolvedValue(mockServer)
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+
+      const watchCallback = mockWatchRegistry.mock.calls[0][0]
+      watchCallback([
+        {
+          host: 'localhost',
+          manifestPath: '/definitely/does/not/exist/create-manifest.json',
+          pid: 2,
+          port: 3334,
+          type: 'studio',
+        },
+      ])
+
+      await vi.waitFor(() => expect(mockServer.ws.send).toHaveBeenCalled())
+
+      const [, payload] = mockServer.ws.send.mock.calls[0]
+      expect(payload.applications[0].manifest).toBeUndefined()
+    })
+
+    test('does not read manifestPath for non-studio entries', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      const mockServer = createMockServer()
+      mockCreateServer.mockResolvedValue(mockServer)
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+
+      const watchCallback = mockWatchRegistry.mock.calls[0][0]
+      watchCallback([
+        {
+          host: 'localhost',
+          // Even if set (shouldn't be in practice), coreApps don't ship a manifest
+          manifestPath: '/tmp/nope.json',
+          pid: 2,
+          port: 3335,
+          type: 'coreApp',
+        },
+      ])
+
+      await vi.waitFor(() => expect(mockServer.ws.send).toHaveBeenCalled())
+
+      const [, payload] = mockServer.ws.send.mock.calls[0]
+      expect(payload.applications[0].manifest).toBeUndefined()
     })
 
     test('close stops watcher and releases lock', async () => {

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -2,7 +2,6 @@ import {styleText} from 'node:util'
 
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
 import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
-import {type CoreAppManifest, type StudioManifest} from '../manifest/types.js'
 import {registerDevServer} from './devServerRegistry.js'
 import {extractStudioManifest} from './extractDevServerManifest.js'
 import {startAppDevServer} from './startAppDevServer.js'
@@ -80,36 +79,41 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     const resolvedHost = server.config.server.host
     const appHost = typeof resolvedHost === 'string' ? resolvedHost : 'localhost'
 
-    // Extract the initial manifest once at startup so the registry entry
-    // already carries the workbench-facing payload. For studios, the
-    // watcher below keeps it in sync with subsequent `sanity.config.ts`
-    // changes; coreApps have no schema to track, so no watcher is needed.
-    let initialManifest: CoreAppManifest | StudioManifest | undefined
-    try {
-      initialManifest = options.isApp
-        ? await extractCoreAppManifest({workDir: options.workDir})
-        : await extractStudioManifest({workDir: options.workDir})
-    } catch (err) {
-      output.warn(
-        `Could not extract manifest for workbench: ${err instanceof Error ? err.message : String(err)}`,
-      )
-    }
-
+    // Register the dev server immediately without a manifest — workbench
+    // clients get the application entry first and the manifest follows in
+    // a rebroadcast once extraction completes. Blocks on neither the heavy
+    // studio worker nor the lighter coreApp config read, so dev startup
+    // stays fast.
     const registration = registerDevServer({
       host: appHost,
       id: getAppId(options.cliConfig),
-      manifest: initialManifest,
-      manifestUpdatedAt: initialManifest ? new Date().toISOString() : undefined,
       port: appPort,
       type: options.isApp ? 'coreApp' : 'studio',
       workDir: options.workDir,
     })
     cleanupManifest = registration.release
 
-    // For studios, run the schema extraction worker and keep the generated
-    // `create-manifest.json` in sync with `sanity.config.ts` changes. Each
-    // successful extraction inlines the manifest into the registry entry
-    // and triggers a workbench rebroadcast to connected clients.
+    // Kick off the initial manifest extraction in the background. On
+    // success the registry entry is patched, which fires the workbench's
+    // registry watcher and triggers a rebroadcast to connected clients.
+    // Updates after `release()` are no-ops (see `registerDevServer`).
+    void (async () => {
+      try {
+        const manifest = options.isApp
+          ? await extractCoreAppManifest({workDir: options.workDir})
+          : await extractStudioManifest({workDir: options.workDir})
+        registration.update({manifest, manifestUpdatedAt: new Date().toISOString()})
+      } catch (err) {
+        output.warn(
+          `Could not extract manifest for workbench: ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+    })()
+
+    // For studios, keep the manifest in sync with subsequent
+    // `sanity.config.ts` changes. Each successful re-extraction inlines
+    // the new manifest into the registry entry and triggers a workbench
+    // rebroadcast to connected clients.
     if (!options.isApp) {
       const watcher = await startDevManifestWatcher({
         output,

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -3,7 +3,6 @@ import {styleText} from 'node:util'
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
 import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
 import {registerDevServer} from './devServerRegistry.js'
-import {extractStudioManifest} from './extractDevServerManifest.js'
 import {startAppDevServer} from './startAppDevServer.js'
 import {startDevManifestWatcher} from './startDevManifestWatcher.js'
 import {startStudioDevServer} from './startStudioDevServer.js'
@@ -93,28 +92,27 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     })
     cleanupManifest = registration.release
 
-    // Kick off the initial manifest extraction in the background. On
-    // success the registry entry is patched, which fires the workbench's
-    // registry watcher and triggers a rebroadcast to connected clients.
-    // Updates after `release()` are no-ops (see `registerDevServer`).
-    void (async () => {
-      try {
-        const manifest = options.isApp
-          ? await extractCoreAppManifest({workDir: options.workDir})
-          : await extractStudioManifest({workDir: options.workDir})
-        registration.update({manifest, manifestUpdatedAt: new Date().toISOString()})
-      } catch (err) {
-        output.warn(
-          `Could not extract manifest for workbench: ${err instanceof Error ? err.message : String(err)}`,
-        )
-      }
-    })()
-
-    // For studios, keep the manifest in sync with subsequent
-    // `sanity.config.ts` changes. Each successful re-extraction inlines
-    // the new manifest into the registry entry and triggers a workbench
-    // rebroadcast to connected clients.
-    if (!options.isApp) {
+    if (options.isApp) {
+      // Core-apps have no schema to watch and no shared output directory
+      // with any other caller, so run the extraction fire-and-forget. On
+      // success the registry entry is patched, which fires the workbench's
+      // registry watcher and triggers a rebroadcast to connected clients.
+      // Updates after `release()` are no-ops (see `registerDevServer`).
+      void (async () => {
+        try {
+          const manifest = await extractCoreAppManifest({workDir: options.workDir})
+          registration.update({manifest, manifestUpdatedAt: new Date().toISOString()})
+        } catch (err) {
+          output.warn(
+            `Could not extract manifest for workbench: ${err instanceof Error ? err.message : String(err)}`,
+          )
+        }
+      })()
+    } else {
+      // For studios, the watcher owns both the initial extraction and the
+      // follow-up regenerations triggered by `sanity.config.ts` changes.
+      // Serializing both through `regenerate` inside the watcher prevents
+      // concurrent worker runs from racing on the manifest output directory.
       const watcher = await startDevManifestWatcher({
         output,
         update: registration.update,

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -4,6 +4,7 @@ import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
 import {readIconFromPath} from '../manifest/extractAppManifest.js'
 import {registerDevServer} from './devServerRegistry.js'
 import {startAppDevServer} from './startAppDevServer.js'
+import {startDevManifestWatcher} from './startDevManifestWatcher.js'
 import {startStudioDevServer} from './startStudioDevServer.js'
 import {startWorkbenchDevServer} from './startWorkbenchDevServer.js'
 import {type DevActionOptions} from './types.js'
@@ -64,6 +65,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
 
   // Register the studio/app dev server in the registry (federated projects only)
   let cleanupManifest: () => void = syncNoop
+  let stopManifestWatcher: () => Promise<void> = noop
   let onSignal: (() => void) | undefined
   if (options.cliConfig?.federation?.enabled) {
     checkForDeprecatedAppId({cliConfig: options.cliConfig, output})
@@ -88,7 +90,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
       }
     }
 
-    cleanupManifest = registerDevServer({
+    const registration = registerDevServer({
       host: appHost,
       icon,
       id: getAppId(options.cliConfig),
@@ -97,6 +99,19 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
       type: options.isApp ? 'coreApp' : 'studio',
       workDir: options.workDir,
     })
+    cleanupManifest = registration.release
+
+    // For studios, generate a manifest file and keep it in sync with
+    // `sanity.config.ts` changes. Each successful regen re-touches the
+    // registry entry so any running workbench rebroadcasts to its clients.
+    if (!options.isApp) {
+      const watcher = await startDevManifestWatcher({
+        output,
+        update: registration.update,
+        workDir: options.workDir,
+      })
+      stopManifestWatcher = watcher.close
+    }
 
     // Ensure manifest and workbench lock are cleaned up on abrupt shutdown.
     // closeWorkbenchServer() starts with synchronous calls (watcher.close,
@@ -127,9 +142,9 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
         process.off('SIGTERM', onSignal)
       }
       cleanupManifest()
-      // Run both closes independently — a failing workbench close must not prevent
-      // the primary server from shutting down
-      await Promise.allSettled([closeWorkbenchServer(), closeAppDevServer()])
+      // Run all closes independently — a failure in one must not prevent the
+      // others from shutting down
+      await Promise.allSettled([stopManifestWatcher(), closeWorkbenchServer(), closeAppDevServer()])
     },
   }
 }

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -1,9 +1,10 @@
 import {styleText} from 'node:util'
 
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
+import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
 import {type CoreAppManifest, type StudioManifest} from '../manifest/types.js'
 import {registerDevServer} from './devServerRegistry.js'
-import {extractCoreAppManifest, extractStudioManifest} from './extractDevServerManifest.js'
+import {extractStudioManifest} from './extractDevServerManifest.js'
 import {startAppDevServer} from './startAppDevServer.js'
 import {startDevManifestWatcher} from './startDevManifestWatcher.js'
 import {startStudioDevServer} from './startStudioDevServer.js'

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -127,6 +127,11 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     // async server.close() is best-effort.
     onSignal = () => {
       cleanupManifest()
+      // `stopManifestWatcher` is async but we don't wait for it here — the
+      // signal handler can't block. It clears the debounce timer and
+      // closes the fs.watch handle synchronously, which is enough to let
+      // the event loop drain.
+      void stopManifestWatcher()
       closeWorkbenchServer()
       process.off('SIGINT', onSignal!)
       process.off('SIGTERM', onSignal!)

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -1,8 +1,9 @@
 import {styleText} from 'node:util'
 
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
-import {readIconFromPath} from '../manifest/extractAppManifest.js'
+import {type CoreAppManifest, type StudioManifest} from '../manifest/types.js'
 import {registerDevServer} from './devServerRegistry.js'
+import {extractCoreAppManifest, extractStudioManifest} from './extractDevServerManifest.js'
 import {startAppDevServer} from './startAppDevServer.js'
 import {startDevManifestWatcher} from './startDevManifestWatcher.js'
 import {startStudioDevServer} from './startStudioDevServer.js'
@@ -78,32 +79,36 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     const resolvedHost = server.config.server.host
     const appHost = typeof resolvedHost === 'string' ? resolvedHost : 'localhost'
 
-    const iconPath = options.cliConfig?.app?.icon
-    let icon: string | undefined
-    if (iconPath) {
-      try {
-        icon = await readIconFromPath(options.workDir, iconPath)
-      } catch (err) {
-        output.warn(
-          `Could not inline app icon for workbench discovery: ${err instanceof Error ? err.message : String(err)}`,
-        )
-      }
+    // Extract the initial manifest once at startup so the registry entry
+    // already carries the workbench-facing payload. For studios, the
+    // watcher below keeps it in sync with subsequent `sanity.config.ts`
+    // changes; coreApps have no schema to track, so no watcher is needed.
+    let initialManifest: CoreAppManifest | StudioManifest | undefined
+    try {
+      initialManifest = options.isApp
+        ? await extractCoreAppManifest({workDir: options.workDir})
+        : await extractStudioManifest({workDir: options.workDir})
+    } catch (err) {
+      output.warn(
+        `Could not extract manifest for workbench: ${err instanceof Error ? err.message : String(err)}`,
+      )
     }
 
     const registration = registerDevServer({
       host: appHost,
-      icon,
       id: getAppId(options.cliConfig),
+      manifest: initialManifest,
+      manifestUpdatedAt: initialManifest ? new Date().toISOString() : undefined,
       port: appPort,
-      title: options.isApp ? options.cliConfig?.app?.title : undefined,
       type: options.isApp ? 'coreApp' : 'studio',
       workDir: options.workDir,
     })
     cleanupManifest = registration.release
 
-    // For studios, generate a manifest file and keep it in sync with
-    // `sanity.config.ts` changes. Each successful regen re-touches the
-    // registry entry so any running workbench rebroadcasts to its clients.
+    // For studios, run the schema extraction worker and keep the generated
+    // `create-manifest.json` in sync with `sanity.config.ts` changes. Each
+    // successful extraction inlines the manifest into the registry entry
+    // and triggers a workbench rebroadcast to connected clients.
     if (!options.isApp) {
       const watcher = await startDevManifestWatcher({
         output,

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -13,6 +13,7 @@ import {join} from 'node:path'
 import {getSanityDataDir} from '@sanity/cli-core'
 import {z} from 'zod/mini'
 
+import {coreAppManifestSchema, studioManifestSchema} from '../manifest/types.js'
 import {devDebug} from './devDebug.js'
 
 /** Bump when the manifest/lock shape changes in a breaking way. */
@@ -27,21 +28,15 @@ const workbenchLockSchema = z.object({
 })
 
 const devServerManifestSchema = z.extend(workbenchLockSchema, {
-  icon: z.optional(z.string()),
   id: z.optional(z.string()),
+  /** Inlined manifest — either a {@link StudioManifest} or {@link CoreAppManifest}. */
+  manifest: z.optional(z.union([studioManifestSchema, coreAppManifestSchema])),
   /**
-   * Absolute path on disk to the generated studio manifest file
-   * (`create-manifest.json`). Only set for studios when federation is enabled
-   * and manifest generation has succeeded at least once.
-   */
-  manifestPath: z.optional(z.string()),
-  /**
-   * ISO timestamp of the most recent successful manifest generation. Bumped
+   * ISO timestamp of the most recent successful manifest extraction. Bumped
    * on every regeneration so re-writing this registry entry triggers the
    * workbench `watchRegistry` watcher and forces a rebroadcast to clients.
    */
   manifestUpdatedAt: z.optional(z.string()),
-  title: z.optional(z.string()),
   type: z.enum(['coreApp', 'studio']),
   workDir: z.string(),
 })

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -157,8 +157,14 @@ export function registerDevServer(
   const filePath = join(registryDir, `${process.pid}.json`)
   writeFileSync(filePath, JSON.stringify(current, null, 2))
 
+  // Guard against late updates from background tasks (e.g. the initial
+  // manifest extraction) landing after `release()` has deleted the file —
+  // without this, the update would re-create the registry entry and leak.
+  let released = false
+
   return {
     release() {
+      released = true
       try {
         unlinkSync(filePath)
       } catch {
@@ -166,6 +172,7 @@ export function registerDevServer(
       }
     },
     update(patch) {
+      if (released) return
       current = {...current, ...patch}
       writeFileSync(filePath, JSON.stringify(current, null, 2))
     },

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -29,6 +29,18 @@ const workbenchLockSchema = z.object({
 const devServerManifestSchema = z.extend(workbenchLockSchema, {
   icon: z.optional(z.string()),
   id: z.optional(z.string()),
+  /**
+   * Absolute path on disk to the generated studio manifest file
+   * (`create-manifest.json`). Only set for studios when federation is enabled
+   * and manifest generation has succeeded at least once.
+   */
+  manifestPath: z.optional(z.string()),
+  /**
+   * ISO timestamp of the most recent successful manifest generation. Bumped
+   * on every regeneration so re-writing this registry entry triggers the
+   * workbench `watchRegistry` watcher and forces a rebroadcast to clients.
+   */
+  manifestUpdatedAt: z.optional(z.string()),
   title: z.optional(z.string()),
   type: z.enum(['coreApp', 'studio']),
   workDir: z.string(),
@@ -110,14 +122,26 @@ function isOurProcess(pid: number, startedAt: string): boolean {
   return Math.abs(osStart.getTime() - storedStart.getTime()) <= START_TIME_TOLERANCE_MS
 }
 
+interface DevServerRegistration {
+  /** Remove the registry entry. */
+  release: () => void
+  /**
+   * Rewrite the registry entry with partial updates merged in. Also bumps the
+   * file's mtime, which fires `watchRegistry` in any workbench process and
+   * triggers a rebroadcast to connected clients.
+   */
+  update: (patch: Partial<Omit<DevServerManifest, 'pid' | 'startedAt' | 'version'>>) => void
+}
+
 /**
- * Write a manifest file for the current process and return a cleanup function
- * that removes it. Uses synchronous I/O so the file exists before any signal
- * handler could fire.
+ * Write a manifest file for the current process and return a handle with a
+ * `release` function that removes it plus an `update` function for patching
+ * fields post-registration. Uses synchronous I/O so the file exists before
+ * any signal handler could fire.
  */
 export function registerDevServer(
   manifest: Omit<DevServerManifest, 'pid' | 'startedAt' | 'version'>,
-): () => void {
+): DevServerRegistration {
   const registryDir = getRegistryDir()
   mkdirSync(registryDir, {recursive: true})
 
@@ -128,7 +152,7 @@ export function registerDevServer(
   // process to reach this point — frequently exceeding START_TIME_TOLERANCE_MS
   // and causing the manifest to be pruned as "stale" immediately after it's
   // written.
-  const fullManifest: DevServerManifest = {
+  let current: DevServerManifest = {
     ...manifest,
     pid: process.pid,
     startedAt: (getProcessStartTime(process.pid) ?? new Date()).toISOString(),
@@ -136,14 +160,20 @@ export function registerDevServer(
   }
 
   const filePath = join(registryDir, `${process.pid}.json`)
-  writeFileSync(filePath, JSON.stringify(fullManifest, null, 2))
+  writeFileSync(filePath, JSON.stringify(current, null, 2))
 
-  return () => {
-    try {
-      unlinkSync(filePath)
-    } catch {
-      // ENOENT is fine — already cleaned up
-    }
+  return {
+    release() {
+      try {
+        unlinkSync(filePath)
+      } catch {
+        // ENOENT is fine — already cleaned up
+      }
+    },
+    update(patch) {
+      current = {...current, ...patch}
+      writeFileSync(filePath, JSON.stringify(current, null, 2))
+    },
   }
 }
 

--- a/packages/@sanity/cli/src/actions/dev/extractDevServerManifest.ts
+++ b/packages/@sanity/cli/src/actions/dev/extractDevServerManifest.ts
@@ -1,8 +1,6 @@
 import {readFile} from 'node:fs/promises'
 import {join, resolve} from 'node:path'
 
-import {findProjectRoot} from '@sanity/cli-core'
-
 import {SANITY_CACHE_DIR} from '../../constants.js'
 import {extractManifest} from '../manifest/extractManifest.js'
 import {type StudioManifest} from '../manifest/types.js'
@@ -19,13 +17,17 @@ const MANIFEST_DIR = `${SANITY_CACHE_DIR}/manifest`
  * Run the heavy worker-based studio schema extraction, write the
  * resulting `create-manifest.json` to `node_modules/.sanity/manifest/`,
  * then read it back so the caller can inline it into the registry.
+ *
+ * `configPath` must be the resolved `sanity.config.(ts|js)` path — the
+ * caller is expected to have produced it (e.g. via `findProjectRoot`) so
+ * this function doesn't re-traverse the filesystem on every call.
  */
 export async function extractStudioManifest(options: {
+  configPath: string
   workDir: string
 }): Promise<StudioManifest | undefined> {
-  const projectRoot = await findProjectRoot(options.workDir)
   const outPath = resolve(options.workDir, MANIFEST_DIR)
-  await extractManifest({outPath, path: projectRoot.path, workDir: options.workDir})
+  await extractManifest({outPath, path: options.configPath, workDir: options.workDir})
   const raw = await readFile(join(outPath, MANIFEST_FILENAME), 'utf8')
   return JSON.parse(raw)
 }

--- a/packages/@sanity/cli/src/actions/dev/extractDevServerManifest.ts
+++ b/packages/@sanity/cli/src/actions/dev/extractDevServerManifest.ts
@@ -3,17 +3,17 @@ import {join, resolve} from 'node:path'
 
 import {findProjectRoot} from '@sanity/cli-core'
 
+import {SANITY_CACHE_DIR} from '../../constants.js'
 import {extractManifest} from '../manifest/extractManifest.js'
 import {type StudioManifest} from '../manifest/types.js'
 import {MANIFEST_FILENAME} from '../manifest/writeManifestFile.js'
 
 /**
  * Dev-time manifest output directory, relative to the studio working
- * directory. Mirrors the `node_modules/.sanity/vite` convention so it
- * stays out of `dist` and is ignored by default in typical `.gitignore`
- * files.
+ * directory. Sibling of Vite's `cacheDir` so it stays out of `dist` and is
+ * ignored by default in typical `.gitignore` files.
  */
-const MANIFEST_DIR = 'node_modules/.sanity/manifest'
+const MANIFEST_DIR = join(SANITY_CACHE_DIR, 'manifest')
 
 /**
  * Run the heavy worker-based studio schema extraction, write the

--- a/packages/@sanity/cli/src/actions/dev/extractDevServerManifest.ts
+++ b/packages/@sanity/cli/src/actions/dev/extractDevServerManifest.ts
@@ -13,7 +13,7 @@ import {MANIFEST_FILENAME} from '../manifest/writeManifestFile.js'
  * directory. Sibling of Vite's `cacheDir` so it stays out of `dist` and is
  * ignored by default in typical `.gitignore` files.
  */
-const MANIFEST_DIR = join(SANITY_CACHE_DIR, 'manifest')
+const MANIFEST_DIR = `${SANITY_CACHE_DIR}/manifest`
 
 /**
  * Run the heavy worker-based studio schema extraction, write the

--- a/packages/@sanity/cli/src/actions/dev/extractDevServerManifest.ts
+++ b/packages/@sanity/cli/src/actions/dev/extractDevServerManifest.ts
@@ -3,9 +3,9 @@ import {join, resolve} from 'node:path'
 
 import {findProjectRoot} from '@sanity/cli-core'
 
-import {extractAppManifest} from '../manifest/extractAppManifest.js'
 import {extractManifest} from '../manifest/extractManifest.js'
-import {type CoreAppManifest, type StudioManifest} from '../manifest/types.js'
+import {type StudioManifest} from '../manifest/types.js'
+import {MANIFEST_FILENAME} from '../manifest/writeManifestFile.js'
 
 /**
  * Dev-time manifest output directory, relative to the studio working
@@ -14,7 +14,6 @@ import {type CoreAppManifest, type StudioManifest} from '../manifest/types.js'
  * files.
  */
 const MANIFEST_DIR = 'node_modules/.sanity/manifest'
-const MANIFEST_FILENAME = 'create-manifest.json'
 
 /**
  * Run the heavy worker-based studio schema extraction, write the
@@ -29,15 +28,4 @@ export async function extractStudioManifest(options: {
   await extractManifest({outPath, path: projectRoot.path, workDir: options.workDir})
   const raw = await readFile(join(outPath, MANIFEST_FILENAME), 'utf8')
   return JSON.parse(raw)
-}
-
-/**
- * Manually build the core-app manifest from the CLI config (title plus
- * the inlined icon SVG). No schema-extraction worker is involved — the
- * payload is small enough that the CLI writes it in full.
- */
-export async function extractCoreAppManifest(options: {
-  workDir: string
-}): Promise<CoreAppManifest | undefined> {
-  return extractAppManifest({workDir: options.workDir})
 }

--- a/packages/@sanity/cli/src/actions/dev/extractDevServerManifest.ts
+++ b/packages/@sanity/cli/src/actions/dev/extractDevServerManifest.ts
@@ -1,0 +1,43 @@
+import {readFile} from 'node:fs/promises'
+import {join, resolve} from 'node:path'
+
+import {findProjectRoot} from '@sanity/cli-core'
+
+import {extractAppManifest} from '../manifest/extractAppManifest.js'
+import {extractManifest} from '../manifest/extractManifest.js'
+import {type CoreAppManifest, type StudioManifest} from '../manifest/types.js'
+
+/**
+ * Dev-time manifest output directory, relative to the studio working
+ * directory. Mirrors the `node_modules/.sanity/vite` convention so it
+ * stays out of `dist` and is ignored by default in typical `.gitignore`
+ * files.
+ */
+const MANIFEST_DIR = 'node_modules/.sanity/manifest'
+const MANIFEST_FILENAME = 'create-manifest.json'
+
+/**
+ * Run the heavy worker-based studio schema extraction, write the
+ * resulting `create-manifest.json` to `node_modules/.sanity/manifest/`,
+ * then read it back so the caller can inline it into the registry.
+ */
+export async function extractStudioManifest(options: {
+  workDir: string
+}): Promise<StudioManifest | undefined> {
+  const projectRoot = await findProjectRoot(options.workDir)
+  const outPath = resolve(options.workDir, MANIFEST_DIR)
+  await extractManifest({outPath, path: projectRoot.path, workDir: options.workDir})
+  const raw = await readFile(join(outPath, MANIFEST_FILENAME), 'utf8')
+  return JSON.parse(raw)
+}
+
+/**
+ * Manually build the core-app manifest from the CLI config (title plus
+ * the inlined icon SVG). No schema-extraction worker is involved — the
+ * payload is small enough that the CLI writes it in full.
+ */
+export async function extractCoreAppManifest(options: {
+  workDir: string
+}): Promise<CoreAppManifest | undefined> {
+  return extractAppManifest({workDir: options.workDir})
+}

--- a/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
@@ -1,23 +1,15 @@
 import {watch} from 'node:fs'
-import {basename, dirname, join, resolve} from 'node:path'
+import {basename, dirname} from 'node:path'
 
 import {findProjectRoot, type Output} from '@sanity/cli-core'
 
-import {extractManifest} from '../manifest/extractManifest.js'
+import {type StudioManifest} from '../manifest/types.js'
 import {devDebug} from './devDebug.js'
-import {type DevServerManifest} from './devServerRegistry.js'
+import {extractStudioManifest} from './extractDevServerManifest.js'
 
 /**
- * Dev-time manifest output directory, relative to the studio working directory.
- * Mirrors the `node_modules/.sanity/vite` convention so it stays out of `dist`
- * and is ignored by default in typical `.gitignore` files.
- */
-const MANIFEST_DIR = 'node_modules/.sanity/manifest'
-const MANIFEST_FILENAME = 'create-manifest.json'
-
-/**
- * Debounce window between `sanity.config.ts` file-system events and the next
- * manifest regeneration. Coalesces rapid saves (e.g. editor auto-save) and
+ * Debounce window between config file events and the next manifest
+ * regeneration. Coalesces rapid saves (e.g. editor auto-save) and
  * atomic-rename bursts emitted by tools like VS Code.
  */
 const DEBOUNCE_MS = 250
@@ -26,24 +18,29 @@ interface DevManifestWatcher {
   close: () => Promise<void>
 }
 
-type RegistryPatch = Partial<Omit<DevServerManifest, 'pid' | 'startedAt' | 'version'>>
+/** Subset of registry fields the watcher is allowed to update. */
+interface ManifestPatch {
+  manifest: StudioManifest | undefined
+  manifestUpdatedAt: string
+}
 
 interface StartDevManifestWatcherOptions {
   output: Output
-  /** Called after every successful regeneration to touch the registry entry. */
-  update: (patch: RegistryPatch) => void
+  /** Called after every successful extraction with the inlined manifest. */
+  update: (patch: ManifestPatch) => void
   workDir: string
 }
 
 /**
- * Generate the studio manifest once and then keep it in sync with the
- * `sanity.config.(ts|js)` file on disk. Each successful regeneration writes
- * the manifest files into `<workDir>/node_modules/.sanity/manifest/` and
- * invokes `update({manifestPath, manifestUpdatedAt})` so callers can touch
- * their registry entry and trigger a workbench rebroadcast.
+ * Keep the studio manifest in sync with the `sanity.config.(ts|js)` file on
+ * disk. The initial extraction happens in `devAction` so the registry entry
+ * already carries a manifest when the watcher starts — this watcher only
+ * re-extracts on subsequent file-system events. Each successful regeneration
+ * inlines the new manifest into the registry via the `update` callback, so
+ * any running workbench rebroadcasts to its clients.
  *
  * Errors during extraction are logged as warnings and do not crash the dev
- * server — the previous manifest on disk (if any) stays in place.
+ * server — the previously extracted manifest stays in the registry.
  */
 export async function startDevManifestWatcher({
   output,
@@ -52,8 +49,6 @@ export async function startDevManifestWatcher({
 }: StartDevManifestWatcherOptions): Promise<DevManifestWatcher> {
   const projectRoot = await findProjectRoot(workDir)
   const configPath = projectRoot.path
-  const outPath = resolve(workDir, MANIFEST_DIR)
-  const manifestPath = join(outPath, MANIFEST_FILENAME)
 
   let running = false
   let pending = false
@@ -67,19 +62,15 @@ export async function startDevManifestWatcher({
     }
     running = true
     try {
-      await extractManifest({
-        outPath,
-        path: configPath,
-        workDir,
-      })
+      const manifest = await extractStudioManifest({workDir})
       if (closed) return
-      update({manifestPath, manifestUpdatedAt: new Date().toISOString()})
+      update({manifest, manifestUpdatedAt: new Date().toISOString()})
     } catch (err) {
-      // extractManifest prints its own spinner failure; log the reason here so
+      // Extractors print their own spinner failure; log the reason here so
       // the user sees what went wrong alongside the spinner indicator.
       devDebug('Manifest regeneration failed: %O', err)
       output.warn(
-        `Could not extract studio manifest for workbench: ${err instanceof Error ? err.message : String(err)}`,
+        `Could not extract manifest for workbench: ${err instanceof Error ? err.message : String(err)}`,
       )
     } finally {
       running = false
@@ -89,11 +80,6 @@ export async function startDevManifestWatcher({
       }
     }
   }
-
-  // Initial generation — awaited so the first registry touch happens before
-  // we hand control back to the caller. A failure here is warned about but
-  // does not prevent the dev server from coming up.
-  await regenerate()
 
   // Watch the config file's parent directory and filter by filename.
   // Watching the file itself is unreliable across editors that perform

--- a/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
@@ -32,15 +32,18 @@ interface StartDevManifestWatcherOptions {
 }
 
 /**
- * Keep the studio manifest in sync with the `sanity.config.(ts|js)` file on
- * disk. The initial extraction happens in `devAction` so the registry entry
- * already carries a manifest when the watcher starts — this watcher only
- * re-extracts on subsequent file-system events. Each successful regeneration
- * inlines the new manifest into the registry via the `update` callback, so
- * any running workbench rebroadcasts to its clients.
+ * Generate the studio manifest once and then keep it in sync with the
+ * `sanity.config.(ts|js)` file on disk. The initial generation runs
+ * fire-and-forget so it doesn't block dev-server startup; subsequent
+ * file-system events are coalesced behind it via `running`/`pending`, so
+ * the single-serializer guarantees there are no overlapping writes to the
+ * manifest output directory. Each successful regeneration inlines the new
+ * manifest into the registry via the `update` callback, so any running
+ * workbench rebroadcasts to its clients.
  *
  * Errors during extraction are logged as warnings and do not crash the dev
- * server — the previously extracted manifest stays in the registry.
+ * server — the previously extracted manifest (if any) stays in the
+ * registry.
  */
 export async function startDevManifestWatcher({
   output,
@@ -80,6 +83,12 @@ export async function startDevManifestWatcher({
       }
     }
   }
+
+  // Kick off the initial extraction in the background. Routing it through
+  // `regenerate` means any file-system events arriving before the first
+  // extraction finishes will be coalesced by `running`/`pending` rather
+  // than racing against it for the shared output directory.
+  void regenerate()
 
   // Watch the config file's parent directory and filter by filename.
   // Watching the file itself is unreliable across editors that perform

--- a/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
@@ -1,0 +1,133 @@
+import {watch} from 'node:fs'
+import {basename, dirname, join, resolve} from 'node:path'
+
+import {findProjectRoot, type Output} from '@sanity/cli-core'
+
+import {extractManifest} from '../manifest/extractManifest.js'
+import {devDebug} from './devDebug.js'
+import {type DevServerManifest} from './devServerRegistry.js'
+
+/**
+ * Dev-time manifest output directory, relative to the studio working directory.
+ * Mirrors the `node_modules/.sanity/vite` convention so it stays out of `dist`
+ * and is ignored by default in typical `.gitignore` files.
+ */
+const MANIFEST_DIR = 'node_modules/.sanity/manifest'
+const MANIFEST_FILENAME = 'create-manifest.json'
+
+/**
+ * Debounce window between `sanity.config.ts` file-system events and the next
+ * manifest regeneration. Coalesces rapid saves (e.g. editor auto-save) and
+ * atomic-rename bursts emitted by tools like VS Code.
+ */
+const DEBOUNCE_MS = 250
+
+interface DevManifestWatcher {
+  close: () => Promise<void>
+}
+
+type RegistryPatch = Partial<Omit<DevServerManifest, 'pid' | 'startedAt' | 'version'>>
+
+interface StartDevManifestWatcherOptions {
+  output: Output
+  /** Called after every successful regeneration to touch the registry entry. */
+  update: (patch: RegistryPatch) => void
+  workDir: string
+}
+
+/**
+ * Generate the studio manifest once and then keep it in sync with the
+ * `sanity.config.(ts|js)` file on disk. Each successful regeneration writes
+ * the manifest files into `<workDir>/node_modules/.sanity/manifest/` and
+ * invokes `update({manifestPath, manifestUpdatedAt})` so callers can touch
+ * their registry entry and trigger a workbench rebroadcast.
+ *
+ * Errors during extraction are logged as warnings and do not crash the dev
+ * server — the previous manifest on disk (if any) stays in place.
+ */
+export async function startDevManifestWatcher({
+  output,
+  update,
+  workDir,
+}: StartDevManifestWatcherOptions): Promise<DevManifestWatcher> {
+  const projectRoot = await findProjectRoot(workDir)
+  const configPath = projectRoot.path
+  const outPath = resolve(workDir, MANIFEST_DIR)
+  const manifestPath = join(outPath, MANIFEST_FILENAME)
+
+  let running = false
+  let pending = false
+  let closed = false
+
+  const regenerate = async () => {
+    if (closed) return
+    if (running) {
+      pending = true
+      return
+    }
+    running = true
+    try {
+      await extractManifest({
+        outPath,
+        path: configPath,
+        workDir,
+      })
+      if (closed) return
+      update({manifestPath, manifestUpdatedAt: new Date().toISOString()})
+    } catch (err) {
+      // extractManifest prints its own spinner failure; log the reason here so
+      // the user sees what went wrong alongside the spinner indicator.
+      devDebug('Manifest regeneration failed: %O', err)
+      output.warn(
+        `Could not extract studio manifest for workbench: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    } finally {
+      running = false
+      if (pending && !closed) {
+        pending = false
+        void regenerate()
+      }
+    }
+  }
+
+  // Initial generation — awaited so the first registry touch happens before
+  // we hand control back to the caller. A failure here is warned about but
+  // does not prevent the dev server from coming up.
+  await regenerate()
+
+  // Watch the config file's parent directory and filter by filename.
+  // Watching the file itself is unreliable across editors that perform
+  // atomic-save (delete + rename) — the watcher loses its target once the
+  // inode changes. Directory watches survive those transitions.
+  const configDir = dirname(configPath)
+  const configFilename = basename(configPath)
+
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined
+
+  const onEvent = (_event: string, filename: Buffer | string | null) => {
+    if (!filename) return
+    const name = typeof filename === 'string' ? filename : filename.toString('utf8')
+    if (name !== configFilename) return
+    clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      void regenerate()
+    }, DEBOUNCE_MS)
+  }
+
+  const watcher = watch(configDir, onEvent)
+
+  watcher.on('error', (err) => {
+    devDebug('Config watcher error: %O', err)
+    output.warn(
+      `Studio manifest watcher error: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  })
+
+  return {
+    close: async () => {
+      closed = true
+      clearTimeout(debounceTimer)
+      watcher.close()
+    },
+  }
+}

--- a/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
@@ -65,7 +65,7 @@ export async function startDevManifestWatcher({
     }
     running = true
     try {
-      const manifest = await extractStudioManifest({workDir})
+      const manifest = await extractStudioManifest({configPath, workDir})
       if (closed) return
       update({manifest, manifestUpdatedAt: new Date().toISOString()})
     } catch (err) {

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -1,5 +1,3 @@
-import {readFile} from 'node:fs/promises'
-
 import {resolveLocalPackage} from '@sanity/cli-core'
 import viteReact from '@vitejs/plugin-react'
 import {createServer, type InlineConfig} from 'vite'
@@ -19,31 +17,14 @@ import {writeWorkbenchRuntime} from './writeWorkbenchRuntime.js'
 
 const noop = async () => {}
 
-/**
- * Read and parse a studio's `create-manifest.json` from disk. Returns
- * `undefined` when the file is missing or malformed — callers treat the
- * manifest as absent and omit it from the payload, which is the same thing
- * clients see before the first generation completes.
- */
-async function readStudioManifest(path: string): Promise<unknown | undefined> {
-  try {
-    const raw = await readFile(path, 'utf8')
-    return JSON.parse(raw)
-  } catch (err) {
-    devDebug('Failed to read studio manifest at %s: %O', path, err)
-    return undefined
-  }
-}
-
-const toApplicationsPayload = async (servers: DevServerManifest[]) => ({
-  applications: await Promise.all(
-    servers.map(async ({host, icon, id, manifestPath, port, title, type}) => {
-      // Only studios ship a manifest — app bundles don't have one.
-      const manifest =
-        type === 'studio' && manifestPath ? await readStudioManifest(manifestPath) : undefined
-      return {host, icon, id, manifest, port, title, type}
-    }),
-  ),
+const toApplicationsPayload = (servers: DevServerManifest[]) => ({
+  applications: servers.map(({host, id, manifest, port, type}) => ({
+    host,
+    id,
+    manifest,
+    port,
+    type,
+  })),
 })
 
 interface WorkbenchDevServerResult {
@@ -182,20 +163,16 @@ export async function startWorkbenchDevServer(
   workbenchLock.updatePort(actualPort)
 
   // Respond to client requests for the current application list.
-  // The payload builder is async (it reads each studio's manifest file from
-  // disk), so send the response once the read completes. Errors are logged;
-  // the client will retry or wait for the next broadcast.
   server.ws.on('sanity:workbench:get-local-applications', (_, client) => {
-    toApplicationsPayload(getRegisteredServers())
-      .then((payload) => client.send('sanity:workbench:local-applications', payload))
-      .catch((err) => devDebug('Failed to build applications payload: %O', err))
+    client.send(
+      'sanity:workbench:local-applications',
+      toApplicationsPayload(getRegisteredServers()),
+    )
   })
 
   // Watch the registry and broadcast updates to all connected clients
   const registryWatcher = watchRegistry((servers) => {
-    toApplicationsPayload(servers)
-      .then((payload) => server.ws.send('sanity:workbench:local-applications', payload))
-      .catch((err) => devDebug('Failed to broadcast applications payload: %O', err))
+    server.ws.send('sanity:workbench:local-applications', toApplicationsPayload(servers))
   })
 
   return {

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -1,3 +1,5 @@
+import {readFile} from 'node:fs/promises'
+
 import {resolveLocalPackage} from '@sanity/cli-core'
 import viteReact from '@vitejs/plugin-react'
 import {createServer, type InlineConfig} from 'vite'
@@ -17,15 +19,31 @@ import {writeWorkbenchRuntime} from './writeWorkbenchRuntime.js'
 
 const noop = async () => {}
 
-const toApplicationsPayload = (servers: DevServerManifest[]) => ({
-  applications: servers.map(({host, icon, id, port, title, type}) => ({
-    host,
-    icon,
-    id,
-    port,
-    title,
-    type,
-  })),
+/**
+ * Read and parse a studio's `create-manifest.json` from disk. Returns
+ * `undefined` when the file is missing or malformed — callers treat the
+ * manifest as absent and omit it from the payload, which is the same thing
+ * clients see before the first generation completes.
+ */
+async function readStudioManifest(path: string): Promise<unknown | undefined> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    return JSON.parse(raw)
+  } catch (err) {
+    devDebug('Failed to read studio manifest at %s: %O', path, err)
+    return undefined
+  }
+}
+
+const toApplicationsPayload = async (servers: DevServerManifest[]) => ({
+  applications: await Promise.all(
+    servers.map(async ({host, icon, id, manifestPath, port, title, type}) => {
+      // Only studios ship a manifest — app bundles don't have one.
+      const manifest =
+        type === 'studio' && manifestPath ? await readStudioManifest(manifestPath) : undefined
+      return {host, icon, id, manifest, port, title, type}
+    }),
+  ),
 })
 
 interface WorkbenchDevServerResult {
@@ -163,17 +181,21 @@ export async function startWorkbenchDevServer(
   // Update the lock file with the actual port so other processes can find us
   workbenchLock.updatePort(actualPort)
 
-  // Respond to client requests for the current application list
+  // Respond to client requests for the current application list.
+  // The payload builder is async (it reads each studio's manifest file from
+  // disk), so send the response once the read completes. Errors are logged;
+  // the client will retry or wait for the next broadcast.
   server.ws.on('sanity:workbench:get-local-applications', (_, client) => {
-    client.send(
-      'sanity:workbench:local-applications',
-      toApplicationsPayload(getRegisteredServers()),
-    )
+    toApplicationsPayload(getRegisteredServers())
+      .then((payload) => client.send('sanity:workbench:local-applications', payload))
+      .catch((err) => devDebug('Failed to build applications payload: %O', err))
   })
 
   // Watch the registry and broadcast updates to all connected clients
   const registryWatcher = watchRegistry((servers) => {
-    server.ws.send('sanity:workbench:local-applications', toApplicationsPayload(servers))
+    toApplicationsPayload(servers)
+      .then((payload) => server.ws.send('sanity:workbench:local-applications', payload))
+      .catch((err) => devDebug('Failed to broadcast applications payload: %O', err))
   })
 
   return {

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -1,5 +1,3 @@
-import {join} from 'node:path'
-
 import {resolveLocalPackage} from '@sanity/cli-core'
 import viteReact from '@vitejs/plugin-react'
 import {createServer, type InlineConfig} from 'vite'
@@ -116,7 +114,7 @@ export async function startWorkbenchDevServer(
   const viteConfig: InlineConfig = {
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
-    cacheDir: join(SANITY_CACHE_DIR, 'vite'),
+    cacheDir: `${SANITY_CACHE_DIR}/vite`,
     configFile: false,
     define: {
       __SANITY_STAGING__: process.env.SANITY_INTERNAL_ENV === 'staging',

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -1,7 +1,10 @@
+import {join} from 'node:path'
+
 import {resolveLocalPackage} from '@sanity/cli-core'
 import viteReact from '@vitejs/plugin-react'
 import {createServer, type InlineConfig} from 'vite'
 
+import {SANITY_CACHE_DIR} from '../../constants.js'
 import {getProjectById} from '../../services/projects.js'
 import {getSharedServerConfig} from '../../util/getSharedServerConfig.js'
 import {devDebug} from './devDebug.js'
@@ -113,7 +116,7 @@ export async function startWorkbenchDevServer(
   const viteConfig: InlineConfig = {
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
-    cacheDir: 'node_modules/.sanity/vite',
+    cacheDir: join(SANITY_CACHE_DIR, 'vite'),
     configFile: false,
     define: {
       __SANITY_STAGING__: process.env.SANITY_INTERNAL_ENV === 'staging',

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -3,7 +3,7 @@ import {readFile} from 'node:fs/promises'
 import {getCliConfig} from '@sanity/cli-core'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {extractAppManifest} from '../extractAppManifest.js'
+import {extractCoreAppManifest} from '../extractCoreAppManifest.js'
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
@@ -28,14 +28,14 @@ vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
 const mockGetCliConfig = vi.mocked(getCliConfig)
 const mockReadFile = vi.mocked(readFile)
 
-describe('extractAppManifest', () => {
+describe('extractCoreAppManifest', () => {
   afterEach(() => {
     vi.clearAllMocks()
   })
 
   test('returns undefined when no app config', async () => {
     mockGetCliConfig.mockResolvedValue({app: undefined} as never)
-    const result = await extractAppManifest({workDir: '/project'})
+    const result = await extractCoreAppManifest({workDir: '/project'})
     expect(result).toBeUndefined()
   })
 
@@ -44,7 +44,7 @@ describe('extractAppManifest', () => {
       app: {organizationId: 'org-1', title: 'My App'},
     } as never)
 
-    const result = await extractAppManifest({workDir: '/project'})
+    const result = await extractCoreAppManifest({workDir: '/project'})
 
     expect(result).toEqual({title: 'My App', version: '1'})
     expect(mockReadFile).not.toHaveBeenCalled()
@@ -57,7 +57,7 @@ describe('extractAppManifest', () => {
     } as never)
     mockReadFile.mockResolvedValue('<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>')
 
-    const result = await extractAppManifest({workDir})
+    const result = await extractCoreAppManifest({workDir})
 
     expect(mockReadFile).toHaveBeenCalledWith(expect.stringContaining('icon.svg'), 'utf8')
     expect(result?.icon).toMatch(/<svg[\s>]/i)
@@ -70,7 +70,7 @@ describe('extractAppManifest', () => {
       app: {icon: '../../../etc/passwd', organizationId: 'org-1'},
     } as never)
 
-    await expect(extractAppManifest({workDir: '/project'})).rejects.toThrow(
+    await expect(extractCoreAppManifest({workDir: '/project'})).rejects.toThrow(
       /resolves outside the project directory/,
     )
 
@@ -83,7 +83,7 @@ describe('extractAppManifest', () => {
     } as never)
     mockReadFile.mockResolvedValue('hello world')
 
-    await expect(extractAppManifest({workDir: '/project'})).rejects.toThrow(
+    await expect(extractCoreAppManifest({workDir: '/project'})).rejects.toThrow(
       /does not contain an SVG element/,
     )
   })
@@ -94,7 +94,7 @@ describe('extractAppManifest', () => {
     } as never)
     mockReadFile.mockRejectedValue(new Error('ENOENT: no such file or directory'))
 
-    await expect(extractAppManifest({workDir: '/project'})).rejects.toThrow(
+    await expect(extractCoreAppManifest({workDir: '/project'})).rejects.toThrow(
       /Could not read icon file at "missing.svg"/,
     )
   })

--- a/packages/@sanity/cli/src/actions/manifest/extractAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractAppManifest.ts
@@ -5,7 +5,7 @@ import {getCliConfig} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 
 import {getErrorMessage} from '../../util/getErrorMessage.js'
-import {type AppManifest} from './types.js'
+import {type CoreAppManifest, coreAppManifestSchema} from './types.js'
 
 interface ExtractAppManifestOptions {
   workDir: string
@@ -16,7 +16,7 @@ interface ExtractAppManifestOptions {
  * The manifest expects the SVG string inline, not a path.
  * Brett sanitizes SVGs so it's skipped here.
  */
-export async function readIconFromPath(workDir: string, iconPath: string): Promise<string> {
+async function readIconFromPath(workDir: string, iconPath: string): Promise<string> {
   const resolvedPath = resolve(workDir, iconPath)
   const pathRelativeToWorkDir = relative(workDir, resolvedPath)
   if (pathRelativeToWorkDir.startsWith('..')) {
@@ -54,7 +54,7 @@ export async function readIconFromPath(workDir: string, iconPath: string): Promi
  */
 export async function extractAppManifest(
   options: ExtractAppManifestOptions,
-): Promise<AppManifest | undefined> {
+): Promise<CoreAppManifest | undefined> {
   const {workDir} = options
   const {app} = await getCliConfig(workDir)
   if (!app) {
@@ -74,11 +74,11 @@ export async function extractAppManifest(
       return undefined
     }
 
-    const manifest: AppManifest = {
+    const manifest = coreAppManifestSchema.parse({
       version: '1',
       ...(icon ? {icon} : {}),
       ...(app.title ? {title: app.title} : {}),
-    }
+    })
 
     spin.succeed(`Extracted manifest`)
 

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -7,7 +7,7 @@ import {spinner} from '@sanity/cli-core/ux'
 import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {type CoreAppManifest, coreAppManifestSchema} from './types.js'
 
-interface ExtractAppManifestOptions {
+interface ExtractCoreAppManifestOptions {
   workDir: string
 }
 
@@ -52,8 +52,8 @@ async function readIconFromPath(workDir: string, iconPath: string): Promise<stri
  * We don't need to parse very complicated information like schemas and tools.
  * The app icon in config is a file path (e.g. relative to project root); its content is read and inlined in the manifest.
  */
-export async function extractAppManifest(
-  options: ExtractAppManifestOptions,
+export async function extractCoreAppManifest(
+  options: ExtractCoreAppManifestOptions,
 ): Promise<CoreAppManifest | undefined> {
   const {workDir} = options
   const {app} = await getCliConfig(workDir)

--- a/packages/@sanity/cli/src/actions/manifest/extractManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractManifest.ts
@@ -1,11 +1,11 @@
-import {findProjectRoot, getTimer, studioWorkerTask} from '@sanity/cli-core'
+import {getTimer, studioWorkerTask} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 
 import {type ExtractSchemaWorkerError} from '../schema/types.js'
 import {SchemaExtractionError} from '../schema/utils/SchemaExtractionError.js'
 import {manifestDebug} from './debug.js'
 import {type CreateWorkspaceManifest, type ExtractManifestWorkerData} from './types'
-import {writeManifestFile} from './writeManifestFile.js'
+import {writeManifestFile, type WriteManifestFileOptions} from './writeManifestFile.js'
 
 const CREATE_TIMER = 'create-manifest'
 
@@ -16,13 +16,17 @@ interface ExtractManifestWorkerResult {
 
 type ExtractManifestWorkerMessage = ExtractManifestWorkerResult | ExtractSchemaWorkerError
 
-export async function extractManifest(outPath: string): Promise<void> {
-  const projectRoot = await findProjectRoot(process.cwd())
+interface ExtractManifestOptions extends Pick<WriteManifestFileOptions, 'outPath' | 'workDir'> {
+  /** Absolute path to the studio's `sanity.config.(ts|js)` entry file. */
+  path: string
+}
 
-  manifestDebug('Project root %o', projectRoot)
-
-  const workDir = projectRoot.directory
-  const configPath = projectRoot.path
+export async function extractManifest({
+  outPath,
+  path,
+  workDir,
+}: ExtractManifestOptions): Promise<void> {
+  manifestDebug('Project root %o', {directory: workDir, path})
 
   const timer = getTimer()
   timer.start(CREATE_TIMER)
@@ -34,7 +38,7 @@ export async function extractManifest(outPath: string): Promise<void> {
       {
         name: 'extractManifest',
         studioRootPath: workDir,
-        workerData: {configPath, workDir} satisfies ExtractManifestWorkerData,
+        workerData: {configPath: path, workDir} satisfies ExtractManifestWorkerData,
       },
     )
 

--- a/packages/@sanity/cli/src/actions/manifest/types.ts
+++ b/packages/@sanity/cli/src/actions/manifest/types.ts
@@ -20,12 +20,28 @@ export interface CreateManifest {
   workspaces: ManifestWorkspaceFile[]
 }
 
-export interface AppManifest {
-  version: '1'
+/**
+ * Core-app application manifest. Mirrors the workbench's
+ * `CoreAppUserApplicationManifest` schema. Strictly validated via zod
+ * since the CLI produces the payload in full.
+ */
+export const coreAppManifestSchema = z.object({
+  icon: z.optional(z.string()),
+  title: z.optional(z.string()),
+  version: z.string(),
+})
 
-  icon?: string
-  title?: string
-}
+export type CoreAppManifest = z.infer<typeof coreAppManifestSchema>
+
+/**
+ * Studio application manifest (serialized `create-manifest.json`). Kept
+ * loose so the CLI isn't coupled to the workbench's evolving client-side
+ * schema — the workbench consumer is authoritative on the inner shape.
+ * See its `ClientManifest` for the fields clients expect.
+ */
+export const studioManifestSchema = z.record(z.string(), z.unknown())
+
+export type StudioManifest = z.infer<typeof studioManifestSchema>
 
 export interface ManifestWorkspaceFile extends Omit<CreateWorkspaceManifest, 'schema' | 'tools'> {
   schema: string // filename

--- a/packages/@sanity/cli/src/actions/manifest/writeManifestFile.ts
+++ b/packages/@sanity/cli/src/actions/manifest/writeManifestFile.ts
@@ -11,15 +11,26 @@ const MANIFEST_FILENAME = 'create-manifest.json'
 
 const debug = subdebug('writeManifestFile')
 
+export interface WriteManifestFileOptions {
+  /**
+   * Target directory for the manifest files. May be absolute or relative — relative
+   * paths are resolved against `workDir`.
+   */
+  outPath: string
+  /**
+   * Studio root directory. Used to resolve a relative `outPath` and to look up the
+   * local `sanity` package version that gets stamped onto the manifest.
+   */
+  workDir: string
+  /** Extracted workspace manifests to serialize alongside the top-level manifest. */
+  workspaceManifests: CreateWorkspaceManifest[]
+}
+
 export async function writeManifestFile({
   outPath,
   workDir,
   workspaceManifests,
-}: {
-  outPath: string
-  workDir: string
-  workspaceManifests: CreateWorkspaceManifest[]
-}) {
+}: WriteManifestFileOptions) {
   const staticPath = isAbsolute(outPath) ? outPath : resolve(join(workDir, outPath))
   debug('Writing manifest to %s', staticPath)
   const path = join(staticPath, MANIFEST_FILENAME)

--- a/packages/@sanity/cli/src/actions/manifest/writeManifestFile.ts
+++ b/packages/@sanity/cli/src/actions/manifest/writeManifestFile.ts
@@ -7,7 +7,7 @@ import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 import {type CreateManifest, type CreateWorkspaceManifest} from './types.js'
 import {writeWorkspaceFiles} from './writeWorkspaceFiles.js'
 
-const MANIFEST_FILENAME = 'create-manifest.json'
+export const MANIFEST_FILENAME = 'create-manifest.json'
 
 const debug = subdebug('writeManifestFile')
 

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.app.test.ts
@@ -5,7 +5,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {buildApp} from '../../actions/build/buildApp.js'
 import {checkDir} from '../../actions/deploy/checkDir.js'
-import {extractAppManifest} from '../../actions/manifest/extractAppManifest.js'
+import {extractCoreAppManifest} from '../../actions/manifest/extractCoreAppManifest.js'
 import {USER_APPLICATIONS_API_VERSION} from '../../services/userApplications.js'
 import {dirIsEmptyOrNonExistent} from '../../util/dirIsEmptyOrNonExistent.js'
 import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
@@ -21,8 +21,8 @@ vi.mock('../../actions/deploy/checkDir.js', () => ({
   checkDir: vi.fn(),
 }))
 
-vi.mock('../../actions/manifest/extractAppManifest.js', () => ({
-  extractAppManifest: vi.fn(),
+vi.mock('../../actions/manifest/extractCoreAppManifest.js', () => ({
+  extractCoreAppManifest: vi.fn(),
 }))
 
 vi.mock('@sanity/cli-core/ux', async () => {
@@ -54,7 +54,7 @@ const mockCheckDir = vi.mocked(checkDir)
 const mockDirIsEmptyOrNonExistent = vi.mocked(dirIsEmptyOrNonExistent)
 const mockGetLocalPackageVersion = vi.mocked(getLocalPackageVersion)
 const mockBuildApp = vi.mocked(buildApp)
-const mockExtractAppManifest = vi.mocked(extractAppManifest)
+const mockExtractCoreAppManifest = vi.mocked(extractCoreAppManifest)
 
 const appId = 'app-id'
 const organizationId = 'org-id'
@@ -80,7 +80,7 @@ describe('#deploy app', () => {
     })
     mockCheckDir.mockResolvedValue()
     // Default to empty manifest for app deployments
-    mockExtractAppManifest.mockResolvedValue(undefined)
+    mockExtractCoreAppManifest.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -206,7 +206,7 @@ describe('#deploy app', () => {
     const cwd = await testFixture('basic-app')
     process.cwd = () => cwd
 
-    mockExtractAppManifest.mockResolvedValue({
+    mockExtractCoreAppManifest.mockResolvedValue({
       title: 'New Title From Manifest',
       version: '1',
     })
@@ -270,7 +270,7 @@ describe('#deploy app', () => {
     process.cwd = () => cwd
 
     const sameTitle = 'Test App'
-    mockExtractAppManifest.mockResolvedValue({
+    mockExtractCoreAppManifest.mockResolvedValue({
       title: sameTitle,
       version: '1',
     })
@@ -1006,7 +1006,7 @@ describe('#deploy app', () => {
       version: '1' as const,
     }
 
-    mockExtractAppManifest.mockResolvedValue(manifest)
+    mockExtractCoreAppManifest.mockResolvedValue(manifest)
 
     mockApi({
       apiVersion: USER_APPLICATIONS_API_VERSION,
@@ -1060,7 +1060,7 @@ describe('#deploy app', () => {
 
     if (error) throw error
     expect(stdout).toContain('Success! Application deployed')
-    expect(mockExtractAppManifest).toHaveBeenCalled()
+    expect(mockExtractCoreAppManifest).toHaveBeenCalled()
   })
 
   test('should test input validation for app title', async () => {

--- a/packages/@sanity/cli/src/commands/manifest/extract.ts
+++ b/packages/@sanity/cli/src/commands/manifest/extract.ts
@@ -1,5 +1,5 @@
 import {Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {findProjectRoot, SanityCommand} from '@sanity/cli-core'
 
 import {manifestDebug} from '../../actions/manifest/debug.js'
 import {extractManifest} from '../../actions/manifest/extractManifest.js'
@@ -37,7 +37,12 @@ export class ExtractManifestCommand extends SanityCommand<typeof ExtractManifest
     const {flags} = await this.parse(ExtractManifestCommand)
 
     try {
-      await extractManifest(flags.path)
+      const projectRoot = await findProjectRoot(process.cwd())
+      await extractManifest({
+        outPath: flags.path,
+        path: projectRoot.path,
+        workDir: projectRoot.directory,
+      })
     } catch (error) {
       manifestDebug('Error extracting manifest in command', error)
       if (

--- a/packages/@sanity/cli/src/constants.ts
+++ b/packages/@sanity/cli/src/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Root directory (relative to the project) used by Sanity tooling for
+ * build-time artifacts and caches — Vite's `cacheDir` and the dev-time
+ * manifest output. Lives under `node_modules/` so it's out of `dist` and
+ * ignored by default in typical `.gitignore` files.
+ */
+export const SANITY_CACHE_DIR = 'node_modules/.sanity'

--- a/packages/@sanity/cli/src/services/userApplications.ts
+++ b/packages/@sanity/cli/src/services/userApplications.ts
@@ -5,7 +5,7 @@ import {debug, getGlobalCliClient} from '@sanity/cli-core'
 import FormData from 'form-data'
 import {type StudioManifest} from 'sanity'
 
-import {type AppManifest} from '../actions/manifest/types.js'
+import {type CoreAppManifest} from '../actions/manifest/types.js'
 
 export const USER_APPLICATIONS_API_VERSION = 'v2024-08-01'
 
@@ -239,7 +239,7 @@ interface CreateDeploymentOptions {
 
   isApp?: boolean
 
-  manifest?: AppManifest | StudioManifest | null
+  manifest?: CoreAppManifest | StudioManifest | null
 
   projectId?: string
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Extract the manifest for studio and core applications, when fedeation is enabled. For studios we extract the static manifest, like before. For core apps we fake a static manifest contract, because they never had static manifests.

The manifests extraction happens in the background, to not block the dev-server startup because it takes quite a while. This means initially it is possible that the list of applications in the dock does not have the full information available and it will be send once the extraction has finished, which imo is an acceptable tradeoff.

Counterpart in workbench https://github.com/sanity-io/workbench/pull/144


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dev-server lifecycle/registry IO and introduces async background extraction + file watching, which can affect workbench discovery and shutdown/cleanup behavior. Deploy-time manifest extraction was renamed/typed but remains optional, limiting production impact.
> 
> **Overview**
> When federation is enabled, `sanity dev` now registers studios and core apps in the local dev-server registry immediately *without* metadata, then **inlines a manifest asynchronously** and patches the registry to trigger workbench rebroadcasts. Studios use a new `startDevManifestWatcher` to run (and debounce) worker-based manifest extraction on `sanity.config.*` changes, while core apps run `extractCoreAppManifest` once in the background.
> 
> The dev-server registry format is updated to store `manifest` + `manifestUpdatedAt`, and `registerDevServer` now returns `{release, update}` with safeguards so late background updates don’t recreate deleted entries; workbench payloads are updated accordingly. Manifest extraction is refactored to accept explicit `workDir`/config `path` (used by the `manifest extract` command and dev watcher), core-app manifests are validated with a zod schema, and Vite cache dirs are unified under the new `SANITY_CACHE_DIR` constant (used for vendor builds, studio builds, and workbench).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff3f547b36557b421b6d1e0b5f17fcd97e9ee84c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->