### PR TITLE
fix(workbench): remove warmup for dependencies

### DIFF
--- a/.changeset/pr-1047.md
+++ b/.changeset/pr-1047.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): remove warmup for dependencies

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -259,7 +259,7 @@ describe('startWorkbenchDevServer', () => {
         expect.objectContaining({
           server: expect.objectContaining({
             warmup: {
-              clientFiles: ['./workbench.js', 'sanity/workbench', '@sanity/workbench/_internal'],
+              clientFiles: ['./workbench.js'],
             },
           }),
         }),

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -140,7 +140,7 @@ export async function startWorkbenchDevServer(
       port: workbenchPort,
       strictPort: false,
       warmup: {
-        clientFiles: ['./workbench.js', 'sanity/workbench', '@sanity/workbench/_internal'],
+        clientFiles: ['./workbench.js'],
       },
     },
   }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Remove the warmup for `sanity/workbench` - first of all that does not work in Vite@7 (needs a relative path) and second it does not make a notable difference that's not within the range of noise.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to Vite dev-server warmup configuration for workbench startup, with tests updated to match; it may only affect initial dev-server responsiveness.
> 
> **Overview**
> Removes Vite `server.warmup` preloading of `sanity/workbench` and `@sanity/workbench/_internal` from the workbench dev server, leaving warmup to only target the local `./workbench.js` entry (for Vite 7 compatibility and to avoid ineffective preloading).
> 
> Updates the `startWorkbenchDevServer` unit test expectation accordingly and adds a changeset for a patch release of `@sanity/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e64b5caf91702cfe441f8e32704104ce1e370ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->