### PR TITLE
feat(templates): add page-builder template using @sanity/presets

### DIFF
--- a/.changeset/pr-1084.md
+++ b/.changeset/pr-1084.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(templates): add page-builder template using @sanity/presets

--- a/packages/@sanity/cli/src/actions/init/__tests__/scaffoldTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/scaffoldTemplate.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, test} from 'vitest'
+
+import {getTemplateChoices} from '../scaffoldTemplate.js'
+
+describe('getTemplateChoices', () => {
+  test('includes the page-builder template in non-production environments', () => {
+    const values = getTemplateChoices('staging').map((choice) => choice.value)
+    expect(values).toContain('page-builder')
+  })
+
+  test('excludes the page-builder template in production', () => {
+    const values = getTemplateChoices('production').map((choice) => choice.value)
+    expect(values).not.toContain('page-builder')
+  })
+})

--- a/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
@@ -4,6 +4,7 @@ import {type TelemetryTrace} from '@sanity/telemetry'
 
 import {promptForTypeScript} from '../../prompts/init/promptForTypescript.js'
 import {type InitStepResult} from '../../telemetry/init.telemetry.js'
+import {getSanityEnv} from '../../util/getSanityEnv.js'
 import {installDeclaredPackages} from '../../util/packageManager/installPackages.js'
 import {type PackageManager} from '../../util/packageManager/packageManagerChoice.js'
 import {bootstrapTemplate} from './bootstrapTemplate.js'
@@ -20,6 +21,28 @@ interface SelectedTemplate {
   useTypeScript: boolean
 }
 
+interface TemplateChoice {
+  name: string
+  value: string
+}
+
+const baseTemplateChoices: TemplateChoice[] = [
+  {name: 'Clean project with no predefined schema types', value: 'clean'},
+  {name: 'Blog (schema)', value: 'blog'},
+  {name: 'E-commerce (Shopify)', value: 'shopify'},
+  {name: 'Movie project (schema + sample data)', value: 'moviedb'},
+]
+
+const stagingTemplateChoices: TemplateChoice[] = [
+  {name: 'Page Builder (presets)', value: 'page-builder'},
+]
+
+export function getTemplateChoices(env: string): TemplateChoice[] {
+  return env === 'production'
+    ? baseTemplateChoices
+    : [...baseTemplateChoices, ...stagingTemplateChoices]
+}
+
 async function promptForTemplate(params: {
   template?: string
   unattended: boolean
@@ -30,24 +53,7 @@ async function promptForTemplate(params: {
   }
 
   return select({
-    choices: [
-      {
-        name: 'Clean project with no predefined schema types',
-        value: 'clean',
-      },
-      {
-        name: 'Blog (schema)',
-        value: 'blog',
-      },
-      {
-        name: 'E-commerce (Shopify)',
-        value: 'shopify',
-      },
-      {
-        name: 'Movie project (schema + sample data)',
-        value: 'moviedb',
-      },
-    ],
+    choices: getTemplateChoices(getSanityEnv()),
     message: 'Select project template',
   })
 }

--- a/packages/@sanity/cli/src/actions/init/templates/__tests__/pageBuilder.test.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/__tests__/pageBuilder.test.ts
@@ -1,0 +1,9 @@
+import {describe, expect, test} from 'vitest'
+
+import pageBuilder from '../pageBuilder.js'
+
+describe('pageBuilder template', () => {
+  test('declares @sanity/presets as a dependency', () => {
+    expect(pageBuilder.dependencies?.['@sanity/presets']).toMatch(/^\^?\d+\.\d+\.\d+/)
+  })
+})

--- a/packages/@sanity/cli/src/actions/init/templates/index.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/index.ts
@@ -5,6 +5,7 @@ import blog from './blog.js'
 import clean from './clean.js'
 import getStartedTemplate from './getStarted.js'
 import moviedb from './moviedb.js'
+import pageBuilder from './pageBuilder.js'
 import quickstart from './quickstart.js'
 import shopify from './shopify.js'
 import shopifyOnline from './shopifyOnline.js'
@@ -16,6 +17,7 @@ const templates: Record<string, ProjectTemplate | undefined> = {
   clean,
   'get-started': getStartedTemplate,
   moviedb,
+  'page-builder': pageBuilder,
   quickstart, // empty project that dynamically imports its own schema
   shopify,
   'shopify-online-storefront': shopifyOnline,

--- a/packages/@sanity/cli/src/actions/init/templates/pageBuilder.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/pageBuilder.ts
@@ -1,0 +1,34 @@
+import {type ProjectTemplate} from '../types.js'
+
+const configTemplate = `
+import {defineConfig} from 'sanity'
+import {structureTool} from 'sanity/structure'
+import {visionTool} from '@sanity/vision'
+import {schemaTypes} from './schemaTypes'
+
+export default defineConfig({
+  name: '%sourceName%',
+  title: '%projectName%',
+
+  projectId: '%projectId%',
+  dataset: '%dataset%',
+
+  plugins: [
+    structureTool(),
+    visionTool(),
+  ],
+
+  schema: {
+    types: schemaTypes,
+  },
+})
+`
+
+const pageBuilderTemplate: ProjectTemplate = {
+  configTemplate,
+  dependencies: {
+    '@sanity/presets': '^0.4.1',
+  },
+}
+
+export default pageBuilderTemplate

--- a/packages/@sanity/cli/templates/page-builder/README.md
+++ b/packages/@sanity/cli/templates/page-builder/README.md
@@ -1,0 +1,9 @@
+# Sanity Page Builder Studio
+
+Congratulations, you have now installed the Sanity Content Studio, an open-source real-time content editing environment connected to the Sanity backend.
+
+Now you can do the following things:
+
+- [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
+- [Join the Sanity community](https://www.sanity.io/community/join?utm_source=readme)
+- [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/page-builder/schemaTypes/hero.js
+++ b/packages/@sanity/cli/templates/page-builder/schemaTypes/hero.js
@@ -1,0 +1,31 @@
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'hero',
+  title: 'Hero',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'heading',
+      title: 'Heading',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'body',
+      title: 'Body',
+      type: 'text',
+      rows: 3,
+    }),
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'imageBlock',
+    }),
+    defineField({
+      name: 'cta',
+      title: 'Call to action',
+      type: 'cta',
+    }),
+  ],
+})

--- a/packages/@sanity/cli/templates/page-builder/schemaTypes/index.js
+++ b/packages/@sanity/cli/templates/page-builder/schemaTypes/index.js
@@ -6,14 +6,12 @@ const {defineCta, defineImage, definePage, defineRichText} = createPresetsRegist
   link: {internalTypes: ['page']},
 })
 
-const page = definePage({
-  name: 'page',
-  title: 'Page',
-  pageBuilderBlocks: ['hero', 'imageBlock', 'cta', 'richText'],
-})
-
 export const schemaTypes = [
-  page,
+  definePage({
+    name: 'page',
+    title: 'Page',
+    pageBuilderBlocks: ['hero', 'imageBlock', 'cta', 'richText'],
+  }),
   hero,
   defineImage({name: 'imageBlock', title: 'Image'}),
   defineCta({name: 'cta', title: 'Call to action'}),

--- a/packages/@sanity/cli/templates/page-builder/schemaTypes/index.js
+++ b/packages/@sanity/cli/templates/page-builder/schemaTypes/index.js
@@ -1,0 +1,21 @@
+import {createPresetsRegistry} from '@sanity/presets'
+
+import hero from './hero'
+
+const {defineCta, defineImage, definePage, defineRichText} = createPresetsRegistry({
+  link: {internalTypes: ['page']},
+})
+
+const page = definePage({
+  name: 'page',
+  title: 'Page',
+  pageBuilderBlocks: ['hero', 'imageBlock', 'cta', 'richText'],
+})
+
+export const schemaTypes = [
+  page,
+  hero,
+  defineImage({name: 'imageBlock', title: 'Image'}),
+  defineCta({name: 'cta', title: 'Call to action'}),
+  defineRichText({name: 'richText', title: 'Rich text'}),
+]


### PR DESCRIPTION
### Description

[SAPP-3677](https://linear.app/sanity/issue/SAPP-3677) tracks adding a starter Studio template that demonstrates `@sanity/presets`, a recently released package providing ready-made schema factories (`definePage`, `defineImage`, `defineCta`, `defineRichText`) for page-builder patterns. The CLI's init flow had no template that exercised the package.

This PR adds a `page-builder` template using `definePage` with hero/image/CTA/rich-text blocks, a shared presets registry configured so internal links target Page documents, and a custom hero block composing `defineImage` and `defineCta` inline. The picker entry is gated to non-production environments via `SANITY_INTERNAL_ENV !== 'production'` so the template can be tested in staging before broader release.

<img width="661" height="933" alt="Screenshot 2026-05-18 at 15 06 53" src="https://github.com/user-attachments/assets/745a1b07-dd2d-419c-ad98-dbedc697044c" />

<img width="636" height="839" alt="Screenshot 2026-05-18 at 15 07 42" src="https://github.com/user-attachments/assets/207d84bb-66f1-4c94-9adf-c6be296547a3" />

### What to review

- `scaffoldTemplate.ts` - extracted `getTemplateChoices(env)` as a pure helper so the gating is unit-testable; the `--template` flag path intentionally bypasses the env check
- `templates/pageBuilder.ts` - shape mirrors `moviedb.ts` (configTemplate + dependencies)
- `schemaTypes/hero.js` - references `imageBlock` rather than `image` because Sanity reserves `image` as a primitive type name
- `schemaTypes/index.js` - shared presets registry; `link.internalTypes: ['page']` cascades to CTAs and rich-text annotations

### Testing

Unit tests cover the env-gating in both directions and assert the `@sanity/presets` dependency is declared. Smoke tested end-to-end by building the CLI, scaffolding a studio with `SANITY_INTERNAL_ENV=staging sanity init`, and verifying the Page document renders all four block types plus SEO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive and the new template option is gated to non-production environments, leaving production init behavior unchanged aside from a small refactor of the template choice list.
> 
> **Overview**
> Adds a new `page-builder` template to `sanity init` that scaffolds a simple page-builder schema using `@sanity/presets` (page, hero, image, CTA, rich-text) and includes a new template README.
> 
> Refactors template selection to use a new `getTemplateChoices(getSanityEnv())` helper and gates the `page-builder` choice to non-production `SANITY_INTERNAL_ENV` values, with unit tests covering both the env gating and the template’s declared `@sanity/presets` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bbd83b9e67c47ebbc696e4152a8b7ad15c71038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->