### PR TITLE
test: skip dataset import tests

### DIFF
--- a/packages/@sanity/cli-e2e/__tests__/init/init.studio-interactive.test.ts
+++ b/packages/@sanity/cli-e2e/__tests__/init/init.studio-interactive.test.ts
@@ -143,18 +143,7 @@ describe('sanity init - studio (interactive)', {timeout: 120_000}, () => {
     expect(existsSync(`${tmp.path}/yarn.lock`)).toBe(false)
   })
 
-  test.each([
-    {
-      answer: 'y\n',
-      name: 'imports sample data when accepted',
-      postAnswerWait: /Imported \d+ documents/i,
-    },
-    {
-      answer: 'n\n',
-      name: 'skips import when declined',
-      postAnswerWait: /installing|Success/i,
-    },
-  ])('$name', async ({answer, postAnswerWait}) => {
+  test.skip('imports sample data when accepted', async () => {
     const session = await runCli({
       args: [
         'init',
@@ -178,16 +167,46 @@ describe('sanity init - studio (interactive)', {timeout: 120_000}, () => {
     session.sendKey('Enter')
 
     await session.waitForText(/sampling.*movies|dataset on the hosted backend/i)
-    session.write(answer)
+    session.write('y\n')
 
-    await session.waitForText(postAnswerWait, {timeout: 90_000})
+    await session.waitForText(/Imported \d+ documents/i, {timeout: 90_000})
+
+    const exitCode = await session.waitForExit(90_000)
+    expect(exitCode).toBe(0)
+  })
+
+  test('skips import when declined', async () => {
+    const session = await runCli({
+      args: [
+        'init',
+        '--project',
+        projectId,
+        '--dataset',
+        'production',
+        '--output-path',
+        tmp.path,
+        '--template',
+        'moviedb',
+        '--no-mcp',
+        '--package-manager',
+        'pnpm',
+        '--no-git',
+      ],
+      interactive: true,
+    })
+
+    await session.waitForText(/TypeScript/i)
+    session.sendKey('Enter')
+
+    await session.waitForText(/sampling.*movies|dataset on the hosted backend/i)
+    session.write('n\n')
+
+    await session.waitForText(/installing|Success/i, {timeout: 90_000})
 
     const exitCode = await session.waitForExit(90_000)
     expect(exitCode).toBe(0)
 
-    if (answer === 'n\n') {
-      const output = session.getOutput()
-      expect(output).not.toMatch(/Imported \d+ documents/i)
-    }
+    const output = session.getOutput()
+    expect(output).not.toMatch(/Imported \d+ documents/i)
   })
 })

--- a/packages/@sanity/cli-e2e/__tests__/init/init.studio.shared.ts
+++ b/packages/@sanity/cli-e2e/__tests__/init/init.studio.shared.ts
@@ -385,7 +385,7 @@ export function registerStudioInitTests(yFlag: string[]): void {
     expect(existsSync(`${tmp.path}/sanity.config.js`)).toBe(false)
   })
 
-  test('imports sample data with --import-dataset', async () => {
+  test.skip('imports sample data with --import-dataset', async () => {
     const {error, exitCode, stdout} = await runCli({
       args: [
         'init',


### PR DESCRIPTION
### Description
Skip import datasets tests for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect CLI E2E tests by skipping dataset import coverage, which may temporarily reduce regression detection but does not impact production code.
> 
> **Overview**
> Disables flaky/expensive dataset-import coverage in the `sanity init` E2E suite by marking the sample-data import tests as `test.skip` (both interactive acceptance and `--import-dataset`).
> 
> Refactors the interactive import prompt assertions by splitting the previous parameterized `test.each` into two explicit tests, keeping the decline-path test active while skipping the accept/import-path test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e56a44f90999e230513bb86cf4b0e1cbf8dcbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->