### PR TITLE
fix(workbench): prune stale lock files

### DIFF
--- a/.changeset/pr-1057.md
+++ b/.changeset/pr-1057.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): prune stale lock files

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
@@ -302,6 +302,33 @@ describe('readWorkbenchLock', () => {
     expect(readWorkbenchLock()).toBeUndefined()
     expect(existsSync(lockPath)).toBe(false)
   })
+
+  // Regression: a zero-byte lock (e.g. left behind by a crashed writer or a
+  // killed `sanity dev` mid-write) used to early-return undefined without
+  // pruning, so the next acquire attempt hit EEXIST forever — `sanity dev`
+  // logged "Workbench dev server started at …" while no Vite was actually
+  // listening.
+  test('prunes zero-byte lock and returns undefined', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    const lockPath = join(dir, 'workbench.lock')
+    writeFileSync(lockPath, '')
+
+    expect(readWorkbenchLock()).toBeUndefined()
+    expect(existsSync(lockPath)).toBe(false)
+  })
+
+  test('prunes unparsable-JSON lock and returns undefined', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    const lockPath = join(dir, 'workbench.lock')
+    writeFileSync(lockPath, 'not json {{{')
+
+    expect(readWorkbenchLock()).toBeUndefined()
+    expect(existsSync(lockPath)).toBe(false)
+  })
 })
 
 describe('PID-reuse detection', () => {

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -228,23 +228,38 @@ export function getRegisteredServers(): DevServerManifest[] {
 export function readWorkbenchLock(): z.infer<typeof workbenchLockSchema> | undefined {
   const lockPath = join(getRegistryDir(), 'workbench.lock')
 
-  let raw: unknown
+  let contents: string
   try {
-    raw = JSON.parse(readFileSync(lockPath, 'utf8'))
+    contents = readFileSync(lockPath, 'utf8')
   } catch {
+    // File doesn't exist — nothing to prune, nothing to return
     return undefined
   }
 
-  const {data, success} = workbenchLockSchema.safeParse(raw)
-
-  devDebug('Read workbench lock: %o', data)
-
-  if (success && isOurProcess(data.pid, data.startedAt)) {
+  // Past this point the file exists. Anything that isn't a live, valid lock
+  // (unparsable JSON, schema mismatch, dead/reused PID) is stale and must be
+  // pruned — otherwise the next `acquireWorkbenchLock` call is blocked by
+  // EEXIST forever and `sanity dev` silently no-ops the workbench server.
+  const data = parseLockContents(contents)
+  if (data && isOurProcess(data.pid, data.startedAt)) {
     devDebug('Workbench process is alive at pid %d on port %d', data.pid, data.port)
     return data
   }
 
-  // Stale lock — prune it
+  pruneWorkbenchLock(lockPath)
+  return undefined
+}
+
+function parseLockContents(contents: string): z.infer<typeof workbenchLockSchema> | undefined {
+  try {
+    const {data, success} = workbenchLockSchema.safeParse(JSON.parse(contents))
+    return success ? data : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function pruneWorkbenchLock(lockPath: string): void {
   try {
     devDebug('Removing stale workbench lock')
     unlinkSync(lockPath)
@@ -252,7 +267,6 @@ export function readWorkbenchLock(): z.infer<typeof workbenchLockSchema> | undef
   } catch {
     // Another process may have already cleaned it up
   }
-  return undefined
 }
 
 interface WorkbenchLock {

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -241,6 +241,7 @@ export function readWorkbenchLock(): z.infer<typeof workbenchLockSchema> | undef
   // pruned — otherwise the next `acquireWorkbenchLock` call is blocked by
   // EEXIST forever and `sanity dev` silently no-ops the workbench server.
   const data = parseLockContents(contents)
+  devDebug('Read workbench lock: %o', data)
   if (data && isOurProcess(data.pid, data.startedAt)) {
     devDebug('Workbench process is alive at pid %d on port %d', data.pid, data.port)
     return data


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

My workbench dev-server wasn't starting anymore:

A 0-byte (or otherwise unparsable) `~/.sanity[-staging]/dev-servers/workbench.lock` — left behind by a crashed or killed `sanity dev` mid-write — permanently blocks every subsequent workbench startup. Symptoms: `sanity dev` logs `Workbench dev server started at http://localhost:3333` but the port refuses connections, and parallel apps each fall back to their configured `server.port` instead of sharing the shell.

`acquireWorkbenchLock` writes with `O_EXCL` (`wx`) and on `EEXIST` defers to `readWorkbenchLock` to decide whether the lock is stale. `readWorkbenchLock` only pruned the file when it parsed *and* failed `isOurProcess`; if `JSON.parse` threw (empty/truncated file) it early-returned without unlinking. The retry then hit `EEXIST` again, `acquireWorkbenchLock` returned `undefined`, and `startWorkbenchDevServer` interpreted that as "another process owns it" and returned `workbenchAvailable: true` *without ever calling `createServer`*. Result: a sticky tombstone no future `sanity dev` could clear.

### Fix

`readWorkbenchLock` now prunes on **any** outcome that isn't a live, valid lock (unparsable JSON, schema mismatch, dead/reused PID). The "exists but not live ⇒ prune" invariant lives in one branch instead of three. Pulled JSON+schema parsing into a `parseLockContents` helper so the read flow reads top-to-bottom.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

- Two regression tests: zero-byte lock and unparsable-JSON lock are both pruned and return `undefined`.
- Manually reproduced by `touch ~/.sanity-staging/dev-servers/workbench.lock` before `pnpm dev` — pre-fix: 3 apps on 3333/3334/3335 with 3333 refused; post-fix: all 3 apps converge on 3333 and the lock is rewritten with a valid JSON pointing at the live PID.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly changes workbench dev-server lockfile parsing/pruning logic and adds regression tests; behavior change is limited to deleting invalid/stale `workbench.lock` files.
> 
> **Overview**
> Fixes a workbench dev-server startup deadlock by ensuring `readWorkbenchLock()` **prunes any existing but invalid/non-live lock file**, including zero-byte and unparsable JSON cases (previously these could block future startups via perpetual `EEXIST`).
> 
> Refactors the lock read path to parse via a `parseLockContents()` helper and centralizes deletion in `pruneWorkbenchLock()`, and adds regression tests covering empty and malformed lock files. Includes a patch changeset for `@sanity/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dac7c0621860341ce736809f18797d4687672e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->