### PR TITLE
fix(ci): use explicit force-with-lease ref in changeset workflow

### DIFF
--- a/.github/workflows/generate-changeset.yml
+++ b/.github/workflows/generate-changeset.yml
@@ -74,13 +74,14 @@ jobs:
           CHANGESET_CONTENT: ${{ steps.analyze.outputs.changeset_content }}
           CHANGESET_FILE: ${{ steps.analyze.outputs.changeset_file }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           mkdir -p "$(dirname "$CHANGESET_FILE")"
           printf '%s' "$CHANGESET_CONTENT" > "$CHANGESET_FILE"
           git add "$CHANGESET_FILE"
           if ! git diff --cached --quiet; then
             git commit -m "chore: update auto-generated changeset for PR #${{ github.event.pull_request.number }}"
-            git push --force-with-lease origin "HEAD:${PR_HEAD_REF}"
+            git push --force-with-lease="${PR_HEAD_REF}:${PR_HEAD_SHA}" origin "HEAD:${PR_HEAD_REF}"
           else
             echo "No changes to changeset file"
           fi
@@ -90,9 +91,10 @@ jobs:
         env:
           CHANGESET_FILE: ${{ steps.analyze.outputs.changeset_file }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -f "$CHANGESET_FILE" ]; then
             git rm "$CHANGESET_FILE"
             git commit -m "chore: remove auto-generated changeset for PR #${{ github.event.pull_request.number }}"
-            git push --force-with-lease origin "HEAD:${PR_HEAD_REF}"
+            git push --force-with-lease="${PR_HEAD_REF}:${PR_HEAD_SHA}" origin "HEAD:${PR_HEAD_REF}"
           fi


### PR DESCRIPTION
### Description

Follow-up to #1069. The `Write changeset and push` step in `generate-changeset.yml` failed on PR #1070 with:

```
! [rejected]        HEAD -> feat/api-command-list (stale info)
error: failed to push some refs to 'https://github.com/sanity-io/cli.git'
```

([failing run](https://github.com/sanity-io/cli/actions/runs/25785434538/job/75737593069?pr=1070))

The bare `git push --force-with-lease` form depends on git having a locally-remembered "expected" value for the remote ref, sourced from a remote-tracking branch. After #1069, the PR-branch checkout uses `fetch-depth: 1` at a specific `head.sha` rather than a full branch checkout, which can leave git without a useful tracking ref — so the lease check trips the "stale info" rejection even though nothing has actually moved on the remote.

Switching to the explicit `--force-with-lease=<refname>:<expect>` form using the PR's immutable `head.sha` bypasses git's local tracking-ref bookkeeping entirely. The safety property is preserved: if the branch has moved since the workflow started, the push is correctly rejected.

This mirrors a matching fix already shipped in the workbench repo.

### What to review

- `.github/workflows/generate-changeset.yml`: both `Write changeset and push` and `Remove changeset and push` steps now pass `PR_HEAD_SHA` as the lease expected value.
- The lease value is `${{ github.event.pull_request.head.sha }}` — the same immutable SHA already used for the earlier `Checkout PR branch` step, so the expected value matches what we just checked out.

### Testing

Cannot be fully tested before merge because `pull_request_target` runs the base-branch's workflow. Once merged, the next PR push that triggers a changeset write should succeed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that only affects how the workflow pushes changeset commits; main risk is misconfigured lease args causing pushes to fail.
> 
> **Overview**
> Updates `.github/workflows/generate-changeset.yml` to pass `PR_HEAD_SHA` into the push steps and switch `git push --force-with-lease` to the explicit `--force-with-lease=<ref>:<expected_sha>` form.
> 
> This makes both the *write* and *remove* changeset pushes validate against the PR branch’s immutable `head.sha`, avoiding failures when the checkout uses `fetch-depth: 1` without a remote-tracking ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 036c56c891d3c0d3d037e69ee1e857a1291148e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->