### PR TITLE
feat(datasets): warn before public visibility and gate --yes for agents

### DIFF
--- a/.changeset/pr-998.md
+++ b/.changeset/pr-998.md
@@ -1,6 +1,5 @@
-<!-- auto-generated -->
 ---
 '@sanity/cli': minor
 ---
 
-warn before public visibility and gate --yes for agents
+Changing a dataset to public visibility now requires explicit confirmation or `--yes` in non-interactive environments.

--- a/.changeset/pr-998.md
+++ b/.changeset/pr-998.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+warn before public visibility and gate --yes for agents

--- a/packages/@sanity/cli/src/actions/dataset/determineDatasetAclMode.ts
+++ b/packages/@sanity/cli/src/actions/dataset/determineDatasetAclMode.ts
@@ -46,6 +46,11 @@ export async function determineDatasetAclMode(
 
   // Handle explicit custom/public requests
   if (visibility === 'custom' || visibility === 'public') {
+    if (visibility === 'public') {
+      output.warn(
+        'Creating a PUBLIC dataset. Anyone on the internet will be able to read its contents without authentication. If you plan to store any sensitive, personal, or proprietary data, re-run with --visibility private.',
+      )
+    }
     return visibility
   }
 

--- a/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/set.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/set.test.ts
@@ -1,4 +1,5 @@
 import {NonInteractiveError} from '@sanity/cli-core'
+import {confirm} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -7,6 +8,16 @@ import {DatasetVisibilitySetCommand} from '../set.js'
 vi.mock('../../../../prompts/promptForProject.js', () => ({
   promptForProject: vi.fn().mockRejectedValue(new NonInteractiveError('select')),
 }))
+
+vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/cli-core/ux')>()
+  return {
+    ...actual,
+    confirm: vi.fn(),
+  }
+})
+
+const mockConfirm = vi.mocked(confirm)
 
 const mockListDatasets = vi.hoisted(() => vi.fn())
 const mockEditDatasetAcl = vi.hoisted(() => vi.fn())
@@ -41,18 +52,79 @@ describe('#dataset:visibility:set', () => {
     vi.clearAllMocks()
   })
 
-  test('sets dataset visibility to public successfully', async () => {
+  test('sets dataset visibility to public successfully after confirmation', async () => {
     mockListDatasets.mockResolvedValue([{aclMode: 'private', name: 'my-dataset'}] as never)
     mockEditDatasetAcl.mockResolvedValue(undefined as never)
+    mockConfirm.mockResolvedValueOnce(true)
+
+    const {stderr, stdout} = await testCommand(
+      DatasetVisibilitySetCommand,
+      ['my-dataset', 'public'],
+      {
+        mocks: defaultMocks,
+      },
+    )
+
+    expect(mockConfirm).toHaveBeenCalledWith({
+      default: false,
+      message: 'Are you sure you want to make "my-dataset" public?',
+    })
+    expect(stderr).toContain('You are about to make')
+    expect(stderr).toContain('PUBLIC')
+    expect(stderr).toContain('Anyone on the internet')
+    expect(stdout).toContain('Dataset visibility changed')
+    expect(mockEditDatasetAcl).toHaveBeenCalledWith('my-dataset', {
+      aclMode: 'public',
+    })
+  })
+
+  test('cancels public visibility change when user declines confirmation', async () => {
+    mockListDatasets.mockResolvedValue([{aclMode: 'private', name: 'my-dataset'}] as never)
+    mockConfirm.mockResolvedValueOnce(false)
 
     const {stdout} = await testCommand(DatasetVisibilitySetCommand, ['my-dataset', 'public'], {
       mocks: defaultMocks,
     })
 
+    expect(stdout).toContain('Operation cancelled')
+    expect(mockEditDatasetAcl).not.toHaveBeenCalled()
+  })
+
+  test('skips confirmation when --yes flag is provided', async () => {
+    mockListDatasets.mockResolvedValue([{aclMode: 'private', name: 'my-dataset'}] as never)
+    mockEditDatasetAcl.mockResolvedValue(undefined as never)
+
+    const {stderr, stdout} = await testCommand(
+      DatasetVisibilitySetCommand,
+      ['my-dataset', 'public', '--yes'],
+      {mocks: defaultMocks},
+    )
+
+    expect(mockConfirm).not.toHaveBeenCalled()
+    expect(stderr).toContain('You are about to make')
+    expect(stderr).toContain('PUBLIC')
+    expect(stderr).toContain('Anyone on the internet')
+    expect(stderr).toContain("'--yes' used: skipping confirmation")
     expect(stdout).toContain('Dataset visibility changed')
     expect(mockEditDatasetAcl).toHaveBeenCalledWith('my-dataset', {
       aclMode: 'public',
     })
+  })
+
+  test('errors when making dataset public in non-interactive mode without --yes', async () => {
+    mockListDatasets.mockResolvedValue([{aclMode: 'private', name: 'my-dataset'}] as never)
+    mockConfirm.mockRejectedValueOnce(new NonInteractiveError('confirm'))
+
+    const {error} = await testCommand(DatasetVisibilitySetCommand, ['my-dataset', 'public'], {
+      mocks: defaultMocks,
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain(
+      'Refusing to change dataset to public in a non-interactive environment without the --yes flag',
+    )
+    expect(error?.oclif?.exit).toBe(1)
+    expect(mockEditDatasetAcl).not.toHaveBeenCalled()
   })
 
   test('sets dataset visibility to private successfully with warning', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/set.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/set.test.ts
@@ -104,7 +104,7 @@ describe('#dataset:visibility:set', () => {
     expect(stderr).toContain('You are about to make')
     expect(stderr).toContain('PUBLIC')
     expect(stderr).toContain('Anyone on the internet')
-    expect(stderr).toContain("'--yes' used: skipping confirmation")
+    expect(stdout).toContain('--yes acknowledged: skipping confirmation')
     expect(stdout).toContain('Dataset visibility changed')
     expect(mockEditDatasetAcl).toHaveBeenCalledWith('my-dataset', {
       aclMode: 'public',

--- a/packages/@sanity/cli/src/commands/datasets/visibility/set.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/set.ts
@@ -1,5 +1,6 @@
-import {Args} from '@oclif/core'
+import {Args, Flags} from '@oclif/core'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {confirm, NonInteractiveError} from '@sanity/cli-core/ux'
 import {DatasetsResponse} from '@sanity/client'
 
 import {validateDatasetName} from '../../../actions/dataset/validateDatasetName.js'
@@ -30,8 +31,8 @@ export class DatasetVisibilitySetCommand extends SanityCommand<typeof DatasetVis
       description: 'Make a dataset private',
     },
     {
-      command: '<%= config.bin %> <%= command.id %> my-dataset public',
-      description: 'Make a dataset public',
+      command: '<%= config.bin %> <%= command.id %> my-dataset public --yes',
+      description: 'Make a dataset public without a confirmation prompt',
     },
   ]
 
@@ -40,13 +41,20 @@ export class DatasetVisibilitySetCommand extends SanityCommand<typeof DatasetVis
       description: 'Project ID to set dataset visibility for',
       semantics: 'override',
     }),
+    yes: Flags.boolean({
+      aliases: ['y'],
+      description:
+        'Skip the confirmation prompt when changing a dataset to public. Required for non-interactive usage (e.g. CI or agents).',
+      required: false,
+    }),
   }
 
   static override hiddenAliases: string[] = ['dataset:visibility:set']
 
   public async run(): Promise<void> {
-    const {args} = await this.parse(DatasetVisibilitySetCommand)
+    const {args, flags} = await this.parse(DatasetVisibilitySetCommand)
     const {dataset, mode} = args
+    const {yes: skipConfirmation} = flags
 
     const projectId = await this.getProjectId({
       fallback: () =>
@@ -88,6 +96,35 @@ export class DatasetVisibilitySetCommand extends SanityCommand<typeof DatasetVis
       this.log(
         'Please note that while documents are private, assets (files and images) are still public',
       )
+    }
+
+    if (mode === 'public') {
+      this.warn(
+        `You are about to make "${dataset}" PUBLIC. Anyone on the internet will be able to read all documents and assets in this dataset without authentication. If this dataset contains any sensitive, personal, or proprietary data, cancel now and keep it private.`,
+      )
+
+      if (skipConfirmation) {
+        this.warn(`'--yes' used: skipping confirmation and changing "${dataset}" to public`)
+      } else {
+        try {
+          const confirmed = await confirm({
+            default: false,
+            message: `Are you sure you want to make "${dataset}" public?`,
+          })
+          if (!confirmed) {
+            this.log('Operation cancelled')
+            return
+          }
+        } catch (error) {
+          if (error instanceof NonInteractiveError) {
+            this.error(
+              'Refusing to change dataset to public in a non-interactive environment without the --yes flag. Re-run with --yes to acknowledge that the data will be readable by anyone on the internet.',
+              {exit: 1},
+            )
+          }
+          throw error
+        }
+      }
     }
 
     try {

--- a/packages/@sanity/cli/src/commands/datasets/visibility/set.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/set.ts
@@ -42,7 +42,7 @@ export class DatasetVisibilitySetCommand extends SanityCommand<typeof DatasetVis
       semantics: 'override',
     }),
     yes: Flags.boolean({
-      aliases: ['y'],
+      char: 'y',
       description:
         'Skip the confirmation prompt when changing a dataset to public. Required for non-interactive usage (e.g. CI or agents).',
       required: false,
@@ -104,7 +104,7 @@ export class DatasetVisibilitySetCommand extends SanityCommand<typeof DatasetVis
       )
 
       if (skipConfirmation) {
-        this.warn(`'--yes' used: skipping confirmation and changing "${dataset}" to public`)
+        this.log(`--yes acknowledged: skipping confirmation and changing "${dataset}" to public`)
       } else {
         try {
           const confirmed = await confirm({

--- a/packages/@sanity/cli/src/prompts/promptForDatasetAclMode.ts
+++ b/packages/@sanity/cli/src/prompts/promptForDatasetAclMode.ts
@@ -23,10 +23,16 @@ export async function promptForDatasetAclMode(output?: Output): Promise<DatasetA
     message: 'Dataset visibility',
   })
 
-  if (mode === 'private' && output) {
-    output.warn(
-      'Please note that while documents are private, assets (files and images) are still public',
-    )
+  if (output) {
+    if (mode === 'public') {
+      output.warn(
+        'Public datasets are readable by anyone on the internet without authentication. If you plan to store any sensitive, personal, or proprietary data, choose "Private" instead.',
+      )
+    } else if (mode === 'private') {
+      output.warn(
+        'Please note that while documents are private, assets (files and images) are still public',
+      )
+    }
   }
 
   return mode


### PR DESCRIPTION
### Description

Makes the safety implications of public datasets clearly visible in the CLI, and prevents non-interactive callers (agents, CI) from silently flipping a dataset from private to public.

Specifically:

- **`datasets create` interactive prompt** (`promptForDatasetAclMode`): when the user picks "Public", emit an explicit warning that anyone on the internet can read the data and suggest "Private" for sensitive content.
- **`datasets create --visibility public`** (`determineDatasetAclMode`): emit the same style of warning so agents that pass the flag are warned too.
- **`datasets visibility set <ds> public`**:
  - Always emit a strong warning describing the exposure (docs + assets, anyone on the internet).
  - In an interactive terminal, prompt for confirmation (default: `No`).
  - In a non-interactive environment (no TTY), **error out with exit 1** unless `--yes` / `-y` is provided — so agents/CI cannot accidentally leak data.
  - New `--yes` flag documented in help and examples.

The `public → private` path is intentionally unchanged — only the direction that exposes data is gated.

### What to review

- `packages/@sanity/cli/src/prompts/promptForDatasetAclMode.ts` — new public-side warning; existing private-side note preserved.
- `packages/@sanity/cli/src/actions/dataset/determineDatasetAclMode.ts` — warning for explicit `--visibility public`.
- `packages/@sanity/cli/src/commands/datasets/visibility/set.ts` — new `--yes` flag, warning + confirmation, `NonInteractiveError` handling.
- `packages/@sanity/cli/src/commands/datasets/visibility/__tests__/set.test.ts` — new coverage for the four flows (confirm accept, confirm decline, `--yes` bypass, non-interactive without `--yes` error).

Please eyeball the warning copy — happy to tighten it if it's too verbose or too mild. Open question: should `datasets create` also gate with `--yes` for agents, or is a warning enough since no data exists yet?

### Testing

- Unit: 4 new test cases in `set.test.ts`. Full `pnpm test --changed` green (134/134).
- Type check + lint clean.
- Live end-to-end against a scratch project + dataset:
  - `datasets create --visibility public` → warning printed ✅
  - `datasets visibility set <ds> public` (no TTY, no `--yes`) → exit 1, no API call ✅
  - `datasets visibility set <ds> public --yes` → warning + acknowledgement + flip ✅
  - `datasets visibility set <ds> private` → unchanged ✅
