### PR TITLE
fix(init): do not resolve dist tags

### DIFF
--- a/.changeset/pr-1000.md
+++ b/.changeset/pr-1000.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+do not resolve dist tags

--- a/packages/@sanity/cli/src/util/__tests__/resolveLatestVersions.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/resolveLatestVersions.test.ts
@@ -37,29 +37,15 @@ describe('resolveLatestVersions', () => {
     expect(result).toEqual({sanity: '^4.5.6'})
   })
 
-  test('resolves arbitrary dist-tags such as `workbench`', async () => {
-    mockGetLatestVersion.mockResolvedValueOnce('7.8.9-workbench.0')
-
+  test('passes arbitrary dist-tags such as `workbench` through without resolving', async () => {
     const result = await resolveLatestVersions({sanity: 'workbench'})
 
-    expect(mockGetLatestVersion).toHaveBeenCalledWith('sanity', {range: 'workbench'})
-    expect(result).toEqual({sanity: '^7.8.9-workbench.0'})
-  })
-
-  test('falls back to the original tag when the lookup returns undefined', async () => {
-    mockGetLatestVersion.mockResolvedValueOnce(undefined)
-
-    const result = await resolveLatestVersions({sanity: 'workbench'})
-
+    expect(mockGetLatestVersion).not.toHaveBeenCalled()
     expect(result).toEqual({sanity: 'workbench'})
   })
 
-  test('resolves a mix of ranges and dist-tags in a single call', async () => {
-    mockGetLatestVersion.mockImplementation(async (_pkg: string, {range}: {range: string}) => {
-      if (range === 'latest') return '1.0.0'
-      if (range === 'workbench') return '2.0.0-workbench.1'
-      return undefined
-    })
+  test('resolves `latest` alongside pass-through ranges and dist-tags in a single call', async () => {
+    mockGetLatestVersion.mockResolvedValueOnce('1.0.0')
 
     const result = await resolveLatestVersions({
       '@sanity/vision': 'latest',
@@ -70,8 +56,9 @@ describe('resolveLatestVersions', () => {
     expect(result).toEqual({
       '@sanity/vision': '^1.0.0',
       react: '^19.2.4',
-      sanity: '^2.0.0-workbench.1',
+      sanity: 'workbench',
     })
-    expect(mockGetLatestVersion).toHaveBeenCalledTimes(2)
+    expect(mockGetLatestVersion).toHaveBeenCalledTimes(1)
+    expect(mockGetLatestVersion).toHaveBeenCalledWith('@sanity/vision', {range: 'latest'})
   })
 })

--- a/packages/@sanity/cli/src/util/resolveLatestVersions.ts
+++ b/packages/@sanity/cli/src/util/resolveLatestVersions.ts
@@ -1,6 +1,5 @@
 import {getLatestVersion} from 'get-latest-version'
 import promiseProps from 'promise-props-recursive'
-import semver from 'semver'
 
 /**
  * Resolve the latest versions of given packages within their defined ranges
@@ -13,15 +12,13 @@ export function resolveLatestVersions(
 ): Promise<Record<string, string>> {
   const lookups: Record<string, Promise<string> | string> = {}
   for (const [packageName, range] of Object.entries(pkgs)) {
-    const isDistTag = semver.validRange(range) === null
-    lookups[packageName] = isDistTag
-      ? getLatestVersion(packageName, {range}).then((version) => caretify(version, range))
-      : range
+    lookups[packageName] =
+      range === 'latest' ? getLatestVersion(packageName, {range}).then(caretify) : range
   }
 
   return promiseProps(lookups)
 }
 
-function caretify(version: string | undefined, fallback: string) {
-  return version ? `^${version}` : fallback
+function caretify(version: string | undefined) {
+  return version ? `^${version}` : 'latest'
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

https://github.com/sanity-io/cli/pull/992 added support for the `workbench` dist-tag for the `sanity` package in the init command. The issue is that we were resolving the dist-tag, where as we want to leave it as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency version resolution used during `init`, which can alter generated `package.json` versions for users relying on non-`latest` dist-tags.
> 
> **Overview**
> Stops resolving non-`latest` dist-tags in `resolveLatestVersions`, so tags like `workbench` are passed through verbatim while only `latest` is looked up and converted to a caret-prefixed version.
> 
> Updates the unit tests to reflect the new behavior (no `getLatestVersion` calls for arbitrary tags, fewer lookups in mixed inputs) and adds a changeset for an `@sanity/cli` patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12de9ded95807eaf4b99ff6b4657f806f102681a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->