### PR TITLE
chore(e2e): add detailed docs for e2e testing

### DIFF
--- a/.claude/skills/writing-cli-e2e-tests/SKILL.md
+++ b/.claude/skills/writing-cli-e2e-tests/SKILL.md
@@ -9,6 +9,8 @@ description: Use when writing, adding, or modifying e2e tests for CLI commands i
 
 E2e tests run real CLI commands against real infrastructure with real side effects. They validate that commands work end-to-end for both humans (interactive) and agents/CI (non-interactive). This skill defines the philosophy and patterns for writing effective e2e tests in `packages/@sanity/cli-e2e/`.
 
+For local setup, CI behavior, and how to add new env vars, see [`packages/@sanity/cli-e2e/README.md`](../../../packages/@sanity/cli-e2e/README.md).
+
 ## When to Use
 
 - Adding e2e test coverage for a new CLI command
@@ -35,23 +37,24 @@ Discover behavior by running the CLI, not by reading source code. The test shoul
 
 **Step 3: Get user approval.** Wait for the user to review and revise the plan before writing any test code.
 
-Example plan output:
+Example plan output (describe behaviors, not final `test()` names — those get refined during implementation):
+
 ```
 __tests__/init/
   init.test.ts
-    - "rejects invalid input with helpful error" (smoke test, no auth)
-    - "outputs project info without creating files" (--bare, non-interactive)
+    - smoke: rejects a known-bad flag (no auth)
+    - --bare mode prints project info without creating any files (non-interactive)
   init.studio.test.ts
     describe.each([{-y}, {no -y}]) — non-interactive, both unattended modes
-      - "creates studio with clean template" → init --template clean ...
-      - "generates JavaScript files with --no-typescript" → init --no-typescript ...
+      - default flow creates a TypeScript studio with the expected config files
+      - --no-typescript produces JavaScript files
   init.studio-interactive.test.ts
-    - "Ctrl+C aborts cleanly" → init (interactive, send Ctrl+C, expect 130)
-    - "walks through all prompts" → init (interactive, no --template/--typescript/--package-manager)
+    - Ctrl+C at the first prompt aborts with exit code 130
+    - walks through all prompts (template, TypeScript, package manager) and produces a working studio
   init.app.test.ts
     describe.each([{-y}, {no -y}]) — non-interactive
-      - "creates app with app-quickstart template" → init --template app-quickstart ...
-    - "shows project config prompt" → init --template app-quickstart (interactive)
+      - app-quickstart template produces the expected app scaffold
+    - interactive: project/dataset prompts appear and selectable
 ```
 
 ## Core Principles
@@ -206,15 +209,7 @@ expect(stdout).toMatch(/Done! Imported \d+ documents/)
 expect(exitCode).toBe(1)
 ```
 
-## Available Tools
-
-- **`runCli()`** — Execute CLI commands. `interactive: true` for PTY, default for spawn. See `helpers/runCli.ts`.
-- **`testFixture()`** — Get an isolated copy of a pre-built project fixture (e.g., `'basic-studio'`, `'nextjs-app'`). From `@sanity/cli-test`.
-- **`createTmpDir()`** — Create an isolated temp directory with a cleanup function. From `@sanity/cli-test`.
-- **Interactive session API** — `waitForText(regex)`, `selectOption(pattern)`, `sendKey('ArrowDown')`, `write('text')`, `sendControl('c')`, `getOutput()`, `waitForExit()`, `kill()`. See `helpers/spawnPty.ts`.
-- **`getE2EDataset()`** — Returns the e2e dataset name (currently `'production'`). From `helpers/runCli.ts`.
-
-Check `@sanity/cli-test` for shared utilities before creating local helpers. Inline CLI args directly in each test for clarity — avoid abstracting args into helper functions as it obscures what each test actually runs.
+**Inline args, don't abstract.** Inline CLI args directly in each test rather than building helper functions that produce them — abstraction obscures what each test actually runs. The full `runCli()` API and interactive session methods are documented in [`packages/@sanity/cli-e2e/README.md`](../../../packages/@sanity/cli-e2e/README.md); shared `testFixture()` / `createTmpDir()` helpers live in `@sanity/cli-test`.
 
 ## Test Structure Patterns
 
@@ -251,7 +246,7 @@ describe('sanity init - studio', {timeout: 120_000}, () => {
 
 ### Interactive Complete Flow
 
-Use `selectOption(pattern)` to navigate select prompts by text instead of counting ArrowDown presses. It scrolls through the list, handles off-screen options, and throws if zero or multiple options match. Pass a string for exact match or a regex for partial match (e.g., matching a project ID inside `"Project Name (id)"`).
+Use `selectOption(pattern)` to navigate select prompts by text instead of counting ArrowDown presses. It scrolls through the list, handles off-screen options, and throws if zero or multiple options match. Pass a string for a literal substring match or a regex for pattern matching (e.g., matching a project ID inside `"Project Name (id)"`). Strings are escaped before matching, so they're treated as literal text — but they still match anywhere in the option line, so prefer regex with anchors when collisions are likely (e.g., `'dev'` would also match `'development'`).
 
 ```typescript
 test('complete interactive flow selects project and dataset', async () => {
@@ -340,15 +335,13 @@ expect(output).toContain('Your custom app has been scaffolded')
 - Use `selectOption(pattern)` for all select prompts — never count ArrowDown presses
 - Use `waitForText(regex)` to detect prompt appearance before interacting
 - Use regex patterns for structural prompts, exact strings for known output messages
-- For `selectOption`, use a string for exact matches (`'production'`) and regex when the display text wraps the value (`new RegExp(`\\(${projectId}\\)`)`)
+- For `selectOption`, pass a string for a literal substring match (`'production'`) and regex when you need anchoring or pattern matching (e.g., `new RegExp(`\\(${projectId}\\)`)` to find an ID inside parentheses). Note that `selectOption` will throw if multiple options match the substring, so collisions surface loudly.
 
 ## Spawn Mode Behavior
 
-Non-interactive tests use `spawnProcess` which sets `stdio: ['ignore', 'pipe', 'pipe']` — no TTY. This means `isInteractive()` returns false, and the CLI treats the run as unattended regardless of whether `-y` is passed.
+Non-interactive runs have no TTY, so the CLI treats them as unattended and skips prompts (see the README's gotcha for the mechanics). The implication for tests: any behavior gated behind a prompt uses its **fallback default**, which often differs from the prompt's default selection. For example, a prompt that defaults to "Yes" interactively may fall back to `undefined` (falsy) when skipped — so the spawn-mode result differs from the interactive default.
 
-**Prompts are skipped in spawn mode.** Any behavior gated behind an interactive prompt will use its fallback default, which may differ from the prompt's default selection. For example, if a prompt defaults to "Yes" when shown to a user, but the code falls back to `undefined` (falsy) when the prompt is skipped, the spawn-mode behavior differs from the interactive default.
-
-Before omitting a flag from a non-interactive test, run the command without it to verify the unattended default matches what your test expects. If the fallback differs from what you'd expect, add the flag explicitly.
+Before omitting a flag from a non-interactive test, run the command without it and verify the unattended default matches what your test expects. If it doesn't, pass the flag explicitly.
 
 **Test both `-y` and non-`-y` unattended modes.** Both `-y` and a non-interactive terminal trigger `isUnattended() === true`, but they enter through different code paths. Use `describe.each` to parameterize all non-interactive tests across both modes. This also gives vitest distinct test entries for better sharding.
 
@@ -368,18 +361,6 @@ describe.each([
 })
 ```
 
-## Running E2E Tests
-
-After writing tests, run them — lint and type checks verify syntax, not behavior. Always validate with an actual e2e run before reporting tests as complete.
-
-```bash
-# Run a specific e2e test file
-pnpm --filter @sanity/cli-e2e exec vitest run __tests__/init/init.studio.test.ts --reporter=verbose
-
-# Run a specific test by name pattern
-pnpm --filter @sanity/cli-e2e exec vitest run __tests__/init/init.studio.test.ts -t "creates studio with default"
-```
-
 ## When Tests Reveal Product Bugs
 
 If a test failure reveals a product bug rather than a test bug, file an issue in Linear, skip the affected test with a link to the issue, and move on. Don't paper over product bugs with workarounds in test assertions.
@@ -391,21 +372,21 @@ test.skip('bare init creates minimal project', () => {
 })
 ```
 
-## What Belongs in E2E vs Command Tests
+## What Belongs in E2E vs Unit Tests
 
 E2e tests validate real commands against real infrastructure with real side effects. They are expensive to run and should focus on proving the full flow works.
 
-**Command tests** (`packages/@sanity/cli/src/commands/__tests__/`) test command handlers with mocked HTTP or client methods. They are fast, isolated, and appropriate for testing the full matrix of input validation, flag parsing, error messages, and edge cases.
+**Unit tests** (`packages/@sanity/cli/src/commands/__tests__/`) exercise command handlers with mocked HTTP or client methods. They are fast, isolated, and appropriate for testing the full matrix of input validation, flag parsing, error messages, and edge cases.
 
-| Concern | Where to test |
-|---------|---------------|
-| Flag validation, argument parsing | Command tests |
-| Error messages and exit codes for bad input | Command tests |
-| Config file parsing, input sanitization | Command tests |
-| Complete command flows with real side effects | E2e tests |
-| Files generated, APIs called, prompts displayed | E2e tests |
+| Concern                                       | Where to test |
+| --------------------------------------------- | ------------- |
+| Flag validation, argument parsing             | Unit tests    |
+| Error messages and exit codes for bad input   | Unit tests    |
+| Config file parsing, input sanitization       | Unit tests    |
+| Complete command flows with real side effects | E2e tests     |
+| Files generated, APIs called, prompts displayed | E2e tests   |
 
-For error handling in e2e, keep a single smoke test per command that confirms the binary rejects bad input. Test the full matrix of validation rules as command tests.
+For error handling in e2e, keep a single smoke test per command that confirms the binary rejects bad input. Test the full matrix of validation rules as unit tests.
 
 ```typescript
 // ONE e2e smoke test for error rejection
@@ -418,7 +399,7 @@ test('rejects deprecated --reconfigure flag', async () => {
   expect(stderr).toContain('--reconfigure is deprecated')
 })
 
-// Individual validation rules → command tests in
+// Individual validation rules → unit tests in
 // packages/@sanity/cli/src/commands/__tests__/
 ```
 
@@ -446,6 +427,6 @@ test('rejects deprecated --reconfigure flag', async () => {
 | Asserting on dynamic API content | Use structural regex patterns |
 | Mutating `process.env` directly | Use `vi.stubEnv()` for env overrides |
 | Mocking functions, APIs, or services | Never mock in e2e tests — test real infrastructure |
-| Testing flag validation/deprecation in e2e | One smoke test per command; validation matrix belongs in command tests |
+| Testing flag validation/deprecation in e2e | One smoke test per command; validation matrix belongs in unit tests |
 | Reading source to predict prompt order | Run the test and observe the actual CLI output to understand the flow |
 | Only running lint/types to validate | Always run the actual e2e tests before reporting done |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ All commands are run from the root of the repo.
 - `pnpm check:deps` - unused dependency / export check
 - `pnpm build:cli` - build the project
 - `pnpm watch:cli` - build in watch mode
-- `pnpm --filter @sanity/cli-e2e exec vitest run <file>` - run specific e2e test file
-- `pnpm --filter @sanity/cli-e2e exec vitest run <file> -t "<pattern>"` - run specific e2e test by name
+- `pnpm test:e2e <file>` - run specific e2e test file (args pass through to vitest)
+- `pnpm test:e2e <file> -t "<pattern>"` - run specific e2e test by name
 
 # Workflow
 

--- a/packages/@sanity/cli-e2e/README.md
+++ b/packages/@sanity/cli-e2e/README.md
@@ -123,6 +123,16 @@ Interactive sessions speak through `node-pty` and expose:
 
 Always prefer `selectOption(pattern)` over counting `ArrowDown` presses — option order is not stable across template/dataset/project changes.
 
+### Environment helpers
+
+`helpers/runCli.ts` also exports three helpers that read the credentials `globalSetup` injects, so tests don't have to touch `process.env` directly:
+
+- `getE2EProjectId()` — reads `SANITY_E2E_PROJECT_ID`
+- `getE2EOrganizationId()` — reads `SANITY_E2E_ORGANIZATION_ID`
+- `getE2EDataset()` — currently hardcoded to `'production'` (see the CI env vars note below)
+
+Each throws with a clear message if the underlying env var is missing, so tests fail loudly instead of passing `undefined` to the CLI.
+
 ### Common options
 
 - `args: string[]` — args passed to the CLI binary

--- a/packages/@sanity/cli-e2e/README.md
+++ b/packages/@sanity/cli-e2e/README.md
@@ -1,0 +1,217 @@
+# @sanity/cli-e2e
+
+End-to-end tests for the Sanity CLI. These tests pack the CLI to a tarball, install it, and run the resulting binary against real infrastructure (Sanity API, real templates, real npm installs) — verifying that the CLI works for both humans (interactive prompts) and agents/CI (non-interactive flag-driven runs).
+
+For test-writing patterns and conventions (test structure, naming, common mistakes), see the [`writing-cli-e2e-tests` skill](../../../.claude/skills/writing-cli-e2e-tests/SKILL.md). This README covers setup, infrastructure, and how to run/debug the tests.
+
+## Unit vs E2E
+
+Two tiers of tests live in this repo. Pick the right one for what you're verifying:
+
+|                  | Unit (`packages/@sanity/cli/src/commands/__tests__/`) | E2E (this package)                                          |
+| ---------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
+| **Runs against** | Mocked HTTP/client                                    | Real CLI binary, real API                                   |
+| **Speed**        | Milliseconds                                          | Seconds (each invocation ~10–60s)                           |
+| **Driver**       | `testCommand()`                                       | `runCli()`                                                  |
+| **Use for**      | Flag parsing, validation, error messages, edge cases  | Full flows: files generated, APIs called, prompts displayed |
+
+Default to unit tests. Reach for an e2e test when the test only has value if the binary actually runs end-to-end.
+
+## Setup
+
+E2E tests need credentials for a real Sanity project. Copy `.env.example` to `.env` and fill in the values:
+
+```bash
+SANITY_E2E_TOKEN=<robot token with read+write on the project>
+SANITY_E2E_PROJECT_ID=<project id used for all e2e tests>
+SANITY_E2E_ORGANIZATION_ID=<org id that owns the project>
+```
+
+`globalSetup.ts` loads `.env` automatically (existing env vars take precedence — CI sets them directly).
+
+## Running tests
+
+All commands run from the repo root.
+
+```bash
+# Build + run the full suite
+pnpm test:e2e
+
+# Run a single file (args after `test:e2e` are passed through to vitest)
+pnpm test:e2e __tests__/init/init.studio.yes.test.ts
+
+# Run a single test by name
+pnpm test:e2e __tests__/init/init.studio.yes.test.ts -t "creates studio with default"
+
+# Bail on first failure (faster feedback while iterating)
+pnpm test:e2e --bail=1
+
+# Verbose reporter (see each test name as it runs)
+pnpm test:e2e --reporter=verbose
+```
+
+`pnpm test:e2e` runs `pnpm build:cli` first via the `pretest:e2e` hook.
+
+## How `globalSetup` works
+
+Before any test runs, `globalSetup.ts`:
+
+1. Loads `.env` into `process.env`.
+2. Packs `@sanity/cli-core`, `@sanity/cli`, and `create-sanity` into tarballs (via `npm pack`).
+3. Installs the tarballs into a temp directory and exposes the resolved binary paths as env vars:
+   - `E2E_BINARY_PATH` — path to the packed `sanity` binary
+   - `E2E_CREATE_SANITY_BINARY_PATH` — path to the packed `create-sanity` binary
+4. Initializes test fixtures via `@sanity/cli-test` (copies `fixtures/*`, installs deps).
+
+After the run, the temp dir and tarballs are cleaned up.
+
+### Skipping the pack step
+
+If `E2E_BINARY_PATH` is already set, `globalSetup` skips the pack and uses the provided binary. The scheduled workflow uses this to run e2e against `sanity@latest` from the npm registry instead of the working tree.
+
+To run against a custom binary locally:
+
+```bash
+E2E_BINARY_PATH=/path/to/sanity pnpm test:e2e
+```
+
+## The `runCli()` API
+
+All tests drive the CLI through `helpers/runCli.ts`. It has two modes — overload-typed so you get the right return shape:
+
+### Non-interactive (default)
+
+```typescript
+const {error, exitCode, stdout, stderr} = await runCli({
+  args: ['datasets', 'list', '--project-id', getE2EProjectId()],
+})
+
+if (error) throw error
+expect(stdout.trim().length).toBeGreaterThan(0)
+```
+
+`stdio` is piped (no TTY), so `isInteractive()` returns false in the spawned CLI — any prompt is skipped and falls back to its non-interactive default. If you need to test prompt behavior, use interactive mode.
+
+### Interactive (PTY)
+
+```typescript
+const session = await runCli({
+  args: ['init', '--project', projectId, '--output-path', tmp.path, '--no-mcp', '--no-git'],
+  interactive: true,
+})
+
+await session.waitForText(/Select project template/i)
+await session.selectOption('clean')
+
+await session.waitForText(/Do you want to use TypeScript/i)
+session.sendKey('Enter')
+
+const exitCode = await session.waitForExit(90_000)
+expect(exitCode).toBe(0)
+```
+
+Interactive sessions speak through `node-pty` and expose:
+
+- `waitForText(regex, {timeout?})` — wait for a pattern in the (ANSI-stripped) output
+- `selectOption(pattern, {timeout?})` — navigate a select prompt by text and confirm; throws if zero or multiple options match
+- `sendKey('Enter' | 'ArrowDown' | ...)` — send a named key
+- `sendControl('c')` — send Ctrl+C (SIGINT, exits with 130)
+- `write(text)` — write raw text to stdin (for free-text prompts)
+- `getOutput()` — full output buffer so far (with ANSI)
+- `waitForExit(timeout?)` — resolve with the exit code, reject on timeout
+- `kill(signal?)` — kill the process
+
+Always prefer `selectOption(pattern)` over counting `ArrowDown` presses — option order is not stable across template/dataset/project changes.
+
+### Common options
+
+- `args: string[]` — args passed to the CLI binary
+- `cwd: string` — working directory (use `testFixture()` or `createTmpDir()` from `@sanity/cli-test`)
+- `env: Record<string, string>` — additional env overrides; merged onto a sane default that includes `SANITY_AUTH_TOKEN`, disables update notifier, and points `SANITY_CLI_CONFIG_PATH` at a non-existent path so the CLI can't read your local auth config
+- `binaryPath: string` — override the resolved binary (used by `create-sanity` tests, which pass `E2E_CREATE_SANITY_BINARY_PATH`)
+
+To test unauthenticated flows, override the token instead of unsetting it globally:
+
+```typescript
+await runCli({args: ['init'], env: {SANITY_AUTH_TOKEN: ''}})
+```
+
+## Writing tests
+
+See the [`writing-cli-e2e-tests` skill](../../../.claude/skills/writing-cli-e2e-tests/SKILL.md) for the canonical patterns — it covers test structure, naming, complete-flow assertions, both interactive and non-interactive modes, abort handling, and common mistakes.
+
+A minimal smoke test for reference:
+
+```typescript
+import {describe, expect, test} from 'vitest'
+import {runCli} from '../helpers/runCli.js'
+
+describe('sanity --help', () => {
+  test('prints usage information and exits 0', async () => {
+    const {error, stdout} = await runCli({args: ['--help']})
+    if (error) throw error
+    expect(stdout).toContain('USAGE')
+    expect(stdout).toContain('COMMANDS')
+  })
+})
+```
+
+## CI
+
+Two workflows run e2e tests:
+
+- **`.github/workflows/e2e.yml`** — runs on PRs that touch `packages/@sanity/cli*`, `packages/create-sanity`, `fixtures/`, or `pnpm-lock.yaml`, and on every push to `main`. Matrix: Node 20/22/24 × 2 vitest shards. Uses the working-tree CLI (packed by `globalSetup`).
+- **`.github/workflows/e2e-scheduled.yml`** — runs hourly (and on manual dispatch) against `sanity@latest` from npm. Catches regressions in the published artifact and posts to Slack on failure.
+
+To trigger the scheduled workflow manually against a specific version, use **Run workflow** on the Actions tab and supply a `cli_version` (e.g. `5.20.0`).
+
+To re-run a failed PR run, click **Re-run failed jobs** on the workflow run. Logs include each test's stdout/stderr; failures from the PTY session also dump the captured output, which is usually enough to diagnose.
+
+### CI environment
+
+Both workflows inject the same `SANITY_E2E_*` env vars from GitHub Actions secrets — there is no `.env` file in CI. Currently injected:
+
+- `SANITY_E2E_TOKEN`
+- `SANITY_E2E_PROJECT_ID`
+- `SANITY_E2E_ORGANIZATION_ID`
+- `SANITY_E2E_DATASET` _(injected but currently unused — `getE2EDataset()` is hardcoded to `production`)_
+
+### Adding a new env var
+
+If a test needs a new credential or configuration value:
+
+1. **Read it via `readEnv()`** in `helpers/runCli.ts` (or a new helper next to it) so the test fails loudly with a clear message when the var is missing, rather than passing `undefined` to the CLI.
+2. **Document it in `.env.example`** with an empty value so contributors know it's required for local runs.
+3. **Add the secret in GitHub** (Settings → Secrets and variables → Actions) on the `sanity-io/cli` repo. Use a secret unless the value is non-sensitive, in which case use a repo-level Variable.
+4. **Wire it into both workflows** under the `Run E2E tests` step's `env:` block:
+   - `.github/workflows/e2e.yml`
+   - `.github/workflows/e2e-scheduled.yml`
+
+## Debugging
+
+- **Run a single failing test by name** (`-t "<pattern>"`) instead of the full suite — each invocation is several seconds.
+- **Use `--reporter=verbose`** to see test names as they run; combine with `--bail=1` to stop on first failure.
+- **`session.getOutput()`** returns the full PTY buffer at any point — log it when an interactive test wedges. The default `waitForText` timeout error already includes the current output.
+- **Check `tmp/`** in this package — `globalSetup` and some tests write there; inspect generated projects after a failure (rerun with the test name to keep the dir intact, since `afterEach` cleans up tmp dirs created via `createTmpDir`).
+- **Enable CLI debug logs** by adding `DEBUG: 'sanity:*'` to the test's `env`. Output appears in `stderr` / `session.getOutput()`.
+- **`E2E_BINARY_PATH`** lets you point the suite at a manually built binary (skip pack, faster iteration on infra changes).
+
+## Gotchas
+
+- **Spawn mode skips prompts.** Non-interactive tests run with `stdio: ['ignore', 'pipe', 'pipe']` — no TTY. Any prompt the CLI would show is skipped and falls back to its non-prompt default, which may differ from the prompt's default selection. If the fallback differs from what you want, pass the flag explicitly.
+- **`CI=true` blocks interactive mode.** `runCli({interactive: true})` deletes `CI` from the spawned env (GitHub Actions sets it) so the CLI shows prompts instead of throwing `NonInteractiveError`.
+- **`SANITY_CLI_CONFIG_PATH`** is pointed at a non-existent path so the CLI can't read your local auth config. Tests authenticate exclusively through `SANITY_AUTH_TOKEN` (sourced from `SANITY_E2E_TOKEN`).
+- **Timeouts.** Vitest defaults to `testTimeout: 30_000`, `hookTimeout: 120_000`. Long flows (full `init` with install) need a `describe`-level timeout (e.g. `{timeout: 120_000}`). Set timeouts on `describe`, not per test.
+- **No mocking in e2e.** Never mock functions, services, or HTTP. If you find yourself wanting to mock, that test belongs in unit tests, not here.
+- **Real side effects.** Tests can publish documents, deploy datasets, and import sample data into the e2e project. Use the dedicated e2e project (not a personal one) and clean up where practical.
+- **PTY-only on supported platforms.** `node-pty` requires native bindings; if `pnpm install` skips them, interactive tests fail to spawn. CI matrix is Linux-only for now.
+- **Lockfile detection in `init`.** If a test pre-creates a lockfile in `tmp.path`, the CLI will auto-detect that package manager and skip the prompt. Useful for testing detection; surprising if unintentional.
+
+## Package layout
+
+- `__tests__/` — test files. Single-file commands live at the top level (`help.test.ts`); commands with multiple flows get a folder (`init/`), with non-interactive and interactive variants split into separate files for sharding.
+- `helpers/` — `runCli.ts` (public API), `spawnProcess.ts` / `spawnPty.ts` (transports), `packCli.ts` (used by `globalSetup`), and small utilities for env/keys/binary resolution.
+- `globalSetup.ts` — packs and installs the CLI before any test runs.
+- `vitest.config.ts`, `.env.example`, `package.json`.
+
+Shared utilities like `testFixture()` and `createTmpDir()` live in [`@sanity/cli-test`](../cli-test). Reach for those before adding helpers here.


### PR DESCRIPTION
### Description

Adds a comprehensive `packages/@sanity/cli-e2e/README.md` covering setup, `globalSetup`, the `runCli()` API (both spawn and PTY modes), CI workflows, debugging, and gotchas — none of which were documented before. Slims the `writing-cli-e2e-tests` skill to focus on test-writing patterns and cross-references the README for infrastructure details, so the two docs don't duplicate or drift.

Also touches up the skill: renames "Command tests" → "Unit tests" to match repo conventions, sharpens the `selectOption` description (literal substring vs. regex semantics), and drops a stale `pnpm --filter @sanity/cli-e2e exec vitest run` snippet in favor of the standard `pnpm test:e2e`.

### What to review

- `packages/@sanity/cli-e2e/README.md` — new file; check that the `runCli()` API description, env helpers, CI section, and gotchas match the actual code in `helpers/` and `globalSetup.ts`.
- `.claude/skills/writing-cli-e2e-tests/SKILL.md` — diff against main; the cross-references back to the README should land on real sections.
- `AGENTS.md` — single-line pointer update.

### Testing

Docs-only — no behavior change, no changeset (per repo convention for docs). Verified all internal links resolve.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that restructure and clarify how to run and write CLI e2e tests; no production code paths are modified.
> 
> **Overview**
> Adds a comprehensive `packages/@sanity/cli-e2e/README.md` documenting local/CI setup, `globalSetup` behavior, the `runCli()` spawn vs PTY APIs, environment variables, debugging tips, and common gotchas.
> 
> Refactors `.claude/skills/writing-cli-e2e-tests/SKILL.md` to focus on test-writing patterns (planning, assertions, interactive `selectOption` semantics, unattended defaults) and cross-links to the new README for infrastructure details, and updates terminology from **command tests** to **unit tests**.
> 
> Updates `AGENTS.md` to point to the standard `pnpm test:e2e` commands for running individual e2e files/tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60650e41ca16242160002e145f07eab220fd9ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->