### PR TITLE
refactor: rename manifest types and share cache dir

### DIFF
--- a/.changeset/upstream-cache-dir-and-manifest-rename.md
+++ b/.changeset/upstream-cache-dir-and-manifest-rename.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+Extract `SANITY_CACHE_DIR` constant for the shared Vite cache path and rename the internal `AppManifest` type to `CoreAppManifest` (with a zod schema) for consistency with the workbench payload.

--- a/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
@@ -5,6 +5,7 @@ import {convertToSystemPath} from '@sanity/cli-test'
 import {type ConfigEnv, type InlineConfig} from 'vite'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
+import {SANITY_CACHE_DIR} from '../../../constants.js'
 import {
   extendViteConfigWithUserConfig,
   finalizeViteConfig,
@@ -115,7 +116,7 @@ describe('#getViteConfig', () => {
         outDir: join(mockTestCwd, 'dist'),
         sourcemap: true,
       },
-      cacheDir: 'node_modules/.sanity/vite',
+      cacheDir: `${SANITY_CACHE_DIR}/vite`,
       configFile: false,
       envPrefix: 'SANITY_STUDIO_',
       logLevel: 'info',

--- a/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
+++ b/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import semver from 'semver'
 import {build} from 'vite'
 
+import {SANITY_CACHE_DIR} from '../../constants.js'
 import {getLocalPackageDir, getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 import {createExternalFromImportMap} from './createExternalFromImportMap.js'
 
@@ -194,7 +195,7 @@ export async function buildVendorDependencies({
     },
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
-    cacheDir: 'node_modules/.sanity/vite-vendor',
+    cacheDir: `${SANITY_CACHE_DIR}/vite-vendor`,
     configFile: false,
     define: {'process.env.NODE_ENV': JSON.stringify('production')},
     logLevel: 'silent',

--- a/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
+++ b/packages/@sanity/cli/src/actions/build/buildVendorDependencies.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import {gt, minVersion, rcompare, satisfies} from 'semver'
 import {build} from 'vite'
 
+import {SANITY_CACHE_DIR} from '../../constants.js'
 import {getLocalPackageDir, getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 import {createExternalFromImportMap} from './createExternalFromImportMap.js'
 
@@ -194,7 +195,7 @@ export async function buildVendorDependencies({
     },
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
-    cacheDir: 'node_modules/.sanity/vite-vendor',
+    cacheDir: `${SANITY_CACHE_DIR}/vite-vendor`,
     configFile: false,
     define: {'process.env.NODE_ENV': JSON.stringify('production')},
     logLevel: 'silent',

--- a/packages/@sanity/cli/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli/src/actions/build/getViteConfig.ts
@@ -12,6 +12,7 @@ import debug from 'debug'
 import {readPackageUp} from 'read-package-up'
 import {type ConfigEnv, type InlineConfig, mergeConfig, type Rollup} from 'vite'
 
+import {SANITY_CACHE_DIR} from '../../constants.js'
 import {sanityBuildEntries} from '../../server/vite/plugin-sanity-build-entries.js'
 import {sanityFaviconsPlugin} from '../../server/vite/plugin-sanity-favicons.js'
 import {sanityRuntimeRewritePlugin} from '../../server/vite/plugin-sanity-runtime-rewrite.js'
@@ -121,7 +122,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     },
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
-    cacheDir: 'node_modules/.sanity/vite',
+    cacheDir: `${SANITY_CACHE_DIR}/vite`,
     configFile: false,
     define: {
       __SANITY_BUILD_TIMESTAMP__: JSON.stringify(Date.now()),

--- a/packages/@sanity/cli/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli/src/actions/build/getViteConfig.ts
@@ -12,6 +12,7 @@ import debug from 'debug'
 import {readPackageUp} from 'read-package-up'
 import {type ConfigEnv, type InlineConfig, mergeConfig, type Rollup} from 'vite'
 
+import {SANITY_CACHE_DIR} from '../../constants.js'
 import {sanityBuildEntries} from '../../server/vite/plugin-sanity-build-entries.js'
 import {sanityFaviconsPlugin} from '../../server/vite/plugin-sanity-favicons.js'
 import {sanityRuntimeRewritePlugin} from '../../server/vite/plugin-sanity-runtime-rewrite.js'
@@ -127,7 +128,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     },
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
-    cacheDir: 'node_modules/.sanity/vite',
+    cacheDir: `${SANITY_CACHE_DIR}/vite`,
     configFile: false,
     define: {
       __SANITY_BUILD_TIMESTAMP__: JSON.stringify(Date.now()),

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -14,7 +14,7 @@ import {getLocalPackageVersion} from '../../util/getLocalPackageVersion.js'
 import {buildApp} from '../build/buildApp.js'
 import {shouldAutoUpdate} from '../build/shouldAutoUpdate.js'
 import {extractAppManifest} from '../manifest/extractAppManifest.js'
-import {type AppManifest} from '../manifest/types.js'
+import {type CoreAppManifest} from '../manifest/types.js'
 import {checkDir} from './checkDir.js'
 import {createUserApplicationForApp} from './createUserApplicationForApp.js'
 import {deployDebug} from './deployDebug.js'
@@ -99,7 +99,7 @@ export async function deployApp(options: DeployAppOptions) {
     const parentDir = dirname(sourceDir)
     const base = basename(sourceDir)
     const tarball = pack(parentDir, {entries: [base]}).pipe(createGzip())
-    let manifest: AppManifest | undefined
+    let manifest: CoreAppManifest | undefined
     try {
       manifest = await extractAppManifest({workDir})
     } catch (err) {

--- a/packages/@sanity/cli/src/actions/manifest/extractAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractAppManifest.ts
@@ -5,7 +5,7 @@ import {getCliConfig} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 
 import {getErrorMessage} from '../../util/getErrorMessage.js'
-import {type AppManifest} from './types.js'
+import {type CoreAppManifest} from './types.js'
 
 interface ExtractAppManifestOptions {
   workDir: string
@@ -54,7 +54,7 @@ async function readIconFromPath(workDir: string, iconPath: string): Promise<stri
  */
 export async function extractAppManifest(
   options: ExtractAppManifestOptions,
-): Promise<AppManifest | undefined> {
+): Promise<CoreAppManifest | undefined> {
   const {workDir} = options
   const {app} = await getCliConfig(workDir)
   if (!app) {
@@ -74,7 +74,7 @@ export async function extractAppManifest(
       return undefined
     }
 
-    const manifest: AppManifest = {
+    const manifest: CoreAppManifest = {
       version: '1',
       ...(icon ? {icon} : {}),
       ...(app.title ? {title: app.title} : {}),

--- a/packages/@sanity/cli/src/actions/manifest/extractAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractAppManifest.ts
@@ -5,7 +5,7 @@ import {getCliConfig} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 
 import {getErrorMessage} from '../../util/getErrorMessage.js'
-import {type CoreAppManifest} from './types.js'
+import {type CoreAppManifest, coreAppManifestSchema} from './types.js'
 
 interface ExtractAppManifestOptions {
   workDir: string
@@ -74,11 +74,11 @@ export async function extractAppManifest(
       return undefined
     }
 
-    const manifest: CoreAppManifest = {
+    const manifest: CoreAppManifest = coreAppManifestSchema.parse({
       version: '1',
       ...(icon ? {icon} : {}),
       ...(app.title ? {title: app.title} : {}),
-    }
+    })
 
     spin.succeed(`Extracted manifest`)
 

--- a/packages/@sanity/cli/src/actions/manifest/types.ts
+++ b/packages/@sanity/cli/src/actions/manifest/types.ts
@@ -20,12 +20,18 @@ export interface CreateManifest {
   workspaces: ManifestWorkspaceFile[]
 }
 
-export interface AppManifest {
-  version: '1'
+/**
+ * Core-app application manifest. Mirrors the workbench's
+ * `CoreAppUserApplicationManifest` schema. Strictly validated via zod
+ * since the CLI produces the payload in full.
+ */
+export const coreAppManifestSchema = z.object({
+  icon: z.optional(z.string()),
+  title: z.optional(z.string()),
+  version: z.string(),
+})
 
-  icon?: string
-  title?: string
-}
+export type CoreAppManifest = z.infer<typeof coreAppManifestSchema>
 
 export interface ManifestWorkspaceFile extends Omit<CreateWorkspaceManifest, 'schema' | 'tools'> {
   schema: string // filename

--- a/packages/@sanity/cli/src/actions/manifest/types.ts
+++ b/packages/@sanity/cli/src/actions/manifest/types.ts
@@ -19,12 +19,18 @@ export interface CreateManifest {
   workspaces: ManifestWorkspaceFile[]
 }
 
-export interface AppManifest {
-  version: '1'
+/**
+ * Core-app application manifest. Mirrors the workbench's
+ * `CoreAppUserApplicationManifest` schema. Strictly validated via zod
+ * since the CLI produces the payload in full.
+ */
+export const coreAppManifestSchema = z.object({
+  icon: z.optional(z.string()),
+  title: z.optional(z.string()),
+  version: z.string(),
+})
 
-  icon?: string
-  title?: string
-}
+export type CoreAppManifest = z.infer<typeof coreAppManifestSchema>
 
 export interface ManifestWorkspaceFile extends Omit<CreateWorkspaceManifest, 'schema' | 'tools'> {
   schema: string // filename

--- a/packages/@sanity/cli/src/constants.ts
+++ b/packages/@sanity/cli/src/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Root directory (relative to the project) used by Sanity tooling for
+ * build-time artifacts and caches — Vite's `cacheDir` and the dev-time
+ * manifest output. Lives under `node_modules/` so it's out of `dist` and
+ * ignored by default in typical `.gitignore` files.
+ */
+export const SANITY_CACHE_DIR = 'node_modules/.sanity'

--- a/packages/@sanity/cli/src/services/userApplications.ts
+++ b/packages/@sanity/cli/src/services/userApplications.ts
@@ -5,7 +5,7 @@ import {debug, getGlobalCliClient} from '@sanity/cli-core'
 import FormData from 'form-data'
 import {type StudioManifest} from 'sanity'
 
-import {type AppManifest} from '../actions/manifest/types.js'
+import {type CoreAppManifest} from '../actions/manifest/types.js'
 
 export const USER_APPLICATIONS_API_VERSION = 'v2024-08-01'
 
@@ -239,7 +239,7 @@ interface CreateDeploymentOptions {
 
   isApp?: boolean
 
-  manifest?: AppManifest | StudioManifest | null
+  manifest?: CoreAppManifest | StudioManifest | null
 
   projectId?: string
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Pure refactoring:

- share the Vite `cacheDir` using a new `SANITY_CACHE_DIR` constant, because we will need it in a 3rd place to avoid drift
- rename `AppManifest` to `CoreAppManifest` to be more in-line with Brett, where SDK apps have `type: coreApp`

This will reduce the overall changes, introduced in https://github.com/sanity-io/cli/pull/997, between `feat/workbench` and `main`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes Vite cache directory configuration and renames/validates the core app manifest type; main risk is unintended type/schema mismatch affecting app deploy manifest payloads.
> 
> **Overview**
> **Refactors cache directory configuration** by introducing `SANITY_CACHE_DIR` and updating Vite `cacheDir` usage (including vendor builds and tests) to derive from this shared path.
> 
> **Renames and tightens manifest typing** by replacing `AppManifest` with `CoreAppManifest`, adding a zod-backed `coreAppManifestSchema`, and updating deploy/manifest extraction and deployment API typing to use the new validated manifest payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db625924ba4a181cf0284c8649a9f2e0143a6494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->