### PR TITLE
feat(workbench): print app url

### DIFF
--- a/.changeset/pr-1009.md
+++ b/.changeset/pr-1009.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+print app url

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -63,20 +63,20 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   const addr = server.httpServer?.address()
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
+  // Read the applied host from the Vite dev server's resolved config —
+  // this reflects any user-supplied Vite config that may have overridden
+  // our defaults. `server.host` is `string | boolean | undefined`; non-string
+  // values (true/false/undefined → 0.0.0.0/localhost) aren't useful as a
+  // URL host, so fall back to 'localhost'.
+  const resolvedHost = server.config.server.host
+  const appHost = typeof resolvedHost === 'string' ? resolvedHost : 'localhost'
+
   // Register the studio/app dev server in the registry (federated projects only)
   let cleanupManifest: () => void = syncNoop
   let stopManifestWatcher: () => Promise<void> = noop
   let onSignal: (() => void) | undefined
   if (options.cliConfig?.federation?.enabled) {
     checkForDeprecatedAppId({cliConfig: options.cliConfig, output})
-
-    // Read the applied host from the Vite dev server's resolved config —
-    // this reflects any user-supplied Vite config that may have overridden
-    // our defaults. `server.host` is `string | boolean | undefined`; non-string
-    // values (true/false/undefined → 0.0.0.0/localhost) aren't useful as a
-    // URL host, so fall back to 'localhost'.
-    const resolvedHost = server.config.server.host
-    const appHost = typeof resolvedHost === 'string' ? resolvedHost : 'localhost'
 
     // Register the dev server immediately without a manifest — workbench
     // clients get the application entry first and the manifest follows in
@@ -141,9 +141,8 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   }
 
   if (workbenchAvailable) {
-    const workbenchUrl = `http://${httpHost || 'localhost'}:${workbenchPort}`
     output.log(
-      `Workbench dev server started at ${styleText(['blue', 'underline'], workbenchUrl)} (app on port ${appPort})`,
+      `Application available at ${styleText(['blue', 'underline'], `http://${httpHost || 'localhost'}:${workbenchPort}/local/${appHost}-${appPort}`)}`,
     )
   }
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Instead of printing the URL to the workspace, we now print the URL to the application that has been started. This avoids the surprise that when users click the link they land on the homepage of workbench, rather than the application, which is an extra click:

<img width="763" height="319" alt="Screenshot 2026-04-23 at 15 43 39" src="https://github.com/user-attachments/assets/3ae873d1-e73e-46dd-ae4d-1d60e9d63a56" />

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a CLI log output change (plus moving host resolution so it’s always available), with no impact on server behavior beyond what URL is printed to users.
> 
> **Overview**
> When running `sanity dev` with workbench enabled, the CLI now prints a direct **application URL** (workbench `local` route including `${appHost}-${appPort}`) instead of the generic workbench root URL, reducing the extra click to reach the started app.
> 
> The resolved Vite `host` used to build the app URL is computed unconditionally (not only in federation mode), ensuring consistent URL construction regardless of federation settings, and a changeset bumps `@sanity/cli` with a minor release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f17a3c4f42b07cd1590d74d11b602a6be9542d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->