### PR TITLE
fix(workbench): forward CLI project id for local applications

### DIFF
--- a/.changeset/pr-1027.md
+++ b/.changeset/pr-1027.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+forward CLI project id for local applications

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -196,6 +196,33 @@ describe('devAction', () => {
       expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({id: 'app-abc'}))
     })
 
+    test('forwards api.projectId from sanity.cli.ts to registerDevServer', async () => {
+      // Workbench resolves a studio's primary project against the org projects
+      // list; without the projectId in the very first registry write, the
+      // workbench falls back to a synthetic `host-port` id that has no match,
+      // breaking the dock until manifest extraction completes.
+      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+      await devAction(
+        createDevOptions({
+          cliConfig: {api: {projectId: 'x1g7jygt'}, federation: {enabled: true}},
+        }),
+      )
+
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({projectId: 'x1g7jygt'}),
+      )
+    })
+
+    test('omits projectId when api.projectId is not configured', async () => {
+      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
+
+      const [registerArg] = mockRegisterDevServer.mock.calls[0]
+      expect(registerArg.projectId).toBeUndefined()
+    })
+
     test('warns about deprecated app.id and falls back to it when registering', async () => {
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
       const output = createMockOutput()

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
@@ -87,6 +87,25 @@ describe('registerDevServer', () => {
     cleanup()
   })
 
+  test('persists projectId in the manifest when provided', () => {
+    const {release: cleanup} = registerDevServer({
+      host: 'localhost',
+      port: 3334,
+      projectId: 'x1g7jygt',
+      type: 'studio',
+      workDir: '/tmp/project',
+    })
+
+    const manifest = JSON.parse(readFileSync(join(registryDir(), `${process.pid}.json`), 'utf8'))
+    expect(manifest.projectId).toBe('x1g7jygt')
+
+    const servers = getRegisteredServers()
+    expect(servers).toHaveLength(1)
+    expect(servers[0].projectId).toBe('x1g7jygt')
+
+    cleanup()
+  })
+
   test('omits optional metadata when not provided and retains manifest through getRegisteredServers', () => {
     const {release: cleanup} = registerDevServer({
       host: 'localhost',

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -493,6 +493,40 @@ describe('startWorkbenchDevServer', () => {
       })
     })
 
+    test('forwards projectId from registry entries through the broadcast payload', async () => {
+      // Workbench needs the projectId on the very first event to resolve a
+      // local studio's primary project before the manifest arrives.
+      mockResolveLocalPackage.mockResolvedValue({})
+      const mockServer = createMockServer()
+      mockCreateServer.mockResolvedValue(mockServer)
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+
+      const watchCallback = mockWatchRegistry.mock.calls[0][0]
+      watchCallback([
+        {
+          host: 'localhost',
+          id: 'app-1',
+          pid: 2,
+          port: 3334,
+          projectId: 'x1g7jygt',
+          type: 'studio',
+        },
+      ])
+
+      expect(mockServer.ws.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
+        applications: [
+          expect.objectContaining({
+            host: 'localhost',
+            id: 'app-1',
+            port: 3334,
+            projectId: 'x1g7jygt',
+            type: 'studio',
+          }),
+        ],
+      })
+    })
+
     test('responds to client request with current applications', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
       const mockServer = createMockServer()

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -88,6 +88,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
       host: appHost,
       id: getAppId(options.cliConfig),
       port: appPort,
+      projectId: options.cliConfig?.api?.projectId,
       type: options.isApp ? 'coreApp' : 'studio',
       workDir: options.workDir,
     })

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -37,6 +37,7 @@ const devServerManifestSchema = z.extend(workbenchLockSchema, {
    * workbench `watchRegistry` watcher and forces a rebroadcast to clients.
    */
   manifestUpdatedAt: z.optional(z.string()),
+  projectId: z.optional(z.string()),
   type: z.enum(['coreApp', 'studio']),
   workDir: z.string(),
 })

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -19,11 +19,12 @@ import {writeWorkbenchRuntime} from './writeWorkbenchRuntime.js'
 const noop = async () => {}
 
 const toApplicationsPayload = (servers: DevServerManifest[]) => ({
-  applications: servers.map(({host, id, manifest, port, type}) => ({
+  applications: servers.map(({host, id, manifest, port, projectId, type}) => ({
     host,
     id,
     manifest,
     port,
+    projectId,
     type,
   })),
 })


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

We weren't forwarding the `projectId` from the CLI config, which made the `new StudioApplication` constructor throw an error, while the manifest wasn't extracted, because the studio did not have a projectId assigned.

Waiting for the manifest to be extracted isn't an option, because the extraction takes about 4s and during that time we would either have to block the startup of the dev-server or not render the studio application at all in the dock.

Workbench PR https://github.com/sanity-io/workbench/pull/162

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 16aad6a45ef2e47b2c0f873ab5fd53d52d603c4f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->