### PR TITLE
docs: document release propagation to sanity monorepo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -827,6 +827,26 @@ This creates a changeset file in `.changeset/`. If you do this, write `N/A` in t
 3. **Merging the Version Packages PR** triggers publishing to npm
 4. **GitHub Releases** are automatically created for each published package
 
+### Propagating Releases to the Sanity Monorepo
+
+Publishing `@sanity/cli` and `create-sanity` to npm is only the first step. Most users do not depend on `@sanity/cli` directly — they invoke it through `npx sanity` or as a transitive dependency of the `sanity` package. For a release to actually reach those users, the CLI version must also be bumped in the [sanity-io/sanity](https://github.com/sanity-io/sanity) monorepo.
+
+**Do not open this bump PR by hand.** The sanity monorepo has Renovate automation that:
+
+- Detects new `@sanity/cli` releases on npm
+- Opens a dependency-update PR
+- Pulls the changelog entries from this repo's release notes into the sanity repo's release notes
+
+Manually bumping the version short-circuits that automation and results in missing or duplicated changelog entries. If a release looks stuck, check Renovate in the sanity repo before intervening.
+
+End-to-end flow for a typical change:
+
+1. PR merged into this repo (with a changeset)
+2. Changesets bot opens / updates the **Version Packages** PR here
+3. Merging the Version Packages PR publishes `@sanity/cli` and `create-sanity` to npm
+4. Renovate in sanity-io/sanity opens a PR bumping `@sanity/cli`, importing the changelog
+5. That PR is reviewed and merged, which is what ships the change to `npx sanity` users
+
 ### Snapshot Releases
 
 Snapshot releases publish ephemeral versions (e.g., `0.0.0-20260327120000`) under a custom npm dist tag for testing:


### PR DESCRIPTION
### Description

Adds a "Propagating Releases to the Sanity Monorepo" subsection to `CONTRIBUTING.md` covering the step that happens after `@sanity/cli` is published to npm.

The existing Releasing section ends at "publishing to npm" and "GitHub Releases are created", which leaves contributors with the impression that the release flow is complete at that point. In reality most users consume the CLI via `npx sanity` or as a transitive dep of `sanity`, so the version must also be bumped in sanity-io/sanity. That bump should go through Renovate (not a manual PR) because Renovate has automation that imports our changelog entries into the sanity repo's release notes.

### What to review

- New subsection added between "How Releases Work" and "Snapshot Releases" in `CONTRIBUTING.md`
- Confirm the description of the Renovate flow matches your understanding — the key claims are:
  - Renovate in sanity-io/sanity opens the bump PR automatically
  - It imports changelog entries from this repo's release notes
  - Manual bumps short-circuit that automation

### Testing

N/A — documentation only.

### Notes for release

N/A: docs only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior, build, or release automation is modified.
> 
> **Overview**
> Adds a new `CONTRIBUTING.md` subsection, **"Propagating Releases to the Sanity Monorepo"**, clarifying that publishing `@sanity/cli`/`create-sanity` to npm is not the end of the release path for most users.
> 
> Documents that the version bump in `sanity-io/sanity` should be handled by Renovate (including changelog import) and explicitly warns against manual bump PRs, with an end-to-end release flow outline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc05a37a5ae4cf446e50f962432ef659189bc48f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->