### PR TITLE
chore(cli): disable oclif auto transpile

### DIFF
--- a/.changeset/pr-1083.md
+++ b/.changeset/pr-1083.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix: disable oclif auto transpile

--- a/.changeset/pr-1083.md
+++ b/.changeset/pr-1083.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix: disable oclif auto transpile

--- a/packages/@sanity/cli/bin/run.js
+++ b/packages/@sanity/cli/bin/run.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import {execute} from '@oclif/core'
+import {execute, settings} from '@oclif/core'
 
 var err = '\u001B[31m\u001B[1mERROR:\u001B[22m\u001B[39m '
 var nodeVersionParts = process.version.replace(/^v/i, '').split('.').map(Number)
@@ -29,5 +29,7 @@ if (!isSupportedNodeVersion(majorVersion, minorVersion, patchVersion)) {
   console.error('')
   process.exit(1)
 }
+
+settings.enableAutoTranspile = false
 
 await execute({dir: import.meta.url})


### PR DESCRIPTION
Disabling oclif's auto transpile feature hs no effect on the built CLI, but when testing locally it gets rid of the warnings from oclif about not being able to find the source. Since the recommended dev flow is to use `pnpm watch` in the `cli` project to continuously rebuild, auto transpile isn't used at all for us.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small CLI bootstrap tweak that disables oclif auto-transpilation and should only affect local/dev execution behavior.
> 
> **Overview**
> Disables oclif’s automatic transpilation in the CLI entrypoint by importing `settings` from `@oclif/core` and setting `settings.enableAutoTranspile = false` before `execute()` runs.
> 
> This is intended to prevent oclif auto-transpile warnings during local runs without changing the CLI’s command logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa43d188e7494cee33461bfc27dc05b008a92c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->