### PR TITLE
fix(workbench): watch for changes of the cli config file

### DIFF
--- a/.changeset/pr-1022.md
+++ b/.changeset/pr-1022.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': patch
+'@sanity/cli': patch
+---
+
+watch for changes of the cli config file

--- a/packages/@sanity/cli-core/src/config/cli/getCliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/getCliConfig.ts
@@ -1,3 +1,5 @@
+import {createRequire} from 'node:module'
+
 import {debug} from '../../debug.js'
 import {NotFoundError} from '../../errors/NotFoundError.js'
 import {importModule} from '../../util/importModule.js'
@@ -18,6 +20,10 @@ const cache = new Map<string, Promise<CliConfig>>()
  *
  * If loading fails the cached promise is evicted so the next call retries.
  *
+ * Long-lived processes that need to observe edits to `sanity.cli.(ts|js)`
+ * (e.g. a dev-server watcher) should use {@link getCliConfigUncached}
+ * instead — it bypasses both this in-memory cache and Node's module cache.
+ *
  * @param rootPath - Root path for the project, eg where `sanity.cli.(ts|js)` is located.
  * @returns The CLI config
  * @internal
@@ -28,7 +34,7 @@ export function getCliConfig(rootPath: string): Promise<CliConfig> {
     return cached
   }
 
-  const promise = loadCliConfig(rootPath).catch((err) => {
+  const promise = getCliConfigUncached(rootPath).catch((err) => {
     cache.delete(rootPath)
     throw err
   })
@@ -37,7 +43,23 @@ export function getCliConfig(rootPath: string): Promise<CliConfig> {
   return promise
 }
 
-async function loadCliConfig(rootPath: string): Promise<CliConfig> {
+/**
+ * Read the CLI config for a project from disk, bypassing both the
+ * `getCliConfig` in-memory cache and Node's module cache. Each call locates
+ * `sanity.cli.(ts|js)`, drops any prior jiti compilation from `require.cache`,
+ * re-imports, and re-validates.
+ *
+ * Use this when the config file is expected to change during the process's
+ * lifetime — typically a dev-server watcher that needs the new values picked
+ * up after each save. One-shot CLI invocations should prefer
+ * {@link getCliConfig} so the prerun hook, SanityCommand helpers, and action
+ * files share a single load.
+ *
+ * @param rootPath - Root path for the project, eg where `sanity.cli.(ts|js)` is located.
+ * @returns The freshly loaded CLI config
+ * @internal
+ */
+export async function getCliConfigUncached(rootPath: string): Promise<CliConfig> {
   const paths = await findPathForFiles(rootPath, ['sanity.cli.ts', 'sanity.cli.js'])
   const configPaths = paths.filter((path) => path.exists)
 
@@ -54,6 +76,13 @@ async function loadCliConfig(rootPath: string): Promise<CliConfig> {
   const configPath = configPaths[0].path
 
   debug(`Loading CLI config from: ${configPath}`)
+
+  // Drop any cached compilation of this file from Node's CJS module cache
+  // (jiti compiles `sanity.cli.ts` to CJS and registers it via `require.cache`).
+  // Without this, repeated calls would receive the previously imported module
+  // even though the file on disk has changed. No-op on first load.
+  const cjsRequire = createRequire(import.meta.url)
+  delete cjsRequire.cache[configPath]
 
   let cliConfig: CliConfig | undefined
   try {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -9,6 +9,7 @@ const mockStartStudioDevServer = vi.hoisted(() => vi.fn())
 const mockRegisterDevServer = vi.hoisted(() => vi.fn())
 const mockStartDevManifestWatcher = vi.hoisted(() => vi.fn())
 const mockExtractCoreAppManifest = vi.hoisted(() => vi.fn())
+const mockExtractStudioManifest = vi.hoisted(() => vi.fn())
 
 vi.mock('../startWorkbenchDevServer.js', () => ({
   startWorkbenchDevServer: mockStartWorkbenchDevServer,
@@ -27,6 +28,9 @@ vi.mock('../startDevManifestWatcher.js', () => ({
 }))
 vi.mock('../../manifest/extractCoreAppManifest.js', () => ({
   extractCoreAppManifest: mockExtractCoreAppManifest,
+}))
+vi.mock('../extractDevServerManifest.js', () => ({
+  extractStudioManifest: mockExtractStudioManifest,
 }))
 
 /** Create a mock Vite dev server config shape — `server.config.server.host`
@@ -326,7 +330,7 @@ describe('devAction', () => {
       )
     })
 
-    test('does not start the manifest watcher for core apps — they have no schema to keep in sync', async () => {
+    test('starts the manifest watcher for core apps — keeps title/icon in sync with sanity.cli.ts', async () => {
       mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       await devAction(
@@ -337,13 +341,13 @@ describe('devAction', () => {
       )
 
       expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({type: 'coreApp'}))
-      expect(mockStartDevManifestWatcher).not.toHaveBeenCalled()
+      expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
+        expect.objectContaining({extract: expect.any(Function), workDir: '/tmp/sanity-project'}),
+      )
     })
 
     test('registers the core-app immediately with no manifest — startup is not blocked on extraction', async () => {
       mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
-      // Never resolves — simulates a slow extraction. devAction must still return.
-      mockExtractCoreAppManifest.mockReturnValue(new Promise(() => {}))
 
       await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true}))
 
@@ -352,45 +356,32 @@ describe('devAction', () => {
       )
     })
 
-    test('patches the registry with the core-app manifest once extraction completes', async () => {
+    test('wires extractCoreAppManifest into the core-app watcher', async () => {
       const appManifest = {icon: '<svg><path d="M0 0"/></svg>', title: 'My App', version: '1'}
-      const mockUpdate = vi.fn()
-      mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: mockUpdate})
       mockExtractCoreAppManifest.mockResolvedValue(appManifest)
       mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true}))
 
-      await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+      const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
+      // The watcher invokes `extract` with the resolved configPath; the
+      // core-app extractor reads `sanity.cli.ts` via `getCliConfigUncached(workDir)`,
+      // so only `workDir` is forwarded.
+      await expect(
+        extract({configPath: '/tmp/sanity-project/sanity.cli.ts', workDir: '/tmp/sanity-project'}),
+      ).resolves.toEqual(appManifest)
       expect(mockExtractCoreAppManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
-      expect(mockUpdate).toHaveBeenCalledWith({
-        manifest: appManifest,
-        manifestUpdatedAt: expect.any(String),
-      })
     })
 
-    test('warns and does not patch the registry when core-app extraction fails', async () => {
-      mockExtractCoreAppManifest.mockRejectedValue(new Error('bad config'))
-      const mockUpdate = vi.fn()
-      mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: mockUpdate})
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
-      const output = createMockOutput()
-
-      await devAction(
-        createDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true, output}),
-      )
-
-      await vi.waitFor(() => expect(output.warn).toHaveBeenCalled())
-      expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('bad config'))
-      expect(mockUpdate).not.toHaveBeenCalled()
-    })
-
-    test('does not extract the core-app manifest for studios', async () => {
+    test('wires extractStudioManifest into the studio watcher', async () => {
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
 
-      expect(mockExtractCoreAppManifest).not.toHaveBeenCalled()
+      const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
+      // The studio extractor is passed by reference — the watcher's
+      // `{configPath, workDir}` arg is forwarded as-is.
+      expect(extract).toBe(mockExtractStudioManifest)
     })
 
     test('registers the studio immediately with no manifest — the watcher owns extraction', async () => {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -1,17 +1,12 @@
 import {EventEmitter} from 'node:events'
 
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, type Mock, test, vi} from 'vitest'
 
 import {startDevManifestWatcher} from '../startDevManifestWatcher.js'
 import {createMockOutput} from './testHelpers.js'
 
-const mockExtractStudioManifest = vi.hoisted(() => vi.fn())
 const mockFindProjectRoot = vi.hoisted(() => vi.fn())
 const mockFsWatch = vi.hoisted(() => vi.fn())
-
-vi.mock('../extractDevServerManifest.js', () => ({
-  extractStudioManifest: mockExtractStudioManifest,
-}))
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
@@ -49,16 +44,17 @@ const STUDIO_CONFIG_PATH = '/tmp/studio/sanity.config.ts'
 
 describe('startDevManifestWatcher', () => {
   let fakeWatcher: FakeFsWatcher
+  let mockExtract: Mock<(params: {configPath: string; workDir: string}) => Promise<unknown>>
   const studioManifest = {createdAt: '2026-01-01', version: 3, workspaces: []}
 
   beforeEach(() => {
     fakeWatcher = new FakeFsWatcher()
+    mockExtract = vi.fn(async () => studioManifest)
     mockFindProjectRoot.mockResolvedValue({
       directory: WORK_DIR,
       path: STUDIO_CONFIG_PATH,
       type: 'studio',
     })
-    mockExtractStudioManifest.mockResolvedValue(studioManifest)
     mockFsWatch.mockImplementation((_dir: string, listener: FakeFsWatcher['handler']) => {
       fakeWatcher.handler = listener
       return fakeWatcher
@@ -75,6 +71,7 @@ describe('startDevManifestWatcher', () => {
     const update = vi.fn()
 
     const watcher = await startDevManifestWatcher({
+      extract: mockExtract,
       output: createMockOutput(),
       update,
       workDir: WORK_DIR,
@@ -84,8 +81,8 @@ describe('startDevManifestWatcher', () => {
     // has time to resolve and patch the registry.
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
-    expect(mockExtractStudioManifest).toHaveBeenCalledWith({
+    expect(mockExtract).toHaveBeenCalledTimes(1)
+    expect(mockExtract).toHaveBeenCalledWith({
       configPath: STUDIO_CONFIG_PATH,
       workDir: WORK_DIR,
     })
@@ -102,7 +99,7 @@ describe('startDevManifestWatcher', () => {
     // user editing sanity.config.ts while the worker is still producing the
     // initial manifest — the watcher must not run a parallel extraction.
     let resolveFirst: ((value: typeof studioManifest) => void) | undefined
-    mockExtractStudioManifest
+    mockExtract
       .mockReturnValueOnce(
         new Promise((resolve) => {
           resolveFirst = resolve
@@ -112,6 +109,7 @@ describe('startDevManifestWatcher', () => {
 
     const update = vi.fn()
     const watcher = await startDevManifestWatcher({
+      extract: mockExtract,
       output: createMockOutput(),
       update,
       workDir: WORK_DIR,
@@ -122,14 +120,14 @@ describe('startDevManifestWatcher', () => {
     await vi.advanceTimersByTimeAsync(300)
 
     // Only the initial extraction is running — the config change is pending.
-    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+    expect(mockExtract).toHaveBeenCalledTimes(1)
 
     // Release the initial extraction; the pending change-triggered run now
     // starts, serialized behind it.
     resolveFirst!(studioManifest)
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(2)
+    expect(mockExtract).toHaveBeenCalledTimes(2)
     expect(update).toHaveBeenCalledTimes(2)
 
     await watcher.close()
@@ -138,6 +136,7 @@ describe('startDevManifestWatcher', () => {
   test('re-extracts and inlines the new manifest after a debounced config file change', async () => {
     const update = vi.fn()
     const watcher = await startDevManifestWatcher({
+      extract: mockExtract,
       output: createMockOutput(),
       update,
       workDir: WORK_DIR,
@@ -146,7 +145,7 @@ describe('startDevManifestWatcher', () => {
     // Wait for the initial extraction to complete before exercising the
     // file-change path.
     await vi.advanceTimersByTimeAsync(0)
-    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+    expect(mockExtract).toHaveBeenCalledTimes(1)
 
     // Fire multiple rapid "change" events — should coalesce into a single
     // regeneration after the debounce window.
@@ -156,7 +155,7 @@ describe('startDevManifestWatcher', () => {
 
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(2)
+    expect(mockExtract).toHaveBeenCalledTimes(2)
     expect(update).toHaveBeenCalledTimes(2)
 
     await watcher.close()
@@ -165,20 +164,21 @@ describe('startDevManifestWatcher', () => {
   test('ignores changes to other files in the config directory', async () => {
     const update = vi.fn()
     const watcher = await startDevManifestWatcher({
+      extract: mockExtract,
       output: createMockOutput(),
       update,
       workDir: WORK_DIR,
     })
 
     await vi.advanceTimersByTimeAsync(0)
-    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+    expect(mockExtract).toHaveBeenCalledTimes(1)
 
     fakeWatcher.emitChange('unrelated.ts')
     fakeWatcher.emitChange('package.json')
 
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+    expect(mockExtract).toHaveBeenCalledTimes(1)
 
     await watcher.close()
   })
@@ -186,11 +186,14 @@ describe('startDevManifestWatcher', () => {
   test('logs a warning and keeps running when extraction fails', async () => {
     const output = createMockOutput()
     const update = vi.fn()
-    mockExtractStudioManifest
-      .mockRejectedValueOnce(new Error('bad schema'))
-      .mockResolvedValueOnce(studioManifest)
+    mockExtract.mockRejectedValueOnce(new Error('bad schema')).mockResolvedValueOnce(studioManifest)
 
-    const watcher = await startDevManifestWatcher({output, update, workDir: WORK_DIR})
+    const watcher = await startDevManifestWatcher({
+      extract: mockExtract,
+      output,
+      update,
+      workDir: WORK_DIR,
+    })
 
     // The initial extraction fails.
     await vi.advanceTimersByTimeAsync(0)
@@ -208,13 +211,14 @@ describe('startDevManifestWatcher', () => {
   test('stops regenerating after close', async () => {
     const update = vi.fn()
     const watcher = await startDevManifestWatcher({
+      extract: mockExtract,
       output: createMockOutput(),
       update,
       workDir: WORK_DIR,
     })
 
     await vi.advanceTimersByTimeAsync(0)
-    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+    expect(mockExtract).toHaveBeenCalledTimes(1)
 
     await watcher.close()
     expect(fakeWatcher.closed).toBe(true)
@@ -222,6 +226,48 @@ describe('startDevManifestWatcher', () => {
     fakeWatcher.emitChange('sanity.config.ts')
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(mockExtractStudioManifest).toHaveBeenCalledTimes(1)
+    expect(mockExtract).toHaveBeenCalledTimes(1)
+  })
+
+  test('watches sanity.cli.ts for app projects', async () => {
+    const APP_WORK_DIR = '/tmp/sdk-app'
+    const APP_CONFIG_PATH = '/tmp/sdk-app/sanity.cli.ts'
+    const appManifest = {icon: '<svg/>', title: 'My App', version: '1'}
+    mockFindProjectRoot.mockResolvedValue({
+      directory: APP_WORK_DIR,
+      path: APP_CONFIG_PATH,
+      type: 'app',
+    })
+    mockExtract.mockResolvedValue(appManifest)
+    const update = vi.fn()
+
+    const watcher = await startDevManifestWatcher({
+      extract: mockExtract,
+      output: createMockOutput(),
+      update,
+      workDir: APP_WORK_DIR,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockExtract).toHaveBeenCalledWith({
+      configPath: APP_CONFIG_PATH,
+      workDir: APP_WORK_DIR,
+    })
+    expect(update).toHaveBeenCalledWith({
+      manifest: appManifest,
+      manifestUpdatedAt: expect.any(String),
+    })
+
+    // sanity.config.ts is not the app's config — should be ignored.
+    fakeWatcher.emitChange('sanity.config.ts')
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockExtract).toHaveBeenCalledTimes(1)
+
+    // sanity.cli.ts saves trigger regeneration.
+    fakeWatcher.emitChange('sanity.cli.ts')
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockExtract).toHaveBeenCalledTimes(2)
+
+    await watcher.close()
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -3,6 +3,7 @@ import {styleText} from 'node:util'
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
 import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
 import {registerDevServer} from './devServerRegistry.js'
+import {extractStudioManifest} from './extractDevServerManifest.js'
 import {startAppDevServer} from './startAppDevServer.js'
 import {startDevManifestWatcher} from './startDevManifestWatcher.js'
 import {startStudioDevServer} from './startStudioDevServer.js'
@@ -92,34 +93,21 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     })
     cleanupManifest = registration.release
 
-    if (options.isApp) {
-      // Core-apps have no schema to watch and no shared output directory
-      // with any other caller, so run the extraction fire-and-forget. On
-      // success the registry entry is patched, which fires the workbench's
-      // registry watcher and triggers a rebroadcast to connected clients.
-      // Updates after `release()` are no-ops (see `registerDevServer`).
-      void (async () => {
-        try {
-          const manifest = await extractCoreAppManifest({workDir: options.workDir})
-          registration.update({manifest, manifestUpdatedAt: new Date().toISOString()})
-        } catch (err) {
-          output.warn(
-            `Could not extract manifest for workbench: ${err instanceof Error ? err.message : String(err)}`,
-          )
-        }
-      })()
-    } else {
-      // For studios, the watcher owns both the initial extraction and the
-      // follow-up regenerations triggered by `sanity.config.ts` changes.
-      // Serializing both through `regenerate` inside the watcher prevents
-      // concurrent worker runs from racing on the manifest output directory.
-      const watcher = await startDevManifestWatcher({
-        output,
-        update: registration.update,
-        workDir: options.workDir,
-      })
-      stopManifestWatcher = watcher.close
-    }
+    // The watcher owns both the initial extraction and the follow-up
+    // regenerations triggered by config-file changes (`sanity.config.ts`
+    // for studios, `sanity.cli.ts` for core-apps). Serializing both
+    // through `regenerate` inside the watcher prevents concurrent worker
+    // runs from racing on the manifest output directory (studio path) and
+    // keeps the `update` callback ordered for both.
+    const watcher = await startDevManifestWatcher({
+      extract: options.isApp
+        ? ({workDir}) => extractCoreAppManifest({workDir})
+        : extractStudioManifest,
+      output,
+      update: registration.update,
+      workDir: options.workDir,
+    })
+    stopManifestWatcher = watcher.close
 
     // Ensure manifest and workbench lock are cleaned up on abrupt shutdown.
     // closeWorkbenchServer() starts with synchronous calls (watcher.close,

--- a/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
@@ -3,9 +3,7 @@ import {basename, dirname} from 'node:path'
 
 import {findProjectRoot, type Output} from '@sanity/cli-core'
 
-import {type StudioManifest} from '../manifest/types.js'
 import {devDebug} from './devDebug.js'
-import {extractStudioManifest} from './extractDevServerManifest.js'
 
 /**
  * Debounce window between config file events and the next manifest
@@ -19,37 +17,45 @@ interface DevManifestWatcher {
 }
 
 /** Subset of registry fields the watcher is allowed to update. */
-interface ManifestPatch {
-  manifest: StudioManifest | undefined
+interface ManifestPatch<T> {
+  manifest: T | undefined
   manifestUpdatedAt: string
 }
 
-interface StartDevManifestWatcherOptions {
+interface StartDevManifestWatcherOptions<T> {
+  /**
+   * Run the project-specific manifest extraction and resolve to the inlined
+   * manifest. Receives the resolved config path (e.g. `sanity.config.ts` for
+   * studios, `sanity.cli.ts` for core-apps) and the working directory.
+   */
+  extract: (params: {configPath: string; workDir: string}) => Promise<T | undefined>
   output: Output
   /** Called after every successful extraction with the inlined manifest. */
-  update: (patch: ManifestPatch) => void
+  update: (patch: ManifestPatch<T>) => void
   workDir: string
 }
 
 /**
- * Generate the studio manifest once and then keep it in sync with the
- * `sanity.config.(ts|js)` file on disk. The initial generation runs
+ * Generate the project manifest once and then keep it in sync with the
+ * project's config file (`sanity.config.(ts|js)` for studios,
+ * `sanity.cli.(ts|js)` for core-apps) on disk. The initial generation runs
  * fire-and-forget so it doesn't block dev-server startup; subsequent
  * file-system events are coalesced behind it via `running`/`pending`, so
- * the single-serializer guarantees there are no overlapping writes to the
- * manifest output directory. Each successful regeneration inlines the new
- * manifest into the registry via the `update` callback, so any running
- * workbench rebroadcasts to its clients.
+ * the single-serializer guarantees there are no overlapping writes to any
+ * shared output directory used by the extractor. Each successful
+ * regeneration inlines the new manifest into the registry via the `update`
+ * callback, so any running workbench rebroadcasts to its clients.
  *
  * Errors during extraction are logged as warnings and do not crash the dev
  * server — the previously extracted manifest (if any) stays in the
  * registry.
  */
-export async function startDevManifestWatcher({
+export async function startDevManifestWatcher<T>({
+  extract,
   output,
   update,
   workDir,
-}: StartDevManifestWatcherOptions): Promise<DevManifestWatcher> {
+}: StartDevManifestWatcherOptions<T>): Promise<DevManifestWatcher> {
   const projectRoot = await findProjectRoot(workDir)
   const configPath = projectRoot.path
 
@@ -65,7 +71,7 @@ export async function startDevManifestWatcher({
     }
     running = true
     try {
-      const manifest = await extractStudioManifest({configPath, workDir})
+      const manifest = await extract({configPath, workDir})
       if (closed) return
       update({manifest, manifestUpdatedAt: new Date().toISOString()})
     } catch (err) {
@@ -113,9 +119,7 @@ export async function startDevManifestWatcher({
 
   watcher.on('error', (err) => {
     devDebug('Config watcher error: %O', err)
-    output.warn(
-      `Studio manifest watcher error: ${err instanceof Error ? err.message : String(err)}`,
-    )
+    output.warn(`Manifest watcher error: ${err instanceof Error ? err.message : String(err)}`)
   })
 
   return {

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -1,6 +1,6 @@
 import {readFile} from 'node:fs/promises'
 
-import {getCliConfig} from '@sanity/cli-core'
+import {getCliConfigUncached} from '@sanity/cli-core'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {extractCoreAppManifest} from '../extractCoreAppManifest.js'
@@ -9,7 +9,7 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
   return {
     ...actual,
-    getCliConfig: vi.fn(),
+    getCliConfigUncached: vi.fn(),
   }
 })
 
@@ -25,7 +25,7 @@ vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
   }
 })
 
-const mockGetCliConfig = vi.mocked(getCliConfig)
+const mockGetCliConfig = vi.mocked(getCliConfigUncached)
 const mockReadFile = vi.mocked(readFile)
 
 describe('extractCoreAppManifest', () => {

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -1,7 +1,7 @@
 import {readFile} from 'node:fs/promises'
 import {relative, resolve} from 'node:path'
 
-import {getCliConfig} from '@sanity/cli-core'
+import {getCliConfigUncached} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 
 import {getErrorMessage} from '../../util/getErrorMessage.js'
@@ -56,7 +56,7 @@ export async function extractCoreAppManifest(
   options: ExtractCoreAppManifestOptions,
 ): Promise<CoreAppManifest | undefined> {
   const {workDir} = options
-  const {app} = await getCliConfig(workDir)
+  const {app} = await getCliConfigUncached(workDir)
   if (!app) {
     return undefined
   }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

While recording the demo I noticed changing the title in a CLI config file for an SDK didn't make it through into workbench. This is happening because the CLI config is cached and only read once.

This PR adds a new method to read a fresh config file every time and initializes the same watcher we are using for the studio config file already. Now updating the title in the CLI config is reflected almost immediately in the dock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an uncached `sanity.cli.(ts|js)` loader that clears Node’s module cache and wires core-app dev mode into the manifest watcher, which could affect dev-server stability/perf if cache invalidation or watch triggers behave unexpectedly.
> 
> **Overview**
> Workbench/core-app dev now *tracks edits to `sanity.cli.(ts|js)`* so changes like title/icon propagate without restarting.
> 
> This adds `getCliConfigUncached()` in `@sanity/cli-core` to bypass both the in-memory config cache and Node/jiti `require.cache`, updates core-app manifest extraction to use it, and switches `devAction` to always run `startDevManifestWatcher` (now generic and extractor-injected) for both studios and core apps, with tests updated/expanded to cover the new watch/extract wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1d116ed3e2c8ef2af0257cc088e2d479dc77d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->