### PR TITLE
fix(cli): default to TypeScript in unattended mode for sanity init

### DIFF
--- a/.changeset/pr-1004.md
+++ b/.changeset/pr-1004.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+default to TypeScript in unattended mode for sanity init

--- a/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
@@ -8,7 +8,7 @@ import {installDeclaredPackages} from '../../util/packageManager/installPackages
 import {type PackageManager} from '../../util/packageManager/packageManagerChoice.js'
 import {bootstrapTemplate} from './bootstrapTemplate.js'
 import {tryGitInit} from './git.js'
-import {writeStagingEnvIfNeeded} from './initHelpers.js'
+import {flagOrDefault, shouldPrompt, writeStagingEnvIfNeeded} from './initHelpers.js'
 import {type RepoInfo} from './remoteTemplate.js'
 import {resolvePackageManager} from './resolvePackageManager.js'
 import templates from './templates/index.js'
@@ -73,10 +73,10 @@ export async function selectTemplate({
 
   const resolvedTemplate = templates[templateName]
 
-  let useTypeScript = typescript
+  let useTypeScript = flagOrDefault(typescript, true)
   if (!remoteTemplateInfo && resolvedTemplate && resolvedTemplate.typescriptOnly === true) {
     useTypeScript = true
-  } else if (!unattended && typescript === undefined) {
+  } else if (shouldPrompt(unattended, typescript)) {
     useTypeScript = await promptForTypeScript()
     trace.log({
       selectedOption: useTypeScript ? 'yes' : 'no',

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -1,6 +1,7 @@
 import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
+import {selectTemplate} from '../../../actions/init/scaffoldTemplate.js'
 import {InitCommand} from '../../init.js'
 
 const mocks = vi.hoisted(() => ({
@@ -8,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   detectFrameworkRecord: vi.fn(),
   getById: vi.fn(),
   getGitHubRepoInfo: vi.fn(),
+  promptForTypeScript: vi.fn(),
 }))
 
 vi.mock('../../../util/detectFramework.js', () => ({
@@ -17,6 +19,10 @@ vi.mock('../../../util/detectFramework.js', () => ({
 vi.mock('../../../actions/init/remoteTemplate.js', () => ({
   checkIsRemoteTemplate: mocks.checkIsRemoteTemplate,
   getGitHubRepoInfo: mocks.getGitHubRepoInfo,
+}))
+
+vi.mock('../../../prompts/init/promptForTypescript.js', () => ({
+  promptForTypeScript: mocks.promptForTypeScript,
 }))
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
@@ -290,5 +296,82 @@ describe('#init: oclif command setup', () => {
 
     // When template is not an app template, it should log "Fetching existing projects"
     expect(stdout).toContain('Fetching existing projects')
+  })
+})
+
+const traceMock = {
+  log: vi.fn(),
+}
+
+describe('#init: selectTemplate', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('defaults to TypeScript when unattended and typescript flag is undefined', async () => {
+    const result = await selectTemplate({
+      remoteTemplateInfo: undefined,
+      template: 'clean',
+      trace: traceMock as never,
+      typescript: undefined,
+      unattended: true,
+    })
+
+    expect(result.useTypeScript).toBe(true)
+    expect(mocks.promptForTypeScript).not.toHaveBeenCalled()
+  })
+
+  test('respects explicit --no-typescript in unattended mode', async () => {
+    const result = await selectTemplate({
+      remoteTemplateInfo: undefined,
+      template: 'clean',
+      trace: traceMock as never,
+      typescript: false,
+      unattended: true,
+    })
+
+    expect(result.useTypeScript).toBe(false)
+    expect(mocks.promptForTypeScript).not.toHaveBeenCalled()
+  })
+
+  test('respects explicit --typescript in unattended mode', async () => {
+    const result = await selectTemplate({
+      remoteTemplateInfo: undefined,
+      template: 'clean',
+      trace: traceMock as never,
+      typescript: true,
+      unattended: true,
+    })
+
+    expect(result.useTypeScript).toBe(true)
+    expect(mocks.promptForTypeScript).not.toHaveBeenCalled()
+  })
+
+  test('prompts for TypeScript when interactive and flag is undefined', async () => {
+    mocks.promptForTypeScript.mockResolvedValueOnce(false)
+
+    const result = await selectTemplate({
+      remoteTemplateInfo: undefined,
+      template: 'clean',
+      trace: traceMock as never,
+      typescript: undefined,
+      unattended: false,
+    })
+
+    expect(result.useTypeScript).toBe(false)
+    expect(mocks.promptForTypeScript).toHaveBeenCalledOnce()
+  })
+
+  test('does not prompt when interactive and --typescript is explicitly set', async () => {
+    const result = await selectTemplate({
+      remoteTemplateInfo: undefined,
+      template: 'clean',
+      trace: traceMock as never,
+      typescript: true,
+      unattended: false,
+    })
+
+    expect(result.useTypeScript).toBe(true)
+    expect(mocks.promptForTypeScript).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### Description

When running `sanity init` in unattended mode (non-interactive terminal or `--yes` flag), the CLI defaulted to JavaScript instead of TypeScript when `--typescript`/`--no-typescript` wasn't explicitly provided. This affected agents, CI pipelines, and any spawned process without a TTY.

The root cause was in `selectTemplate()` — `useTypeScript` was initialized to the raw `typescript` flag (`undefined` by default), and the prompt that would default to TypeScript was skipped in unattended mode, leaving `useTypeScript` as `undefined` (falsy → JavaScript).

The fix uses the existing `flagOrDefault(typescript, true)` and `shouldPrompt(unattended, typescript)` helpers — the same pattern already used in `initNextJs.ts` — so unattended mode now defaults to TypeScript, matching the interactive prompt default.

Fixes [SDK-1316](https://linear.app/sanity/issue/SDK-1316)

### What to review

- `packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts` — The 3-line fix in `selectTemplate()` (lines 76, 79)
- Verify the fix matches the pattern in `initNextJs.ts:165-168`
- Confirm explicit `--typescript` and `--no-typescript` flags are still respected

### Testing

Added 5 unit tests to `init.setup.test.ts` covering all branches of the TypeScript flag logic in `selectTemplate()`:
- Defaults to TypeScript when unattended and flag is undefined
- Respects explicit `--no-typescript` in unattended mode
- Respects explicit `--typescript` in unattended mode
- Prompts when interactive and flag is undefined
- Skips prompt when interactive and flag is explicitly set

All 31 tests in `init.setup.test.ts` pass. Full init test suite (95 tests) passes. Type check, lint, and build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavioral tweak to `sanity init` defaults in unattended mode, with explicit flags still honored and new unit tests covering the decision branches.
> 
> **Overview**
> `sanity init` now **defaults to TypeScript in unattended mode** when `--typescript/--no-typescript` isn’t explicitly provided, by initializing `useTypeScript` via `flagOrDefault(..., true)` and reusing `shouldPrompt()` to gate the interactive prompt.
> 
> Adds unit tests for `selectTemplate()` covering unattended defaults, explicit flag handling, and interactive prompting, and includes a patch changeset for `@sanity/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253e8e01f30726e67ad3da1290354a2854428365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->