### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ jq '{total: .numTotalTests, passed: .numPassedTests, failed: .numFailedTests, fi
 ## Cursor Cloud specific instructions
 
 - The update script runs `pnpm install --frozen-lockfile` and `pnpm build:cli` on startup. Dependencies and build artifacts should already be up to date when a session begins.
-- The test results JSON file (used for reading failures) is only written when `CLAUDECODE=1` or `CODEX_CI=1` is set. In Cursor Cloud, read test output from the terminal directly instead, or set `CLAUDECODE=1` before running tests if you need the JSON workflow.
-- The full test suite takes ~10 minutes. Prefer scoped runs (`--changed`, `--filter`, or single files) during development. Some test files (e.g. `deploy.studio.test.ts`, `graphql/deploy.test.ts`, `schemas/deploy.test.ts`, `schemas/delete.test.ts`) have pre-existing failures on `main`; do not spend time fixing these unless your changes touch those areas.
+- The test results JSON file requires `CLAUDECODE=1` (or `CODEX_CI=1`). Set `export CLAUDECODE=1` before running tests so the `$TEST_RESULTS` / `jq` workflow described above works as expected.
+- The full test suite takes ~10 minutes. Prefer scoped runs (`--changed`, `--filter`, or single files) during development. Before assuming a test failure is caused by your changes, check whether the same test also fails on `origin/main`.
 - CLI commands that hit the Sanity API (e.g. `documents query`, `login`) require authentication. Use fixture directories (e.g. `fixtures/basic-studio`) to run commands like `npx sanity debug`, `npx sanity doctor`, or `npx sanity versions` without authentication.
 - `pnpm install` may warn about ignored build scripts for `sharp` and `unrs-resolver`. These are safe to ignore; the `pnpm.onlyBuiltDependencies` allowlist in `package.json` already covers the required native modules (`@swc/core`, `esbuild`, `node-pty`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,3 +162,11 @@ jq '{total: .numTotalTests, passed: .numPassedTests, failed: .numFailedTests, fi
 - Run single command: `npx sanity <command>`
 - Enable debug logs: `DEBUG=sanity:* npx sanity <command>`
 - Most commands need to be run within one of the fixture folders.
+
+## Cursor Cloud specific instructions
+
+- The update script runs `pnpm install --frozen-lockfile` and `pnpm build:cli` on startup. Dependencies and build artifacts should already be up to date when a session begins.
+- The test results JSON file (used for reading failures) is only written when `CLAUDECODE=1` or `CODEX_CI=1` is set. In Cursor Cloud, read test output from the terminal directly instead, or set `CLAUDECODE=1` before running tests if you need the JSON workflow.
+- The full test suite takes ~10 minutes. Prefer scoped runs (`--changed`, `--filter`, or single files) during development. Some test files (e.g. `deploy.studio.test.ts`, `graphql/deploy.test.ts`, `schemas/deploy.test.ts`, `schemas/delete.test.ts`) have pre-existing failures on `main`; do not spend time fixing these unless your changes touch those areas.
+- CLI commands that hit the Sanity API (e.g. `documents query`, `login`) require authentication. Use fixture directories (e.g. `fixtures/basic-studio`) to run commands like `npx sanity debug`, `npx sanity doctor`, or `npx sanity versions` without authentication.
+- `pnpm install` may warn about ignored build scripts for `sharp` and `unrs-resolver`. These are safe to ignore; the `pnpm.onlyBuiltDependencies` allowlist in `package.json` already covers the required native modules (`@swc/core`, `esbuild`, `node-pty`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with practical guidance for future Cloud Agent sessions, including:
- Confirmation that the update script handles `pnpm install` and `pnpm build:cli`
- Note about the `CLAUDECODE` env var needed for JSON test results
- Guidance on pre-existing test failures on `main`
- Tips for running CLI commands from fixture directories without auth
- Note about safe-to-ignore `sharp`/`unrs-resolver` build script warnings

### What to review

Review the new section at the bottom of `AGENTS.md`. These are non-obvious gotchas discovered during Cloud Agent environment setup that will save future agents time.

### Testing

N/A — documentation-only change. Verified the full development workflow works:
- `pnpm install --frozen-lockfile` ✅
- `pnpm build:cli` ✅
- `pnpm check:lint` ✅ (warnings only, 0 errors)
- `pnpm check:types` ✅
- `pnpm check:deps` ✅
- `pnpm test` — 231/244 test files pass; 13 pre-existing failures on `main`
- CLI commands (`sanity --help`, `sanity versions`, `sanity debug`, `sanity doctor`) all work from fixture directories
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b476759-5daa-42bd-a4f3-7f5cdd1f02d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b476759-5daa-42bd-a4f3-7f5cdd1f02d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

