### PR TITLE
chore(deps): remove import-meta-resolve

### DIFF
--- a/.changeset/remove-import-meta-resolve.md
+++ b/.changeset/remove-import-meta-resolve.md
@@ -1,0 +1,6 @@
+---
+'@sanity/cli': patch
+'@sanity/cli-core': patch
+---
+
+Remove the import-meta-resolve dependency in favor of Node's built-in module resolution APIs.

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -87,7 +87,6 @@ const baseConfig = {
       entry: ['package.config.ts'],
       project,
     },
-    'packages/create-sanity': {},
   },
 } satisfies KnipConfig
 

--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -71,7 +71,6 @@
     "debug": "catalog:",
     "get-it": "^8.7.0",
     "get-tsconfig": "catalog:",
-    "import-meta-resolve": "catalog:",
     "jiti": "^2.7.0",
     "jsdom": "catalog:",
     "json-lexer": "^1.2.0",

--- a/packages/@sanity/cli-core/src/util/__tests__/getLocalPackageVersion.test.ts
+++ b/packages/@sanity/cli-core/src/util/__tests__/getLocalPackageVersion.test.ts
@@ -1,20 +1,20 @@
 import {dirname, join, resolve} from 'node:path'
 import {fileURLToPath, pathToFileURL} from 'node:url'
 
-import {moduleResolve} from 'import-meta-resolve'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {type PackageJson} from '../readPackageJson.js'
 
 const mockReadPackageJson = vi.hoisted(() => vi.fn())
+const mockResolveModuleUrl = vi.hoisted(() => vi.fn())
 
-vi.mock('import-meta-resolve')
+vi.mock('../resolveModuleUrl.js', () => ({
+  resolveModuleUrl: mockResolveModuleUrl,
+}))
 
 vi.mock('../readPackageJson.js', () => ({
   readPackageJson: mockReadPackageJson,
 }))
-
-const mockedModuleResolve = vi.mocked(moduleResolve)
 
 const {getLocalPackageDir, getLocalPackageVersion} = await import('../getLocalPackageVersion.js')
 
@@ -39,7 +39,7 @@ describe('getLocalPackageVersion', () => {
     const expectedPackageDir = resolve(mockWorkDir, 'node_modules', mockModuleId)
     const mockVersion = '1.0.0'
 
-    mockedModuleResolve.mockReturnValueOnce(mockPackageUrl)
+    mockResolveModuleUrl.mockReturnValueOnce(mockPackageUrl)
     mockReadPackageJson.mockResolvedValueOnce({
       name: mockModuleId,
       version: mockVersion,
@@ -47,7 +47,7 @@ describe('getLocalPackageVersion', () => {
 
     const result = await getLocalPackageVersion(mockModuleId, mockWorkDir)
 
-    expect(mockedModuleResolve).toHaveBeenCalledWith(
+    expect(mockResolveModuleUrl).toHaveBeenCalledWith(
       `${mockModuleId}/package.json`,
       pathToFileURL(resolve(mockWorkDir, 'noop.js')),
     )
@@ -61,12 +61,12 @@ describe('getLocalPackageVersion', () => {
     )
     const expectedPackageDir = resolve(mockWorkDir, 'node_modules', mockModuleId)
 
-    mockedModuleResolve.mockReturnValueOnce(mockPackageUrl)
+    mockResolveModuleUrl.mockReturnValueOnce(mockPackageUrl)
     mockReadPackageJson.mockRejectedValueOnce(new Error('Failed to read package.json'))
 
     const result = await getLocalPackageVersion(mockModuleId, mockWorkDir)
 
-    expect(mockedModuleResolve).toHaveBeenCalledOnce()
+    expect(mockResolveModuleUrl).toHaveBeenCalledOnce()
     expect(mockReadPackageJson).toHaveBeenCalledWith(join(expectedPackageDir, 'package.json'))
     expect(result).toBeNull()
   })
@@ -78,7 +78,7 @@ describe('getLocalPackageVersion', () => {
     const mockVersion = '2.0.0'
     const dirUrl = pathToFileURL(resolve(mockWorkDir, 'noop.js'))
 
-    mockedModuleResolve
+    mockResolveModuleUrl
       .mockImplementationOnce(() => {
         throw createNodeError('ERR_PACKAGE_PATH_NOT_EXPORTED', 'Package path not exported')
       })
@@ -91,15 +91,15 @@ describe('getLocalPackageVersion', () => {
 
     const result = await getLocalPackageVersion(mockModuleId, mockWorkDir)
 
-    expect(mockedModuleResolve).toHaveBeenCalledTimes(2)
-    expect(mockedModuleResolve).toHaveBeenNthCalledWith(1, `${mockModuleId}/package.json`, dirUrl)
-    expect(mockedModuleResolve).toHaveBeenNthCalledWith(2, mockModuleId, dirUrl)
+    expect(mockResolveModuleUrl).toHaveBeenCalledTimes(2)
+    expect(mockResolveModuleUrl).toHaveBeenNthCalledWith(1, `${mockModuleId}/package.json`, dirUrl)
+    expect(mockResolveModuleUrl).toHaveBeenNthCalledWith(2, mockModuleId, dirUrl)
     expect(mockReadPackageJson).toHaveBeenCalledWith(join(expectedPackageDir, 'package.json'))
     expect(result).toBe(mockVersion)
   })
 
-  test('returns null when fallback moduleResolve also throws', async () => {
-    mockedModuleResolve
+  test('returns null when fallback resolveModuleUrl also throws', async () => {
+    mockResolveModuleUrl
       .mockImplementationOnce(() => {
         throw createNodeError('ERR_PACKAGE_PATH_NOT_EXPORTED', 'Package path not exported')
       })
@@ -109,7 +109,7 @@ describe('getLocalPackageVersion', () => {
 
     const result = await getLocalPackageVersion(mockModuleId, mockWorkDir)
 
-    expect(mockedModuleResolve).toHaveBeenCalledTimes(2)
+    expect(mockResolveModuleUrl).toHaveBeenCalledTimes(2)
     expect(mockReadPackageJson).not.toHaveBeenCalled()
     expect(result).toBeNull()
   })
@@ -117,7 +117,7 @@ describe('getLocalPackageVersion', () => {
   test('returns null when readPackageJson fails in fallback path', async () => {
     const mainEntryPath = resolve(mockWorkDir, 'node_modules', mockModuleId, 'dist', 'index.js')
 
-    mockedModuleResolve
+    mockResolveModuleUrl
       .mockImplementationOnce(() => {
         throw createNodeError('ERR_PACKAGE_PATH_NOT_EXPORTED', 'Package path not exported')
       })
@@ -127,7 +127,7 @@ describe('getLocalPackageVersion', () => {
 
     const result = await getLocalPackageVersion(mockModuleId, mockWorkDir)
 
-    expect(mockedModuleResolve).toHaveBeenCalledTimes(2)
+    expect(mockResolveModuleUrl).toHaveBeenCalledTimes(2)
     expect(mockReadPackageJson).toHaveBeenCalledOnce()
     expect(result).toBeNull()
   })
@@ -143,7 +143,7 @@ describe('getLocalPackageVersion', () => {
     )
     const mockVersion = '3.0.0'
 
-    mockedModuleResolve.mockReturnValueOnce(mockPackageUrl)
+    mockResolveModuleUrl.mockReturnValueOnce(mockPackageUrl)
     mockReadPackageJson.mockResolvedValueOnce({
       name: mockModuleId,
       version: mockVersion,
@@ -151,21 +151,21 @@ describe('getLocalPackageVersion', () => {
 
     const result = await getLocalPackageVersion(mockModuleId, importMetaUrl)
 
-    expect(mockedModuleResolve).toHaveBeenCalledWith(
+    expect(mockResolveModuleUrl).toHaveBeenCalledWith(
       `${mockModuleId}/package.json`,
       pathToFileURL(resolve(expectedDir, 'noop.js')),
     )
     expect(result).toBe(mockVersion)
   })
 
-  test('returns null when moduleResolve throws a non-fallback error', async () => {
-    mockedModuleResolve.mockImplementationOnce(() => {
+  test('returns null when resolveModuleUrl throws a non-fallback error', async () => {
+    mockResolveModuleUrl.mockImplementationOnce(() => {
       throw createNodeError('ERR_MODULE_NOT_FOUND', 'Module not found')
     })
 
     const result = await getLocalPackageVersion(mockModuleId, mockWorkDir)
 
-    expect(mockedModuleResolve).toHaveBeenCalledOnce()
+    expect(mockResolveModuleUrl).toHaveBeenCalledOnce()
     expect(mockReadPackageJson).not.toHaveBeenCalled()
     expect(result).toBeNull()
   })
@@ -184,12 +184,12 @@ describe('getLocalPackageDir', () => {
       resolve(mockWorkDir, 'node_modules', mockModuleId, 'package.json'),
     )
 
-    mockedModuleResolve.mockReturnValueOnce(mockPackageUrl)
+    mockResolveModuleUrl.mockReturnValueOnce(mockPackageUrl)
 
     const result = getLocalPackageDir(mockModuleId, mockWorkDir)
 
     expect(result).toBe(resolve(mockWorkDir, 'node_modules', mockModuleId))
-    expect(mockedModuleResolve).toHaveBeenCalledWith(
+    expect(mockResolveModuleUrl).toHaveBeenCalledWith(
       `${mockModuleId}/package.json`,
       pathToFileURL(resolve(mockWorkDir, 'noop.js')),
     )
@@ -203,7 +203,7 @@ describe('getLocalPackageDir', () => {
       resolve(monorepoRoot, 'node_modules', 'react', 'package.json'),
     )
 
-    mockedModuleResolve.mockReturnValueOnce(hoistedPackageUrl)
+    mockResolveModuleUrl.mockReturnValueOnce(hoistedPackageUrl)
 
     const result = getLocalPackageDir('react', workspaceDir)
 
@@ -214,7 +214,7 @@ describe('getLocalPackageDir', () => {
     const mainEntryPath = resolve(mockWorkDir, 'node_modules', mockModuleId, 'dist', 'index.js')
     const mainEntryUrl = pathToFileURL(mainEntryPath)
 
-    mockedModuleResolve
+    mockResolveModuleUrl
       .mockImplementationOnce(() => {
         throw createNodeError('ERR_PACKAGE_PATH_NOT_EXPORTED', 'Package path not exported')
       })
@@ -223,11 +223,11 @@ describe('getLocalPackageDir', () => {
     const result = getLocalPackageDir(mockModuleId, mockWorkDir)
 
     expect(result).toBe(resolve(mockWorkDir, 'node_modules', mockModuleId))
-    expect(mockedModuleResolve).toHaveBeenCalledTimes(2)
+    expect(mockResolveModuleUrl).toHaveBeenCalledTimes(2)
   })
 
-  test('throws when moduleResolve throws a non-fallback error', () => {
-    mockedModuleResolve.mockImplementationOnce(() => {
+  test('throws when resolveModuleUrl throws a non-fallback error', () => {
+    mockResolveModuleUrl.mockImplementationOnce(() => {
       throw createNodeError('ERR_MODULE_NOT_FOUND', 'Module not found')
     })
 
@@ -235,7 +235,7 @@ describe('getLocalPackageDir', () => {
   })
 
   test('throws when both resolution strategies fail', () => {
-    mockedModuleResolve
+    mockResolveModuleUrl
       .mockImplementationOnce(() => {
         throw createNodeError('ERR_PACKAGE_PATH_NOT_EXPORTED', 'Package path not exported')
       })

--- a/packages/@sanity/cli-core/src/util/environment/getStudioEnvironmentVariables.ts
+++ b/packages/@sanity/cli-core/src/util/environment/getStudioEnvironmentVariables.ts
@@ -1,9 +1,8 @@
 import {resolve} from 'node:path'
 import {pathToFileURL} from 'node:url'
 
-import {moduleResolve} from 'import-meta-resolve'
-
 import {doImport} from '../doImport.js'
+import {resolveModuleUrl} from '../resolveModuleUrl.js'
 
 /**
  * Loads the `getStudioEnvironmentVariables` function from the studio's
@@ -25,7 +24,7 @@ export async function getStudioEnvironmentVariables(
   // Load `getStudioEnvironmentVariables` from the `sanity/cli` module installed
   // relative to where the studio is located, instead of resolving from where this CLI is
   // running, in order to ensure we're using the same version as the studio would.
-  const sanityCliUrl = moduleResolve('sanity/cli', fakeConfigUrl)
+  const sanityCliUrl = resolveModuleUrl('sanity/cli', fakeConfigUrl)
   try {
     const {getStudioEnvironmentVariables: getEnvVars} = await doImport(sanityCliUrl.href)
     if (typeof getEnvVars !== 'function') {

--- a/packages/@sanity/cli-core/src/util/getLocalPackageVersion.ts
+++ b/packages/@sanity/cli-core/src/util/getLocalPackageVersion.ts
@@ -1,9 +1,8 @@
 import {dirname, join, normalize, resolve} from 'node:path'
 import {fileURLToPath, pathToFileURL} from 'node:url'
 
-import {moduleResolve} from 'import-meta-resolve'
-
 import {readPackageJson} from './readPackageJson.js'
+import {resolveModuleUrl} from './resolveModuleUrl.js'
 
 /**
  * Get the version of a package installed locally.
@@ -41,7 +40,7 @@ export function getLocalPackageDir(moduleName: string, workDir: string): string 
   const dirUrl = pathToFileURL(resolve(dir, 'noop.js'))
 
   try {
-    const packageJsonUrl = moduleResolve(`${moduleName}/package.json`, dirUrl)
+    const packageJsonUrl = resolveModuleUrl(`${moduleName}/package.json`, dirUrl)
     return dirname(fileURLToPath(packageJsonUrl))
   } catch (err: unknown) {
     if (!isErrPackagePathNotExported(err)) {
@@ -50,7 +49,7 @@ export function getLocalPackageDir(moduleName: string, workDir: string): string 
   }
 
   // Fallback: resolve main entry point and derive package root
-  const mainUrl = moduleResolve(moduleName, dirUrl)
+  const mainUrl = resolveModuleUrl(moduleName, dirUrl)
   const mainPath = fileURLToPath(mainUrl)
   const normalizedName = normalize(moduleName)
   const idx = mainPath.lastIndexOf(normalizedName)

--- a/packages/@sanity/cli-core/src/util/resolveLocalPackage.ts
+++ b/packages/@sanity/cli-core/src/util/resolveLocalPackage.ts
@@ -1,9 +1,8 @@
 import {resolve} from 'node:path'
 import {pathToFileURL} from 'node:url'
 
-import {moduleResolve} from 'import-meta-resolve'
-
 import {doImport} from './doImport.js'
+import {resolveModuleUrl} from './resolveModuleUrl.js'
 
 /**
  * Resolves and imports a package from the local project's node_modules,
@@ -53,7 +52,7 @@ export function resolveLocalPackagePath(packageName: string, workDir: string): U
   const fakeCliConfigUrl = pathToFileURL(resolve(workDir, 'sanity.cli.mjs'))
 
   try {
-    return moduleResolve(packageName, fakeCliConfigUrl)
+    return resolveModuleUrl(packageName, fakeCliConfigUrl)
   } catch (error) {
     throw new Error(
       `Failed to resolve package "${packageName}" from "${workDir}": ${error instanceof Error ? error.message : String(error)}`,
@@ -85,7 +84,7 @@ export async function resolveLocalPackageFrom<T = unknown>(
   parentUrl: URL,
 ): Promise<T> {
   try {
-    const packageUrl = moduleResolve(packageName, parentUrl)
+    const packageUrl = resolveModuleUrl(packageName, parentUrl)
     const module = await doImport(packageUrl.href)
     return module as T
   } catch (error) {

--- a/packages/@sanity/cli-core/src/util/resolveModuleUrl.ts
+++ b/packages/@sanity/cli-core/src/util/resolveModuleUrl.ts
@@ -1,0 +1,6 @@
+import {createRequire} from 'node:module'
+import {pathToFileURL} from 'node:url'
+
+export function resolveModuleUrl(specifier: string, parentUrl: string | URL): URL {
+  return pathToFileURL(createRequire(parentUrl).resolve(specifier))
+}

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -104,7 +104,6 @@
     "get-latest-version": "^6.0.1",
     "groq-js": "catalog:",
     "gunzip-maybe": "^1.4.2",
-    "import-meta-resolve": "catalog:",
     "is-installed-globally": "^1.0.0",
     "isomorphic-dompurify": "^2.32.0",
     "json5": "^2.2.3",

--- a/packages/@sanity/cli/src/util/packageManager/installationInfo/detectPackages.ts
+++ b/packages/@sanity/cli/src/util/packageManager/installationInfo/detectPackages.ts
@@ -1,8 +1,6 @@
 import fs from 'node:fs/promises'
+import {createRequire} from 'node:module'
 import path from 'node:path'
-import {fileURLToPath, pathToFileURL} from 'node:url'
-
-import {resolve as resolveImport} from 'import-meta-resolve'
 
 import {readJsonFile} from './readJsonFile.js'
 import {resolveVersionRange} from './resolveVersionRange.js'
@@ -233,9 +231,8 @@ async function resolvePackagePath(packagePath: string): Promise<string | null> {
 async function resolveCliFromSanity(sanityPath: string): Promise<InstalledPackage | null> {
   try {
     // Resolve @sanity/cli/package.json from sanity's perspective
-    const sanityPkgUrl = pathToFileURL(path.join(sanityPath, 'package.json')).href
-    const cliPkgUrl = resolveImport('@sanity/cli/package.json', sanityPkgUrl)
-    const cliPkgPath = fileURLToPath(cliPkgUrl)
+    const resolveFromSanity = createRequire(path.join(sanityPath, 'package.json'))
+    const cliPkgPath = resolveFromSanity.resolve('@sanity/cli/package.json')
     const cliPath = path.dirname(cliPkgPath)
 
     const packageJson = await readJsonFile<PackageJson>(cliPkgPath)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ catalogs:
     groq-js:
       specifier: ^1.30.1
       version: 1.30.1
-    import-meta-resolve:
-      specifier: ^4.2.0
-      version: 4.2.0
     jsdom:
       specifier: ^29.1.1
       version: 29.1.1
@@ -580,9 +577,6 @@ importers:
       gunzip-maybe:
         specifier: ^1.4.2
         version: 1.4.2
-      import-meta-resolve:
-        specifier: 'catalog:'
-        version: 4.2.0
       is-installed-globally:
         specifier: ^1.0.0
         version: 1.0.0
@@ -873,9 +867,6 @@ importers:
       get-tsconfig:
         specifier: 'catalog:'
         version: 4.14.0
-      import-meta-resolve:
-        specifier: 'catalog:'
-        version: 4.2.0
       jiti:
         specifier: ^2.7.0
         version: 2.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,7 +54,6 @@ catalog:
   jsdom: ^29.1.1
   zod: ^4.3.6
   'get-tsconfig': ^4.14.0
-  'import-meta-resolve': ^4.2.0
   execa: ^9.6.0
   read-package-up: ^12.0.0
   ora: ^9.0.0


### PR DESCRIPTION
### Description

Removes the direct `import-meta-resolve` dependency from `@sanity/cli` and `@sanity/cli-core`.

The remaining resolver call sites need to resolve modules as though they were loaded from a user Studio/project path, so this PR uses Node's built-in `createRequire(parentUrl).resolve()` behind a small `resolveModuleUrl()` helper instead of relying on the `import-meta-resolve` package. This keeps the existing "resolve relative to this project/package" behavior without using the experimental second argument to `import.meta.resolve()`.

This also removes the now-empty `packages/create-sanity` Knip workspace config left behind after #1063.

Note: `import-meta-resolve` still appears in `pnpm-lock.yaml` transitively via root dev tooling (`@commitlint/resolve-extends`). This PR removes it from the published CLI package dependency declarations, not from every transitive repo dependency.

### What to review

Review the resolver replacement in:

- `packages/@sanity/cli-core/src/util/resolveModuleUrl.ts`
- `packages/@sanity/cli-core/src/util/resolveLocalPackage.ts`
- `packages/@sanity/cli-core/src/util/getLocalPackageVersion.ts`
- `packages/@sanity/cli-core/src/util/environment/getStudioEnvironmentVariables.ts`
- `packages/@sanity/cli/src/util/packageManager/installationInfo/detectPackages.ts`

Also review the package and lockfile changes to confirm `import-meta-resolve` is removed from `@sanity/cli` and `@sanity/cli-core` only, while the remaining lockfile entry is still owned by commitlint.

### Testing

- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts`
- `CLAUDECODE=1 pnpm test packages/@sanity/cli-core/src/util/__tests__/getLocalPackageVersion.test.ts packages/@sanity/cli/src/util/packageManager/installationInfo/__tests__/detectPackages.test.ts`
- `pnpm check:types`
- `pnpm check:lint`
- `pnpm check:deps`
- `pnpm dlx fallow audit --base HEAD`

I also ran `CLAUDECODE=1 pnpm test --changed --bail=1`; it still fails locally on `packages/@sanity/cli/src/commands/__tests__/build.app.test.ts > #build app > should error when @sanity/sdk-react is not installed` because a fixture `pnpm install --prefer-offline --config.minimum-release-age=0` exits non-zero, plus existing `EMFILE: too many open files, watch` errors from `dev.test.ts`. This matches the local failure pattern seen before this branch and is not in the touched resolver code.
