### PR TITLE
fix(workbench): throw error on invalid `SANITY_INTERNAL_WORKBENCH_REMOTE_URL`

### DIFF
--- a/.changeset/pr-1066.md
+++ b/.changeset/pr-1066.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): throw error on invalid `SANITY_INTERNAL_WORKBENCH_REMOTE_URL`

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -381,6 +381,36 @@ describe('startWorkbenchDevServer', () => {
       expect(setHeader).not.toHaveBeenCalled()
       expect(next).toHaveBeenCalled()
     })
+
+    test('throws when remote URL is set but invalid', async () => {
+      vi.stubEnv('SANITY_INTERNAL_WORKBENCH_REMOTE_URL', 'javascript:alert(1)')
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+
+      await expect(
+        startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig})),
+      ).rejects.toThrow(/Invalid SANITY_INTERNAL_WORKBENCH_REMOTE_URL/)
+    })
+
+    test('accepts an http:// remote URL', async () => {
+      vi.stubEnv(
+        'SANITY_INTERNAL_WORKBENCH_REMOTE_URL',
+        'http://workbench.example/mf-manifest.json',
+      )
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+
+      const middleware = getMiddleware()
+      const setHeader = vi.fn()
+      middleware({url: '/'}, {setHeader}, vi.fn())
+
+      expect(setHeader).toHaveBeenCalledWith(
+        'Link',
+        '<http://workbench.example/mf-manifest.json>; rel=preload; as=fetch; crossorigin',
+      )
+    })
   })
 
   describe('reactStrictMode', () => {

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -1,6 +1,7 @@
 import {resolveLocalPackage} from '@sanity/cli-core'
 import viteReact from '@vitejs/plugin-react'
 import {createServer, type InlineConfig, type Plugin} from 'vite'
+import {z} from 'zod/mini'
 
 import {SANITY_CACHE_DIR} from '../../constants.js'
 import {getProjectById} from '../../services/projects.js'
@@ -134,15 +135,9 @@ async function createWorkbenchViteServer(
 ): Promise<CreateWorkbenchViteServerResult | undefined> {
   const {cliConfig, httpHost, output, workbenchPort, workDir} = options
 
+  const remoteUrl = parseRemoteUrl(process.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL)
   const reactStrictMode = resolveReactStrictMode(cliConfig)
   const organizationId = await resolveOrganizationId(cliConfig)
-
-  let remoteUrl: string | undefined = undefined
-  try {
-    remoteUrl = new URL(process.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL || '').toString()
-  } catch {
-    // Ignore parsing errors
-  }
 
   devDebug('Writing workbench runtime files')
   const root = await writeWorkbenchRuntime({
@@ -244,6 +239,24 @@ const resolveOrganizationId = async (cliConfig: DevActionOptions['cliConfig']): 
   throw new Error(
     'Unable to determine organization ID for workbench runtime. Please ensure that your sanity.json has either "app.organizationId" or "api.projectId" configured.',
   )
+}
+
+// Restricts protocol to http(s) so the URL is safe to interpolate into HTML
+// attributes and Link headers downstream.
+const remoteUrlSchema = z.url({normalize: true, protocol: /^https?$/})
+
+function parseRemoteUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined
+
+  const result = remoteUrlSchema.safeParse(value)
+
+  if (!result.success) {
+    throw new Error(
+      `Invalid SANITY_INTERNAL_WORKBENCH_REMOTE_URL: ${value} (must be an http(s) URL)`,
+    )
+  }
+
+  return result.data
 }
 
 /**


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Validate `SANITY_INTERNAL_WORKBENCH_REMOTE_URL` is a valid URL using `http` or `https` as protocol. Otherwise throw an error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that tightens validation of a dev-only env var; main impact is that previously-ignored invalid values will now fail fast during workbench startup.
> 
> **Overview**
> **Workbench dev server startup now validates** `SANITY_INTERNAL_WORKBENCH_REMOTE_URL` and **throws a clear error** if it’s present but not an `http(s)` URL (instead of silently ignoring parse failures).
> 
> Adds coverage to ensure invalid protocols (e.g. `javascript:`) are rejected while both `https://` and `http://` URLs are accepted, and ships a patch changeset for `@sanity/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f366cee6cffcf92e3e08ff8cf470e07c4c6c0820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->