### PR TITLE
fix: Prevent buildStudio from running shouldAutoUpdate a second time

### DIFF
--- a/.changeset/sour-zebras-share.md
+++ b/.changeset/sour-zebras-share.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+Restore auto update check logic ordering when building a studio

--- a/.changeset/sour-zebras-share.md
+++ b/.changeset/sour-zebras-share.md
@@ -2,4 +2,4 @@
 "@sanity/cli": patch
 ---
 
-Restore auto update check logic ordering when building a studio
+Prevent auto update check from running twice when building a studio

--- a/.changeset/sour-zebras-share.md
+++ b/.changeset/sour-zebras-share.md
@@ -2,4 +2,4 @@
 "@sanity/cli": patch
 ---
 
-Prevent auto update check from running twice when building a studio
+Fix duplicate auto-update warning when building a studio.

--- a/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.appIdWarning.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.appIdWarning.test.ts
@@ -30,10 +30,6 @@ vi.mock('../checkRequiredDependencies.js', () => ({
   checkRequiredDependencies: vi.fn().mockResolvedValue({installedSanityVersion: '3.0.0'}),
 }))
 
-vi.mock('../shouldAutoUpdate.js', () => ({
-  shouldAutoUpdate: vi.fn().mockReturnValue(true),
-}))
-
 vi.mock('../../../util/compareDependencyVersions.js', () => ({
   compareDependencyVersions: vi.fn().mockResolvedValue({mismatched: [], unresolvedPrerelease: []}),
 }))
@@ -85,7 +81,6 @@ vi.mock('@sanity/cli-core/ux', () => ({
 
 // Import after mocks are set up
 const {buildStudio} = await import('../buildStudio.js')
-const {shouldAutoUpdate} = await import('../shouldAutoUpdate.js')
 
 function createMockOutput(): Output {
   return {
@@ -137,7 +132,6 @@ describe('buildStudio appId warning', () => {
 
   test('should not warn about missing appId when auto-updates are disabled', async () => {
     mockGetAppId.mockReturnValue(undefined)
-    vi.mocked(shouldAutoUpdate).mockReturnValueOnce(false)
     const output = createMockOutput()
 
     await buildStudio({
@@ -150,23 +144,6 @@ describe('buildStudio appId warning', () => {
     })
 
     expect(mockWarnAboutMissingAppId).not.toHaveBeenCalled()
-  })
-
-  test('should not call shouldAutoUpdate when called from deploy', async () => {
-    mockGetAppId.mockReturnValue('my-app-id')
-    const output = createMockOutput()
-
-    await buildStudio({
-      autoUpdatesEnabled: true,
-      calledFromDeploy: true,
-      cliConfig: {deployment: {autoUpdates: true}},
-      flags: FLAGS,
-      outDir: '/tmp/dist',
-      output,
-      workDir: '/tmp',
-    })
-
-    expect(shouldAutoUpdate).not.toHaveBeenCalled()
   })
 
   test('should not warn about missing appId when appId is configured', async () => {

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -125,7 +125,7 @@ async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
 
     output.log(`${logSymbols.info} Building with auto-updates enabled`)
 
-    // Warn if no appId configured.
+    // Warn if auto updates enabled but no appId configured.
     // Skip when called from deploy, since deploy handles appId itself
     // (prompts the user and tells them to add it to config).
     if (!appId && !options.calledFromDeploy) {

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -125,7 +125,7 @@ async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
 
     output.log(`${logSymbols.info} Building with auto-updates enabled`)
 
-    // Warn if auto updates enabled but no appId configured.
+    // Warn if no appId configured.
     // Skip when called from deploy, since deploy handles appId itself
     // (prompts the user and tells them to add it to config).
     if (!appId && !options.calledFromDeploy) {

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -80,9 +80,12 @@ export async function buildApp(options: BuildOptions): Promise<void> {
  * @param options - options for the build
  */
 async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
+  buildDebug(`Building app`)
+
   const {appId, determineBasePath, outDir, output, workDir} = options
   let {autoUpdatesEnabled} = options
   const unattendedMode = options.unattendedMode
+
   const timer = getTimer()
 
   const defaultOutputDir = path.resolve(path.join(workDir, 'dist'))

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -36,7 +36,7 @@ import {type BuildOptions} from './types.js'
 
 interface InternalBuildOptions {
   appId: string | undefined
-  autoUpdatesEnabled: boolean
+  autoUpdatesEnabled: () => boolean
   calledFromDeploy: boolean | undefined
   determineBasePath: () => string
   isApp: boolean
@@ -62,9 +62,10 @@ interface InternalBuildOptions {
 export async function buildStudio(options: BuildOptions): Promise<void> {
   const {calledFromDeploy, cliConfig, flags, outDir, output, workDir} = options
 
-  const autoUpdatesEnabled = options.calledFromDeploy
-    ? options.autoUpdatesEnabled
-    : shouldAutoUpdate({cliConfig, flags, output})
+  const autoUpdatesEnabled = () =>
+    options.calledFromDeploy
+      ? options.autoUpdatesEnabled
+      : shouldAutoUpdate({cliConfig, flags, output})
 
   const upgradePkgs = async (options: {
     packages: [name: string, version: string][]
@@ -104,6 +105,8 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
  * @param options - options for the build
  */
 async function internalBuildStudio(options: InternalBuildOptions): Promise<void> {
+  buildDebug(`Building studio`)
+
   const timer = getTimer()
   const {
     appId,
@@ -122,7 +125,6 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     vite,
     workDir,
   } = options
-  let autoUpdatesEnabled = options.autoUpdatesEnabled
   const defaultOutputDir = path.resolve(path.join(workDir, 'dist'))
   const outputDir = path.resolve(outDir || defaultOutputDir)
 
@@ -135,6 +137,8 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     output,
     workDir,
   })
+
+  let autoUpdatesEnabled = options.autoUpdatesEnabled()
 
   let autoUpdatesImports = {}
   let autoUpdatesCssUrls: string[] = []

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -31,7 +31,6 @@ import {determineBasePath} from './determineBasePath.js'
 import {getAutoUpdatesCssUrls, getAutoUpdatesImportMap} from './getAutoUpdatesImportMap.js'
 import {getStudioEnvVars} from './getStudioEnvVars.js'
 import {handlePrereleaseVersions} from './handlePrereleaseVersions.js'
-import {shouldAutoUpdate} from './shouldAutoUpdate.js'
 import {type BuildOptions} from './types.js'
 
 interface InternalBuildOptions {

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -36,7 +36,7 @@ import {type BuildOptions} from './types.js'
 
 interface InternalBuildOptions {
   appId: string | undefined
-  autoUpdatesEnabled: () => boolean
+  autoUpdatesEnabled: boolean
   calledFromDeploy: boolean | undefined
   determineBasePath: () => string
   isApp: boolean
@@ -62,11 +62,6 @@ interface InternalBuildOptions {
 export async function buildStudio(options: BuildOptions): Promise<void> {
   const {calledFromDeploy, cliConfig, flags, outDir, output, workDir} = options
 
-  const autoUpdatesEnabled = () =>
-    options.calledFromDeploy
-      ? options.autoUpdatesEnabled
-      : shouldAutoUpdate({cliConfig, flags, output})
-
   const upgradePkgs = async (options: {
     packages: [name: string, version: string][]
   }): Promise<void> => {
@@ -81,7 +76,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
 
   await internalBuildStudio({
     appId: getAppId(cliConfig),
-    autoUpdatesEnabled,
+    autoUpdatesEnabled: options.autoUpdatesEnabled,
     calledFromDeploy,
     determineBasePath: () => determineBasePath(cliConfig, 'studio', output),
     isApp: determineIsApp(cliConfig),
@@ -138,7 +133,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     workDir,
   })
 
-  let autoUpdatesEnabled = options.autoUpdatesEnabled()
+  let autoUpdatesEnabled = options.autoUpdatesEnabled
 
   let autoUpdatesImports = {}
   let autoUpdatesCssUrls: string[] = []

--- a/packages/@sanity/cli/src/commands/build.ts
+++ b/packages/@sanity/cli/src/commands/build.ts
@@ -2,7 +2,6 @@ import {Args, Flags} from '@oclif/core'
 import {SanityCommand} from '@sanity/cli-core'
 
 import {buildApp} from '../actions/build/buildApp.js'
-import {buildDebug} from '../actions/build/buildDebug.js'
 import {buildStudio} from '../actions/build/buildStudio.js'
 import {shouldAutoUpdate} from '../actions/build/shouldAutoUpdate.js'
 import {determineIsApp} from '../util/determineIsApp.js'
@@ -60,7 +59,6 @@ export class BuildCommand extends SanityCommand<typeof BuildCommand> {
     const autoUpdatesEnabled = shouldAutoUpdate({cliConfig, flags, output})
 
     if (isApp) {
-      buildDebug(`Building app`)
       await buildApp({
         autoUpdatesEnabled,
         cliConfig,
@@ -70,7 +68,6 @@ export class BuildCommand extends SanityCommand<typeof BuildCommand> {
         workDir,
       })
     } else {
-      buildDebug(`Building studio`)
       await buildStudio({
         autoUpdatesEnabled,
         cliConfig,


### PR DESCRIPTION
### Description

This PR corrects a bug in buildStudio logic where shouldAutoUpdate could be called a second time and warn the user twice. It also consolidates called to `buildDebug` under the actions/build folder to make future refactoring simpler.

### Testing

Ran all tests successfully, no new tests needed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk logic change that removes an extra `shouldAutoUpdate` evaluation during `buildStudio`, mainly affecting warning/prompt behavior during builds.
> 
> **Overview**
> Fixes a bug where `buildStudio` could call `shouldAutoUpdate` again and emit duplicate deprecation/auto-update warnings by removing that internal check and always using the `autoUpdatesEnabled` value passed in.
> 
> Also moves `buildDebug` logging into the internal build actions (`internalBuildStudio`/`internalBuildApp`) and updates/trim tests accordingly, plus adds a changeset for the patch release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d427ddfceb0da332b8c9e5c9dc87a32d00d60a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->