### PR TITLE
chore: add Next.js gitignore to fixture dir

### DIFF
--- a/fixtures/nextjs-app/.gitignore
+++ b/fixtures/nextjs-app/.gitignore
@@ -1,0 +1,41 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts


### PR DESCRIPTION
Adds the Next.js gitignore template ([link](https://raw.githubusercontent.com/vercel/next.js/refs/heads/canary/packages/create-next-app/templates/app/js/gitignore)) to the `fixtures/nextjs-app` dir, so that your Git modified files doesn't get screwed up from running a root-level `pnpm build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only a `.gitignore` file in a fixture directory with no runtime or build logic changes.
> 
> **Overview**
> Adds a Next.js-specific `.gitignore` under `fixtures/nextjs-app` to prevent build artifacts, dependency folders, env files, and other generated files (e.g., `.next/`, `out/`, `node_modules/`) from showing up as modified when running builds in the fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eddea1770843ab58f0dee12e797a37cf6474f500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->