### PR TITLE
ci: add 2027 eval workflow for per-PR CLI evaluation

### DIFF
--- a/.github/workflows/2027-eval.yml
+++ b/.github/workflows/2027-eval.yml
@@ -1,0 +1,113 @@
+name: 2027 eval
+on:
+  pull_request:
+    types: [labeled, synchronize, opened, reopened]
+  issue_comment:
+    types: [created]
+
+# Concurrency note: GitHub evaluates concurrency BEFORE the job's `if:`,
+# so keying off issue.number means unrelated bot comments on the same PR
+# (e.g. claude[bot], dependabot) cancel an in-flight eval even when their
+# bodies fail the @2027dev filter. Key on comment.id instead so each
+# comment is its own group; pull_request events still group by head_ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.comment.id || github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  checks: read
+  pull-requests: write
+  statuses: write
+  contents: read
+
+env:
+  PROMPT_ID: 1d8004c6-d00c-432e-998b-e868a957807c
+
+jobs:
+  eval:
+    # Fires on:
+    # - any labeled/synchronize/opened/reopened PR that carries the
+    #   `trigger: preview` label (existing behavior)
+    # - any PR comment that mentions @2027dev (new — issue_comment loads
+    #   the workflow from the default branch, so this YAML must be on main)
+    if: >-
+      (github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'trigger: preview')) ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@2027dev'))
+    runs-on: ubuntu-latest
+    steps:
+      # Resolve the PR head sha. pull_request payloads carry it directly;
+      # issue_comment doesn't, so fetch via pulls.get. Downstream steps key
+      # off steps.pr.outputs.sha so they stay event-agnostic.
+      - name: Resolve PR head sha
+        id: pr
+        uses: actions/github-script@v9
+        with:
+          script: |
+            if (context.eventName === 'pull_request') {
+              core.setOutput('sha', context.payload.pull_request.head.sha)
+              core.setOutput('number', String(context.payload.pull_request.number))
+              return
+            }
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.payload.issue.number,
+            })
+            core.setOutput('sha', pr.head.sha)
+            core.setOutput('number', String(pr.number))
+
+      - name: Wait for pkg-pr-new on this SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.pr.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Poll pkg-pr-new's "Continuous Releases" commit status. This is
+          # pkg-pr-new's authoritative "package is uploaded and reachable"
+          # signal — stronger than our internal publish workflow exiting 0.
+          # success wins, hard failure aborts, anything else keeps polling.
+          for i in $(seq 1 30); do
+            STATE=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/check-runs" \
+              --jq '
+                [.check_runs[] | select(.name == "Continuous Releases")] as $c
+                | if any($c[]; .conclusion == "success") then "success"
+                  elif any($c[]; .conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") then "hard_fail"
+                  else "pending" end
+              ')
+            case "$STATE" in
+              success)
+                echo "pkg-pr-new succeeded on $SHA"
+                exit 0
+                ;;
+              hard_fail)
+                echo "::error::pkg-pr-new failed on $SHA — aborting eval"
+                exit 1
+                ;;
+            esac
+            echo "waiting for Continuous Releases on $SHA (attempt $i/30, state: $STATE)..."
+            sleep 20
+          done
+          echo "::error::Timed out waiting for Continuous Releases — is the pkg-pr-new GitHub App installed on $GITHUB_REPOSITORY?"
+          exit 1
+
+      - name: Compute cliInstall
+        id: cli
+        env:
+          SHA: ${{ steps.pr.outputs.sha }}
+        run: |
+          set -euo pipefail
+          echo "install=npm i -g https://pkg.pr.new/${GITHUB_REPOSITORY}/@sanity/cli@${SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Run 2027 eval
+        # team2027/evals-action@v0.7.0 — SHA-pinned per GitHub's hardening
+        # guidance for third-party actions that handle secrets.
+        uses: team2027/evals-action@f322589b36320fcbc0ea4756686d240bc7fcda88
+        with:
+          api-key: ${{ secrets.EVALS_API_KEY }}
+          prompt-id: ${{ env.PROMPT_ID }}
+          url-map: '{}'
+          template-vars: |
+            { "cliInstall": "${{ steps.cli.outputs.install }}" }
+          wait-timeout-minutes: 60


### PR DESCRIPTION
### Description

Integrated 2027's agent experience evaluations, allowing to test preview builds of Sanity CLI automatically on PRs labeled `trigger: preview`. Uses existing `pkg-pr-new` action to provide build preview URL to the 2027 runner (https://github.com/team2027/evals-action).

Uses prompt https://2027.dev/evals/sanity.io/prompts/1d8004c6-d00c-432e-998b-e868a957807c, and triggers an eval, passing over the per-commit `@sanity/cli` build. `evals-action` posts a sticky comment with eval status.

The intent is to catch CLI regressions that hurt agent workflows (Claude Code, Codex, Cursor, etc.) before they ship — measuring time, cost, error count, and score for an end-to-end "set up a Sanity project with the CLI" task.

Dogfooded extensively in the [team2027/sanity-cli fork](https://github.com/team2027/sanity-cli) — pipeline confirmed exercising the per-PR build (https://github.com/team2027/sanity-cli/pull/3#issuecomment-4482742976 -- intentionally broken CLI scored differently than working CLI).

Uses 2027 API, see full reference here: https://2027.dev/evals/api/openapi

### What to review

- `.github/workflows/2027-eval.yml` — single new file
- Triggers off the existing `Publish Preview Packages` (pkg-pr-new) workflow's completion via SHA polling
- Uses [`team2027/evals-action@v0.5.0`](https://github.com/team2027/evals-action) (pinned to a tag, action source is public)
- Sticky PR comment + commit status come from the action; no custom commenting

**Prerequisites for this to do anything:**

1. Repo secret `EVALS_API_KEY` set in `sanity-io/cli` → Settings → Secrets and variables → Actions. Generate at https://2027.dev/evals/sanity.io/settings.
2. Without the secret, the job will fail loudly with `api-key input is required` — no silent skip.
3. The prompt id (`1d8004c6-d00c-432e-998b-e868a957807c`) is owned by the `sanity.io` org domain on 2027 and is the "Getting Started: Staging CLI" prompt. Anyone with a `sanity.io` 2027 API key can run it. To use a different prompt, edit the `PROMPT_ID` env var.

### Security considerations

1. Prompt ID `1d8004c6-d00c-432e-998b-e868a957807c` is public on this repo. However, 2027 API is authenticated via org-level API token (stored in `EVALS_API_KEY` repo secrets), so no information is visible to the public visitors, except for evals results in the public github comment
2. The only data being sent *to* the 2027 API is the `pkg-pr-new` build SHA (which is public)
3. By default, action polls for 60min -- might run into Github Actions limits if 2027 runs take too long. Alternatively, same testing could be configured via Github app, which would lift the need to run custom Github action.

### Testing

- Validated end-to-end in fork: 4 successful eval runs across 2 PRs, with both happy-path and intentionally-broken CLI scenarios
- Action itself (`team2027/evals-action`) has its own test suite with contract tests for the API wire format
