### PR TITLE
fix(workbench): detect PID reuse on Windows via PowerShell

### DIFF
--- a/.changeset/pr-1067.md
+++ b/.changeset/pr-1067.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-Fixed stale workbench locks on Windows that blocked `sanity dev` startup when a crashed dev server's PID had been reused by another process.
+fix(workbench): detect PID reuse on Windows via PowerShell

--- a/.changeset/pr-1067.md
+++ b/.changeset/pr-1067.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): detect PID reuse on Windows via PowerShell

--- a/.changeset/pr-1067.md
+++ b/.changeset/pr-1067.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-fix(workbench): detect PID reuse on Windows via PowerShell
+Fixed stale workbench locks on Windows that blocked `sanity dev` startup when a crashed dev server's PID had been reused by another process.

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.test.ts
@@ -5,6 +5,7 @@ import {join} from 'node:path'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {
+  __resetStartTimeCacheForTesting,
   acquireWorkbenchLock,
   type DevServerManifest,
   getRegisteredServers,
@@ -40,6 +41,7 @@ beforeEach(() => {
   mkdirSync(testDataDir, {recursive: true})
   // By default, return a start time matching "now" so our own PID passes isOurProcess
   mockExecSync.mockReturnValue(new Date().toString())
+  __resetStartTimeCacheForTesting()
 })
 
 afterEach(() => {
@@ -424,6 +426,127 @@ describe('PID-reuse detection', () => {
 
     expect(readWorkbenchLock()).toBeUndefined()
     expect(existsSync(lockPath)).toBe(false)
+  })
+})
+
+describe('Windows / win32', () => {
+  let originalPlatform: NodeJS.Platform
+
+  beforeEach(() => {
+    originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', {configurable: true, value: 'win32'})
+    __resetStartTimeCacheForTesting()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', {configurable: true, value: originalPlatform})
+  })
+
+  test('shells out to PowerShell with -NoProfile -NonInteractive', () => {
+    mockExecSync.mockReturnValue('2026-04-17T11:38:10.0000000+00:00')
+
+    const {release: cleanup} = registerDevServer({
+      host: 'localhost',
+      port: 3334,
+      type: 'studio',
+      workDir: 'C:\\projects\\win',
+    })
+
+    expect(mockExecSync).toHaveBeenCalled()
+    const cmd = mockExecSync.mock.calls[0][0] as string
+    expect(cmd).toMatch(/^powershell\.exe /)
+    expect(cmd).toContain('-NoProfile')
+    expect(cmd).toContain('-NonInteractive')
+    expect(cmd).toContain('Get-CimInstance Win32_Process')
+    expect(cmd).toContain(`ProcessId=${process.pid}`)
+    expect(cmd).toContain("CreationDate.ToString('o')")
+
+    cleanup()
+  })
+
+  test('parses PowerShell ISO 8601 round-trip output', () => {
+    const osStart = new Date('2026-04-17T11:38:10.000Z')
+    mockExecSync.mockReturnValue('2026-04-17T11:38:10.0000000+00:00')
+
+    const {release: cleanup} = registerDevServer({
+      host: 'localhost',
+      port: 3334,
+      type: 'studio',
+      workDir: 'C:\\projects\\win',
+    })
+
+    const manifest = JSON.parse(readFileSync(join(registryDir(), `${process.pid}.json`), 'utf8'))
+    expect(new Date(manifest.startedAt).getTime()).toBe(osStart.getTime())
+
+    cleanup()
+  })
+
+  test('detects PID reuse on Windows (PowerShell start time mismatch)', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    const staleManifest: DevServerManifest = {
+      host: 'localhost',
+      pid: process.pid,
+      port: 9999,
+      startedAt: '2020-01-01T00:00:00.000Z',
+      type: 'studio',
+      version: 1,
+      workDir: 'C:\\projects\\stale',
+    }
+    writeFileSync(join(dir, `${process.pid}.json`), JSON.stringify(staleManifest))
+
+    mockExecSync.mockReturnValue('2026-04-17T11:38:10.0000000+00:00')
+
+    const servers = getRegisteredServers()
+    expect(servers).toHaveLength(0)
+    expect(existsSync(join(dir, `${process.pid}.json`))).toBe(false)
+  })
+
+  test('falls back to alive-check when PowerShell fails (e.g. no PowerShell)', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    const manifest: DevServerManifest = {
+      host: 'localhost',
+      pid: process.pid,
+      port: 9999,
+      startedAt: new Date().toISOString(),
+      type: 'studio',
+      version: 1,
+      workDir: 'C:\\projects\\fallback',
+    }
+    writeFileSync(join(dir, `${process.pid}.json`), JSON.stringify(manifest))
+
+    mockExecSync.mockImplementation(() => {
+      throw new Error("'powershell.exe' is not recognized")
+    })
+
+    const servers = getRegisteredServers()
+    expect(servers).toHaveLength(1)
+  })
+
+  test("memoises own PID's start time across calls (avoids repeated PowerShell spawns)", () => {
+    mockExecSync.mockReturnValue('2026-04-17T11:38:10.0000000+00:00')
+
+    const {release: cleanup} = registerDevServer({
+      host: 'localhost',
+      port: 3334,
+      type: 'studio',
+      workDir: 'C:\\projects\\cache',
+    })
+
+    const callsAfterRegistration = mockExecSync.mock.calls.length
+
+    // Each of these recomputes isOurProcess(process.pid, ...) → would
+    // shell out again without the cache.
+    getRegisteredServers()
+    getRegisteredServers()
+    getRegisteredServers()
+
+    expect(mockExecSync.mock.calls.length).toBe(callsAfterRegistration)
+
+    cleanup()
   })
 })
 

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.windows.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devServerRegistry.windows.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Windows-only integration tests for {@link getProcessStartTime} and the
+ * registry/lock plumbing that depends on it.
+ *
+ * Unlike `devServerRegistry.test.ts`, this file does **not** mock
+ * `node:child_process` — it shells out to a real PowerShell so we catch
+ * regressions where the command doesn't run, the output format drifts, or
+ * `Get-Process` behaves differently on a real Windows host.
+ *
+ * Skipped on macOS / Linux. The matching `windows-8core` shards in CI run
+ * this file end-to-end.
+ */
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {
+  __resetStartTimeCacheForTesting,
+  acquireWorkbenchLock,
+  getRegisteredServers,
+  readWorkbenchLock,
+  registerDevServer,
+} from '../devServerRegistry.js'
+
+let testDataDir: string
+
+vi.mock('@sanity/cli-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/cli-core')>()
+  return {
+    ...actual,
+    getSanityDataDir: () => testDataDir,
+  }
+})
+
+beforeEach(() => {
+  testDataDir = join(tmpdir(), `sanity-registry-win-${process.pid}-${Date.now()}`)
+  mkdirSync(testDataDir, {recursive: true})
+  __resetStartTimeCacheForTesting()
+})
+
+afterEach(() => {
+  __resetStartTimeCacheForTesting()
+})
+
+function registryDir() {
+  return join(testDataDir, 'dev-servers')
+}
+
+describe.skipIf(process.platform !== 'win32')('Windows integration', () => {
+  test('getProcessStartTime returns a Date close to now for our PID via real PowerShell', () => {
+    const {release} = registerDevServer({
+      host: 'localhost',
+      port: 3334,
+      type: 'studio',
+      workDir: testDataDir,
+    })
+
+    const manifestPath = join(registryDir(), `${process.pid}.json`)
+    expect(existsSync(manifestPath)).toBe(true)
+
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    const startedAt = new Date(manifest.startedAt)
+    expect(Number.isNaN(startedAt.getTime())).toBe(false)
+
+    // The start time must predate "now" but not be older than this test's
+    // process — generous bound covers slow-runner cold-starts.
+    const ageMs = Date.now() - startedAt.getTime()
+    expect(ageMs).toBeGreaterThanOrEqual(0)
+    expect(ageMs).toBeLessThan(15 * 60_000)
+
+    release()
+  })
+
+  test('round-trip: register → re-read keeps our manifest live (PowerShell-verified)', () => {
+    const {release} = registerDevServer({
+      host: 'localhost',
+      port: 3335,
+      type: 'studio',
+      workDir: testDataDir,
+    })
+
+    // Re-reading invokes isOurProcess(process.pid, ...) which goes through
+    // the real PowerShell branch. If the command/output drifts, the
+    // manifest gets pruned as "stale" and this returns 0.
+    const servers = getRegisteredServers()
+    expect(servers).toHaveLength(1)
+    expect(servers[0].port).toBe(3335)
+
+    release()
+  })
+
+  test('acquireWorkbenchLock + readWorkbenchLock round-trip on Windows', () => {
+    const lock = acquireWorkbenchLock({host: 'localhost', port: 3336})
+    expect(lock).toBeDefined()
+
+    const read = readWorkbenchLock()
+    expect(read).toBeDefined()
+    expect(read!.pid).toBe(process.pid)
+    expect(read!.port).toBe(3336)
+
+    lock!.release()
+  })
+
+  test('detects PID reuse on Windows (manually-written stale lock is pruned)', () => {
+    const dir = registryDir()
+    mkdirSync(dir, {recursive: true})
+
+    // Write a workbench lock claiming our PID started in the distant past.
+    // PowerShell will report the real (recent) start time of this test
+    // process, so isOurProcess sees the mismatch and prunes.
+    const lockPath = join(dir, 'workbench.lock')
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        host: 'localhost',
+        pid: process.pid,
+        port: 4000,
+        startedAt: '2020-01-01T00:00:00.000Z',
+        version: 1,
+      }),
+    )
+
+    expect(readWorkbenchLock()).toBeUndefined()
+    expect(existsSync(lockPath)).toBe(false)
+  })
+})

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -80,16 +80,64 @@ const START_TIME_TOLERANCE_MS = 2000
 
 /**
  * Retrieve the OS-reported start time for a process.
- * Uses `ps -o lstart=` which works on both macOS and Linux.
+ *
+ * - Unix (macOS / Linux): `ps -o lstart=`
+ * - Windows: PowerShell `Get-CimInstance Win32_Process` (`CreationDate`).
+ *   We prefer CIM over `Get-Process -Id <pid>.StartTime` because `StartTime`
+ *   opens a process handle and can throw "Access is denied" when the target
+ *   is owned by another user, while `Win32_Process.CreationDate` is readable
+ *   for any process the user can enumerate.
+ *
+ * On Windows the result for {@link process.pid} is memoised because the
+ * start time of the current process never changes and PowerShell cold-start
+ * is expensive (1–3s). Without the cache, a single `sanity dev` startup
+ * spawns PowerShell 4–5 times for our own PID. Other PIDs are not cached —
+ * they may be reused over time.
+ *
  * Returns `undefined` if the process doesn't exist or the command fails.
  */
+let ownWindowsStartTime: {cached: true; date: Date | undefined} | undefined
+
 function getProcessStartTime(pid: number): Date | undefined {
+  if (process.platform === 'win32') {
+    if (pid === process.pid && ownWindowsStartTime) return ownWindowsStartTime.date
+    const result = readWindowsStartTime(pid)
+    if (pid === process.pid) ownWindowsStartTime = {cached: true, date: result}
+    return result
+  }
+  return readUnixStartTime(pid)
+}
+
+/** Test-only: clear the cached own-process start time. */
+export function __resetStartTimeCacheForTesting(): void {
+  ownWindowsStartTime = undefined
+}
+
+function readUnixStartTime(pid: number): Date | undefined {
   try {
     const output = execSync(`ps -o lstart= -p ${pid}`, {
       encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
+      stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 1000,
     }).trim()
+    if (!output) return undefined
+    const date = new Date(output)
+    return Number.isNaN(date.getTime()) ? undefined : date
+  } catch {
+    return undefined
+  }
+}
+
+function readWindowsStartTime(pid: number): Date | undefined {
+  try {
+    // `-NoProfile -NonInteractive` keeps PowerShell start-up minimal.
+    // `Get-CimInstance Win32_Process` exposes `CreationDate` for any process
+    // the user can enumerate — unlike `Get-Process.StartTime`, which opens
+    // a process handle and can fail with "Access is denied".
+    const output = execSync(
+      `powershell.exe -NoProfile -NonInteractive -Command "(Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}').CreationDate.ToString('o')"`,
+      {encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000},
+    ).trim()
     if (!output) return undefined
     const date = new Date(output)
     return Number.isNaN(date.getTime()) ? undefined : date
@@ -104,7 +152,9 @@ function getProcessStartTime(pid: number): Date | undefined {
  *
  * Compares the stored `startedAt` timestamp against the OS-reported process
  * start time. Falls back to a plain alive-check when the start time cannot
- * be retrieved (unsupported platform, permissions, etc.).
+ * be retrieved (permissions, missing tools, etc.) — in that mode PID-reuse
+ * goes undetected, but in practice {@link getProcessStartTime} succeeds on
+ * all supported platforms.
  */
 function isOurProcess(pid: number, startedAt: string): boolean {
   if (!isProcessAlive(pid)) return false


### PR DESCRIPTION
### Description

`getProcessStartTime` in `devServerRegistry.ts` shelled out to `ps -o lstart=`, which doesn't exist on Windows (non-WSL). On Windows the call always threw, so `isOurProcess` fell back to `process.kill(pid, 0)` — a plain alive-check that can't detect PID reuse. A workbench lock from a crashed `sanity dev` whose PID had since been reused by an unrelated live process was treated as live, and every subsequent `sanity dev` was blocked until the user manually deleted `~/.sanity/dev-servers/workbench.lock`.

### Fix

Branch on `process.platform`:
- **Unix:** unchanged — `ps -o lstart= -p <pid>`
- **Windows:** `powershell.exe -NoProfile -NonInteractive -Command "(Get-Process -Id <pid>).StartTime.ToString('o')"`

PowerShell cold-start is 1–3s, and `getProcessStartTime(process.pid)` is called 4–5× during a single `sanity dev` startup. The result for our own PID is memoised on Windows only (process start time never changes for the running process), so the spawn cost is paid once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process verification and lock/registry pruning behavior on Windows by shelling out to PowerShell and caching results, which could affect `sanity dev` startup/lock acquisition if the command/output differs across environments.
> 
> **Overview**
> Fixes Windows PID-reuse detection for the dev-server registry/workbench lock by adding a `win32` code path to `getProcessStartTime` that queries process creation time via `powershell.exe` (`Get-CimInstance Win32_Process`) and memoises the current process’ start time to avoid repeated spawns.
> 
> Expands test coverage with Windows-specific unit tests (mocked PowerShell) and a new Windows-only integration test file that exercises the real PowerShell command and verifies stale manifest/lock pruning and round-trip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fae2c9e54501de3b9e99fdcb4456bf542aec307d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->