### PR TITLE
ci: update upload-docs workflow to match new release tag format

### DIFF
--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.release.tag_name, 'cli-v')
+      startsWith(github.event.release.tag_name, '@sanity/cli@')
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}


### PR DESCRIPTION
### Description

The release tag format changed from `cli-vX.Y.Z` to `@sanity/cli@X.Y.Z`, which caused the `Upload Docs` workflow to skip on every release (e.g. [this run](https://github.com/sanity-io/cli/actions/runs/24742374044)).

Updates the `startsWith` condition to match the new tag prefix.

### What to review

- `.github/workflows/upload-docs.yml` — single-line change to the tag prefix in the `if` condition

### Testing

No automated tests — this is a CI workflow condition. Can be verified by manually triggering the workflow or observing the next `@sanity/cli@*` release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to a GitHub Actions `if` condition that only affects when the docs upload job triggers on releases.
> 
> **Overview**
> Updates the `Upload Docs` GitHub Actions workflow so the `upload-docs` job runs for published releases whose tag name starts with `@sanity/cli@` (replacing the previous `cli-v` prefix), preventing the workflow from being skipped after the release tag format change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1514d3630b354f6a5aa4c5a0f22dab33c98a9e8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->