### PR TITLE
fix(init): respect --project and --dataset flags for app templates

### DIFF
--- a/.changeset/fix-app-quickstart-flags.md
+++ b/.changeset/fix-app-quickstart-flags.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+Respect `--project` and `--dataset` flags for app templates in `init`

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -3,7 +3,6 @@ import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
-import {ORGANIZATIONS_API_VERSION} from '../../../services/organizations.js'
 import {initAction} from '../initAction.js'
 import {InitError} from '../initError.js'
 import {type InitContext, type InitOptions} from '../types.js'
@@ -154,12 +153,6 @@ describe('initAction (direct)', () => {
       name: 'Test User',
       provider: 'google',
     })
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
 
     mockApi({
       apiVersion: PROJECT_FEATURES_API_VERSION,

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -282,15 +282,21 @@ function checkFlagsInUnattendedMode(
 ): void {
   debug('Unattended mode, validating required options')
 
+  if (options.projectName && !options.organization) {
+    throw new InitError('`--project-name` requires `--organization <id>` in unattended mode', 1)
+  }
+
   if (isAppTemplate) {
     if (!options.outputPath) {
       throw new InitError('`--output-path` must be specified in unattended mode', 1)
     }
 
-    if (!options.organization) {
+    const hasProjectFlag = Boolean(options.project || options.projectName)
+
+    if (!hasProjectFlag && !options.organization) {
       throw new InitError(
         'The --organization flag is required for app templates in unattended mode. ' +
-          'Use --organization <id> to specify which organization to use.',
+          'Use --organization <id>, or pass --project <id> / --project-name <name>.',
         1,
       )
     }
@@ -307,10 +313,6 @@ function checkFlagsInUnattendedMode(
       '`--project <id>` or `--project-name <name>` must be specified in unattended mode',
       1,
     )
-  }
-
-  if (options.projectName && !options.organization) {
-    throw new InitError('`--project-name` requires `--organization <id>` in unattended mode', 1)
   }
 }
 

--- a/packages/@sanity/cli/src/actions/init/project/getOrCreateProject.ts
+++ b/packages/@sanity/cli/src/actions/init/project/getOrCreateProject.ts
@@ -28,6 +28,7 @@ export async function getOrCreateProject({
 }): Promise<{
   displayName: string
   isFirstProject: boolean
+  organizationId?: string
   projectId: string
   userAction: 'create' | 'select'
 }> {
@@ -35,15 +36,23 @@ export async function getOrCreateProject({
   let projects
   let organizations: ProjectOrganization[]
 
+  // When a projectId is provided, organizations aren't needed for the fast path, so
+  // skip that request entirely. Only fetch both in parallel when prompting is required.
   try {
-    const [allProjects, allOrgs] = await Promise.all([listProjects(), listOrganizations()])
-    projects = allProjects.toSorted((a, b) => b.createdAt.localeCompare(a.createdAt))
-    organizations = allOrgs
+    if (projectId) {
+      projects = (await listProjects()).toSorted((a, b) => b.createdAt.localeCompare(a.createdAt))
+      organizations = []
+    } else {
+      const [allProjects, allOrgs] = await Promise.all([listProjects(), listOrganizations()])
+      projects = allProjects.toSorted((a, b) => b.createdAt.localeCompare(a.createdAt))
+      organizations = allOrgs
+    }
   } catch (err: unknown) {
     if (unattended && projectId) {
       return {
         displayName: 'Unknown project',
         isFirstProject: false,
+        organizationId: organization,
         projectId,
         userAction: 'select',
       }
@@ -57,8 +66,11 @@ export async function getOrCreateProject({
   }
 
   if (projectId) {
+    // When called after createProjectFromName (--project-name flow), the new project
+    // is expected to appear here since listProjects reads the same user's own projects.
+    // If it doesn't, fail loudly rather than continuing with an "Unknown project" placeholder.
     const proj = projects.find((p) => p.id === projectId)
-    if (!proj && !unattended) {
+    if (!proj) {
       throw new InitError(
         `Given project ID (${projectId}) not found, or you do not have access to it`,
         1,
@@ -66,8 +78,9 @@ export async function getOrCreateProject({
     }
 
     return {
-      displayName: proj ? proj.displayName : 'Unknown project',
+      displayName: proj.displayName,
       isFirstProject: false,
+      organizationId: proj.organizationId ?? undefined,
       projectId,
       userAction: 'select',
     }
@@ -149,9 +162,11 @@ export async function getOrCreateProject({
   }
 
   debug(`Returning selected project (${selected})`)
+  const selectedProject = projects.find((proj) => proj.id === selected)
   return {
-    displayName: projects.find((proj) => proj.id === selected)?.displayName || '',
+    displayName: selectedProject?.displayName || '',
     isFirstProject: isUsersFirstProject,
+    organizationId: selectedProject?.organizationId ?? undefined,
     projectId: selected,
     userAction: 'select',
   }

--- a/packages/@sanity/cli/src/actions/init/project/getProjectDetails.ts
+++ b/packages/@sanity/cli/src/actions/init/project/getProjectDetails.ts
@@ -51,8 +51,9 @@ export async function getProjectDetails({
   schemaUrl?: string
 }> {
   if (isAppTemplate) {
+    const hasProjectFlag = Boolean(project || newProject)
     let appOrganizationId: string | undefined = organization
-    if (!appOrganizationId) {
+    if (!appOrganizationId && !hasProjectFlag) {
       let organizations: ProjectOrganization[]
       try {
         organizations = await listOrganizations()
@@ -70,6 +71,7 @@ export async function getProjectDetails({
     const {
       datasetName: appDatasetName,
       displayName: appDisplayName,
+      organizationId: resolvedOrganizationId,
       projectId: appProjectId,
     } = await promptForAppTemplateSetup({
       coupon,
@@ -91,7 +93,7 @@ export async function getProjectDetails({
       datasetName: appDatasetName,
       displayName: appDisplayName,
       isFirstProject: false,
-      organizationId: appOrganizationId,
+      organizationId: resolvedOrganizationId ?? appOrganizationId,
       projectId: appProjectId,
     }
   }

--- a/packages/@sanity/cli/src/actions/init/project/promptForAppTemplateSetup.ts
+++ b/packages/@sanity/cli/src/actions/init/project/promptForAppTemplateSetup.ts
@@ -37,8 +37,15 @@ export async function promptForAppTemplateSetup({
   unattended: boolean
   user: SanityOrgUser
   visibility: 'private' | 'public' | undefined
-}): Promise<{datasetName: string; displayName: string; projectId: string}> {
-  if (unattended) {
+}): Promise<{
+  datasetName: string
+  displayName: string
+  organizationId?: string
+  projectId: string
+}> {
+  const hasProjectFlag = Boolean(project || newProject)
+
+  if (unattended || hasProjectFlag) {
     if (!project && !newProject) {
       return {datasetName: '', displayName: '', projectId: ''}
     }
@@ -64,6 +71,7 @@ export async function promptForAppTemplateSetup({
     return {
       datasetName: datasetResult.datasetName,
       displayName: projectResult.displayName,
+      organizationId: projectResult.organizationId,
       projectId: projectResult.projectId,
     }
   }
@@ -97,6 +105,7 @@ export async function promptForAppTemplateSetup({
     step: 'configureAppProject',
   })
 
+  const selectedProject = projects.find((p) => p.id === selected)
   const projectResult =
     selected === NEW_PROJECT
       ? await promptForProjectCreation({
@@ -108,7 +117,8 @@ export async function promptForAppTemplateSetup({
           user,
         })
       : {
-          displayName: projects.find((p) => p.id === selected)?.displayName ?? '',
+          displayName: selectedProject?.displayName ?? '',
+          organizationId: selectedProject?.organizationId ?? undefined,
           projectId: selected,
         }
 
@@ -125,6 +135,7 @@ export async function promptForAppTemplateSetup({
   return {
     datasetName: datasetResult.datasetName,
     displayName: projectResult.displayName,
+    organizationId: projectResult.organizationId,
     projectId: projectResult.projectId,
   }
 }

--- a/packages/@sanity/cli/src/actions/init/project/promptForProjectCreation.ts
+++ b/packages/@sanity/cli/src/actions/init/project/promptForProjectCreation.ts
@@ -48,6 +48,7 @@ export async function promptForProjectCreation({
   return {
     ...newProjectResult,
     isFirstProject: isUsersFirstProject,
+    organizationId: org,
     userAction: 'create' as const,
   }
 }

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -3,7 +3,6 @@ import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
-import {ORGANIZATIONS_API_VERSION} from '../../../services/organizations.js'
 import {PROJECTS_API_VERSION} from '../../../services/projects.js'
 import {InitCommand} from '../../init.js'
 
@@ -98,12 +97,6 @@ vi.mock('../../../util/packageManager/installPackages.js', () => ({
 }))
 
 const setupInitSuccessMocks = () => {
-  mockApi({
-    apiVersion: ORGANIZATIONS_API_VERSION,
-    method: 'get',
-    uri: '/organizations',
-  }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
   mockApi({
     apiVersion: PROJECT_FEATURES_API_VERSION,
     method: 'get',

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -113,12 +113,6 @@ vi.mock('../../../actions/init/git.js', () => ({
 
 const setupInitSuccessMocks = () => {
   mockApi({
-    apiVersion: ORGANIZATIONS_API_VERSION,
-    method: 'get',
-    uri: '/organizations',
-  }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-  mockApi({
     apiVersion: PROJECT_FEATURES_API_VERSION,
     method: 'get',
     uri: '/features',

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
@@ -139,12 +139,6 @@ vi.mock('../../../util/packageManager/installPackages.js', () => ({
 
 const setupInitSuccessMocks = () => {
   mockApi({
-    apiVersion: ORGANIZATIONS_API_VERSION,
-    method: 'get',
-    uri: '/organizations',
-  }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-  mockApi({
     apiVersion: PROJECT_FEATURES_API_VERSION,
     method: 'get',
     uri: '/features',
@@ -602,12 +596,6 @@ describe('#init: create new project', () => {
 
   test('initializes studio in unattended mode', async () => {
     mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-    mockApi({
       apiVersion: PROJECTS_API_VERSION,
       method: 'get',
       uri: '/projects/test',
@@ -646,12 +634,6 @@ describe('#init: create new project', () => {
 
   test('--no-git skips git initialization', async () => {
     mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-    mockApi({
       apiVersion: PROJECTS_API_VERSION,
       method: 'get',
       uri: '/projects/test',
@@ -684,12 +666,6 @@ describe('#init: create new project', () => {
   })
 
   test('initializes git by default when --no-git is not passed', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
     mockApi({
       apiVersion: PROJECTS_API_VERSION,
       method: 'get',

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
@@ -180,10 +180,7 @@ describe('#init: get project details', () => {
   })
 
   test('returns `Unknown project` if project/organization call fails and in unattended mode with project id provided', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(500, {message: 'Internal Server Error'})
+    mocks.listProjects.mockRejectedValueOnce(new Error('Internal Server Error'))
 
     setupInitSuccessMocks('test-project-123')
 
@@ -230,11 +227,6 @@ describe('#init: get project details', () => {
   test('throws error if no projects are returned and in unattended mode', async () => {
     mocks.listProjects.mockResolvedValueOnce([])
 
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
-
     const {error} = await testCommand(
       InitCommand,
       ['--yes', '--project=some-project', '--dataset=production', '--output-path=/tmp/test'],
@@ -257,11 +249,6 @@ describe('#init: get project details', () => {
         id: 'project-123',
       },
     ])
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
 
     const {error} = await testCommand(InitCommand, ['--project=non-existent-project'], {
       mocks: {
@@ -531,11 +518,6 @@ describe('#init: get project details', () => {
       },
     ])
 
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
-
     setupInitSuccessMocks('test-project-123')
 
     const {error} = await testCommand(
@@ -557,11 +539,6 @@ describe('#init: get project details', () => {
         id: 'test-project-123',
       },
     ])
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
 
     mocks.listDatasets.mockResolvedValueOnce([])
 
@@ -601,11 +578,6 @@ describe('#init: get project details', () => {
       },
     ])
 
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
-
     mocks.listDatasets.mockResolvedValueOnce([])
 
     mockApi({
@@ -643,11 +615,6 @@ describe('#init: get project details', () => {
         id: 'test-project-123',
       },
     ])
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
 
     mocks.listDatasets.mockResolvedValueOnce([])
 
@@ -687,11 +654,6 @@ describe('#init: get project details', () => {
       },
     ])
 
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
-
     mocks.listDatasets.mockResolvedValueOnce([{aclMode: 'public', name: 'production'}])
 
     mockApi({
@@ -723,11 +685,6 @@ describe('#init: get project details', () => {
         id: 'test-project-123',
       },
     ])
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
 
     mocks.listDatasets.mockResolvedValueOnce([])
 
@@ -771,11 +728,6 @@ describe('#init: get project details', () => {
       },
     ])
 
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
-
     mocks.listDatasets.mockResolvedValueOnce([
       {
         aclMode: 'public',
@@ -813,11 +765,6 @@ describe('#init: get project details', () => {
         id: 'test-project-123',
       },
     ])
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
 
     mocks.listDatasets.mockResolvedValueOnce([])
 
@@ -870,11 +817,6 @@ describe('#init: get project details', () => {
       },
     ])
 
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
-
     mocks.listDatasets.mockResolvedValueOnce([
       {
         aclMode: 'public',
@@ -920,11 +862,6 @@ describe('#init: get project details', () => {
         id: 'test-project-123',
       },
     ])
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [])
 
     mocks.listDatasets.mockResolvedValueOnce([
       {
@@ -1121,15 +1058,10 @@ describe('#init: promptForAppTemplateSetup', () => {
     }).reply(200, {displayName: 'My App Project', projectId: 'new-app-pid-456'})
 
     // promptForAppTemplateSetup (unattended + newProject set) → getOrCreateProject
+    // newProject takes the projectId fast path: listProjects only, no listOrganizations
     mocks.listProjects.mockResolvedValueOnce([
       {createdAt: '2024-01-01T00:00:00Z', displayName: 'My App Project', id: 'new-app-pid-456'},
     ])
-
-    // getOrCreateProject calls listOrganizations (no params) in parallel with listProjects
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-123', name: 'Test Organization', slug: 'test-organization'}])
 
     // getOrCreateDataset (unattended + dataset flag provided → no API needed for dataset)
 
@@ -1232,5 +1164,138 @@ describe('#init: promptForAppTemplateSetup', () => {
     expect(mocks.select).not.toHaveBeenCalled()
     expect(mocks.listProjects).not.toHaveBeenCalled()
     expect(mocks.listDatasets).not.toHaveBeenCalled()
+  })
+
+  test('interactive + --project + --dataset: skips org prompt and "Configure a project" prompt, reuses existing dataset', async () => {
+    mocks.listProjects.mockResolvedValueOnce([
+      {
+        createdAt: '2024-01-01T00:00:00Z',
+        displayName: 'App Project',
+        id: 'existing-app-pid',
+        organizationId: 'org-derived',
+      },
+    ])
+
+    mocks.listDatasets.mockResolvedValueOnce([{aclMode: 'public', name: 'production'}])
+
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      uri: '/features',
+    }).reply(200, ['privateDataset'])
+
+    const {error} = await testCommand(
+      InitCommand,
+      [
+        '--template=app-quickstart',
+        '--project=existing-app-pid',
+        '--dataset=production',
+        '--output-path=./test-project',
+        '--no-typescript',
+        '--no-overwrite-files',
+      ],
+      {
+        mocks: {
+          ...defaultMocks,
+          isInteractive: true,
+        },
+      },
+    )
+
+    if (error) throw error
+
+    // Neither the org prompt nor the "Configure a project for this app?" prompt should fire
+    expect(mocks.select).not.toHaveBeenCalledWith(
+      expect.objectContaining({message: 'Select organization:'}),
+    )
+    expect(mocks.select).not.toHaveBeenCalledWith(
+      expect.objectContaining({message: 'Configure a project for this app?'}),
+    )
+    expect(mocks.createDataset).not.toHaveBeenCalled()
+  })
+
+  test('SDK-1314: unattended + --project + --dataset without --organization succeeds without prompts', async () => {
+    mocks.listProjects.mockResolvedValueOnce([
+      {
+        createdAt: '2024-01-01T00:00:00Z',
+        displayName: 'App Project',
+        id: 'existing-app-pid',
+        organizationId: 'org-derived',
+      },
+    ])
+
+    const {error} = await testCommand(
+      InitCommand,
+      [
+        '--yes',
+        '--template=app-quickstart',
+        '--project=existing-app-pid',
+        '--dataset=production',
+        '--output-path=/tmp/test-app',
+        '--no-typescript',
+        '--no-overwrite-files',
+      ],
+      {
+        mocks: {...defaultMocks},
+      },
+    )
+
+    if (error) throw error
+
+    expect(mocks.select).not.toHaveBeenCalled()
+    expect(mocks.createDataset).not.toHaveBeenCalled()
+  })
+
+  test('unattended + --project=<not-in-list> errors instead of silently falling through', async () => {
+    mocks.listProjects.mockResolvedValueOnce([
+      {
+        createdAt: '2024-01-01T00:00:00Z',
+        displayName: 'Some Other Project',
+        id: 'real-pid',
+        organizationId: 'org-123',
+      },
+    ])
+
+    const {error} = await testCommand(
+      InitCommand,
+      [
+        '--yes',
+        '--template=app-quickstart',
+        '--project=nonexistent-pid',
+        '--dataset=production',
+        '--output-path=/tmp/test-app',
+        '--no-typescript',
+        '--no-overwrite-files',
+      ],
+      {
+        mocks: {...defaultMocks},
+      },
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('nonexistent-pid')
+    expect(error?.message).toContain('not found')
+    expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test('unattended without --project and without --organization: errors with helpful message', async () => {
+    const {error} = await testCommand(
+      InitCommand,
+      [
+        '--yes',
+        '--template=app-quickstart',
+        '--output-path=/tmp/test-app',
+        '--no-typescript',
+        '--no-overwrite-files',
+      ],
+      {
+        mocks: {...defaultMocks},
+      },
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('--organization')
+    expect(error?.message).toContain('--project')
+    expect(error?.oclif?.exit).toBe(1)
   })
 })

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.nextjs.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.nextjs.test.ts
@@ -11,7 +11,6 @@ import {afterEach, describe, expect, test, vi} from 'vitest'
 import {CORS_API_VERSION} from '../../../services/cors.js'
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
 import {MCP_JOURNEY_API_VERSION} from '../../../services/mcp.js'
-import {ORGANIZATIONS_API_VERSION} from '../../../services/organizations.js'
 import {InitCommand} from '../../init.js'
 
 const mocks = vi.hoisted(() => ({
@@ -135,12 +134,6 @@ vi.mock('../../../util/getSanityEnv.js', () => ({
 
 const setupInitSuccessMocks = () => {
   mockApi({
-    apiVersion: ORGANIZATIONS_API_VERSION,
-    method: 'get',
-    uri: '/organizations',
-  }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-  mockApi({
     apiVersion: PROJECT_FEATURES_API_VERSION,
     method: 'get',
     uri: '/features',
@@ -260,13 +253,6 @@ describe('#init:nextjs-app-initialization', () => {
     const cwd = await testFixture('basic-app')
     process.cwd = () => cwd
 
-    // Mock to resolve correctly up to initializing nextjs app
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
     // Mocks for nextjs initialization
     mockApi({
       apiVersion: CORS_API_VERSION,
@@ -342,12 +328,6 @@ describe('#init:nextjs-app-initialization', () => {
 
     const cwd = await testFixture('basic-app')
     process.cwd = () => cwd
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
 
     mockApi({
       apiVersion: CORS_API_VERSION,

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.plan.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.plan.test.ts
@@ -4,7 +4,6 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {INIT_API_VERSION} from '../../../actions/init/constants.js'
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
-import {ORGANIZATIONS_API_VERSION} from '../../../services/organizations.js'
 import {PROJECTS_API_VERSION} from '../../../services/projects.js'
 import {InitCommand} from '../../init.js'
 
@@ -110,12 +109,6 @@ vi.mock('../../../util/packageManager/installPackages.js', () => ({
 }))
 
 const setupInitSuccessMocks = () => {
-  mockApi({
-    apiVersion: ORGANIZATIONS_API_VERSION,
-    method: 'get',
-    uri: '/organizations',
-  }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
   mockApi({
     apiVersion: PROJECT_FEATURES_API_VERSION,
     method: 'get',
@@ -236,12 +229,6 @@ describe('#init: retrieving plan', () => {
     }).reply(404, {message: 'Coupon not found'})
 
     // Mock to resolve rest of command successfully
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
     mockApi({
       apiVersion: PROJECTS_API_VERSION,
       method: 'get',
@@ -387,12 +374,6 @@ describe('#init: retrieving plan', () => {
     }).reply(404, {message: 'Plan not found'})
 
     // Mock to resolve rest of command successfully
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
     mockApi({
       apiVersion: PROJECTS_API_VERSION,
       method: 'get',

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.staging-env.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.staging-env.test.ts
@@ -5,7 +5,6 @@ import {afterEach, describe, expect, test, vi} from 'vitest'
 import {setupMCP} from '../../../actions/mcp/setupMCP.js'
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
 import {MCP_JOURNEY_API_VERSION} from '../../../services/mcp.js'
-import {ORGANIZATIONS_API_VERSION} from '../../../services/organizations.js'
 import {PROJECTS_API_VERSION} from '../../../services/projects.js'
 import {InitCommand} from '../../init.js'
 
@@ -118,12 +117,6 @@ vi.mock('../../../util/getSanityEnv.js', () => ({
 
 const setupInitSuccessMocks = () => {
   mockApi({
-    apiVersion: ORGANIZATIONS_API_VERSION,
-    method: 'get',
-    uri: '/organizations',
-  }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-  mockApi({
     apiVersion: PROJECT_FEATURES_API_VERSION,
     method: 'get',
     uri: '/features',
@@ -169,13 +162,7 @@ describe('#init: staging env propagation', () => {
   test('writes SANITY_INTERNAL_ENV to .env when in staging (--env flag path)', async () => {
     mocks.getSanityEnv.mockReturnValue('staging')
 
-    // The --env flag path exits early, so only organizations and features are needed
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
+    // The --env flag path exits early, so only features are needed
     mockApi({
       apiVersion: PROJECT_FEATURES_API_VERSION,
       method: 'get',


### PR DESCRIPTION
### Description                                                                                                                                                   
                                                                                                                                                                    
  Fixes SDK-1314
                                                                                                                                                                    
  Previously, running `sanity init --template app-quickstart --project <id> --dataset <name>` still prompted the user to select an organization and showed a        
  redundant "Configure a project for this app?" prompt. Unattended mode (`--yes`) also required `--organization` even when `--project` already supplied enough      
  context to derive it.                                                                                                                                             
                                                                                                                                                                    
  **The fix:**                           

  - `promptForAppTemplateSetup` now takes a flag-driven path whenever `--project` or `--project-name` is provided — in both interactive and unattended modes. This  
  matches the behavior of the non-app template flow and stops the spurious "Configure a project for this app?" prompt.
  - `getProjectDetails` no longer prompts for the organization when `--project`/`--project-name` is provided for app templates — the org is derived from the        
  resolved project instead.                                                                                                                                         
  - `getOrCreateProject` and `promptForProjectCreation` now return `organizationId` so callers can propagate it.
  - `checkFlagsInUnattendedMode` relaxes the `--organization` requirement for app templates when `--project`/`--project-name` provides enough context (still        
  required for `--project-name` since creation needs it).                                                                                                           
  - Tightens `getOrCreateProject`: an explicit `--project=<not-in-list>` now errors in unattended mode too, instead of silently proceeding with a bogus projectId.  
  The separate API-failure catch block still handles transient failures.                                                                                            
                                                                                  
  ### What to review                                                                                                                                                
                                                                                  
  - `packages/@sanity/cli/src/actions/init/project/getOrCreateProject.ts` — the removed `!unattended` guard on the project-not-found branch, plus the               
  `organizationId` now threaded through all return sites.                         
  - `packages/@sanity/cli/src/actions/init/project/getProjectDetails.ts` — the `hasProjectFlag` gate that skips `promptUserForOrganization` and derives the org from
   the resolved project.                                                                                                                                            
  - `packages/@sanity/cli/src/actions/init/project/promptForAppTemplateSetup.ts` — the flag-driven early path now triggers in interactive mode too.
  - `packages/@sanity/cli/src/actions/init/initAction.ts` — the relaxed `checkFlagsInUnattendedMode` for app templates.                                             
  - Confirm the UX: we silently use the project's org rather than asking the user to confirm it when `--project` is set.                                            
                                                                                                                                                                    
  ### Testing                                                                                                                                                       
                                                                                                                                                                    
  Four new tests added in `init.get-project-details.test.ts`:                                                                                                       
                                         
  1. **Interactive + `--project` + `--dataset`** — neither the org selection nor the "Configure a project" prompt fires; existing dataset is reused.                
  2. **SDK-1314 reproducer: unattended + `--project` + `--dataset` without `--organization`** — succeeds with no prompts, org derived from the project.
  3. **Unattended + `--project=<not-in-list>`** — errors with "not found" instead of silently proceeding.                                                           
  4. **Unattended without `--project` nor `--organization`** — still errors, with an updated message mentioning `--project` / `--project-name` as alternatives.     
                                                                                                                                                                    
  `pnpm check:types`, `pnpm check:lint`, and the full init test suite (106 tests) all pass. Manual testing against a real project would be appreciated before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes init’s app-template flag handling and unattended validation, which can affect CLI UX and CI/bootstrap flows; mis-threading `organizationId` or the new project fast path could cause init failures for some flag combinations.
> 
> **Overview**
> Fixes `sanity init` for app templates so `--project`/`--project-name` and `--dataset` drive a **no-prompt** setup path (interactive and unattended), skipping organization selection and the redundant “Configure a project for this app?” prompt.
> 
> Threads `organizationId` through project selection/creation (`getOrCreateProject`, `promptForProjectCreation`, `promptForAppTemplateSetup`) so app-template init can derive the org from the resolved project, and tightens behavior to **error** when an explicit `--project` is not found (instead of silently continuing).
> 
> Relaxes unattended app-template requirements to allow `--project` without `--organization` (while still requiring `--organization` for `--project-name`), and updates/extends tests accordingly while removing now-unneeded `/organizations` mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 286402ca372462c29641b85b3f0065daa34a6813. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->