### PR TITLE
refactor: reorganise branch additions in a coherent way

### DIFF
--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -1,15 +1,13 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {devAction} from '../devAction.js'
-import {createDevOptions, createMockOutput} from './testHelpers.js'
+import {createBaseDevOptions, createMockOutput} from './testHelpers.js'
 
 const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
 const mockStartAppDevServer = vi.hoisted(() => vi.fn())
 const mockStartStudioDevServer = vi.hoisted(() => vi.fn())
-const mockRegisterDevServer = vi.hoisted(() => vi.fn())
-const mockStartDevManifestWatcher = vi.hoisted(() => vi.fn())
-const mockExtractCoreAppManifest = vi.hoisted(() => vi.fn())
-const mockExtractStudioManifest = vi.hoisted(() => vi.fn())
+const mockStartFederationRegistration = vi.hoisted(() => vi.fn())
+const mockGetSharedServerConfig = vi.hoisted(() => vi.fn())
 
 vi.mock('../startWorkbenchDevServer.js', () => ({
   startWorkbenchDevServer: mockStartWorkbenchDevServer,
@@ -20,17 +18,11 @@ vi.mock('../startAppDevServer.js', () => ({
 vi.mock('../startStudioDevServer.js', () => ({
   startStudioDevServer: mockStartStudioDevServer,
 }))
-vi.mock('../devServerRegistry.js', () => ({
-  registerDevServer: mockRegisterDevServer,
+vi.mock('../startFederationRegistration.js', () => ({
+  startFederationRegistration: mockStartFederationRegistration,
 }))
-vi.mock('../startDevManifestWatcher.js', () => ({
-  startDevManifestWatcher: mockStartDevManifestWatcher,
-}))
-vi.mock('../../manifest/extractCoreAppManifest.js', () => ({
-  extractCoreAppManifest: mockExtractCoreAppManifest,
-}))
-vi.mock('../extractDevServerManifest.js', () => ({
-  extractStudioManifest: mockExtractStudioManifest,
+vi.mock('../../../util/getSharedServerConfig.js', () => ({
+  getSharedServerConfig: mockGetSharedServerConfig,
 }))
 
 /** Create a mock Vite dev server config shape — `server.config.server.host`
@@ -44,6 +36,7 @@ function mockServer({host, port = 3334}: {host?: boolean | string; port?: number
 
 describe('devAction', () => {
   beforeEach(() => {
+    mockGetSharedServerConfig.mockReturnValue({httpHost: 'localhost', httpPort: 3333})
     // Default: no workbench (federation disabled)
     mockStartWorkbenchDevServer.mockResolvedValue({
       close: vi.fn().mockResolvedValue(undefined),
@@ -51,9 +44,9 @@ describe('devAction', () => {
       workbenchAvailable: false,
       workbenchPort: 3333,
     })
-    mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
-    mockStartDevManifestWatcher.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
-    mockExtractCoreAppManifest.mockResolvedValue(undefined)
+    mockStartFederationRegistration.mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+    })
   })
 
   afterEach(() => {
@@ -63,7 +56,7 @@ describe('devAction', () => {
   test('studio mode without workbench uses original port', async () => {
     mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
 
-    await devAction(createDevOptions())
+    await devAction(createBaseDevOptions())
 
     expect(mockStartStudioDevServer).toHaveBeenCalledWith(
       expect.objectContaining({flags: expect.objectContaining({port: '3333'})}),
@@ -80,7 +73,7 @@ describe('devAction', () => {
     mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
     const output = createMockOutput()
 
-    await devAction(createDevOptions({output}))
+    await devAction(createBaseDevOptions({output}))
 
     expect(mockStartStudioDevServer).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -95,7 +88,7 @@ describe('devAction', () => {
   test('app mode routes to startAppDevServer', async () => {
     mockStartAppDevServer.mockResolvedValue(mockServer({port: 3333}))
 
-    await devAction(createDevOptions({isApp: true}))
+    await devAction(createBaseDevOptions({isApp: true}))
 
     expect(mockStartAppDevServer).toHaveBeenCalled()
     expect(mockStartStudioDevServer).not.toHaveBeenCalled()
@@ -110,7 +103,7 @@ describe('devAction', () => {
     })
     mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
-    await devAction(createDevOptions())
+    await devAction(createBaseDevOptions())
 
     expect(mockStartStudioDevServer).toHaveBeenCalledWith(
       expect.objectContaining({reactRefreshHost: 'http://localhost:3333'}),
@@ -120,7 +113,7 @@ describe('devAction', () => {
   test('does not pass reactRefreshHost when workbench is not running', async () => {
     mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
 
-    await devAction(createDevOptions())
+    await devAction(createBaseDevOptions())
 
     expect(mockStartStudioDevServer).toHaveBeenCalledWith(
       expect.objectContaining({reactRefreshHost: undefined}),
@@ -138,7 +131,7 @@ describe('devAction', () => {
     const startupError = new Error('Port already in use')
     mockStartStudioDevServer.mockRejectedValue(startupError)
 
-    const thrown = await devAction(createDevOptions()).catch((err) => err)
+    const thrown = await devAction(createBaseDevOptions()).catch((err) => err)
 
     expect(thrown).toBe(startupError)
     expect(mockWorkbenchClose).toHaveBeenCalled()
@@ -158,335 +151,105 @@ describe('devAction', () => {
       close: mockAppClose,
     })
 
-    const result = await devAction(createDevOptions())
+    const result = await devAction(createBaseDevOptions())
 
     await expect(result.close()).resolves.toBeUndefined()
     expect(mockWorkbenchClose).toHaveBeenCalled()
     expect(mockAppClose).toHaveBeenCalled()
   })
 
-  describe('registry integration', () => {
-    test('registers studio in registry when federation is enabled', async () => {
+  describe('federation registration', () => {
+    test('starts federation registration when federation is enabled', async () => {
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
-      await devAction(
-        createDevOptions({
-          cliConfig: {federation: {enabled: true}},
-        }),
-      )
+      await devAction(createBaseDevOptions({cliConfig: {federation: {enabled: true}}}))
 
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
+      expect(mockStartFederationRegistration).toHaveBeenCalledWith(
         expect.objectContaining({
-          host: 'localhost',
-          port: 3334,
-          type: 'studio',
+          isApp: false,
+          workDir: '/tmp/sanity-project',
         }),
       )
     })
 
-    test('passes deployment.appId to registerDevServer', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {deployment: {appId: 'app-abc'}, federation: {enabled: true}},
-        }),
-      )
-
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({id: 'app-abc'}))
-    })
-
-    test('forwards api.projectId from sanity.cli.ts to registerDevServer', async () => {
-      // Workbench resolves a studio's primary project against the org projects
-      // list; without the projectId in the very first registry write, the
-      // workbench falls back to a synthetic `host-port` id that has no match,
-      // breaking the dock until manifest extraction completes.
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {api: {projectId: 'x1g7jygt'}, federation: {enabled: true}},
-        }),
-      )
-
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({projectId: 'x1g7jygt'}),
-      )
-    })
-
-    test('omits projectId when api.projectId is not configured', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
-
-      const [registerArg] = mockRegisterDevServer.mock.calls[0]
-      expect(registerArg.projectId).toBeUndefined()
-    })
-
-    test('warns about deprecated app.id and falls back to it when registering', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-      const output = createMockOutput()
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {app: {id: 'legacy-app'}, federation: {enabled: true}},
-          output,
-        }),
-      )
-
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({id: 'legacy-app'}),
-      )
-      expect(output.warn).toHaveBeenCalledWith(
-        expect.stringContaining('`app.id` config has moved to `deployment.appId`'),
-      )
-    })
-
-    test('errors out when both app.id and deployment.appId are set', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-      const output = createMockOutput()
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {
-            app: {id: 'legacy-app'},
-            deployment: {appId: 'new-app'},
-            federation: {enabled: true},
-          },
-          output,
-        }),
-      )
-
-      expect(output.error).toHaveBeenCalledWith(
-        expect.stringContaining('Found both app.id (deprecated) and deployment.appId'),
-        expect.objectContaining({exit: 1}),
-      )
-    })
-
-    test('registers without icon/title — they are derived from the inlined manifest', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
-
-      const [registerArg] = mockRegisterDevServer.mock.calls[0]
-      expect(registerArg).not.toHaveProperty('icon')
-      expect(registerArg).not.toHaveProperty('title')
-      expect(registerArg.id).toBeUndefined()
-    })
-
-    test('registers app under the host applied by the vite dev server', async () => {
-      // The resolved host on `server.config.server.host` reflects the final,
-      // user-merged Vite config — use that as the authoritative source.
-      mockStartStudioDevServer.mockResolvedValue(mockServer({host: 'mydev.local', port: 3334}))
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {federation: {enabled: true}, server: {hostname: 'mydev.local'}},
-        }),
-      )
-
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({host: 'mydev.local'}),
-      )
-    })
-
-    test('registered host reflects the vite server even when user vite config overrides the cli config', async () => {
-      // User's vite config set `server.host` to 'app.local' — that wins over
-      // the cli config's `server.hostname`. The registered host must follow
-      // the vite server's resolved config, not the cli config.
-      mockStartStudioDevServer.mockResolvedValue(mockServer({host: 'app.local', port: 3334}))
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {federation: {enabled: true}, server: {hostname: 'cli-config.local'}},
-        }),
-      )
-
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({host: 'app.local'}),
-      )
-    })
-
-    test('falls back to localhost when the vite server host is not a string', async () => {
-      // `server.host: true` (bind to all interfaces) is not a usable URL host.
-      mockStartStudioDevServer.mockResolvedValue(mockServer({host: true, port: 3334}))
-
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
-
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({host: 'localhost'}),
-      )
-    })
-
-    test('registers app type when isApp is true', async () => {
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(
-        createDevOptions({
-          cliConfig: {federation: {enabled: true}},
-          isApp: true,
-        }),
-      )
-
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({type: 'coreApp'}))
-    })
-
-    test('does not register when federation is disabled', async () => {
+    test('does not start federation registration when federation is disabled', async () => {
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
 
-      await devAction(createDevOptions())
+      await devAction(createBaseDevOptions())
 
-      expect(mockRegisterDevServer).not.toHaveBeenCalled()
+      expect(mockStartFederationRegistration).not.toHaveBeenCalled()
     })
 
-    test('does not start the manifest watcher when federation is disabled', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
-
-      await devAction(createDevOptions())
-
-      expect(mockStartDevManifestWatcher).not.toHaveBeenCalled()
-    })
-
-    test('starts the manifest watcher for studios when federation is enabled', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
-
-      expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
-        expect.objectContaining({workDir: '/tmp/sanity-project'}),
-      )
-    })
-
-    test('starts the manifest watcher for core apps — keeps title/icon in sync with sanity.cli.ts', async () => {
+    test('passes isApp: true for app mode', async () => {
       mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
 
-      await devAction(
-        createDevOptions({
-          cliConfig: {federation: {enabled: true}},
-          isApp: true,
-        }),
-      )
+      await devAction(createBaseDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true}))
 
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({type: 'coreApp'}))
-      expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
-        expect.objectContaining({extract: expect.any(Function), workDir: '/tmp/sanity-project'}),
+      expect(mockStartFederationRegistration).toHaveBeenCalledWith(
+        expect.objectContaining({isApp: true}),
       )
     })
 
-    test('registers the core-app immediately with no manifest — startup is not blocked on extraction', async () => {
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
+    test('passes the vite dev server to federation registration', async () => {
+      const server = mockServer({port: 3334})
+      mockStartStudioDevServer.mockResolvedValue(server)
 
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true}))
+      await devAction(createBaseDevOptions({cliConfig: {federation: {enabled: true}}}))
 
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.not.objectContaining({manifest: expect.anything()}),
+      expect(mockStartFederationRegistration).toHaveBeenCalledWith(
+        expect.objectContaining({server: server.server}),
       )
     })
 
-    test('wires extractCoreAppManifest into the core-app watcher', async () => {
-      const appManifest = {icon: '<svg><path d="M0 0"/></svg>', title: 'My App', version: '1'}
-      mockExtractCoreAppManifest.mockResolvedValue(appManifest)
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}, isApp: true}))
-
-      const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
-      // The watcher invokes `extract` with the resolved configPath; the
-      // core-app extractor reads `sanity.cli.ts` via `getCliConfigUncached(workDir)`,
-      // so only `workDir` is forwarded.
-      await expect(
-        extract({configPath: '/tmp/sanity-project/sanity.cli.ts', workDir: '/tmp/sanity-project'}),
-      ).resolves.toEqual(appManifest)
-      expect(mockExtractCoreAppManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
-    })
-
-    test('wires extractStudioManifest into the studio watcher', async () => {
+    test('calls federation close on close', async () => {
+      const mockFederationClose = vi.fn().mockResolvedValue(undefined)
+      mockStartFederationRegistration.mockResolvedValue({close: mockFederationClose})
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
-
-      const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
-      // The studio extractor is passed by reference — the watcher's
-      // `{configPath, workDir}` arg is forwarded as-is.
-      expect(extract).toBe(mockExtractStudioManifest)
-    })
-
-    test('registers the studio immediately with no manifest — the watcher owns extraction', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
-
-      expect(mockRegisterDevServer).toHaveBeenCalledWith(
-        expect.not.objectContaining({manifest: expect.anything()}),
+      const result = await devAction(
+        createBaseDevOptions({cliConfig: {federation: {enabled: true}}}),
       )
-      expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
-        expect.objectContaining({update: expect.any(Function), workDir: '/tmp/sanity-project'}),
-      )
-    })
-
-    test('calls manifest cleanup on close', async () => {
-      const mockCleanup = vi.fn()
-      mockRegisterDevServer.mockReturnValue({release: mockCleanup, update: vi.fn()})
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      const result = await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
 
       await result.close()
-      expect(mockCleanup).toHaveBeenCalled()
+      expect(mockFederationClose).toHaveBeenCalled()
+    })
+  })
+
+  test('registers signal handlers that trigger close on SIGINT', async () => {
+    const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
+    const mockAppClose = vi.fn().mockResolvedValue(undefined)
+    mockStartWorkbenchDevServer.mockResolvedValue({
+      close: mockWorkbenchClose,
+      httpHost: 'localhost',
+      workbenchAvailable: false,
+      workbenchPort: 3333,
+    })
+    mockStartStudioDevServer.mockResolvedValue({
+      ...mockServer({port: 3333}),
+      close: mockAppClose,
     })
 
-    test('close removes signal handlers to prevent listener leaks', async () => {
-      const offSpy = vi.spyOn(process, 'off')
-      mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+    await devAction(createBaseDevOptions())
 
-      const result = await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
-      await result.close()
+    expect(process.listenerCount('SIGINT')).toBeGreaterThanOrEqual(1)
+    expect(process.listenerCount('SIGTERM')).toBeGreaterThanOrEqual(1)
+  })
 
-      expect(offSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function))
-      expect(offSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function))
+  test('close removes signal handlers', async () => {
+    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
 
-      offSpy.mockRestore()
-    })
+    const sigintBefore = process.listenerCount('SIGINT')
+    const sigtermBefore = process.listenerCount('SIGTERM')
 
-    test('SIGINT handler cleans up manifest, workbench, and the manifest watcher, and removes itself', async () => {
-      const mockCleanup = vi.fn()
-      const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
-      const mockWatcherClose = vi.fn().mockResolvedValue(undefined)
-      mockRegisterDevServer.mockReturnValue({release: mockCleanup, update: vi.fn()})
-      mockStartWorkbenchDevServer.mockResolvedValue({
-        close: mockWorkbenchClose,
-        httpHost: 'localhost',
-        workbenchAvailable: true,
-        workbenchPort: 3333,
-      })
-      mockStartDevManifestWatcher.mockResolvedValue({close: mockWatcherClose})
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+    const result = await devAction(createBaseDevOptions())
 
-      const onSpy = vi.spyOn(process, 'on')
-      const offSpy = vi.spyOn(process, 'off')
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + 1)
 
-      const result = await devAction(createDevOptions({cliConfig: {federation: {enabled: true}}}))
+    await result.close()
 
-      // Grab the registered SIGINT handler (first call matching 'SIGINT')
-      const sigintCall = onSpy.mock.calls.find(([ev]) => ev === 'SIGINT')
-      expect(sigintCall).toBeDefined()
-      const handler = sigintCall![1] as () => void
-
-      // Invoke the handler directly — simulates the OS delivering SIGINT
-      handler()
-
-      expect(mockCleanup).toHaveBeenCalled()
-      expect(mockWatcherClose).toHaveBeenCalled()
-      expect(mockWorkbenchClose).toHaveBeenCalled()
-      expect(offSpy).toHaveBeenCalledWith('SIGINT', handler)
-      expect(offSpy).toHaveBeenCalledWith('SIGTERM', handler)
-
-      // Prevent the close teardown from double-invoking the handlers we just removed
-      await result.close()
-      onSpy.mockRestore()
-      offSpy.mockRestore()
-    })
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)
   })
 
   test('returns early with workbench-only close when app server exits without a server', async () => {
@@ -500,13 +263,13 @@ describe('devAction', () => {
     })
     mockStartAppDevServer.mockResolvedValue({})
 
-    const result = await devAction(createDevOptions({isApp: true}))
+    const result = await devAction(createBaseDevOptions({isApp: true}))
 
     expect(result.close).toBeDefined()
     // The close must still tear down the workbench server
     await result.close()
     expect(mockWorkbenchClose).toHaveBeenCalled()
     // No registration should have happened because federation wasn't evaluated
-    expect(mockRegisterDevServer).not.toHaveBeenCalled()
+    expect(mockStartFederationRegistration).not.toHaveBeenCalled()
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -252,6 +252,30 @@ describe('devAction', () => {
     expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)
   })
 
+  test('uses local httpHost for workbench URL even when existing lock reports a different host', async () => {
+    // Scenario: process A started workbench on mydev.local:3333, process B starts
+    // with --host localhost. startWorkbenchDevServer returns the existing lock's host,
+    // but devAction ignores it and uses its own httpHost from getSharedServerConfig.
+    mockGetSharedServerConfig.mockReturnValue({httpHost: 'localhost', httpPort: 3333})
+    mockStartWorkbenchDevServer.mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      httpHost: 'mydev.local',
+      workbenchAvailable: true,
+      workbenchPort: 3333,
+    })
+    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+    const output = createMockOutput()
+
+    await devAction(createBaseDevOptions({output}))
+
+    // The workbench is running on mydev.local — the URL and reactRefreshHost
+    // should reflect the existing workbench's host, not the caller's.
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('mydev.local:3333'))
+    expect(mockStartStudioDevServer).toHaveBeenCalledWith(
+      expect.objectContaining({reactRefreshHost: 'http://mydev.local:3333'}),
+    )
+  })
+
   test('returns early with workbench-only close when app server exits without a server', async () => {
     // startAppDevServer resolves with {} when orgId is missing — no `server`.
     const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
@@ -1,0 +1,306 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {startFederationRegistration} from '../startFederationRegistration.js'
+import {createMockOutput} from './testHelpers.js'
+
+const mockRegisterDevServer = vi.hoisted(() => vi.fn())
+const mockStartDevManifestWatcher = vi.hoisted(() => vi.fn())
+const mockExtractCoreAppManifest = vi.hoisted(() => vi.fn())
+const mockExtractStudioManifest = vi.hoisted(() => vi.fn())
+const mockCheckForDeprecatedAppId = vi.hoisted(() => vi.fn())
+const mockGetAppId = vi.hoisted(() => vi.fn())
+
+vi.mock('../devServerRegistry.js', () => ({
+  registerDevServer: mockRegisterDevServer,
+}))
+vi.mock('../startDevManifestWatcher.js', () => ({
+  startDevManifestWatcher: mockStartDevManifestWatcher,
+}))
+vi.mock('../../manifest/extractCoreAppManifest.js', () => ({
+  extractCoreAppManifest: mockExtractCoreAppManifest,
+}))
+vi.mock('../extractDevServerManifest.js', () => ({
+  extractStudioManifest: mockExtractStudioManifest,
+}))
+vi.mock('../../../util/appId.js', () => ({
+  checkForDeprecatedAppId: mockCheckForDeprecatedAppId,
+  getAppId: mockGetAppId,
+}))
+
+function mockServer({host, port = 3334}: {host?: boolean | string; port?: number} = {}) {
+  return {
+    config: {server: {host, port}},
+    httpServer: {address: () => ({address: '127.0.0.1', family: 'IPv4', port})},
+  }
+}
+
+describe('startFederationRegistration', () => {
+  beforeEach(() => {
+    mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
+    mockStartDevManifestWatcher.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
+    mockExtractCoreAppManifest.mockResolvedValue(undefined)
+    mockGetAppId.mockReturnValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('registers studio in registry', async () => {
+    await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: false,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockRegisterDevServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'localhost',
+        port: 3334,
+        type: 'studio',
+      }),
+    )
+  })
+
+  test('passes deployment.appId to registerDevServer', async () => {
+    mockGetAppId.mockReturnValue('app-abc')
+
+    await startFederationRegistration({
+      cliConfig: {deployment: {appId: 'app-abc'}, federation: {enabled: true}},
+      isApp: false,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({id: 'app-abc'}))
+  })
+
+  test('forwards api.projectId to registerDevServer', async () => {
+    await startFederationRegistration({
+      cliConfig: {api: {projectId: 'x1g7jygt'}, federation: {enabled: true}},
+      isApp: false,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockRegisterDevServer).toHaveBeenCalledWith(
+      expect.objectContaining({projectId: 'x1g7jygt'}),
+    )
+  })
+
+  test('omits projectId when api.projectId is not configured', async () => {
+    await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: false,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    const [registerArg] = mockRegisterDevServer.mock.calls[0]
+    expect(registerArg.projectId).toBeUndefined()
+  })
+
+  test('checks for deprecated app.id', async () => {
+    const output = createMockOutput()
+
+    await startFederationRegistration({
+      cliConfig: {app: {id: 'legacy-app'}, federation: {enabled: true}},
+      isApp: false,
+      output,
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockCheckForDeprecatedAppId).toHaveBeenCalledWith(expect.objectContaining({output}))
+  })
+
+  test('registers without icon/title — they are derived from the inlined manifest', async () => {
+    await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: false,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    const [registerArg] = mockRegisterDevServer.mock.calls[0]
+    expect(registerArg).not.toHaveProperty('icon')
+    expect(registerArg).not.toHaveProperty('title')
+  })
+
+  test('registers app under the host applied by the vite dev server', async () => {
+    await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: false,
+      output: createMockOutput(),
+      server: mockServer({host: 'mydev.local', port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockRegisterDevServer).toHaveBeenCalledWith(
+      expect.objectContaining({host: 'mydev.local'}),
+    )
+  })
+
+  test('falls back to localhost when the vite server host is not a string', async () => {
+    await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: false,
+      output: createMockOutput(),
+      server: mockServer({host: true, port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({host: 'localhost'}))
+  })
+
+  test('registers app type when isApp is true', async () => {
+    await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: true,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({type: 'coreApp'}))
+  })
+
+  test('starts the manifest watcher for studios', async () => {
+    await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: false,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
+      expect.objectContaining({workDir: '/tmp/sanity-project'}),
+    )
+  })
+
+  test('starts the manifest watcher for core apps', async () => {
+    await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: true,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
+      expect.objectContaining({extract: expect.any(Function), workDir: '/tmp/sanity-project'}),
+    )
+  })
+
+  test('wires extractCoreAppManifest into the core-app watcher', async () => {
+    const appManifest = {icon: '<svg><path d="M0 0"/></svg>', title: 'My App', version: '1'}
+    mockExtractCoreAppManifest.mockResolvedValue(appManifest)
+
+    await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: true,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
+    await expect(
+      extract({configPath: '/tmp/sanity-project/sanity.cli.ts', workDir: '/tmp/sanity-project'}),
+    ).resolves.toEqual(appManifest)
+    expect(mockExtractCoreAppManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
+  })
+
+  test('wires extractStudioManifest into the studio watcher', async () => {
+    await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: false,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
+    expect(extract).toBe(mockExtractStudioManifest)
+  })
+
+  test('calls manifest cleanup on close', async () => {
+    const mockCleanup = vi.fn()
+    mockRegisterDevServer.mockReturnValue({release: mockCleanup, update: vi.fn()})
+
+    const result = await startFederationRegistration({
+      cliConfig: {federation: {enabled: true}},
+      isApp: false,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    await result.close()
+    expect(mockCleanup).toHaveBeenCalled()
+  })
+
+  test('propagates error when registerDevServer throws', async () => {
+    const error = new Error('Registry write failed')
+    mockRegisterDevServer.mockImplementation(() => {
+      throw error
+    })
+
+    await expect(
+      startFederationRegistration({
+        cliConfig: {federation: {enabled: true}},
+        isApp: false,
+        output: createMockOutput(),
+        server: mockServer({port: 3334}) as any,
+        workDir: '/tmp/sanity-project',
+      }),
+    ).rejects.toThrow(error)
+  })
+
+  test('propagates error when startDevManifestWatcher rejects', async () => {
+    const error = new Error('Watcher setup failed')
+    mockStartDevManifestWatcher.mockRejectedValue(error)
+
+    await expect(
+      startFederationRegistration({
+        cliConfig: {federation: {enabled: true}},
+        isApp: false,
+        output: createMockOutput(),
+        server: mockServer({port: 3334}) as any,
+        workDir: '/tmp/sanity-project',
+      }),
+    ).rejects.toThrow(error)
+  })
+
+  test('calls output.error when both app.id and deployment.appId are set', async () => {
+    mockCheckForDeprecatedAppId.mockImplementation(({output}: {output: any}) => {
+      output.error('Found both app.id (deprecated) and deployment.appId', {exit: 1})
+    })
+
+    const output = createMockOutput()
+
+    await startFederationRegistration({
+      cliConfig: {
+        app: {id: 'legacy-app'},
+        deployment: {appId: 'new-app'},
+        federation: {enabled: true},
+      },
+      isApp: false,
+      output,
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(output.error).toHaveBeenCalledWith(
+      expect.stringContaining('Found both app.id (deprecated) and deployment.appId'),
+      expect.objectContaining({exit: 1}),
+    )
+  })
+})

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -5,7 +5,6 @@ import {createDevOptions, createMockOutput} from './testHelpers.js'
 
 const mockResolveLocalPackage = vi.hoisted(() => vi.fn())
 const mockCreateServer = vi.hoisted(() => vi.fn())
-const mockGetSharedServerConfig = vi.hoisted(() => vi.fn())
 const mockWriteWorkbenchRuntime = vi.hoisted(() => vi.fn())
 const mockAcquireWorkbenchLock = vi.hoisted(() => vi.fn())
 const mockGetRegisteredServers = vi.hoisted(() => vi.fn())
@@ -22,9 +21,6 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
 })
 vi.mock('vite', () => ({createServer: mockCreateServer}))
 vi.mock('@vitejs/plugin-react', () => ({default: vi.fn(() => [])}))
-vi.mock('../../../util/getSharedServerConfig.js', () => ({
-  getSharedServerConfig: mockGetSharedServerConfig,
-}))
 vi.mock('../writeWorkbenchRuntime.js', () => ({
   writeWorkbenchRuntime: mockWriteWorkbenchRuntime,
 }))
@@ -50,7 +46,6 @@ function createMockServer(port = 3333) {
 
 describe('startWorkbenchDevServer', () => {
   beforeEach(() => {
-    mockGetSharedServerConfig.mockReturnValue({httpHost: 'localhost', httpPort: 3333})
     mockWriteWorkbenchRuntime.mockResolvedValue('/tmp/sanity-project/.sanity/workbench')
     mockAcquireWorkbenchLock.mockReturnValue({release: vi.fn(), updatePort: vi.fn()})
     mockGetRegisteredServers.mockReturnValue([])
@@ -84,9 +79,9 @@ describe('startWorkbenchDevServer', () => {
     })
 
     test('returns httpHost and workbenchPort even when federation is disabled', async () => {
-      mockGetSharedServerConfig.mockReturnValue({httpHost: '0.0.0.0', httpPort: 4000})
-
-      const result = await startWorkbenchDevServer(createDevOptions())
+      const result = await startWorkbenchDevServer(
+        createDevOptions({httpHost: '0.0.0.0', httpPort: 4000}),
+      )
 
       expect(result.httpHost).toBe('0.0.0.0')
       expect(result.workbenchPort).toBe(4000)
@@ -107,11 +102,14 @@ describe('startWorkbenchDevServer', () => {
     })
 
     test('returns httpHost and workbenchPort even when workbench is unavailable', async () => {
-      mockGetSharedServerConfig.mockReturnValue({httpHost: '0.0.0.0', httpPort: 4000})
       mockResolveLocalPackage.mockRejectedValue(new Error('Cannot find package'))
 
       const result = await startWorkbenchDevServer(
-        createDevOptions({cliConfig: {federation: {enabled: true}}}),
+        createDevOptions({
+          cliConfig: {federation: {enabled: true}},
+          httpHost: '0.0.0.0',
+          httpPort: 4000,
+        }),
       )
 
       expect(result.httpHost).toBe('0.0.0.0')
@@ -136,12 +134,13 @@ describe('startWorkbenchDevServer', () => {
       expect(result.close).toBeDefined()
     })
 
-    test('returns httpHost and workbenchPort from getSharedServerConfig', async () => {
-      mockGetSharedServerConfig.mockReturnValue({httpHost: '0.0.0.0', httpPort: 4000})
+    test('returns httpHost and workbenchPort from provided options', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
       mockCreateServer.mockResolvedValue(createMockServer(4000))
 
-      const result = await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+      const result = await startWorkbenchDevServer(
+        createDevOptions({cliConfig: federationConfig, httpHost: '0.0.0.0', httpPort: 4000}),
+      )
 
       expect(result.httpHost).toBe('0.0.0.0')
       expect(result.workbenchPort).toBe(4000)

--- a/packages/@sanity/cli/src/actions/dev/__tests__/testHelpers.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/testHelpers.ts
@@ -2,6 +2,7 @@ import {type CliConfig, type Output} from '@sanity/cli-core'
 // eslint-disable-next-line import-x/no-extraneous-dependencies
 import {vi} from 'vitest'
 
+import {type StartWorkbenchOptions} from '../startWorkbenchDevServer.js'
 import {type DevActionOptions} from '../types.js'
 
 /** Shared test helpers for dev-action test suites. */
@@ -23,7 +24,22 @@ const DEV_FLAGS = {
   port: '3333',
 } as const
 
-export function createDevOptions(overrides: Partial<DevActionOptions> = {}): DevActionOptions {
+export function createDevOptions(
+  overrides: Partial<StartWorkbenchOptions> = {},
+): StartWorkbenchOptions {
+  return {
+    cliConfig: {} as CliConfig,
+    flags: DEV_FLAGS,
+    httpHost: 'localhost',
+    httpPort: 3333,
+    isApp: false,
+    output: createMockOutput(),
+    workDir: '/tmp/sanity-project',
+    ...overrides,
+  }
+}
+
+export function createBaseDevOptions(overrides: Partial<DevActionOptions> = {}): DevActionOptions {
   return {
     cliConfig: {} as CliConfig,
     flags: DEV_FLAGS,

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -27,6 +27,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
 
   const {
     close: closeWorkbenchServer,
+    httpHost: workbenchHost,
     workbenchAvailable,
     workbenchPort,
   } = await startWorkbenchDevServer({...options, httpHost, httpPort})
@@ -35,7 +36,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   const desiredAppPort = workbenchAvailable ? workbenchPort + 1 : workbenchPort
 
   const reactRefreshHost = workbenchAvailable
-    ? `http://${httpHost || 'localhost'}:${workbenchPort}`
+    ? `http://${workbenchHost || 'localhost'}:${workbenchPort}`
     : undefined
 
   const appOptions: DevActionOptions = {
@@ -73,7 +74,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     : undefined
 
   if (workbenchAvailable) {
-    const workbenchUrl = `http://${httpHost || 'localhost'}:${workbenchPort}`
+    const workbenchUrl = `http://${workbenchHost || 'localhost'}:${workbenchPort}`
     const addr = server.httpServer?.address()
     const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
     output.log(

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -1,34 +1,39 @@
 import {styleText} from 'node:util'
 
-import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
-import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
-import {registerDevServer} from './devServerRegistry.js'
-import {extractStudioManifest} from './extractDevServerManifest.js'
+import {getSharedServerConfig} from '../../util/getSharedServerConfig.js'
 import {startAppDevServer} from './startAppDevServer.js'
-import {startDevManifestWatcher} from './startDevManifestWatcher.js'
+import {startFederationRegistration} from './startFederationRegistration.js'
 import {startStudioDevServer} from './startStudioDevServer.js'
 import {startWorkbenchDevServer} from './startWorkbenchDevServer.js'
 import {type DevActionOptions} from './types.js'
 
 const noop = async () => {}
-const syncNoop = () => {}
 
+/**
+ * Orchestrates the dev servers required by the process. It will attempt to run a workbench
+ * dev-server and, if successful, will run the app/studio dev server on the next available port.
+ * If the workbench dev-server fails to start for an expected reason, e.g. because there is already
+ * a workbench instance running or the workbench package is unavailable, it will run the app/studio
+ * dev server on the configured port.
+ */
 export async function devAction(options: DevActionOptions): Promise<{close: () => Promise<void>}> {
-  const {output} = options
+  const {cliConfig, flags, output, workDir} = options
+
+  const {httpHost, httpPort} = getSharedServerConfig({
+    cliConfig,
+    flags: {host: flags.host, port: flags.port},
+    workDir,
+  })
 
   const {
     close: closeWorkbenchServer,
-    httpHost,
     workbenchAvailable,
     workbenchPort,
-  } = await startWorkbenchDevServer(options)
+  } = await startWorkbenchDevServer({...options, httpHost, httpPort})
 
-  // Start app/studio dev server: use workbenchPort + 1 if workbench feature is
-  // available (reserves the configured port for it), otherwise use the original port
+  // Use workbenchPort + 1 when workbench claims the configured port
   const desiredAppPort = workbenchAvailable ? workbenchPort + 1 : workbenchPort
 
-  // When the workbench is running, point the remote's react-refresh preamble at
-  // the workbench dev server so HMR updates flow through the host.
   const reactRefreshHost = workbenchAvailable
     ? `http://${httpHost || 'localhost'}:${workbenchPort}`
     : undefined
@@ -53,100 +58,45 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     throw err
   }
 
-  // server is undefined only when startAppDevServer exits early (e.g. missing orgId);
-  // in that case the process is already exiting so no workbench needed.
   if (!server) {
     return {close: closeWorkbenchServer}
   }
 
-  // Vite may have picked a different port if the desired one was occupied —
-  // read the actual bound port from the http server address when available.
-  const addr = server.httpServer?.address()
-  const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
-
-  // Register the studio/app dev server in the registry (federated projects only)
-  let cleanupManifest: () => void = syncNoop
-  let stopManifestWatcher: () => Promise<void> = noop
-  let onSignal: (() => void) | undefined
-  if (options.cliConfig?.federation?.enabled) {
-    checkForDeprecatedAppId({cliConfig: options.cliConfig, output})
-
-    // Read the applied host from the Vite dev server's resolved config —
-    // this reflects any user-supplied Vite config that may have overridden
-    // our defaults. `server.host` is `string | boolean | undefined`; non-string
-    // values (true/false/undefined → 0.0.0.0/localhost) aren't useful as a
-    // URL host, so fall back to 'localhost'.
-    const resolvedHost = server.config.server.host
-    const appHost = typeof resolvedHost === 'string' ? resolvedHost : 'localhost'
-
-    // Register the dev server immediately without a manifest — workbench
-    // clients get the application entry first and the manifest follows in
-    // a rebroadcast once extraction completes. Blocks on neither the heavy
-    // studio worker nor the lighter coreApp config read, so dev startup
-    // stays fast.
-    const registration = registerDevServer({
-      host: appHost,
-      id: getAppId(options.cliConfig),
-      port: appPort,
-      projectId: options.cliConfig?.api?.projectId,
-      type: options.isApp ? 'coreApp' : 'studio',
-      workDir: options.workDir,
-    })
-    cleanupManifest = registration.release
-
-    // The watcher owns both the initial extraction and the follow-up
-    // regenerations triggered by config-file changes (`sanity.config.ts`
-    // for studios, `sanity.cli.ts` for core-apps). Serializing both
-    // through `regenerate` inside the watcher prevents concurrent worker
-    // runs from racing on the manifest output directory (studio path) and
-    // keeps the `update` callback ordered for both.
-    const watcher = await startDevManifestWatcher({
-      extract: options.isApp
-        ? ({workDir}) => extractCoreAppManifest({workDir})
-        : extractStudioManifest,
-      output,
-      update: registration.update,
-      workDir: options.workDir,
-    })
-    stopManifestWatcher = watcher.close
-
-    // Ensure manifest and workbench lock are cleaned up on abrupt shutdown.
-    // closeWorkbenchServer() starts with synchronous calls (watcher.close,
-    // lock.release) that complete before the process exits; the trailing
-    // async server.close() is best-effort.
-    onSignal = () => {
-      cleanupManifest()
-      // `stopManifestWatcher` is async but we don't wait for it here — the
-      // signal handler can't block. It clears the debounce timer and
-      // closes the fs.watch handle synchronously, which is enough to let
-      // the event loop drain.
-      void stopManifestWatcher()
-      closeWorkbenchServer()
-      process.off('SIGINT', onSignal!)
-      process.off('SIGTERM', onSignal!)
-    }
-    process.on('SIGINT', onSignal)
-    process.on('SIGTERM', onSignal)
-  }
+  const closeFederation = cliConfig?.federation?.enabled
+    ? await startFederationRegistration({
+        cliConfig,
+        isApp: options.isApp,
+        output,
+        server,
+        workDir,
+      })
+    : undefined
 
   if (workbenchAvailable) {
     const workbenchUrl = `http://${httpHost || 'localhost'}:${workbenchPort}`
+    const addr = server.httpServer?.address()
+    const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
     output.log(
       `Workbench dev server started at ${styleText(['blue', 'underline'], workbenchUrl)} (app on port ${appPort})`,
     )
   }
 
-  return {
-    close: async () => {
-      // Remove signal handlers to prevent double-cleanup and listener leaks
-      if (onSignal) {
-        process.off('SIGINT', onSignal)
-        process.off('SIGTERM', onSignal)
-      }
-      cleanupManifest()
-      // Run all closes independently — a failure in one must not prevent the
-      // others from shutting down
-      await Promise.allSettled([stopManifestWatcher(), closeWorkbenchServer(), closeAppDevServer()])
-    },
+  const close = async () => {
+    process.off('SIGINT', onSignal)
+    process.off('SIGTERM', onSignal)
+    await Promise.allSettled([
+      closeFederation?.close(),
+      closeWorkbenchServer(),
+      closeAppDevServer(),
+    ])
   }
+
+  // Ensure the workbench lock file and registry entries are cleaned up on
+  // abrupt shutdown. The registry is self-healing (stale PIDs are pruned on
+  // next read), but eager cleanup avoids the detect-prune-retry cycle.
+  const onSignal = () => void close()
+  process.once('SIGINT', onSignal)
+  process.once('SIGTERM', onSignal)
+
+  return {close}
 }

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -5,6 +5,7 @@ import {spinner} from '@sanity/cli-core/ux'
 
 import {type DevServerOptions} from '../../server/devServer.js'
 import {getSharedServerConfig} from '../../util/getSharedServerConfig.js'
+import {resolveReactStrictMode} from '../../util/resolveReactStrictMode.js'
 import {type DevFlags} from './types.js'
 
 export function getDevServerConfig({
@@ -32,10 +33,7 @@ export function getDevServerConfig({
   configSpinner.succeed()
 
   const isApp = cliConfig && 'app' in cliConfig
-  const env = process.env
-  const reactStrictMode = env.SANITY_STUDIO_REACT_STRICT_MODE
-    ? env.SANITY_STUDIO_REACT_STRICT_MODE === 'true'
-    : Boolean(cliConfig?.reactStrictMode)
+  const reactStrictMode = resolveReactStrictMode(cliConfig)
 
   const envBasePath = getSanityEnvVar('BASEPATH', isApp ?? false)
   if (envBasePath && cliConfig?.project?.basePath) {

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -1,0 +1,64 @@
+import {type CliConfig, type Output} from '@sanity/cli-core'
+import {type ViteDevServer} from 'vite'
+
+import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
+import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
+import {registerDevServer} from './devServerRegistry.js'
+import {extractStudioManifest} from './extractDevServerManifest.js'
+import {startDevManifestWatcher} from './startDevManifestWatcher.js'
+
+interface FederationRegistrationOptions {
+  cliConfig: CliConfig
+  isApp: boolean
+  output: Output
+  server: ViteDevServer
+  workDir: string
+}
+
+interface FederationRegistration {
+  close: () => Promise<void>
+}
+
+/**
+ * Registers the dev server in the dev server registry and starts a watcher for the manifest file. The registration
+ * is used by the workbench to know where the dev server is running and to display it in the UI. The manifest watcher
+ * is used to update the registration with the latest manifest, which the workbench uses to display project metadata.
+ */
+export async function startFederationRegistration(
+  options: FederationRegistrationOptions,
+): Promise<FederationRegistration> {
+  const {cliConfig, isApp, output, server, workDir} = options
+
+  checkForDeprecatedAppId({cliConfig, output})
+
+  const resolvedHost = server.config.server.host
+  const appHost = typeof resolvedHost === 'string' ? resolvedHost : 'localhost'
+
+  const addr = server.httpServer?.address()
+  const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
+
+  const registration = registerDevServer({
+    host: appHost,
+    id: getAppId(cliConfig),
+    port: appPort,
+    projectId: cliConfig?.api?.projectId,
+    type: isApp ? 'coreApp' : 'studio',
+    workDir,
+  })
+
+  const watcher = await startDevManifestWatcher({
+    extract: isApp
+      ? ({workDir: wd}) => extractCoreAppManifest({workDir: wd})
+      : extractStudioManifest,
+    output,
+    update: registration.update,
+    workDir,
+  })
+
+  return {
+    close: async () => {
+      registration.release()
+      await watcher.close()
+    },
+  }
+}

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -4,7 +4,7 @@ import {createServer, type InlineConfig, type Plugin} from 'vite'
 
 import {SANITY_CACHE_DIR} from '../../constants.js'
 import {getProjectById} from '../../services/projects.js'
-import {getSharedServerConfig} from '../../util/getSharedServerConfig.js'
+import {resolveReactStrictMode} from '../../util/resolveReactStrictMode.js'
 import {devDebug} from './devDebug.js'
 import {
   acquireWorkbenchLock,
@@ -36,39 +36,33 @@ interface WorkbenchDevServerResult {
   workbenchPort: number
 }
 
-export async function startWorkbenchDevServer(
-  options: DevActionOptions,
-): Promise<WorkbenchDevServerResult> {
-  const {cliConfig, flags, output, workDir} = options
+export interface StartWorkbenchOptions extends DevActionOptions {
+  httpHost: string | undefined
+  httpPort: number
+}
 
-  const {httpHost, httpPort: workbenchPort} = getSharedServerConfig({
-    cliConfig,
-    flags: {host: flags.host, port: flags.port},
-    workDir,
-  })
+/**
+ * Attempts to start the workbench dev server if federation is enabled and the workbench package is available.
+ * It also handles the case where the desired port is already occupied, either by another workbench instance or
+ * an unrelated process, by falling back to running without a workbench and letting the app/studio dev server
+ * claim the configured port.
+ */
+export async function startWorkbenchDevServer(
+  options: StartWorkbenchOptions,
+): Promise<WorkbenchDevServerResult> {
+  const {cliConfig, httpHost, httpPort: workbenchPort, output, workDir} = options
 
   if (!cliConfig?.federation?.enabled) {
     devDebug('Federation not enabled, skipping workbench dev server')
     return {close: noop, httpHost, workbenchAvailable: false, workbenchPort}
   }
 
-  const reactStrictMode = process.env.SANITY_STUDIO_REACT_STRICT_MODE
-    ? process.env.SANITY_STUDIO_REACT_STRICT_MODE === 'true'
-    : Boolean(cliConfig?.reactStrictMode)
-
   let workbenchAvailable = false
 
-  /**
-   * Check whether the `sanity` package has the `workbench` export available. If not,
-   * it means an incompatible version of `sanity` is installed and workbench will not
-   * be able to start, because the runtime requires the `renderWorkbench` function from
-   * that export.
-   */
   try {
     await resolveLocalPackage('sanity/workbench', workDir)
     workbenchAvailable = true
   } catch {
-    // sanity/workbench not available in this version — skip workbench server
     devDebug('Workbench not available, skipping workbench dev server')
   }
 
@@ -95,14 +89,59 @@ export async function startWorkbenchDevServer(
     }
   }
 
+  const result = await createWorkbenchViteServer({
+    cliConfig,
+    httpHost,
+    output,
+    workbenchPort,
+    workDir,
+  })
+
+  if (!result) {
+    workbenchLock.release()
+    return {close: noop, httpHost, workbenchAvailable: false, workbenchPort}
+  }
+
+  const {actualPort, close} = result
+  workbenchLock.updatePort(actualPort)
+
+  return {
+    close: async () => {
+      workbenchLock.release()
+      await close()
+    },
+    httpHost,
+    workbenchAvailable,
+    workbenchPort: actualPort,
+  }
+}
+
+interface CreateWorkbenchViteServerOptions {
+  cliConfig: DevActionOptions['cliConfig']
+  httpHost: string | undefined
+  output: DevActionOptions['output']
+  workbenchPort: number
+  workDir: string
+}
+
+interface CreateWorkbenchViteServerResult {
+  actualPort: number
+  close: () => Promise<void>
+}
+
+async function createWorkbenchViteServer(
+  options: CreateWorkbenchViteServerOptions,
+): Promise<CreateWorkbenchViteServerResult | undefined> {
+  const {cliConfig, httpHost, output, workbenchPort, workDir} = options
+
+  const reactStrictMode = resolveReactStrictMode(cliConfig)
   const organizationId = await resolveOrganizationId(cliConfig)
 
   let remoteUrl: string | undefined = undefined
-
   try {
     remoteUrl = new URL(process.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL || '').toString()
   } catch {
-    // Ignore parsing errors, the variable might not be set or might be an invalid URL, in which case we just won't use it
+    // Ignore parsing errors
   }
 
   devDebug('Writing workbench runtime files')
@@ -114,8 +153,7 @@ export async function startWorkbenchDevServer(
   })
 
   const viteConfig: InlineConfig = {
-    // Define a custom cache directory so that sanity's vite cache
-    // does not conflict with any potential local vite projects
+    // Custom cache directory so sanity's vite cache doesn't conflict with local vite projects
     cacheDir: `${SANITY_CACHE_DIR}/vite`,
     configFile: false,
     define: {
@@ -151,19 +189,15 @@ export async function startWorkbenchDevServer(
     await server.listen()
   } catch (err) {
     await server.close()
-    workbenchLock.release()
     output.warn(
       `Workbench dev server failed to start: ${err instanceof Error ? err.message : String(err)}`,
     )
-    return {close: noop, httpHost, workbenchAvailable: false, workbenchPort}
+    return undefined
   }
 
   // Vite may have picked a different port if the desired one was occupied
   const addr = server.httpServer?.address()
   const actualPort = typeof addr === 'object' && addr ? addr.port : workbenchPort
-
-  // Update the lock file with the actual port so other processes can find us
-  workbenchLock.updatePort(actualPort)
 
   // Fire-and-forget: warm the workbench remote's Vite transform pipeline so
   // the first browser request hits a pre-populated module graph.
@@ -174,7 +208,6 @@ export async function startWorkbenchDevServer(
     devDebug('Warming workbench remote at %s', remoteUrl)
   }
 
-  // Respond to client requests for the current application list.
   server.ws.on('sanity:workbench:get-local-applications', (_, client) => {
     client.send(
       'sanity:workbench:local-applications',
@@ -182,20 +215,16 @@ export async function startWorkbenchDevServer(
     )
   })
 
-  // Watch the registry and broadcast updates to all connected clients
   const registryWatcher = watchRegistry((servers) => {
     server.ws.send('sanity:workbench:local-applications', toApplicationsPayload(servers))
   })
 
   return {
+    actualPort,
     close: async () => {
       registryWatcher.close()
-      workbenchLock.release()
       await server.close()
     },
-    httpHost,
-    workbenchAvailable,
-    workbenchPort: actualPort,
   }
 }
 

--- a/packages/@sanity/cli/src/util/resolveReactStrictMode.ts
+++ b/packages/@sanity/cli/src/util/resolveReactStrictMode.ts
@@ -1,0 +1,8 @@
+import {type CliConfig} from '@sanity/cli-core'
+
+export function resolveReactStrictMode(cliConfig?: CliConfig): boolean {
+  if (process.env.SANITY_STUDIO_REACT_STRICT_MODE) {
+    return process.env.SANITY_STUDIO_REACT_STRICT_MODE === 'true'
+  }
+  return Boolean(cliConfig?.reactStrictMode)
+}


### PR DESCRIPTION
## Description

Since the feature branch here is become more "we've got all the pieces we need" i've decided to take a quick look and reorganise the dev action updates introduced across the feature branch into smaller, single-responsibility modules. With the primary change that `devAction` acts as an orchestrator (previously a one-liner that delegated to `startAppDevServer`/`startStudioDevServer`) it now owns the full lifecycle:
* starting the workbench
* starting the app/studio server
* starting federation registration
* logging
* teardown. 

Other smaller changes are:
* Federation registration and signal handling that was inlined there has been extracted.
* `startWorkbenchDevServer` split in two — the public function handles availability checks and lock acquisition; the private `createWorkbenchViteServer` handles Vite config and server lifecycle.
* `resolveReactStrictMode` deduplicated, now a shared utility in `src/utill`
* `startStudioDevServer` / `startAppDevServer` now return {server} alongside {close}, so `devAction` can pass the Vite server to federation registration without re-resolving it.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `sanity dev` startup/teardown path (port selection, signal handling, workbench/federation lifecycle), so regressions could break local dev flows even though changes are mostly a refactor with test coverage.
> 
> **Overview**
> **Refactors `devAction` into a true orchestrator**: it now resolves shared host/port via `getSharedServerConfig`, starts the workbench first, then starts the app/studio on `workbenchPort + 1` when needed, logs the workbench URL using the *actual workbench host*, and centralizes teardown.
> 
> **Extracts federation-specific side effects** into a new `startFederationRegistration` module that handles dev-server registry registration + manifest watching (including deprecated `app.id` checks), returning a single `close()` for cleanup.
> 
> **Splits workbench startup responsibilities** in `startWorkbenchDevServer` by passing resolved `httpHost/httpPort` in, and moving Vite server creation/lifecycle into a private helper, including improved failure cleanup behavior.
> 
> Adds `resolveReactStrictMode` utility and switches both workbench and dev server config to use it. Test suites are updated and expanded to cover the new module boundaries and signal-handler behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4f37359ace6dec09c3e845d6de1fd51c4d323b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->