### PR TITLE
chore: ignore pnpm store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 node_modules
+.pnpm-store/
 # Allow node_modules in test fixtures (needed for install detection tests)
 !**/__fixtures__/**/node_modules
 .pnp


### PR DESCRIPTION
### Description

Adds `.pnpm-store/` to `.gitignore`.

The repo does not configure a local pnpm store, but local sandboxed installs can create one in the workspace. Ignoring it keeps generated pnpm cache content out of `git status`.

### What to review

Review the single `.gitignore` entry under the dependencies section.

### Testing

- `git diff --check`

No runtime tests were run because this only changes ignored local workspace artifacts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to exclude generated pnpm cache artifacts; no runtime or build logic changes.
> 
> **Overview**
> Adds `.pnpm-store/` to `.gitignore` under dependencies so locally created pnpm store/cache artifacts are not tracked or surfaced in `git status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8170f8d61c25fcb5af73fb5c42a9e1e28a2ffc4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->