### PR TITLE
test(cli-test): disable pnpm minimumReleaseAge for fixture installs

### DIFF
--- a/packages/@sanity/cli-test/src/test/setupFixtures.ts
+++ b/packages/@sanity/cli-test/src/test/setupFixtures.ts
@@ -151,9 +151,14 @@ export async function setup(_: TestProject, options: SetupTestFixturesOptions = 
       // Run pnpm install --no-lockfile in the temp directory
       try {
         const ignoreWsFlag = ignoreWorkspace ? ' --ignore-workspace' : ''
-        await exec(`pnpm install --prefer-offline --no-lockfile${ignoreWsFlag}`, {
-          cwd: toPath,
-        })
+        // Disable pnpm's minimumReleaseAge for fixture installs. With
+        // `--ignore-workspace`, the workspace's `minimumReleaseAgeExclude` list
+        // is not applied, which can reject freshly-published Sanity versions
+        // pinned in fixture package.json files.
+        await exec(
+          `pnpm install --prefer-offline --no-lockfile --config.minimum-release-age=0${ignoreWsFlag}`,
+          {cwd: toPath},
+        )
       } catch (error) {
         const execError = error as {message: string; stderr?: string; stdout?: string}
         spinner.fail('Failed to install dependencies')


### PR DESCRIPTION
### Description

E2E and renovate dep-bump PRs are currently failing in CI with:

```
ERR_PNPM_NO_MATURE_MATCHING_VERSION  Version 5.23.0 (released 28 hours ago) of sanity does not meet the minimumReleaseAge constraint
```

The repo's `pnpm-workspace.yaml` sets `minimumReleaseAge: 4320` (3 days) as a supply-chain mitigation, with a `minimumReleaseAgeExclude` list that includes `sanity` and `@sanity/*`.

The e2e setup in `packages/@sanity/cli-e2e/globalSetup.ts` calls `setupFixtures(project, {ignoreWorkspace: true})`, which adds `--ignore-workspace` to the `pnpm install` for each fixture. That flag makes pnpm ignore `pnpm-workspace.yaml` entirely — including the exclude list — so freshly-published Sanity versions get rejected.

This PR adds `--config.minimum-release-age=0` to the fixture install so the constraint doesn't apply to throwaway test fixtures. The existing test in `packages/@sanity/cli/src/commands/__tests__/build.app.test.ts:128` already uses the same approach for a manual `pnpm install` after a fixture is set up.

Failing run: https://github.com/sanity-io/cli/actions/runs/25175382942/job/73806196122?pr=1031

### What to review

- `packages/@sanity/cli-test/src/test/setupFixtures.ts` — added `--config.minimum-release-age=0` to the `pnpm install` invocation, alongside the existing `--prefer-offline --no-lockfile` and conditional `--ignore-workspace`.

### Testing

The fix can be validated by re-running e2e on PR #1031 (the renovate sanity-tooling bump that surfaced this); the install of `sanity@5.23.0` into the fixture tmp dir should no longer be blocked. No new automated test added — this is e2e-infra plumbing whose behavior is observable from CI itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the test-fixture dependency install command to relax pnpm constraints, with no impact on production code paths.
> 
> **Overview**
> Test fixture setup now installs dependencies with `pnpm --config.minimum-release-age=0`, preventing CI/e2e failures when fixtures pin newly published Sanity packages.
> 
> The override is applied alongside the existing `--prefer-offline --no-lockfile` install and still respects the optional `--ignore-workspace` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b33c559a04388a424933edbfba8922aae644a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->