### PR TITLE
fix: Prevent listing lowercase env vars as included in JS bundle

### DIFF
--- a/.changeset/pr-1094.md
+++ b/.changeset/pr-1094.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix: Prevent listing lowercase env vars as included in JS bundle

--- a/packages/@sanity/cli/src/actions/build/__tests__/buildApp.appIdWarning.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/buildApp.appIdWarning.test.ts
@@ -32,8 +32,8 @@ vi.mock('../getAutoUpdatesImportMap.js', () => ({
   getAutoUpdatesImportMap: vi.fn().mockReturnValue({}),
 }))
 
-vi.mock('../getAppEnvVars.js', () => ({
-  getAppEnvVars: vi.fn().mockReturnValue([]),
+vi.mock('../getEnvironmentVariables.js', () => ({
+  getAppEnvironmentVariables: vi.fn().mockReturnValue({}),
 }))
 
 vi.mock('../buildStaticFiles.js', () => ({

--- a/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.appIdWarning.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.appIdWarning.test.ts
@@ -39,8 +39,8 @@ vi.mock('../getAutoUpdatesImportMap.js', () => ({
   getAutoUpdatesImportMap: vi.fn().mockReturnValue({}),
 }))
 
-vi.mock('../getStudioEnvVars.js', () => ({
-  getStudioEnvVars: vi.fn().mockReturnValue([]),
+vi.mock('../getEnvironmentVariables.js', () => ({
+  getStudioEnvironmentVariables: vi.fn().mockReturnValue({}),
 }))
 
 vi.mock('../buildStaticFiles.js', () => ({

--- a/packages/@sanity/cli/src/actions/build/__tests__/getEnvironmentVariables.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getEnvironmentVariables.test.ts
@@ -3,7 +3,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 import {
   getAppEnvironmentVariables,
   getStudioEnvironmentVariables,
-} from '../getStudioEnvironmentVariables.js'
+} from '../getEnvironmentVariables.js'
 
 describe('#getStudioEnvironmentVariables', () => {
   beforeEach(() => {

--- a/packages/@sanity/cli/src/actions/build/__tests__/getEnvironmentVariables.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getEnvironmentVariables.test.ts
@@ -13,6 +13,8 @@ describe('#getStudioEnvironmentVariables', () => {
     vi.stubEnv('SANITY_APP_SECRET', 'app-secret-456')
     vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://next.example.com')
     vi.stubEnv('VITE_CUSTOM_VAR', 'vite-value')
+    vi.stubEnv('sanity_studio_foo', 'bar')
+    vi.stubEnv('sanity_app_foo', 'bar')
   })
 
   afterEach(() => {
@@ -40,6 +42,8 @@ describe('#getStudioEnvironmentVariables', () => {
     expect(result).not.toHaveProperty('NEXT_PUBLIC_API_URL')
     expect(result).not.toHaveProperty('VITE_CUSTOM_VAR')
     expect(result).not.toHaveProperty('SANITY_APP_SECRET')
+    expect(result).not.toHaveProperty('sanity_studio_foo')
+    expect(result).not.toHaveProperty('sanity_app_foo')
   })
 
   test('applies jsonEncode option', () => {
@@ -85,6 +89,8 @@ describe('#getAppEnvironmentVariables', () => {
     vi.stubEnv('SANITY_STUDIO_API_KEY', 'studio-key-123')
     vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://next.example.com')
     vi.stubEnv('VITE_CUSTOM_VAR', 'vite-value')
+    vi.stubEnv('sanity_studio_foo', 'bar')
+    vi.stubEnv('sanity_app_foo', 'bar')
   })
 
   afterEach(() => {
@@ -112,6 +118,8 @@ describe('#getAppEnvironmentVariables', () => {
     expect(result).not.toHaveProperty('NEXT_PUBLIC_API_URL')
     expect(result).not.toHaveProperty('VITE_CUSTOM_VAR')
     expect(result).not.toHaveProperty('SANITY_STUDIO_API_KEY')
+    expect(result).not.toHaveProperty('sanity_studio_foo')
+    expect(result).not.toHaveProperty('sanity_app_foo')
   })
 
   test('applies jsonEncode option', () => {

--- a/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
@@ -36,7 +36,7 @@ vi.mock('../getBrowserAliases.js', () => ({
   getSanityPkgExportAliases: vi.fn(() => Promise.resolve({alias1: 'path1', alias2: 'path2'})),
 }))
 
-vi.mock('../getStudioEnvironmentVariables.js', () => ({
+vi.mock('../getEnvironmentVariables.js', () => ({
   getAppEnvironmentVariables: vi.fn(() => ({
     'process.env.APP_VAR': '"app-value"',
   })),

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -23,8 +23,8 @@ import {buildDebug} from './buildDebug.js'
 import {buildStaticFiles} from './buildStaticFiles.js'
 import {buildVendorDependencies} from './buildVendorDependencies.js'
 import {determineBasePath} from './determineBasePath.js'
-import {getAppEnvVars} from './getAppEnvVars.js'
 import {getAutoUpdatesCssUrls, getAutoUpdatesImportMap} from './getAutoUpdatesImportMap.js'
+import {getAppEnvironmentVariables} from './getEnvironmentVariables.js'
 import {handlePrereleaseVersions} from './handlePrereleaseVersions.js'
 import {type BuildOptions} from './types.js'
 
@@ -170,7 +170,7 @@ async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
     }
   }
 
-  const envVarKeys = getAppEnvVars()
+  const envVarKeys = Object.keys(getAppEnvironmentVariables())
   if (envVarKeys.length > 0) {
     output.log('\nIncluding the following environment variables as part of the JavaScript bundle:')
     for (const key of envVarKeys) output.log(`- ${key}`)

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -29,7 +29,7 @@ import {buildVendorDependencies} from './buildVendorDependencies.js'
 import {checkRequiredDependencies} from './checkRequiredDependencies.js'
 import {determineBasePath} from './determineBasePath.js'
 import {getAutoUpdatesCssUrls, getAutoUpdatesImportMap} from './getAutoUpdatesImportMap.js'
-import {getStudioEnvVars} from './getStudioEnvVars.js'
+import {getStudioEnvironmentVariables} from './getEnvironmentVariables.js'
 import {handlePrereleaseVersions} from './handlePrereleaseVersions.js'
 import {type BuildOptions} from './types.js'
 
@@ -234,7 +234,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     }
   }
 
-  const envVarKeys = getStudioEnvVars()
+  const envVarKeys = Object.keys(getStudioEnvironmentVariables())
   if (envVarKeys.length > 0) {
     output.log('\nIncluding the following environment variables as part of the JavaScript bundle:')
     for (const key of envVarKeys) {

--- a/packages/@sanity/cli/src/actions/build/getAppEnvVars.ts
+++ b/packages/@sanity/cli/src/actions/build/getAppEnvVars.ts
@@ -1,8 +1,0 @@
-/**
- * Get all `SANITY_APP_` prefix env vars
- *
- * @internal
- */
-export function getAppEnvVars(env: Record<string, string | undefined> = process.env): string[] {
-  return Object.keys(env).filter((key) => key.toUpperCase().startsWith('SANITY_APP_'))
-}

--- a/packages/@sanity/cli/src/actions/build/getEnvironmentVariables.ts
+++ b/packages/@sanity/cli/src/actions/build/getEnvironmentVariables.ts
@@ -1,7 +1,7 @@
 import {loadEnv} from '../../util/loadEnv.js'
 
-const envPrefix = 'SANITY_STUDIO_'
 const appEnvPrefix = 'SANITY_APP_'
+const studioEnvPrefix = 'SANITY_STUDIO_'
 
 /**
  * The params for the `getStudioEnvironmentVariables` function that gets Studio focused environment variables.
@@ -45,20 +45,7 @@ export interface StudioEnvVariablesOptions {
 export function getStudioEnvironmentVariables(
   options: StudioEnvVariablesOptions = {},
 ): Record<string, string> {
-  const {envFile = false, jsonEncode = false, prefix = ''} = options
-  const fullEnv = envFile
-    ? {...process.env, ...loadEnv(envFile.mode, envFile.envDir || process.cwd(), [envPrefix])}
-    : process.env
-
-  const studioEnv: Record<string, string> = {}
-  for (const key in fullEnv) {
-    if (key.startsWith(envPrefix)) {
-      studioEnv[`${prefix}${key}`] = jsonEncode
-        ? JSON.stringify(fullEnv[key] || '')
-        : fullEnv[key] || ''
-    }
-  }
-  return studioEnv
+  return getEnvironmentVariables({...options, varTypePrefix: studioEnvPrefix})
 }
 
 /**
@@ -73,14 +60,20 @@ export function getStudioEnvironmentVariables(
 export function getAppEnvironmentVariables(
   options: StudioEnvVariablesOptions = {},
 ): Record<string, string> {
-  const {envFile = false, jsonEncode = false, prefix = ''} = options
+  return getEnvironmentVariables({...options, varTypePrefix: appEnvPrefix})
+}
+
+function getEnvironmentVariables(
+  options: StudioEnvVariablesOptions & {varTypePrefix: string},
+): Record<string, string> {
+  const {envFile = false, jsonEncode = false, prefix = '', varTypePrefix} = options
   const fullEnv = envFile
-    ? {...process.env, ...loadEnv(envFile.mode, envFile.envDir || process.cwd(), [appEnvPrefix])}
+    ? {...process.env, ...loadEnv(envFile.mode, envFile.envDir || process.cwd(), [varTypePrefix])}
     : process.env
 
   const appEnv: Record<string, string> = {}
   for (const key in fullEnv) {
-    if (key.startsWith(appEnvPrefix)) {
+    if (key.startsWith(varTypePrefix)) {
       appEnv[`${prefix}${key}`] = jsonEncode
         ? JSON.stringify(fullEnv[key] || '')
         : fullEnv[key] || ''

--- a/packages/@sanity/cli/src/actions/build/getEnvironmentVariables.ts
+++ b/packages/@sanity/cli/src/actions/build/getEnvironmentVariables.ts
@@ -4,7 +4,8 @@ const appEnvPrefix = 'SANITY_APP_'
 const studioEnvPrefix = 'SANITY_STUDIO_'
 
 /**
- * The params for the `getStudioEnvironmentVariables` function that gets Studio focused environment variables.
+ * The params for the `getStudioEnvironmentVariables` and `getAppEnvironmentVariables` function
+ * that gets Studio/App-focused environment variables.
  *
  * @public
  */

--- a/packages/@sanity/cli/src/actions/build/getStudioEnvVars.ts
+++ b/packages/@sanity/cli/src/actions/build/getStudioEnvVars.ts
@@ -1,8 +1,0 @@
-/**
- * Get all `SANITY_STUDIO_` prefix env vars
- *
- * @internal
- */
-export function getStudioEnvVars(env: Record<string, string | undefined> = process.env): string[] {
-  return Object.keys(env).filter((key) => key.toUpperCase().startsWith('SANITY_STUDIO_'))
-}

--- a/packages/@sanity/cli/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli/src/actions/build/getViteConfig.ts
@@ -22,7 +22,7 @@ import {createExternalFromImportMap} from './createExternalFromImportMap.js'
 import {
   getAppEnvironmentVariables,
   getStudioEnvironmentVariables,
-} from './getStudioEnvironmentVariables.js'
+} from './getEnvironmentVariables.js'
 import {normalizeBasePath} from './normalizeBasePath.js'
 
 interface ViteOptions {

--- a/packages/@sanity/cli/src/exports/_internal.ts
+++ b/packages/@sanity/cli/src/exports/_internal.ts
@@ -1,3 +1,3 @@
-export {getStudioEnvironmentVariables} from '../actions/build/getStudioEnvironmentVariables.js'
-export type {StudioEnvVariablesOptions} from '../actions/build/getStudioEnvironmentVariables.js'
+export {getStudioEnvironmentVariables} from '../actions/build/getEnvironmentVariables.js'
+export type {StudioEnvVariablesOptions} from '../actions/build/getEnvironmentVariables.js'
 export {extractManifestSchemaTypes} from '../actions/manifest/extractWorkspaceManifest.js'


### PR DESCRIPTION
### Description

This PR prevents the build from listing env vars that will not actually be included in the JS bundle such as `sanity_studio_foo`. This PR also cleans up some duplicated code related to environment variables. This will simplify future refactoring for the cli-build package.

### Testing

Updated mocks as needed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to env-var filtering/logging during CLI builds and consolidate duplicated helpers, with updated tests to guard behavior.
> 
> **Overview**
> Build logging now lists bundled env vars based on the same case-sensitive filtering used for injection, so lowercase `sanity_studio_*`/`sanity_app_*` entries are no longer reported as included.
> 
> This removes the old `get*EnvVars` key-list helpers, consolidates Studio/App env var loading behind `getEnvironmentVariables`, updates Vite/build call sites and internal exports, and adjusts mocks/tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbcd2b09af7498b631084bfe4b547e1c97d59bfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->