### PR TITLE
ci: keep version heading matchable for changesets PR body

### DIFF
--- a/.changeset/postversion.mjs
+++ b/.changeset/postversion.mjs
@@ -120,7 +120,7 @@ function transformChangelog(content, packageName, currentVersion) {
 
   section = section.replace(
     `## ${currentVersion}`,
-    `## [${currentVersion}](${compareUrl}) (${today})`,
+    `## [${currentVersion}](${compareUrl})\n\n_${today}_`,
   )
 
   for (const [from, to] of Object.entries(SECTION_MAP)) {


### PR DESCRIPTION
### Description

The Changesets release PR (#1003) was shipping with empty per-package content and a `content exceeds size limit` note in its body, even though the actual changelog entries are small.

Root cause: `.changeset/postversion.mjs` was rewriting each version heading from `## 6.4.1` to `## [6.4.1](compare-url) (2026-04-24)`. `changesets/action` builds the PR body by calling `getChangelogEntry(contents, version)` from `@changesets/release-utils`, which walks the markdown AST and does a **strict string equality** check:

```js
if (mdastToString(node) === version) { /* found it */ }
```

The rewritten heading stringifies to `6.4.1 (2026-04-24)`, not `6.4.1`, so extraction falls through. The action then ends up treating the entire `CHANGELOG.md` (~61KB for `@sanity/cli`) as the entry content, which trips the default `prBodyMaxCharacters = 60_000` and produces the truncated "omitted" body.

Fix: keep the link-wrapped version as the heading (`## [6.4.1](compare-url)`, which stringifies to just `6.4.1`) and move the release date to a sub-line underneath. No changes to the workflow or to `changeset version` invocation.

### What to review

- `.changeset/postversion.mjs:121-124` — new heading shape:
  ```
  ## [6.4.1](https://github.com/sanity-io/cli/compare/cli-v6.4.0...cli-v6.4.1)

  _2026-04-24_
  ```
- Downstream `### Bug Fixes` / `### Features` / `### Dependencies` section rewrites are unchanged.

### Testing

Verified end-to-end locally:

1. Reconstructed the pre-transform `packages/@sanity/cli/CHANGELOG.md` (`## 6.4.1` / `### Patch Changes`).
2. Ran the updated `postversion.mjs` against it — produced the new heading shape.
3. Fed the transformed file to `@changesets/release-utils`' `getChangelogEntry(contents, '6.4.1')` — it returned the correct Bug Fixes section (previously returned empty / whole-file).

Minor: `highestLevel` comes back as `dep` (the `/(major|minor|patch)/` regex no longer matches `### Bug Fixes`). This is cosmetic only — `changesets/action` uses it purely for ordering packages within the PR body; it does not gate publish or content inclusion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts changelog post-processing used in release automation; a small formatting change but it can affect Changesets PR body extraction and release tooling output.
> 
> **Overview**
> Updates `.changeset/postversion.mjs` to change how version headings are rewritten in generated `CHANGELOG.md` entries: the version stays as a link-only heading (`## [x.y.z](compare-url)`) and the release date is moved to a separate italic line below.
> 
> This keeps the heading text equal to the raw version so `changesets/action` can correctly extract per-version changelog entries instead of falling back to large, truncated PR bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ad1574bb86fb85f63f85d6128815d321f770edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->