### PR TITLE
fix(init): respect --project and --dataset flags for app-quickstart template

### DIFF
--- a/.changeset/pr-1006.md
+++ b/.changeset/pr-1006.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+respect --project and --dataset flags for app-quickstart template

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
@@ -1179,4 +1179,117 @@ describe('#init: promptForAppTemplateSetup', () => {
     expect(mocks.listProjects).not.toHaveBeenCalled()
     expect(mocks.listDatasets).not.toHaveBeenCalled()
   })
+
+  test('interactive with --project and --dataset: skips the app-template selection prompt and the organization prompt', async () => {
+    // getOrCreateProject fetches projects and organizations in parallel
+    mocks.listProjects.mockResolvedValueOnce([
+      {
+        createdAt: '2024-01-01T00:00:00Z',
+        displayName: 'Existing App Project',
+        id: 'jbvzi6yv',
+        organizationId: 'org-from-project',
+      },
+    ])
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [{id: 'org-from-project', name: 'Test Organization', slug: 'test-organization'}])
+
+    // In interactive mode, getOrCreateDataset fetches datasets + project features before returning
+    mocks.listDatasets.mockResolvedValueOnce([{aclMode: 'public', name: 'production'}])
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      uri: '/features',
+    }).reply(200, ['privateDataset'])
+
+    const {error} = await testCommand(
+      InitCommand,
+      [
+        '--template=app-quickstart',
+        '--project=jbvzi6yv',
+        '--dataset=production',
+        '--output-path=./test-project',
+        '--no-typescript',
+        '--no-overwrite-files',
+      ],
+      {
+        mocks: {
+          ...defaultMocks,
+          isInteractive: true,
+        },
+      },
+    )
+
+    if (error) throw error
+
+    // No prompts should fire: neither the org selection nor the "Configure a project" app prompt
+    expect(mocks.select).not.toHaveBeenCalled()
+    expect(mocks.input).not.toHaveBeenCalled()
+    // Existing "production" dataset is reused, no dataset creation
+    expect(mocks.createDataset).not.toHaveBeenCalled()
+  })
+
+  test('unattended with --project and --dataset but no --organization: succeeds without prompts (SDK-1314)', async () => {
+    mocks.listProjects.mockResolvedValueOnce([
+      {
+        createdAt: '2024-01-01T00:00:00Z',
+        displayName: 'Existing App Project',
+        id: 'jbvzi6yv',
+        organizationId: 'org-from-project',
+      },
+    ])
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [{id: 'org-from-project', name: 'Test Organization', slug: 'test-organization'}])
+
+    const {error} = await testCommand(
+      InitCommand,
+      [
+        '--yes',
+        '--template=app-quickstart',
+        '--project=jbvzi6yv',
+        '--dataset=production',
+        '--output-path=/tmp/test-app',
+        '--no-typescript',
+        '--no-overwrite-files',
+      ],
+      {
+        mocks: {...defaultMocks},
+      },
+    )
+
+    if (error) throw error
+
+    expect(mocks.select).not.toHaveBeenCalled()
+    expect(mocks.listDatasets).not.toHaveBeenCalled()
+    expect(mocks.createDataset).not.toHaveBeenCalled()
+  })
+
+  test('unattended without --project nor --organization: still errors with helpful message', async () => {
+    const {error} = await testCommand(
+      InitCommand,
+      [
+        '--yes',
+        '--template=app-quickstart',
+        '--dataset=production',
+        '--output-path=/tmp/test-app',
+        '--no-typescript',
+        '--no-overwrite-files',
+      ],
+      {
+        mocks: {...defaultMocks},
+      },
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.message).toContain(
+      'The --organization flag is required for app templates in unattended mode',
+    )
+    expect(error?.message).toContain('--project')
+  })
 })

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -555,7 +555,9 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
   }) {
     debug('Unattended mode, validating required options')
 
-    // App templates only require --organization and --output-path
+    // App templates require --output-path, and either --organization or a project reference
+    // (--project / --project-name). When a project is specified, the organization is derived
+    // from it, so --organization is not required.
     if (isAppTemplate) {
       if (!this.flags['output-path']) {
         this.error('`--output-path` must be specified in unattended mode', {
@@ -563,12 +565,17 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
         })
       }
 
-      if (!this.flags.organization) {
+      const hasProjectReference = Boolean(this.flags.project || createProjectName)
+      if (!this.flags.organization && !hasProjectReference) {
         this.error(
-          'The --organization flag is required for app templates in unattended mode. ' +
-            'Use --organization <id> to specify which organization to use.',
+          'The --organization flag is required for app templates in unattended mode ' +
+            'unless --project or --project-name is provided.',
           {exit: 1},
         )
+      }
+
+      if (createProjectName && !this.flags.organization) {
+        this.error('`--project-name` requires `--organization <id>` in unattended mode', {exit: 1})
       }
 
       return
@@ -805,6 +812,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
   }): Promise<{
     displayName: string
     isFirstProject: boolean
+    organizationId?: string
     projectId: string
     userAction: 'create' | 'select'
   }> {
@@ -846,6 +854,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       return {
         displayName: project ? project.displayName : 'Unknown project',
         isFirstProject: false,
+        organizationId: project?.organizationId ?? undefined,
         projectId,
         userAction: 'select',
       }
@@ -926,9 +935,11 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
     }
 
     debug(`Returning selected project (${selected})`)
+    const selectedProject = projects.find((proj) => proj.id === selected)
     return {
-      displayName: projects.find((proj) => proj.id === selected)?.displayName || '',
+      displayName: selectedProject?.displayName || '',
       isFirstProject: isUsersFirstProject,
+      organizationId: selectedProject?.organizationId ?? undefined,
       projectId: selected,
       userAction: 'select',
     }
@@ -969,7 +980,10 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
   }> {
     if (isAppTemplate) {
       let organizationId: string | undefined = this.flags.organization
-      if (!organizationId) {
+      // When --project (or --project-name) is provided, defer org resolution — it can be
+      // derived from the project itself instead of prompting the user.
+      const hasProjectSpecified = Boolean(this.flags.project || newProject)
+      if (!organizationId && !hasProjectSpecified) {
         let organizations: ProjectOrganization[]
         try {
           organizations = await listOrganizations()
@@ -985,7 +999,12 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
         })
       }
 
-      const {datasetName, displayName, projectId} = await this.promptForAppTemplateSetup({
+      const {
+        datasetName,
+        displayName,
+        organizationId: resolvedOrganizationId,
+        projectId,
+      } = await this.promptForAppTemplateSetup({
         newProject,
         organizationId,
         planId,
@@ -996,7 +1015,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
         datasetName,
         displayName,
         isFirstProject: false,
-        organizationId,
+        organizationId: organizationId ?? resolvedOrganizationId,
         projectId,
       }
     }
@@ -1063,11 +1082,16 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
     organizationId: string | undefined
     planId: string | undefined
     user: SanityOrgUser
-  }): Promise<{datasetName: string; displayName: string; projectId: string}> {
-    if (this.isUnattended()) {
-      if (!this.flags.project && !newProject) {
-        return {datasetName: '', displayName: '', projectId: ''}
-      }
+  }): Promise<{
+    datasetName: string
+    displayName: string
+    organizationId?: string
+    projectId: string
+  }> {
+    // When --project or --project-name is specified, skip the interactive selection prompt
+    // and resolve the project/dataset directly from flags. This matches the behavior of
+    // non-app-template init and applies to both interactive and unattended modes.
+    if (this.flags.project || newProject) {
       const project = await this.getOrCreateProject({newProject, planId, user})
       const dataset = await this.getOrCreateDataset({
         displayName: project.displayName,
@@ -1077,8 +1101,14 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       return {
         datasetName: dataset.datasetName,
         displayName: project.displayName,
+        organizationId: project.organizationId,
         projectId: project.projectId,
       }
+    }
+
+    // Unattended mode without --project: skip project configuration entirely
+    if (this.isUnattended()) {
+      return {datasetName: '', displayName: '', projectId: ''}
     }
 
     const projects = (await listProjects()).toSorted((a, b) =>
@@ -1123,6 +1153,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
           })
         : {
             displayName: projects.find((p) => p.id === selected)?.displayName ?? '',
+            organizationId: projects.find((p) => p.id === selected)?.organizationId ?? undefined,
             projectId: selected,
           }
 
@@ -1134,6 +1165,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
     return {
       datasetName: dataset.datasetName,
       displayName: project.displayName,
+      organizationId: project.organizationId,
       projectId: project.projectId,
     }
   }
@@ -1180,6 +1212,7 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
     return {
       ...newProject,
       isFirstProject: isUsersFirstProject,
+      organizationId: organization,
       userAction: 'create',
     }
   }


### PR DESCRIPTION
### Description

Fixes [SDK-1314](https://linear.app/sanity/issue/SDK-1314/yes-still-prompts-for-project-id-and-dataset) and the related interactive-mode regression.

Previously, running `sanity init --template app-quickstart --project <id> --dataset <name>` would still prompt the user to select a project (and an organization), ignoring the supplied flags. Unattended mode (`--yes`) also required `--organization` even when `--project` already supplied enough context to derive it.

**The fix** (in `packages/@sanity/cli/src/commands/init.ts`):

- `promptForAppTemplateSetup` now takes a flag-driven path whenever `--project` or `--project-name` is provided — in both interactive and unattended modes. This matches the behavior of the non-app template flow and stops the spurious "Configure a project for this app?" prompt.
- The organization is derived from the resolved project when not explicitly supplied, so the org prompt is skipped and `--organization` is no longer required in unattended mode when a project is specified.
- `getOrCreateProject` and `promptForProjectCreation` now return the `organizationId` of the resolved/created project so callers can propagate it.

### What to review

- `packages/@sanity/cli/src/commands/init.ts` — the early-return path in `promptForAppTemplateSetup`, the conditional skip of the org prompt in `getProjectDetails`, and the relaxed unattended validation in `checkFlagsInUnattendedMode`.
- Confirm the derived-org behavior is acceptable UX (we silently use the project's org rather than asking the user to confirm).

### Testing

Three new tests added in `init.get-project-details.test.ts`:

1. **Interactive + `--project` + `--dataset`** — neither the org selection nor the "Configure a project" prompt fires; existing dataset is reused.
2. **Unattended + `--project` + `--dataset` without `--organization`** (SDK-1314) — succeeds with no prompts, org derived from the project.
3. **Unattended without `--project` nor `--organization`** — still errors, but with an updated message mentioning `--project` / `--project-name` as alternatives.

All 93 `init` tests pass; the wider `@sanity/cli` suite has one pre-existing unrelated failure in `cliInstallationCheck.test.ts` (reproduced on `main`). Typecheck, lint, and build all green.

Manual testing not performed against a live Sanity project in this branch — would appreciate a reviewer sanity-checking the flow against a real org/project before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)