### PR TITLE
chore: release to re-publish new cli-build package

### DIFF
--- a/.changeset/wacky-roses-laugh.md
+++ b/.changeset/wacky-roses-laugh.md
@@ -1,0 +1,6 @@
+---
+"@sanity/cli": patch
+"@sanity/cli-build": patch
+---
+
+Release to fix cli-build publishing issues


### PR DESCRIPTION
### Description

This is a changeset-only PR to force the cli-build package to be republished now that the OIDC settings have been created.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changeset-only release metadata change; main risk is unintended package version bumps/publish behavior, with no runtime code changes.
> 
> **Overview**
> Adds a changeset to publish *patch* releases for `@sanity/cli` and `@sanity/cli-build`, intended to resolve `cli-build` publishing issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71aceb3cf62139a6450f00381759fed4e91b9e4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->