### PR TITLE
fix: update sanity cors add copy

### DIFF
--- a/.changeset/pr-1095.md
+++ b/.changeset/pr-1095.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix: update sanity cors add copy

--- a/.changeset/pr-1095.md
+++ b/.changeset/pr-1095.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-fix: update sanity cors add copy
+Clarify `cors add` prompts to mention apps built with the Sanity App SDK alongside Studios.

--- a/.changeset/pr-1095.md
+++ b/.changeset/pr-1095.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-Clarify `cors add` prompts to mention apps built with the Sanity App SDK alongside Studios.
+fix: update sanity cors add copy

--- a/packages/@sanity/cli/src/commands/cors/add.ts
+++ b/packages/@sanity/cli/src/commands/cors/add.ts
@@ -127,7 +127,7 @@ export class Add extends SanityCommand<typeof Add> {
       this.log(oneline`
       ${styleText('yellow', `${logSymbols.warning} Warning:`)}
       We ${styleText(['red', 'underline'], 'HIGHLY')} recommend NOT allowing credentials
-      on origins containing wildcards. If you are logged in to a studio, people will
+      on origins containing wildcards. If you are logged in to a studio or app, people will
       be able to send requests ${styleText('underline', 'on your behalf')} to read and modify
       data, from any matching origin. Please tread carefully!
     `)
@@ -137,8 +137,8 @@ export class Add extends SanityCommand<typeof Add> {
       Should this origin be allowed to send requests using authentication tokens or
       session cookies? Be aware that any script on this origin will be able to send
       requests ${styleText('underline', 'on your behalf')} to read and modify data if you
-      are logged in to a Sanity studio. If this origin hosts a studio, you will need
-      this, otherwise you should probably answer "No" (n).
+      are logged in to a Sanity studio. If this origin hosts a studio or an app built with
+      the Sanity App SDK, you will need this, otherwise you should probably answer "No" (n).
     `)
     }
 

--- a/packages/@sanity/cli/src/commands/cors/add.ts
+++ b/packages/@sanity/cli/src/commands/cors/add.ts
@@ -127,9 +127,9 @@ export class Add extends SanityCommand<typeof Add> {
       this.log(oneline`
       ${styleText('yellow', `${logSymbols.warning} Warning:`)}
       We ${styleText(['red', 'underline'], 'HIGHLY')} recommend NOT allowing credentials
-      on origins containing wildcards. If you are logged in to a studio or app, people will
-      be able to send requests ${styleText('underline', 'on your behalf')} to read and modify
-      data, from any matching origin. Please tread carefully!
+      on origins containing wildcards. If you are logged in to a Sanity studio or an app built with
+      the Sanity App SDK, people will be able to send requests ${styleText('underline', 'on your behalf')}
+      to read and modify data, from any matching origin. Please tread carefully!
     `)
     } else {
       this.log(oneline`
@@ -137,7 +137,7 @@ export class Add extends SanityCommand<typeof Add> {
       Should this origin be allowed to send requests using authentication tokens or
       session cookies? Be aware that any script on this origin will be able to send
       requests ${styleText('underline', 'on your behalf')} to read and modify data if you
-      are logged in to a Sanity studio. If this origin hosts a studio or an app built with
+      are logged in to a Sanity studio or app. If this origin hosts a studio or an app built with
       the Sanity App SDK, you will need this, otherwise you should probably answer "No" (n).
     `)
     }


### PR DESCRIPTION
### Description

Update `sanity cors add` copy text to include 'Sanity App sdk app' wording alongside studio for clarity, `cors` applies to both studios and sdk apps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to interactive CLI prompts; no functional behavior or API interactions are modified.
> 
> **Overview**
> Updates the `sanity cors add` interactive credentials warning text to explicitly mention *apps built with the Sanity App SDK* alongside studios (including the wildcard-origin warning).
> 
> Adds a patch changeset for `@sanity/cli` reflecting the copy update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c455f709d67216e9fa677a190a6ada95bc37a34e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->