### PR TITLE
fix(workbench): add `__mf__temp` directory to .gitignore

### DIFF
--- a/.changeset/pr-1028.md
+++ b/.changeset/pr-1028.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-add `__mf__temp` directory to .gitignore
+fix(workbench): add `__mf__temp` directory to .gitignore

--- a/.changeset/pr-1028.md
+++ b/.changeset/pr-1028.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+add `__mf__temp` directory to .gitignore

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
@@ -125,6 +125,9 @@ describe('bootstrapLocalTemplate (federation)', () => {
 
     const pkgJson = JSON.parse(await readFile(path.join(tmp, 'package.json'), 'utf8'))
     expect(pkgJson.dependencies.sanity).toBe('1.0.0')
+
+    const gitignore = await readFile(path.join(tmp, '.gitignore'), 'utf8')
+    expect(gitignore).toContain('.__mf__temp/')
   })
 
   test('keeps the `sanity` dependency on the `latest` dist-tag when federation is disabled', async () => {

--- a/packages/@sanity/cli/templates/shared/gitignore.txt
+++ b/packages/@sanity/cli/templates/shared/gitignore.txt
@@ -27,3 +27,6 @@
 
 # Dotenv and similar local-only files
 *.local
+
+# Module federation temporary files
+.__mf__temp/


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Module federation still generates the `__mf__temp` directory in the root of the bootstrapped application when running `sanity init`, so we need to add it to the gitignore file.

I've added it unconditionally, because if a user would enable module-federation later, it is already ignored.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, template-only change plus a matching test assertion; no runtime logic changes beyond the generated `.gitignore` contents.
> 
> **Overview**
> Bootstrapped projects from `sanity init` will now ignore the module federation temporary directory by adding `.__mf__temp/` to the shared `.gitignore` template.
> 
> The federation init test is updated to assert the generated `.gitignore` contains this entry, and a changeset is added to ship the CLI patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f7345b1e596bf0902276634050da0b36c8d5af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->