### PR TITLE
fix(cli): pass schemaExtraction config through to build

### DIFF
--- a/.changeset/fix-build-schema-extraction.md
+++ b/.changeset/fix-build-schema-extraction.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+Pass schemaExtraction config through to build so `sanity build` respects `schemaExtraction.enabled` in `sanity.cli.ts`

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -169,6 +169,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
       outputDir,
       reactCompiler:
         cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
+      schemaExtraction: cliConfig?.schemaExtraction,
       sourceMap: Boolean(flags['source-maps']),
       vite: cliConfig && 'vite' in cliConfig ? cliConfig.vite : undefined,
     })

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import {type UserViteConfig} from '@sanity/cli-core'
+import {type CliConfig, type UserViteConfig} from '@sanity/cli-core'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {build} from 'vite'
 
@@ -33,6 +33,7 @@ interface StaticBuildOptions {
   minify?: boolean
   profile?: boolean
   reactCompiler?: ReactCompilerConfig
+  schemaExtraction?: CliConfig['schemaExtraction']
   sourceMap?: boolean
   vite?: UserViteConfig
 }
@@ -55,6 +56,7 @@ export async function buildStaticFiles(
     minify = true,
     outputDir,
     reactCompiler,
+    schemaExtraction,
     sourceMap = false,
     vite: extendViteConfig,
   } = options
@@ -81,6 +83,7 @@ export async function buildStaticFiles(
     mode,
     outputDir,
     reactCompiler,
+    schemaExtraction,
     sourceMap,
   })
 

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -168,6 +168,10 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
   // Determine base path for built studio
   const basePath = determineBasePath(cliConfig, 'studio', output)
 
+  if (cliConfig?.schemaExtraction?.enabled) {
+    output.log(`${logSymbols.info} Building with schema extraction enabled`)
+  }
+
   let spin: SpinnerInstance
   if (shouldClean) {
     timer.start('cleanOutputFolder')
@@ -205,6 +209,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
       outputDir,
       reactCompiler:
         cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
+      schemaExtraction: cliConfig?.schemaExtraction,
       sourceMap: Boolean(flags['source-maps']),
       vite: cliConfig && 'vite' in cliConfig ? cliConfig.vite : undefined,
     })


### PR DESCRIPTION
### Description

The `schemaExtraction` config from `sanity.cli.ts` was not being passed through to the Vite build pipeline during `sanity build` (both studio and app builds). This was a gap from the CLI migration — the dev server path (`sanity dev`) correctly wired it through, but the build path did not.

This means users with `schemaExtraction: { enabled: true }` in their `sanity.cli.ts` would see schema extraction work during development but silently be skipped during production builds.

### What to review

- `buildStaticFiles.ts` — Added `schemaExtraction` to `StaticBuildOptions` and threaded it through to `getViteConfig`
- `buildStudio.ts` — Passes `cliConfig?.schemaExtraction` to `buildStaticFiles` and logs an info message when enabled (matching old CLI behavior)
- `buildApp.ts` — Same pass-through for the app build path

### Testing

Existing `getViteConfig` tests (25/25 passing) already cover schema extraction in the Vite config layer. The fix threads the config through to that layer which was previously unreachable from the build path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive wiring/logging change that only affects builds when `schemaExtraction` is configured and enabled.
> 
> **Overview**
> `sanity build` now threads `schemaExtraction` from `sanity.cli.ts` through the production build pipeline so schema extraction is applied during Studio and App builds.
> 
> This adds `schemaExtraction` to `buildStaticFiles` options (and forwards it to `getViteConfig`), passes the config from both `buildStudio` and `buildApp`, and logs an info message when schema extraction is enabled. A patch changeset is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f5ef6ce815bd7189731edf1873523a6b5af6ad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->