### PR TITLE
ci: remove post-release e2e test trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  actions: write # for gh workflow run in post-release
   contents: write # for version bump commits and tags
   pull-requests: write # for creating Version Packages PR
   id-token: write # to enable use of OIDC for npm provenance
@@ -106,16 +105,3 @@ jobs:
           repository_name: ${{ github.event.repository.name }}
           initial_state_id: 'c56956cd-c281-4ca5-889f-6189ce231a6d'
           done_state_id: '5a35b7bf-6d37-4cc2-854a-2f18d160e2e5'
-
-      - name: Trigger post-release E2E tests
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PUBLISHED_PACKAGES: ${{ needs.release.outputs.publishedPackages }}
-        run: |
-          HAS_CLI=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | select(.name == "@sanity/cli") | .name')
-          if [ -n "$HAS_CLI" ]; then
-            echo "Triggering E2E tests for latest sanity"
-            gh workflow run e2e-scheduled.yml -f cli_version="latest"
-          else
-            echo "No @sanity/cli in published packages, skipping E2E"
-          fi


### PR DESCRIPTION
### Description

Removes the post-release step in `release.yml` that triggers `e2e-scheduled.yml` after publishing.

The hourly scheduled E2E workflow already runs against `sanity@latest`, so it will catch any post-release breakage on the next cron tick. Triggering it immediately after publish is also unreliable — npm cache propagation means the just-published version isn't always served by `npm install sanity@latest` for a short window, so the immediate run can fail or test the previous version.

Also drops the now-unused `actions: write` permission that was only needed for `gh workflow run`.

### What to review

- `.github/workflows/release.yml` — `post-release` job no longer dispatches `e2e-scheduled.yml`, and the workflow's `actions: write` permission is removed.

### Testing

CI-only change. The hourly `e2e-scheduled.yml` cron continues to provide coverage of the published CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that removes an automated workflow dispatch and reduces required GitHub Actions permissions; the main impact is losing immediate post-release E2E coverage.
> 
> **Overview**
> Stops the release workflow from dispatching `e2e-scheduled.yml` after publishing by removing the post-release E2E trigger step.
> 
> Also drops the workflow-level `actions: write` permission that was only required to run `gh workflow run`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa2919a354b822d060e5304da323afa039ecf6dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->