### PR TITLE
test(cli-e2e): pack @sanity/cli-core alongside cli and create-sanity

### DIFF
--- a/packages/@sanity/cli-e2e/globalSetup.ts
+++ b/packages/@sanity/cli-e2e/globalSetup.ts
@@ -25,18 +25,25 @@ export async function setup(project: TestProject): Promise<void> {
       )
     }
   } else {
+    console.log('Packing @sanity/cli-core...')
+    const cliCoreTarball = packPackage('@sanity/cli-core')
+
     console.log('Packing @sanity/cli...')
     const cliTarball = packCli()
 
     console.log('Packing create-sanity...')
     const createSanityTarball = packPackage('create-sanity')
-    tarballPaths = [cliTarball, createSanityTarball]
+    tarballPaths = [cliCoreTarball, cliTarball, createSanityTarball]
 
     const tmpDir = mkdtempSync(join(tmpdir(), 'cli-e2e-'))
     cleanupDir = tmpDir
 
     console.log(`Installing tarballs into ${tmpDir}...`)
-    const binaryPath = installFromTarball([cliTarball, createSanityTarball], tmpDir, 'sanity')
+    const binaryPath = installFromTarball(
+      [cliCoreTarball, cliTarball, createSanityTarball],
+      tmpDir,
+      'sanity',
+    )
 
     process.env.E2E_BINARY_PATH = binaryPath
     console.log(`E2E_BINARY_PATH set to ${binaryPath}`)


### PR DESCRIPTION
### Description

E2E tests pack `@sanity/cli` and `create-sanity` and `npm install` the resulting tarballs. The `@sanity/cli-core` dependency (declared as `workspace:^` in source) is rewritten to a regular semver range during pack, so npm resolves it from the **registry** — not from local source. As a result, e2e tests run against the published `@sanity/cli-core`, not the version in this repo.

This caused the e2e failures on #1011: that branch added `stdout` and `errors` exports to `@sanity/cli-core/ux` and started importing them from `@sanity/cli`, but the published `@sanity/cli-core@1.3.1` doesn't have those exports yet, so every init test crashed with `SyntaxError: The requested module '@sanity/cli-core/ux' does not provide an export named 'stdout'`.

This PR packs `@sanity/cli-core` too and includes it in the `npm install` invocation. npm resolves the workspace dep to the local tarball (verified via the resulting `package-lock.json`: `"resolved": "file:..."`), so e2e tests now exercise the local source of cli-core.

### What to review

- `packages/@sanity/cli-e2e/globalSetup.ts` — adds a third `pnpm pack` for `@sanity/cli-core` and includes the tarball in `installFromTarball`.

### Testing

- Verified locally: packed all three packages, ran `npm install` against them in a temp dir, and confirmed `package-lock.json` resolves `@sanity/cli-core` from the local tarball rather than the registry.
- `pnpm --filter @sanity/cli-e2e check:types` and `pnpm --filter @sanity/cli-e2e lint` pass.
- No changeset (test-infra-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test setup-only change that just alters which local tarballs are packed/installed before running E2E tests.
> 
> **Overview**
> E2E test global setup now also packs `@sanity/cli-core` and includes its tarball in the temp-directory `npm install` alongside `@sanity/cli` and `create-sanity`.
> 
> This ensures E2E runs resolve the `@sanity/cli-core` workspace dependency from the locally packed artifact rather than the npm registry, and updates cleanup bookkeeping to remove the additional tarball.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5acb0f90f4846d2f05d98dafdc2fd1959ac87c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->