### PR TITLE
fix(cli): apply user vite config to federation builds [SDK-1281]

### DIFF
--- a/.changeset/pr-1005.md
+++ b/.changeset/pr-1005.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+apply user vite config to federation builds [SDK-1281]

--- a/packages/@sanity/cli/src/actions/build/__tests__/buildStaticFiles.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/buildStaticFiles.test.ts
@@ -1,0 +1,141 @@
+import {convertToSystemPath} from '@sanity/cli-test'
+import {type InlineConfig} from 'vite'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {buildStaticFiles} from '../buildStaticFiles.js'
+
+const mockBuildApp = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const mockCreateBuilder = vi.hoisted(() => vi.fn().mockResolvedValue({buildApp: mockBuildApp}))
+const mockBuild = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({output: [{modules: {}, name: 'test', type: 'chunk'}]}),
+)
+const mockGetViteConfig = vi.hoisted(() => vi.fn())
+const mockExtendViteConfigWithUserConfig = vi.hoisted(() => vi.fn())
+const mockFinalizeViteConfig = vi.hoisted(() => vi.fn())
+const mockWriteSanityRuntime = vi.hoisted(() => vi.fn())
+const mockResolveEntries = vi.hoisted(() => vi.fn())
+
+vi.mock('vite', () => ({
+  build: mockBuild,
+  createBuilder: mockCreateBuilder,
+}))
+
+vi.mock('../getViteConfig.js', () => ({
+  extendViteConfigWithUserConfig: mockExtendViteConfigWithUserConfig,
+  finalizeViteConfig: mockFinalizeViteConfig,
+  getViteConfig: mockGetViteConfig,
+}))
+
+vi.mock('../writeSanityRuntime.js', () => ({
+  resolveEntries: mockResolveEntries,
+  writeSanityRuntime: mockWriteSanityRuntime,
+}))
+
+vi.mock('../writeFavicons.js', () => ({
+  writeFavicons: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../../util/copyDir.js', () => ({
+  copyDir: vi.fn().mockResolvedValue(undefined),
+}))
+
+const cwd = convertToSystemPath('/test/cwd')
+const outputDir = convertToSystemPath('/test/cwd/dist')
+
+describe('buildStaticFiles', () => {
+  beforeEach(() => {
+    const defaultViteConfig: InlineConfig = {plugins: [{name: 'sanity-default'}], root: cwd}
+    mockGetViteConfig.mockResolvedValue(defaultViteConfig)
+    mockExtendViteConfigWithUserConfig.mockImplementation(async (_env, base, user) =>
+      typeof user === 'function' ? user(base, _env) : {...base, ...user},
+    )
+    mockFinalizeViteConfig.mockImplementation(async (config) => config)
+    mockResolveEntries.mockResolvedValue({
+      relativeConfigLocation: '../../sanity.config.ts',
+      relativeEntry: '../../src/App.tsx',
+    })
+    mockWriteSanityRuntime.mockResolvedValue({
+      entries: {relativeConfigLocation: null, relativeEntry: '../../src/App.tsx'},
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('federation enabled', () => {
+    test('applies user vite config so custom plugins run during build', async () => {
+      const userPlugin = {name: 'vanilla-extract-plugin'}
+      const userVite = vi.fn((config: InlineConfig) => ({
+        ...config,
+        plugins: [...(config.plugins ?? []), userPlugin],
+      }))
+
+      await buildStaticFiles({
+        basePath: '/',
+        cwd,
+        federation: {enabled: true},
+        outputDir,
+        vite: userVite,
+      })
+
+      expect(mockExtendViteConfigWithUserConfig).toHaveBeenCalledWith(
+        {command: 'build', mode: 'production'},
+        expect.objectContaining({root: cwd}),
+        userVite,
+      )
+
+      // Config passed to createBuilder must contain the user plugin — otherwise
+      // transforms like vanilla-extract never run on `.css.ts` files.
+      const builderConfig = mockCreateBuilder.mock.calls[0][0]
+      expect(builderConfig.plugins).toContainEqual(userPlugin)
+
+      // Federation builds must not call finalizeViteConfig; it forces a
+      // Studio-specific entry the federation environment does not use.
+      expect(mockFinalizeViteConfig).not.toHaveBeenCalled()
+
+      expect(mockBuildApp).toHaveBeenCalled()
+    })
+
+    test('skips user config merge when no user vite config is provided', async () => {
+      await buildStaticFiles({
+        basePath: '/',
+        cwd,
+        federation: {enabled: true},
+        outputDir,
+      })
+
+      expect(mockExtendViteConfigWithUserConfig).not.toHaveBeenCalled()
+      expect(mockBuildApp).toHaveBeenCalled()
+    })
+
+    test('does not write sanity runtime or copy static files', async () => {
+      await buildStaticFiles({
+        basePath: '/',
+        cwd,
+        federation: {enabled: true},
+        outputDir,
+      })
+
+      expect(mockWriteSanityRuntime).not.toHaveBeenCalled()
+      expect(mockBuild).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('federation disabled', () => {
+    test('still merges user vite config via finalizeViteConfig', async () => {
+      const userVite = {define: {CUSTOM: '"value"'}}
+
+      await buildStaticFiles({
+        basePath: '/',
+        cwd,
+        outputDir,
+        vite: userVite,
+      })
+
+      expect(mockExtendViteConfigWithUserConfig).toHaveBeenCalled()
+      expect(mockFinalizeViteConfig).toHaveBeenCalled()
+      expect(mockBuild).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -73,7 +73,7 @@ export async function buildStaticFiles(
     const entries = await resolveEntries({cwd, entry, isApp})
 
     buildDebug('Resolving vite config (federation)')
-    const viteConfig = await getViteConfig({
+    let viteConfig = await getViteConfig({
       basePath,
       cwd,
       entries,
@@ -85,6 +85,18 @@ export async function buildStaticFiles(
       reactCompiler,
       sourceMap,
     })
+
+    // Apply the user's Vite config so plugins like `@vanilla-extract/vite-plugin`
+    // transform source files before the federation environment is bundled.
+    // `finalizeViteConfig` is intentionally skipped: the federation environment
+    // has its own entry and does not use `.sanity/runtime/app.js`.
+    if (extendViteConfig) {
+      viteConfig = await extendViteConfigWithUserConfig(
+        {command: 'build', mode},
+        viteConfig,
+        extendViteConfig,
+      )
+    }
 
     buildDebug('Bundling federation environment')
     const builder = await createBuilder(viteConfig)


### PR DESCRIPTION
### Description

Fixes SDK-1281 — remote applications using `@vanilla-extract/vite-plugin` (or any other user-registered Vite plugin) fail to mount when federation is enabled.

The federation branch of `buildStaticFiles.ts` took an early-return code path that called `getViteConfig` → `createBuilder.buildApp()` without ever calling `extendViteConfigWithUserConfig`. So any plugins a user added via `vite` in `sanity.cli.ts` were silently dropped during `sanity build`.

Concretely: vanilla-extract's `.css.ts` files shipped untransformed. At runtime, the first import of a `.css.ts` module in the host threw `Styles were unable to be assigned to a file`, crashing the `<Island>` and triggering the error boundary.

Dev mode already applies `extendViteConfigWithUserConfig` in `devServer.ts`, so only production/preview builds were affected.

### What to review

- `packages/@sanity/cli/src/actions/build/buildStaticFiles.ts:69-105` — merge user vite config into the federation branch. `finalizeViteConfig` is intentionally skipped; the federation env has its own entry and does not use `.sanity/runtime/app.js`.
- `packages/@sanity/cli/src/actions/build/__tests__/buildStaticFiles.test.ts` — new tests covering plugin forwarding, the no-user-config case, and that federation skips runtime/static-copy steps.

Verified end-to-end by linking this CLI into `../workbench`, adding `@vanilla-extract/vite-plugin` to `dev/athlete-desk`, and inspecting the built bundle:

| | Before | After |
|---|---|---|
| `remote-entry.js` | `style({color:"hotpink",fontSize:"2rem"})` (raw) | References compiled class name `"d7i5bk0"` |
| `remote-entry.css` | No vanilla-extract output | `.d7i5bk0{color:#ff69b4;font-size:2rem}` |
| Runtime | "Styles were unable to be assigned" bundled in | Error text gone |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production build path for federated builds; mis-merging user Vite config could change bundling output or break federation builds, but scope is limited and covered by new unit tests.
> 
> **Overview**
> Federated `sanity build` now **applies the user-provided Vite config** (via `extendViteConfigWithUserConfig`) before bundling, ensuring user plugins run during federation builds.
> 
> Adds unit tests for `buildStaticFiles` covering plugin propagation into `createBuilder` config, the no-user-config case, and confirming federation builds still skip `finalizeViteConfig` and client-only steps (runtime/static copying).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaa54437999010fefb3559e736eb7d6150c7b543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->