### PR TITLE
fix(create-sanity): use native import.meta.resolve to support yarn pnp

### DIFF
--- a/.changeset/pr-1063.md
+++ b/.changeset/pr-1063.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'create-sanity': patch
+---
+
+fix(create-sanity): use native import.meta.resolve to support yarn pnp

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -81,9 +81,7 @@ const baseConfig = {
       entry: ['package.config.ts'],
       project,
     },
-    'packages/create-sanity': {
-      ignoreDependencies: ['@sanity/cli'],
-    },
+    'packages/create-sanity': {},
   },
 } satisfies KnipConfig
 

--- a/packages/create-sanity/index.js
+++ b/packages/create-sanity/index.js
@@ -4,13 +4,11 @@ import {readFile} from 'node:fs/promises'
 import {dirname, resolve} from 'node:path'
 import {fileURLToPath} from 'node:url'
 
-import {moduleResolve} from 'import-meta-resolve'
-
 const args = process.argv.slice(2)
 
 let cliBin
 try {
-  const cliPkgDir = fileURLToPath(await moduleResolve('@sanity/cli/package.json', import.meta.url))
+  const cliPkgDir = fileURLToPath(import.meta.resolve('@sanity/cli/package.json'))
   const cliDir = dirname(cliPkgDir)
 
   // Read the package.json file and extract the bin path

--- a/packages/create-sanity/package.json
+++ b/packages/create-sanity/package.json
@@ -31,8 +31,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@sanity/cli": "workspace:*",
-    "import-meta-resolve": "catalog:"
+    "@sanity/cli": "workspace:*"
   },
   "devDependencies": {
     "publint": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,9 +1061,6 @@ importers:
       '@sanity/cli':
         specifier: workspace:*
         version: link:../@sanity/cli
-      import-meta-resolve:
-        specifier: 'catalog:'
-        version: 4.2.0
     devDependencies:
       publint:
         specifier: 'catalog:'


### PR DESCRIPTION
> Heads up — this is my first PR to this repo, so feel free to be skeptical
> of anything I've gotten wrong here. Happy to iterate on framing, scope, or
> approach.

### Description

`yarn create sanity@latest` fails under Yarn 4 (PnP — the default install mode) with:

```
Error: Failed to resolve `@sanity/cli` package
  [cause]: Error: Cannot find package '@sanity/cli' imported from .../create-sanity/index.js
  code: 'ERR_MODULE_NOT_FOUND'
```

`packages/create-sanity/index.js` resolves `@sanity/cli` via `moduleResolve` from the `import-meta-resolve` package. That's a userland reimplementation of Node's ESM resolver — it walks `node_modules` directly and bypasses any loader hooks Node has registered. Under `yarn dlx` / `yarn create`, Yarn's PnP resolver is hooked into the native resolver but there is no `node_modules` tree on disk, so `import-meta-resolve` returns `ERR_MODULE_NOT_FOUND`.

This is why the bug only surfaces under Yarn — npm, pnpm, and bun all use real (or symlinked) `node_modules` layouts, so `import-meta-resolve` finds the package the same way Node would.

The fix swaps `moduleResolve(...)` for native `import.meta.resolve(...)`, which delegates through the active loader (PnP included). The package's `engines` field already requires `>=20.19.1 <22 || >=22.12`, where `import.meta.resolve()` is stable — so the `import-meta-resolve` dep can be dropped entirely. Also removed the now-unneeded `ignoreDependencies: ['@sanity/cli']` entry in `knip.config.ts` since knip can statically detect `@sanity/cli` again.

### What to review

- [packages/create-sanity/index.js](packages/create-sanity/index.js) — the one-line resolver swap.
- [packages/create-sanity/package.json](packages/create-sanity/package.json) — `import-meta-resolve` removed from dependencies.
- [knip.config.ts](knip.config.ts) — `ignoreDependencies` cleanup for `packages/create-sanity`.
- `pnpm-lock.yaml` — lockfile updates from the dep removal.

### Testing

- `pnpm check:types`, `pnpm check:lint`, `pnpm check:deps`, and the `create-sanity` vitest suite all pass.
- Ran the full `create-sanity` init flow under **npm, pnpm, bun, and yarn**, on both `main` and this branch (8 cells). Yarn on `main` reproduces the `ERR_MODULE_NOT_FOUND`; this branch passes under all four. npm / pnpm / bun pass on both branches with identical scaffolded output, so the fix doesn't appear to regress those flows.

User-facing workaround for users on a published version until this ships: `YARN_NODE_LINKER=node-modules yarn create sanity@latest`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to how `create-sanity` resolves the `@sanity/cli` entrypoint plus dependency/lockfile cleanup; main risk is compatibility if Node versions without stable `import.meta.resolve` are used despite the engines constraint.
> 
> **Overview**
> Fixes Yarn PnP execution of `create-sanity` by switching `@sanity/cli` resolution from the `import-meta-resolve` polyfill to native `import.meta.resolve()`.
> 
> Drops the `import-meta-resolve` dependency (and updates `pnpm-lock.yaml`), and simplifies Knip workspace config for `packages/create-sanity` now that `@sanity/cli` is statically detectable. **Includes a patch changeset** for `create-sanity`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59aa1f49939cf4b1908849d2f8c057982e9da357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->