### PR TITLE
feat(login): add token login

### DIFF
--- a/.changeset/login-token.md
+++ b/.changeset/login-token.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": minor
+---
+
+Add `sanity login --with-token` for token-based CLI login from standard input.

--- a/packages/@sanity/cli/README.md
+++ b/packages/@sanity/cli/README.md
@@ -2489,13 +2489,14 @@ Log in to your Sanity account
 
 ```
 USAGE
-  $ sanity login [--open] [--provider <providerId> | --sso <slug>] [--sso-provider <name> ]
+  $ sanity login [--open] [--provider <providerId> | --sso <slug> | --with-token] [--sso-provider <name> ]
 
 FLAGS
   --[no-]open              Open a browser window to log in (`--no-open` only prints URL)
   --provider=<providerId>  Log in using the given provider
   --sso=<slug>             Log in using Single Sign-On, using the given organization slug
   --sso-provider=<name>    Select a specific SSO provider by name (use with --sso)
+  --with-token             Read token from standard input
 
 DESCRIPTION
   Log in to your Sanity account
@@ -2516,6 +2517,10 @@ EXAMPLES
   Log in using a specific SSO provider within an organization
 
     $ sanity login --sso my-organization --sso-provider "Okta SSO"
+
+  Log in using a token from standard input
+
+    $ sanity login --with-token < token.txt
 ```
 
 ## `sanity logout`

--- a/packages/@sanity/cli/src/actions/auth/login/__tests__/login.vercel.test.ts
+++ b/packages/@sanity/cli/src/actions/auth/login/__tests__/login.vercel.test.ts
@@ -5,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 import {startServerForTokenCallback} from '../../authServer.js'
 import {getProvider} from '../getProvider.js'
 import {login} from '../login.js'
+import {validateToken} from '../validateToken.js'
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
@@ -36,6 +37,10 @@ vi.mock('../../authServer.js', () => ({
 vi.mock('../getProvider.js', () => ({
   getProvider: vi.fn(),
 }))
+vi.mock('../validateToken.js', () => ({
+  isSanityApiToken: vi.fn(),
+  validateToken: vi.fn(),
+}))
 vi.mock('../../../../util/canLaunchBrowser.js', () => ({
   canLaunchBrowser: vi.fn(() => true),
 }))
@@ -44,19 +49,21 @@ const mockedGetCliToken = vi.mocked(getCliToken)
 const mockedSetCliUserConfig = vi.mocked(setCliUserConfig)
 const mockedStartServerForTokenCallback = vi.mocked(startServerForTokenCallback)
 const mockedGetProvider = vi.mocked(getProvider)
+const mockedValidateToken = vi.mocked(validateToken)
 const mockedOpen = vi.mocked(open)
+const mockTrace = {
+  complete: vi.fn(),
+  error: vi.fn(),
+  log: vi.fn(),
+  start: vi.fn(),
+}
 
 const output = {
   log: vi.fn(),
   warn: vi.fn(),
 } as unknown as Parameters<typeof login>[0]['output']
 const telemetry = {
-  trace: vi.fn(() => ({
-    complete: vi.fn(),
-    error: vi.fn(),
-    log: vi.fn(),
-    start: vi.fn(),
-  })),
+  trace: vi.fn(() => mockTrace),
 } as unknown as Parameters<typeof login>[0]['telemetry']
 
 describe('#login vercel provider', () => {
@@ -108,5 +115,19 @@ describe('#login vercel provider', () => {
     )
     expect(mockedOpen).not.toHaveBeenCalled()
     expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'test-token')
+  })
+
+  test('records telemetry errors for token validation failures', async () => {
+    const validationError = new Error('Token is invalid or expired')
+    mockedValidateToken.mockRejectedValue(validationError)
+
+    await expect(login({output, telemetry, token: 'invalid-token'})).rejects.toThrow(
+      validationError,
+    )
+
+    expect(mockTrace.start).toHaveBeenCalled()
+    expect(mockTrace.error).toHaveBeenCalledWith(validationError)
+    expect(mockTrace.complete).not.toHaveBeenCalled()
+    expect(mockedSetCliUserConfig).not.toHaveBeenCalled()
   })
 })

--- a/packages/@sanity/cli/src/actions/auth/login/login.ts
+++ b/packages/@sanity/cli/src/actions/auth/login/login.ts
@@ -7,6 +7,7 @@ import {
   subdebug,
 } from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
+import {isHttpError} from '@sanity/client'
 import open from 'open'
 
 import {logout} from '../../../services/auth.js'
@@ -14,6 +15,7 @@ import {LoginTrace} from '../../../telemetry/login.telemetry.js'
 import {canLaunchBrowser} from '../../../util/canLaunchBrowser.js'
 import {startServerForTokenCallback} from '../authServer.js'
 import {getProvider} from './getProvider.js'
+import {isSanityApiToken, validateToken} from './validateToken.js'
 
 const debug = subdebug('login')
 
@@ -27,12 +29,14 @@ interface LoginOptions {
   provider?: string
   sso?: string
   ssoProvider?: string
+  token?: string
 }
 
 /**
  * Trigger the authentication flow for the CLI.
  *
- * NOTE: This uses terminal prompts and will not work for non-interactive/programmatic uses.
+ * NOTE: Without a token option, this uses terminal prompts and will not work for
+ * non-interactive/programmatic uses.
  *
  * @param options - Options for the login operation
  * @returns Promise that resolves when the login operation is complete
@@ -42,10 +46,21 @@ interface LoginOptions {
 export async function login(options: LoginOptions) {
   const {output, telemetry} = options
   const previousToken = await getCliToken()
-  const hasExistingToken = Boolean(previousToken)
 
   const trace = telemetry.trace(LoginTrace)
   trace.start()
+
+  if (typeof options.token === 'string') {
+    try {
+      const authToken = await validateToken(options.token)
+      await storeAuthToken(authToken, previousToken, output)
+      trace.complete()
+    } catch (err: unknown) {
+      trace.error(err as Error)
+      throw err
+    }
+    return
+  }
 
   const provider = await getProvider({
     experimental: options.experimental,
@@ -92,21 +107,37 @@ export async function login(options: LoginOptions) {
     })
   }
 
-  // Store the token
-  setCliUserConfig('authToken', authToken)
+  await storeAuthToken(authToken, previousToken, output)
 
-  // Clear cached telemetry consent
+  trace.complete()
+}
+
+async function storeAuthToken(
+  authToken: string,
+  previousToken: string | undefined,
+  output: Output,
+) {
+  setCliUserConfig('authToken', authToken)
   getUserConfig().delete('telemetryConsent')
 
   // If we had a session previously, attempt to clear it
-  if (hasExistingToken) {
-    await logout(previousToken).catch((err) => {
-      const statusCode = err && err.response && err.response.statusCode
-      if (statusCode !== 401) {
-        output.warn('Failed to invalidate previous session')
-      }
-    })
+  if (previousToken && previousToken !== authToken) {
+    await invalidateAuthToken(previousToken, output)
+  }
+}
+
+async function invalidateAuthToken(token: string, output: Output) {
+  try {
+    if (await isSanityApiToken(token)) return
+  } catch (err) {
+    if (isHttpError(err) && err.statusCode === 401) return
   }
 
-  trace.complete()
+  try {
+    await logout(token)
+  } catch (err) {
+    if (!isHttpError(err) || err.statusCode !== 401) {
+      output.warn('Failed to invalidate previous session')
+    }
+  }
 }

--- a/packages/@sanity/cli/src/actions/auth/login/validateToken.ts
+++ b/packages/@sanity/cli/src/actions/auth/login/validateToken.ts
@@ -1,0 +1,50 @@
+import {getGlobalCliClient} from '@sanity/cli-core'
+import {isHttpError} from '@sanity/client'
+
+import {USERS_API_VERSION} from '../../../services/user.js'
+import {getErrorMessage} from '../../../util/getErrorMessage.js'
+
+export async function validateToken(token: string): Promise<string> {
+  const trimmedToken = token.trim()
+
+  if (!trimmedToken) {
+    throw new Error(
+      'Token is required on standard input. Run `sanity login --with-token < token.txt`.',
+    )
+  }
+
+  try {
+    await getTokenUser(trimmedToken)
+  } catch (error) {
+    if (isHttpError(error) && (error.statusCode === 401 || error.statusCode === 403)) {
+      throw new Error('Token is invalid or expired. Check the token and try again.', {cause: error})
+    }
+
+    throw new Error(`Could not verify token: ${getErrorMessage(error)}`, {cause: error})
+  }
+
+  return trimmedToken
+}
+
+export async function isSanityApiToken(token: string): Promise<boolean> {
+  return isSanityApiTokenUser(await getTokenUser(token))
+}
+
+async function getTokenUser(token: string): Promise<unknown> {
+  const client = await getGlobalCliClient({
+    apiVersion: USERS_API_VERSION,
+    requireUser: true,
+    token,
+  })
+
+  return client.users.getById('me')
+}
+
+function isSanityApiTokenUser(user: unknown): boolean {
+  return (
+    typeof user === 'object' &&
+    user !== null &&
+    'provider' in user &&
+    (user as {provider?: unknown}).provider === 'sanity-token'
+  )
+}

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -1,4 +1,5 @@
 import http from 'node:http'
+import {Readable} from 'node:stream'
 
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -6,6 +7,7 @@ import open from 'open'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {AUTH_API_VERSION} from '../../services/auth.js'
+import {USERS_API_VERSION} from '../../services/user.js'
 import {canLaunchBrowser} from '../../util/canLaunchBrowser.js'
 import {LoginCommand} from '../login.js'
 
@@ -40,18 +42,19 @@ const mockConfigStoreDelete = vi.hoisted(() => vi.fn())
 vi.mock('@sanity/cli-core', async () => {
   const actual = await vi.importActual('@sanity/cli-core')
 
-  const testClient = createTestClient({
-    apiVersion: 'v2025-09-23',
-    token: undefined,
-  })
-
   return {
     ...actual,
     getCliToken: mockedGetCliToken,
-    getGlobalCliClient: vi.fn().mockResolvedValue({
-      request: testClient.request,
-      withConfig: vi.fn().mockReturnValue({request: testClient.request}),
-    }),
+    getGlobalCliClient: vi
+      .fn()
+      .mockImplementation((options: {apiVersion: string; token?: string}) => {
+        const {client} = createTestClient({
+          apiVersion: options.apiVersion,
+          token: options.token,
+        })
+
+        return Promise.resolve(client)
+      }),
     getUserConfig: vi.fn().mockReturnValue({
       delete: mockConfigStoreDelete,
       get: vi.fn(),
@@ -64,6 +67,18 @@ vi.mock('@sanity/cli-core', async () => {
 
 const mockedOpen = vi.mocked(open)
 const mockedCanLaunchBrowser = vi.mocked(canLaunchBrowser)
+const originalStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin')
+type MockStdin = Readable & {isTTY?: boolean}
+
+function mockStdin(input: string, options: {isTTY?: boolean} = {}) {
+  const stdin: MockStdin = Readable.from([input])
+  stdin.isTTY = options.isTTY
+
+  Object.defineProperty(process, 'stdin', {
+    configurable: true,
+    value: stdin,
+  })
+}
 
 /**
  * Simulates OAuth provider redirecting back to local callback server.
@@ -110,12 +125,271 @@ function mockSingleProviderLogin(sessionId = 'test-session-id') {
   }).reply(200, {label: 'Test Session', token: 'new-auth-token'})
 }
 
+function testTokenLogin(token: string) {
+  mockStdin(token)
+  return testCommand(LoginCommand, ['--with-token'])
+}
+
 describe('#login', {timeout: 10_000}, () => {
   afterEach(() => {
+    if (originalStdinDescriptor) {
+      Object.defineProperty(process, 'stdin', originalStdinDescriptor)
+    }
     vi.clearAllMocks()
+    mockedIsInteractive.mockReturnValue(true)
     const pending = pendingMocks()
     cleanAll()
     expect(pending, 'pending mocks').toEqual([])
+  })
+
+  describe('Token Login', () => {
+    test('stores a valid token', async () => {
+      mockedGetCliToken.mockResolvedValue('')
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer valid-token')
+        .reply(200, {
+          email: 'test@example.com',
+          id: 'user-123',
+          name: 'Test User',
+          provider: 'github',
+        })
+
+      const {error, stdout} = await testTokenLogin(' valid-token\n')
+
+      if (error) throw error
+      expect(stdout).toContain('Login successful')
+      expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'valid-token')
+      expect(mockConfigStoreDelete).toHaveBeenCalledWith('telemetryConsent')
+      expect(mockedOpen).not.toHaveBeenCalled()
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+
+    test('stores a valid token in non-interactive mode', async () => {
+      mockedIsInteractive.mockReturnValue(false)
+      mockedGetCliToken.mockResolvedValue('')
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer non-interactive-token')
+        .reply(200, {
+          email: 'test@example.com',
+          id: 'user-123',
+          name: 'Test User',
+          provider: 'github',
+        })
+
+      const {error, stdout} = await testTokenLogin('non-interactive-token')
+
+      if (error) throw error
+      expect(stdout).toContain('Login successful')
+      expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'non-interactive-token')
+      expect(mockConfigStoreDelete).toHaveBeenCalledWith('telemetryConsent')
+      expect(mockedOpen).not.toHaveBeenCalled()
+      expect(mockInput).not.toHaveBeenCalled()
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+
+    test('does not store an invalid token', async () => {
+      mockedGetCliToken.mockResolvedValue('')
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer invalid-token')
+        .reply(401, {message: 'Unauthorized'})
+
+      const {error} = await testTokenLogin('invalid-token')
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('Token is invalid or expired')
+      expect(error?.oclif?.exit).toBe(1)
+      expect(mockedSetCliUserConfig).not.toHaveBeenCalled()
+      expect(mockConfigStoreDelete).not.toHaveBeenCalled()
+      expect(mockedOpen).not.toHaveBeenCalled()
+    })
+
+    test('does not store a token that cannot be verified', async () => {
+      mockedGetCliToken.mockResolvedValue('')
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      }).reply(500, {message: 'Internal Server Error'})
+
+      const {error} = await testTokenLogin('server-error-token')
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('Could not verify token')
+      expect(error?.message).toContain('Internal Server Error')
+      expect(error?.oclif?.exit).toBe(1)
+      expect(mockedSetCliUserConfig).not.toHaveBeenCalled()
+      expect(mockConfigStoreDelete).not.toHaveBeenCalled()
+      expect(mockedOpen).not.toHaveBeenCalled()
+    })
+
+    test('stores a valid Sanity API token', async () => {
+      mockedGetCliToken.mockResolvedValue('')
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer robot-token')
+        .reply(200, {
+          id: 'robot-123',
+          name: 'Deploy Token',
+          provider: 'sanity-token',
+        })
+
+      const {error, stdout} = await testTokenLogin('robot-token')
+
+      if (error) throw error
+      expect(stdout).toContain('Login successful')
+      expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'robot-token')
+      expect(mockConfigStoreDelete).toHaveBeenCalledWith('telemetryConsent')
+      expect(mockedOpen).not.toHaveBeenCalled()
+    })
+
+    test('requires a non-empty token', async () => {
+      mockedGetCliToken.mockResolvedValue('')
+
+      const {error} = await testTokenLogin('  \n')
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain(
+        'Token is required on standard input. Run `sanity login --with-token < token.txt`.',
+      )
+      expect(error?.oclif?.exit).toBe(1)
+      expect(mockedSetCliUserConfig).not.toHaveBeenCalled()
+    })
+
+    test('requires token input from stdin', async () => {
+      mockedGetCliToken.mockResolvedValue('')
+      mockStdin('', {isTTY: true})
+
+      const {error} = await testCommand(LoginCommand, ['--with-token'])
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain(
+        'Token is required on standard input. Run `sanity login --with-token < token.txt`.',
+      )
+      expect(error?.oclif?.exit).toBe(1)
+      expect(mockedSetCliUserConfig).not.toHaveBeenCalled()
+      expect(mockedOpen).not.toHaveBeenCalled()
+    })
+
+    test('invalidates an existing session after token login', async () => {
+      mockedGetCliToken.mockResolvedValue('old-auth-token')
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer new-auth-token')
+        .reply(200, {
+          email: 'test@example.com',
+          id: 'user-123',
+          name: 'Test User',
+          provider: 'github',
+        })
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer old-auth-token')
+        .reply(200, {
+          email: 'old@example.com',
+          id: 'old-user-123',
+          name: 'Old User',
+          provider: 'github',
+        })
+
+      mockApi({
+        apiVersion: AUTH_API_VERSION,
+        method: 'post',
+        uri: '/auth/logout',
+      })
+        .matchHeader('authorization', 'Bearer old-auth-token')
+        .reply(200)
+
+      const {error} = await testTokenLogin('new-auth-token')
+
+      if (error) throw error
+      expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'new-auth-token')
+    })
+
+    test('does not invalidate an existing Sanity API token after token login', async () => {
+      mockedGetCliToken.mockResolvedValue('old-api-token')
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer new-auth-token')
+        .reply(200, {
+          email: 'test@example.com',
+          id: 'user-123',
+          name: 'Test User',
+          provider: 'github',
+        })
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer old-api-token')
+        .reply(200, {
+          id: 'robot-123',
+          name: 'Deploy Token',
+          provider: 'sanity-token',
+        })
+
+      const {error, stderr} = await testTokenLogin('new-auth-token')
+
+      if (error) throw error
+      expect(stderr).not.toContain('Failed to invalidate previous session')
+      expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'new-auth-token')
+    })
+
+    test('does not invalidate an unchanged token after token login', async () => {
+      mockedGetCliToken.mockResolvedValue('same-token')
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer same-token')
+        .reply(200, {
+          email: 'test@example.com',
+          id: 'user-123',
+          name: 'Test User',
+          provider: 'github',
+        })
+
+      const {error, stderr} = await testTokenLogin('same-token')
+
+      if (error) throw error
+      expect(stderr).not.toContain('Failed to invalidate previous session')
+      expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'same-token')
+    })
   })
 
   describe('Provider Selection', () => {
@@ -126,6 +400,15 @@ describe('#login', {timeout: 10_000}, () => {
 
       expect(error).toBeDefined()
       expect(error?.message).toContain('--provider=github cannot also be provided when using --sso')
+    })
+
+    test('errors when --provider and --with-token are both specified', async () => {
+      mockStdin('token')
+
+      const {error} = await testCommand(LoginCommand, ['--provider', 'github', '--with-token'])
+
+      expect(error).toBeDefined()
+      expect(error?.message).toContain('--provider=github cannot also be provided')
     })
 
     test('throws error for invalid --provider flag', async () => {
@@ -812,12 +1095,26 @@ describe('#login', {timeout: 10_000}, () => {
       mockedGetCliToken.mockResolvedValue('old-auth-token')
       mockSingleProviderLogin()
 
-      // Mock logout call
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer old-auth-token')
+        .reply(200, {
+          email: 'old@example.com',
+          id: 'old-user-123',
+          name: 'Old User',
+          provider: 'github',
+        })
+
       mockApi({
         apiVersion: AUTH_API_VERSION,
         method: 'post',
         uri: '/auth/logout',
-      }).reply(200)
+      })
+        .matchHeader('authorization', 'Bearer old-auth-token')
+        .reply(200)
 
       const commandPromise = testCommand(LoginCommand, [])
       await simulateOAuthCallback(4321, 'test-session-id')
@@ -827,15 +1124,14 @@ describe('#login', {timeout: 10_000}, () => {
       expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'new-auth-token')
     })
 
-    test('handles session invalidation errors gracefully', async () => {
-      // 401 should be silently ignored (expired token)
+    test('clears an expired previous token without invalidating it', async () => {
       mockedGetCliToken.mockResolvedValue('expired-token')
       mockSingleProviderLogin('session-401')
 
       mockApi({
-        apiVersion: AUTH_API_VERSION,
-        method: 'post',
-        uri: '/auth/logout',
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
       }).reply(401, {message: 'Unauthorized'})
 
       const commandPromise = testCommand(LoginCommand, [])
@@ -853,10 +1149,25 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer old-token')
+        .reply(200, {
+          email: 'old@example.com',
+          id: 'old-user-123',
+          name: 'Old User',
+          provider: 'github',
+        })
+
+      mockApi({
         apiVersion: AUTH_API_VERSION,
         method: 'post',
         uri: '/auth/logout',
-      }).reply(500, {message: 'Internal Server Error'})
+      })
+        .matchHeader('authorization', 'Bearer old-token')
+        .reply(500, {message: 'Internal Server Error'})
 
       const commandPromise = testCommand(LoginCommand, [])
       await simulateOAuthCallback(4321, 'test-session-id')
@@ -864,6 +1175,60 @@ describe('#login', {timeout: 10_000}, () => {
 
       expect(error).toBeUndefined()
       expect(stderr).toContain('Failed to invalidate previous session')
+      expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'new-auth-token')
+    })
+
+    test('does not invalidate a previous Sanity API token on new login', async () => {
+      mockedGetCliToken.mockResolvedValue('old-api-token')
+      mockSingleProviderLogin()
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer old-api-token')
+        .reply(200, {
+          id: 'robot-123',
+          name: 'Deploy Token',
+          provider: 'sanity-token',
+        })
+
+      const commandPromise = testCommand(LoginCommand, [])
+      await simulateOAuthCallback(4321, 'test-session-id')
+      const {error, stderr} = await commandPromise
+
+      expect(error).toBeUndefined()
+      expect(stderr).not.toContain('Failed to invalidate previous session')
+      expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'new-auth-token')
+    })
+
+    test('attempts logout when previous token type check fails', async () => {
+      mockedGetCliToken.mockResolvedValue('old-token')
+      mockSingleProviderLogin()
+
+      mockApi({
+        apiVersion: USERS_API_VERSION,
+        method: 'get',
+        uri: '/users/me',
+      })
+        .matchHeader('authorization', 'Bearer old-token')
+        .reply(500, {message: 'Internal Server Error'})
+
+      mockApi({
+        apiVersion: AUTH_API_VERSION,
+        method: 'post',
+        uri: '/auth/logout',
+      })
+        .matchHeader('authorization', 'Bearer old-token')
+        .reply(200)
+
+      const commandPromise = testCommand(LoginCommand, [])
+      await simulateOAuthCallback(4321, 'test-session-id')
+      const {error, stderr} = await commandPromise
+
+      if (error) throw error
+      expect(stderr).not.toContain('Failed to invalidate previous session')
       expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'new-auth-token')
     })
   })

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -1,3 +1,5 @@
+import {text} from 'node:stream/consumers'
+
 import {Command, Flags} from '@oclif/core'
 import {type FlagInput} from '@oclif/core/interfaces'
 import {SanityCommand} from '@sanity/cli-core'
@@ -24,6 +26,10 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
         '<%= config.bin %> <%= command.id %> --sso my-organization --sso-provider "Okta SSO"',
       description: 'Log in using a specific SSO provider within an organization',
     },
+    {
+      command: '<%= config.bin %> <%= command.id %> --with-token < token.txt',
+      description: 'Log in using a token from standard input',
+    },
   ]
   static override flags = {
     experimental: Flags.boolean({
@@ -37,12 +43,12 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
     }),
     provider: Flags.string({
       description: 'Log in using the given provider',
-      exclusive: ['sso'],
+      exclusive: ['sso', 'with-token'],
       helpValue: '<providerId>',
     }),
     sso: Flags.string({
       description: 'Log in using Single Sign-On, using the given organization slug',
-      exclusive: ['provider'],
+      exclusive: ['provider', 'with-token'],
       helpValue: '<slug>',
     }),
     'sso-provider': Flags.string({
@@ -50,17 +56,25 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
       description: 'Select a specific SSO provider by name (use with --sso)',
       helpValue: '<name>',
     }),
+    'with-token': Flags.boolean({
+      description: 'Read token from standard input',
+      exclusive: ['provider', 'sso'],
+    }),
   } satisfies FlagInput
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(LoginCommand)
+    const {'sso-provider': ssoProvider, 'with-token': withToken, ...loginFlags} = flags
 
     try {
+      const token = withToken ? await readTokenFromStdin() : undefined
+
       await login({
-        ...flags,
+        ...loginFlags,
         output: this.output,
-        ssoProvider: flags['sso-provider'],
+        ssoProvider,
         telemetry: this.telemetry,
+        token,
       })
       this.log('Login successful')
     } catch (error) {
@@ -68,4 +82,14 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
       this.error(`Login failed: ${message}`, {exit: 1})
     }
   }
+}
+
+async function readTokenFromStdin(): Promise<string> {
+  if (process.stdin.isTTY) {
+    throw new Error(
+      'Token is required on standard input. Run `sanity login --with-token < token.txt`.',
+    )
+  }
+
+  return text(process.stdin)
 }


### PR DESCRIPTION
### Description

Adds `sanity login --with-token` for token-based CLI login from standard input. The token is validated through `users/me`; any token accepted by that endpoint is stored in the normal CLI auth config, while invalid or expired tokens fail before storage.

All login flows now use the same auth-token storage path, which clears cached telemetry consent and handles previous-token cleanup. When replacing an existing token, the CLI checks whether the previous token is a Sanity API token and skips `/auth/logout` for API tokens because the backend does not treat them as sessions. Expired previous tokens are also ignored.

Fixes AIGRO-4983

### What to review

Review the `sanity login --with-token < token.txt` flow, token validation, previous-token invalidation behavior, TTY/stdin handling, and telemetry handling in `packages/@sanity/cli/src/actions/auth/login/` and `packages/@sanity/cli/src/commands/login.ts`.

### Testing

- `CI=true mise exec -- pnpm test packages/@sanity/cli/src/commands/__tests__/login.test.ts packages/@sanity/cli/src/actions/auth/login/__tests__/login.vercel.test.ts`
- `mise exec -- pnpm check:types`
- `mise exec -- pnpm check:lint`
- `mise exec -- pnpm check:deps`
- `mise exec -- pnpm --filter @sanity/cli readme`

Latest affected login tests passed with 50 passed and 0 failed.