### PR TITLE
chore(ci): limit default github token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   depcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   update-readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Addresses the active GitHub Actions `actions/missing-workflow-permissions` code scanning findings by setting the default `GITHUB_TOKEN` permissions to read-only in the workflows that still exist:

- https://github.com/sanity-io/cli/security/code-scanning/1
- https://github.com/sanity-io/cli/security/code-scanning/2
- https://github.com/sanity-io/cli/security/code-scanning/4
- https://github.com/sanity-io/cli/security/code-scanning/5
- https://github.com/sanity-io/cli/security/code-scanning/6

Also notes https://github.com/sanity-io/cli/security/code-scanning/3 as stale: it points to `.github/workflows/discover-sanity-commands.yml`, which was already deleted from `main` in #598, so there is no current workflow file to patch for that finding.

### What to review

Review the top-level `permissions: contents: read` additions in the build, depcheck, lint, test, and update-readme workflows. The `test` workflow keeps its job-level overrides for PR coverage comments, and `update-readme` still uses its generated GitHub App token for write operations.

### Testing

- `pnpm check:format`
- `pnpm check:lint` (passes with existing unrelated warnings)
- `pnpm check:types`
- `pnpm check:deps` (passes with existing Knip hint)
- `pnpm build:cli`
- `CLAUDECODE=1 pnpm test --changed --bail=1` (no test files found for workflow-only changes)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that reduce default token privileges; existing job-level overrides (e.g., PR coverage commenting) remain in place.
> 
> **Overview**
> **Security hardening for CI workflows.** Adds top-level `permissions: contents: read` to the `build`, `depcheck`, `lint`, `test`, and `update-readme` GitHub Actions workflows to make the default `GITHUB_TOKEN` read-only.
> 
> The `test` workflow keeps job-level permission overrides where needed (notably `pull-requests: write` for coverage reporting), and `update-readme` continues to use a generated GitHub App token for write operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea9c1e3ec24f332d450a8a427341423527ee2d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
