### PR TITLE
chore: remove extra blank lines between changelog bullet points

### DIFF
--- a/.changeset/changelog.mjs
+++ b/.changeset/changelog.mjs
@@ -62,9 +62,9 @@ async function getReleaseLine(changeset, _type, options) {
 
   const formatted = `${scopePrefix}${firstLine}${prLink}${commitLink}`
   if (restLines.length > 0) {
-    return `\n- ${formatted}\n${restLines.map((l) => (l ? '  ' + l : l)).join('\n')}`
+    return `- ${formatted}\n${restLines.map((l) => (l ? '  ' + l : l)).join('\n')}`
   }
-  return `\n- ${formatted}`
+  return `- ${formatted}`
 }
 
 async function getDependencyReleaseLine(_changesets, dependenciesUpdated, _options) {


### PR DESCRIPTION
### Description

Remove unnecessary blank lines between bullet points in generated changelogs.

The `getReleaseLine()` function in `.changeset/changelog.mjs` prefixed each bullet with `\n`, which created blank lines between bullets when the changesets library joined them with `"\n"`. This resulted in changelog entries like:

```markdown
### Bug Fixes

- first fix

- second fix

- third fix
```

Instead of:

```markdown
### Bug Fixes

- first fix
- second fix
- third fix
```

### What to review

The change is in `.changeset/changelog.mjs` — the leading `\n` is removed from both return paths in `getReleaseLine()`. The changesets library already joins release lines with `"\n"` and provides `\n\n` after section headings, so the extra newline was redundant.

### Testing

This is a formatting-only change to the changelog generator. The next `changeset version` run will produce changelogs without the extra spacing between bullets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk formatting-only change that affects how release notes are rendered, with no runtime or data/security impact beyond changelog output.
> 
> **Overview**
> Removes the leading newline prefix from `.changeset/changelog.mjs` `getReleaseLine()` so each changeset entry renders as a contiguous `-` bullet when the changesets tool joins lines.
> 
> This eliminates extra blank lines between changelog bullets (including the multi-line bullet case) without changing the actual content of the messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 083290fecf69ab757421d8e37a7c9a352729c857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->