### PR TITLE
perf(workbench): preload workbench and warmup dev-server files

### DIFF
--- a/.changeset/pr-1042.md
+++ b/.changeset/pr-1042.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+perf(workbench): preload workbench and warmup dev-server files

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -258,10 +258,129 @@ describe('startWorkbenchDevServer', () => {
       expect(mockCreateServer).toHaveBeenCalledWith(
         expect.objectContaining({
           server: expect.objectContaining({
-            warmup: {clientFiles: ['./workbench.js']},
+            warmup: {
+              clientFiles: ['./workbench.js', 'sanity/workbench', '@sanity/workbench/_internal'],
+            },
           }),
         }),
       )
+    })
+  })
+
+  describe('remote-preload Link header', () => {
+    const federationConfig = {
+      app: {organizationId: 'org-test'},
+      federation: {enabled: true},
+    } as const
+
+    function getMiddleware(): (req: {url?: string}, res: ResLike, next: () => void) => void {
+      const calls = mockCreateServer.mock.calls
+      const lastCall = calls.at(-1)
+      if (!lastCall) throw new Error('createServer was not called')
+      const config = lastCall[0] as {plugins: PluginLike[]}
+      const plugin = config.plugins.find(
+        (p) => p && typeof p === 'object' && p.name === 'sanity:workbench-remote-preload-header',
+      )
+      if (!plugin) throw new Error('remote-preload plugin not registered')
+      const middlewareUse = vi.fn()
+      plugin.configureServer?.({middlewares: {use: middlewareUse}})
+      return middlewareUse.mock.calls[0][0]
+    }
+
+    interface ResLike {
+      setHeader: (name: string, value: string) => void
+    }
+
+    interface PluginLike {
+      configureServer?: (server: {middlewares: {use: (mw: unknown) => void}}) => void
+      name?: string
+    }
+
+    test('does not register plugin when remoteUrl is not set', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+
+      const config = mockCreateServer.mock.calls[0][0] as {plugins: PluginLike[]}
+      expect(
+        config.plugins.find((p) => p?.name === 'sanity:workbench-remote-preload-header'),
+      ).toBeUndefined()
+    })
+
+    test('sets Link header on the root document', async () => {
+      vi.stubEnv(
+        'SANITY_INTERNAL_WORKBENCH_REMOTE_URL',
+        'https://workbench.example/mf-manifest.json',
+      )
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+
+      const middleware = getMiddleware()
+      const setHeader = vi.fn()
+      const next = vi.fn()
+      middleware({url: '/'}, {setHeader}, next)
+
+      expect(setHeader).toHaveBeenCalledWith(
+        'Link',
+        '<https://workbench.example/mf-manifest.json>; rel=preload; as=fetch; crossorigin',
+      )
+      expect(next).toHaveBeenCalled()
+    })
+
+    test('sets Link header on /index.html', async () => {
+      vi.stubEnv(
+        'SANITY_INTERNAL_WORKBENCH_REMOTE_URL',
+        'https://workbench.example/mf-manifest.json',
+      )
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+
+      const middleware = getMiddleware()
+      const setHeader = vi.fn()
+      middleware({url: '/index.html'}, {setHeader}, vi.fn())
+
+      expect(setHeader).toHaveBeenCalledWith('Link', expect.stringContaining('as=fetch'))
+    })
+
+    test('ignores query strings when matching the index document', async () => {
+      vi.stubEnv(
+        'SANITY_INTERNAL_WORKBENCH_REMOTE_URL',
+        'https://workbench.example/mf-manifest.json',
+      )
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+
+      const middleware = getMiddleware()
+      const setHeader = vi.fn()
+      middleware({url: '/?t=1'}, {setHeader}, vi.fn())
+
+      expect(setHeader).toHaveBeenCalledWith('Link', expect.stringContaining('rel=preload'))
+    })
+
+    test('does not set Link header on non-document requests', async () => {
+      vi.stubEnv(
+        'SANITY_INTERNAL_WORKBENCH_REMOTE_URL',
+        'https://workbench.example/mf-manifest.json',
+      )
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+
+      const middleware = getMiddleware()
+      const setHeader = vi.fn()
+      const next = vi.fn()
+      middleware({url: '/workbench.js'}, {setHeader}, next)
+
+      expect(setHeader).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
     })
   })
 

--- a/packages/@sanity/cli/src/actions/dev/__tests__/writeWorkbenchRuntime.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/writeWorkbenchRuntime.test.ts
@@ -143,5 +143,63 @@ describe('writeWorkbenchRuntime', () => {
       expect(content).toContain('<!DOCTYPE html>')
       expect(content).toContain('<meta charset="UTF-8" />')
     })
+
+    describe('prefetch hints', () => {
+      test('omits prefetch hints when remoteUrl is not provided', async () => {
+        await writeWorkbenchRuntime({cwd: tmpDir, reactStrictMode: false})
+
+        const content = await fs.readFile(
+          join(tmpDir, '.sanity', 'workbench', 'index.html'),
+          'utf8',
+        )
+        expect(content).not.toContain('rel="preconnect"')
+        expect(content).not.toContain('rel="preload"')
+      })
+
+      test('omits prefetch hints when remoteUrl is invalid', async () => {
+        await writeWorkbenchRuntime({
+          cwd: tmpDir,
+          reactStrictMode: false,
+          remoteUrl: 'not-a-url',
+        })
+
+        const content = await fs.readFile(
+          join(tmpDir, '.sanity', 'workbench', 'index.html'),
+          'utf8',
+        )
+        expect(content).not.toContain('rel="preconnect"')
+        expect(content).not.toContain('rel="preload"')
+      })
+
+      test('emits a preconnect hint pointing at the remote origin', async () => {
+        await writeWorkbenchRuntime({
+          cwd: tmpDir,
+          reactStrictMode: false,
+          remoteUrl: 'https://workbench.example/mf-manifest.json',
+        })
+
+        const content = await fs.readFile(
+          join(tmpDir, '.sanity', 'workbench', 'index.html'),
+          'utf8',
+        )
+        expect(content).toContain('<link rel="preconnect" href="https://workbench.example" />')
+      })
+
+      test('emits a preload hint for the manifest with as=fetch and crossorigin', async () => {
+        await writeWorkbenchRuntime({
+          cwd: tmpDir,
+          reactStrictMode: false,
+          remoteUrl: 'https://workbench.example/mf-manifest.json',
+        })
+
+        const content = await fs.readFile(
+          join(tmpDir, '.sanity', 'workbench', 'index.html'),
+          'utf8',
+        )
+        expect(content).toContain(
+          '<link rel="preload" as="fetch" href="https://workbench.example/mf-manifest.json" crossorigin />',
+        )
+      })
+    })
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -1,6 +1,6 @@
 import {resolveLocalPackage} from '@sanity/cli-core'
 import viteReact from '@vitejs/plugin-react'
-import {createServer, type InlineConfig} from 'vite'
+import {createServer, type InlineConfig, type Plugin} from 'vite'
 
 import {SANITY_CACHE_DIR} from '../../constants.js'
 import {getProjectById} from '../../services/projects.js'
@@ -97,13 +97,6 @@ export async function startWorkbenchDevServer(
 
   const organizationId = await resolveOrganizationId(cliConfig)
 
-  devDebug('Writing workbench runtime files')
-  const root = await writeWorkbenchRuntime({
-    cwd: workDir,
-    organizationId,
-    reactStrictMode,
-  })
-
   let remoteUrl: string | undefined = undefined
 
   try {
@@ -111,6 +104,14 @@ export async function startWorkbenchDevServer(
   } catch {
     // Ignore parsing errors, the variable might not be set or might be an invalid URL, in which case we just won't use it
   }
+
+  devDebug('Writing workbench runtime files')
+  const root = await writeWorkbenchRuntime({
+    cwd: workDir,
+    organizationId,
+    reactStrictMode,
+    remoteUrl,
+  })
 
   const viteConfig: InlineConfig = {
     // Define a custom cache directory so that sanity's vite cache
@@ -131,7 +132,7 @@ export async function startWorkbenchDevServer(
       // discovery to silently not fire.
       exclude: ['sanity', '@sanity/workbench'],
     },
-    plugins: [viteReact()],
+    plugins: [viteReact(), ...(remoteUrl ? [remoteManifestPreloadHeaderPlugin(remoteUrl)] : [])],
     resolve: {dedupe: ['react', 'react-dom']},
     root,
     server: {
@@ -139,7 +140,7 @@ export async function startWorkbenchDevServer(
       port: workbenchPort,
       strictPort: false,
       warmup: {
-        clientFiles: ['./workbench.js'],
+        clientFiles: ['./workbench.js', 'sanity/workbench', '@sanity/workbench/_internal'],
       },
     },
   }
@@ -163,6 +164,15 @@ export async function startWorkbenchDevServer(
 
   // Update the lock file with the actual port so other processes can find us
   workbenchLock.updatePort(actualPort)
+
+  // Fire-and-forget: warm the workbench remote's Vite transform pipeline so
+  // the first browser request hits a pre-populated module graph.
+  if (remoteUrl) {
+    fetch(remoteUrl)
+      .then((r) => r.body?.cancel())
+      .catch(() => {})
+    devDebug('Warming workbench remote at %s', remoteUrl)
+  }
 
   // Respond to client requests for the current application list.
   server.ws.on('sanity:workbench:get-local-applications', (_, client) => {
@@ -205,4 +215,27 @@ const resolveOrganizationId = async (cliConfig: DevActionOptions['cliConfig']): 
   throw new Error(
     'Unable to determine organization ID for workbench runtime. Please ensure that your sanity.json has either "app.organizationId" or "api.projectId" configured.',
   )
+}
+
+/**
+ * Sets a `Link: <remoteUrl>; rel=preload; as=fetch; crossorigin` response header
+ * on the index document so the browser can start fetching the Module Federation
+ * manifest as soon as response headers arrive — before HTML parsing reaches the
+ * in-head preconnect hint. `as=fetch` matches how the federation runtime later
+ * retrieves the JSON manifest, allowing the preload entry to satisfy that fetch.
+ */
+function remoteManifestPreloadHeaderPlugin(remoteUrl: string): Plugin {
+  return {
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const pathname = (req.url || '/').split('?')[0]
+        if (pathname === '/' || pathname === '/index.html') {
+          res.setHeader('Link', `<${remoteUrl}>; rel=preload; as=fetch; crossorigin`)
+        }
+        next()
+      })
+    },
+    name: 'sanity:workbench-remote-preload-header',
+  }
 }

--- a/packages/@sanity/cli/src/actions/dev/writeWorkbenchRuntime.ts
+++ b/packages/@sanity/cli/src/actions/dev/writeWorkbenchRuntime.ts
@@ -15,13 +15,14 @@ renderWorkbench(
 )
 `
 
-const indexHtml = `\
+const indexHtmlTemplate = `\
 <!DOCTYPE html>
 <!-- This file is auto-generated on 'sanity dev' -->
 <!-- Modifications to this file are automatically discarded -->
 <html>
   <head>
     <meta charset="UTF-8" />
+%SANITY_WORKBENCH_PREFETCH_HINTS%
   </head>
   <body>
     <div id="workbench"></div>
@@ -42,8 +43,9 @@ export async function writeWorkbenchRuntime(options: {
   cwd: string
   organizationId?: string
   reactStrictMode: boolean
+  remoteUrl?: string
 }): Promise<string> {
-  const {cwd, organizationId, reactStrictMode} = options
+  const {cwd, organizationId, reactStrictMode, remoteUrl} = options
   const workbenchDir = path.join(cwd, '.sanity', 'workbench')
 
   const workbenchJs = workbenchJsTemplate
@@ -52,6 +54,10 @@ export async function writeWorkbenchRuntime(options: {
       organizationId === undefined ? 'undefined' : JSON.stringify(organizationId),
     )
     .replace(/%SANITY_WORKBENCH_REACT_STRICT_MODE%/, JSON.stringify(reactStrictMode))
+
+  const prefetchHints = buildPrefetchHints(remoteUrl)
+
+  const indexHtml = indexHtmlTemplate.replace(/%SANITY_WORKBENCH_PREFETCH_HINTS%/, prefetchHints)
 
   devDebug('Making workbench runtime directory')
   await fs.mkdir(workbenchDir, {recursive: true})
@@ -63,4 +69,18 @@ export async function writeWorkbenchRuntime(options: {
   await fs.writeFile(path.join(workbenchDir, 'index.html'), indexHtml)
 
   return workbenchDir
+}
+
+function buildPrefetchHints(remoteUrl: string | undefined): string {
+  if (!remoteUrl) return ''
+
+  try {
+    const url = new URL(remoteUrl)
+    return [
+      `    <link rel="preconnect" href="${url.origin}" />`,
+      `    <link rel="preload" as="fetch" href="${url.toString()}" crossorigin />`,
+    ].join('\n')
+  } catch {
+    return ''
+  }
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Preload the module federation manifest using a `Link` HTTP header and HTML tags and warmup more workbench-related files in Vite.

Speeds up loading of workbench - the `remoteUrl` is known ahead of time. This reduces the waterfall of `load manifest -> load entry` to `load entry`.

Companion PR: https://github.com/sanity-io/workbench/pull/182

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the workbench dev-server startup path and only add optional preloading/warmup behavior when a valid remote URL is configured.
> 
> **Overview**
> Speeds up workbench startup by **preloading the Module Federation manifest** when `SANITY_INTERNAL_WORKBENCH_REMOTE_URL` is set: `writeWorkbenchRuntime` now injects `preconnect` + `preload as=fetch` hints into the generated `index.html`, and the Vite dev server adds a middleware that sets a matching `Link` preload header on `/` and `/index.html`.
> 
> Improves dev-server responsiveness by expanding Vite `server.warmup.clientFiles` to include additional workbench modules and by fire-and-forget fetching the remote manifest to warm the remote's transform/module graph. Tests are extended to cover the new warmup list and header/prefetch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b96d165e83a8cc3a52bdb007ef80e34dfadcb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->