### PR TITLE
ci: fix changelog path in changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
-    "./.changeset/changelog.mjs",
+    "./changelog.mjs",
     {
       "repo": "sanity-io/cli"
     }


### PR DESCRIPTION
### Description

The Release workflow on `main` has been failing since #994 with:

```
🦋  error Error: Cannot find module './.changeset/changelog.mjs'
```

([failed run](https://github.com/sanity-io/cli/actions/runs/24898596602/job/72909977161))

`@changesets/apply-release-plan` resolves `config.changelog[0]` relative to the `.changeset/` directory via `resolveFrom(cwd + '/.changeset', path)`. The path `./.changeset/changelog.mjs` therefore resolved to `.changeset/.changeset/changelog.mjs` — which does not exist — and the version step failed with `MODULE_NOT_FOUND`.

Fix: change the path to `./changelog.mjs` so it resolves correctly relative to `.changeset/`.

### What to review

- Single-line change to `.changeset/config.json`.
- The resolution behavior is in `@changesets/apply-release-plan/dist/changesets-apply-release-plan.cjs.js` around line 396–401.

### Testing

Verified directly with `resolve-from`:

```
new: /…/cli/.changeset/changelog.mjs
old FAILED: MODULE_NOT_FOUND
```

The old path reproduces the CI error exactly; the new path resolves the file. The next Release workflow run on `main` after merge will exercise the full path end-to-end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single configuration-path change that only affects release/changelog generation in CI.
> 
> **Overview**
> Fixes the Changesets release workflow by correcting the `changelog` module path in `.changeset/config.json` from `./.changeset/changelog.mjs` to `./changelog.mjs`, ensuring it resolves relative to the `.changeset/` directory during versioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7daebf0d43706b062c66f6c46dde589acd10dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->