### PR TITLE
test(cli-e2e): bump createSanityPackageManagers timeout to 120s

### DIFF
--- a/packages/@sanity/cli-e2e/__tests__/createSanityPackageManagers.test.ts
+++ b/packages/@sanity/cli-e2e/__tests__/createSanityPackageManagers.test.ts
@@ -14,7 +14,7 @@ const nodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10)
 // and yarn v1 enforces engine checks. Remove this skip when Node 20 is dropped.
 const skipYarnOnOldNode = (name: string) => name === 'yarn' && nodeMajor < 22
 
-describe.skipIf(!isRegistryMode)('create-sanity via package managers', {timeout: 60_000}, () => {
+describe.skipIf(!isRegistryMode)('create-sanity via package managers', {timeout: 120_000}, () => {
   const version = 'latest'
   const managers = getAvailablePackageManagers()
 
@@ -44,7 +44,7 @@ describe.skipIf(!isRegistryMode)('create-sanity via package managers', {timeout:
                 NODE_NO_WARNINGS: '1',
               },
               stdio: 'pipe',
-              timeout: 60_000,
+              timeout: 120_000,
             })
           } catch (err) {
             const stderr = (err as {stderr?: Buffer | string}).stderr


### PR DESCRIPTION
### Description

The `npm create sanity@latest --help` e2e test timed out on CI ([run 25342211077](https://github.com/sanity-io/cli/actions/runs/25342211077/job/74302123374)) with `spawnSync npm ETIMEDOUT`. Yarn was already running ~45s on the same job, leaving almost no margin under the previous 60s ceiling.

Bump both the `describe` block timeout and the `execFileSync` timeout from 60s → 120s in `createSanityPackageManagers.test.ts`.

### What to review

- `packages/@sanity/cli-e2e/__tests__/createSanityPackageManagers.test.ts` — only the two timeout values changed.

### Testing

Test-only change; runs against the live npm/yarn/pnpm registry flow in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that just increases timeouts, with no production code or logic changes; main impact is slightly longer waits before CI fails on genuine hangs.
> 
> **Overview**
> Increases the `create-sanity via package managers` e2e test time budget by bumping both the Vitest `describe` timeout and the `execFileSync` spawn timeout from 60s to 120s to reduce CI flakiness when registry commands run slowly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c632b42e801fc1866770e06e53a0b8744c7d53b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->