### PR TITLE
fix(deps): update runtime cli

### DIFF
--- a/.changeset/pr-1108.md
+++ b/.changeset/pr-1108.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(deps): update runtime cli

--- a/.changeset/pr-1108.md
+++ b/.changeset/pr-1108.md
@@ -1,6 +1,5 @@
-<!-- auto-generated -->
 ---
 '@sanity/cli': patch
 ---
 
-fix(deps): update runtime cli
+Update @sanity/runtime-cli to 15.1.1 to fix terminal width detection in non-TTY environments.

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -84,7 +84,7 @@
     "@sanity/id-utils": "^1.0.0",
     "@sanity/import": "^6.0.1",
     "@sanity/migrate": "^6.1.2",
-    "@sanity/runtime-cli": "^15.0.2",
+    "@sanity/runtime-cli": "^15.1.1",
     "@sanity/schema": "catalog:",
     "@sanity/telemetry": "catalog:",
     "@sanity/template-validator": "^3.1.0",

--- a/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
+++ b/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
@@ -55,7 +55,13 @@ vi.mock('../../../util/update/resolveRunnerPackage.js', () => ({
 
 const mockIsCi = vi.mocked(isCi)
 const originalIsTTY = process.stdout.isTTY
+const originalStdoutGetWindowSize = process.stdout.getWindowSize
+const originalStderrGetWindowSize = process.stderr.getWindowSize
 const originalArgv1 = process.argv[1]
+
+function getWindowSize(): [number, number] {
+  return [80, 24]
+}
 
 function setCachedLatestVersion(options: {
   key?: string
@@ -85,6 +91,8 @@ describe('#checkForUpdates', () => {
       packageName: '@sanity/cli',
     })
     process.stdout.isTTY = true
+    process.stdout.getWindowSize = getWindowSize
+    process.stderr.getWindowSize = getWindowSize
     process.argv[1] = originalArgv1
 
     mockConfigStore.clear()
@@ -93,6 +101,8 @@ describe('#checkForUpdates', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     process.stdout.isTTY = originalIsTTY
+    process.stdout.getWindowSize = originalStdoutGetWindowSize
+    process.stderr.getWindowSize = originalStderrGetWindowSize
     process.argv[1] = originalArgv1
   })
 

--- a/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
+++ b/packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
@@ -1,6 +1,6 @@
 import {getUserConfig, isCi} from '@sanity/cli-core'
 import {testFixture, testHook} from '@sanity/cli-test'
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import {afterAll, afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {getCommandAndConfig} from '../../../../test/helpers/getCommandAndConfig.js'
 import {checkForUpdates} from '../checkForUpdates.js'
@@ -58,9 +58,22 @@ const originalIsTTY = process.stdout.isTTY
 const originalStdoutGetWindowSize = process.stdout.getWindowSize
 const originalStderrGetWindowSize = process.stderr.getWindowSize
 const originalArgv1 = process.argv[1]
+const windowSize: [number, number] = [80, 24]
 
-function getWindowSize(): [number, number] {
-  return [80, 24]
+function mockGetWindowSize(stream: NodeJS.WriteStream): void {
+  stream.getWindowSize ||= () => windowSize
+  vi.spyOn(stream, 'getWindowSize').mockReturnValue(windowSize)
+}
+
+function restoreGetWindowSize(
+  stream: NodeJS.WriteStream,
+  getWindowSize: NodeJS.WriteStream['getWindowSize'] | undefined,
+): void {
+  if (getWindowSize) {
+    stream.getWindowSize = getWindowSize
+  } else {
+    Reflect.deleteProperty(stream, 'getWindowSize')
+  }
 }
 
 function setCachedLatestVersion(options: {
@@ -91,8 +104,8 @@ describe('#checkForUpdates', () => {
       packageName: '@sanity/cli',
     })
     process.stdout.isTTY = true
-    process.stdout.getWindowSize = getWindowSize
-    process.stderr.getWindowSize = getWindowSize
+    mockGetWindowSize(process.stdout)
+    mockGetWindowSize(process.stderr)
     process.argv[1] = originalArgv1
 
     mockConfigStore.clear()
@@ -101,9 +114,12 @@ describe('#checkForUpdates', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     process.stdout.isTTY = originalIsTTY
-    process.stdout.getWindowSize = originalStdoutGetWindowSize
-    process.stderr.getWindowSize = originalStderrGetWindowSize
     process.argv[1] = originalArgv1
+  })
+
+  afterAll(() => {
+    restoreGetWindowSize(process.stdout, originalStdoutGetWindowSize)
+    restoreGetWindowSize(process.stderr, originalStderrGetWindowSize)
   })
 
   test('returns early if running on CI', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,7 +379,7 @@ importers:
     dependencies:
       '@sanity/code-input':
         specifier: ^7.1.0
-        version: 7.1.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.23.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.0)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 7.1.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.2)(@codemirror/lint@6.9.2)(@codemirror/search@6.7.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.23.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.0)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@sanity/vision':
         specifier: 'catalog:'
         version: 5.23.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.23.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.0)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
@@ -521,8 +521,8 @@ importers:
         specifier: ^6.1.2
         version: 6.1.2(@oclif/core@4.10.6)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(xstate@5.30.0)
       '@sanity/runtime-cli':
-        specifier: ^15.0.2
-        version: 15.0.2(@types/node@20.19.39)(esbuild@0.28.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
+        specifier: ^15.1.1
+        version: 15.1.1(@types/node@20.19.39)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
       '@sanity/schema':
         specifier: 'catalog:'
         version: 5.23.0(@types/react@19.2.14)
@@ -3656,6 +3656,10 @@ packages:
     resolution: {integrity: sha512-avWOKYmjANtyu8ipju/kopIIrSrbS/scJjiZTpBp/HKEHNm46v5riOo5LQj6MZ4bYJVQEoyHPg/2Seig5Ilkjw==}
     engines: {node: '>=18.0.0'}
 
+  '@oclif/plugin-help@6.2.49':
+    resolution: {integrity: sha512-fEsO0YU7ThtzHE1RGuoHxFu/OGlqxm7PCfFp+U1PS8sde4E0cDqjVDuv78+VKrr45LpC5lWOApj7pm3FNfHrVA==}
+    engines: {node: '>=18.0.0'}
+
   '@oclif/plugin-not-found@3.2.81':
     resolution: {integrity: sha512-M88tLONBH36hLAbkFbmCo1hoZPSdU5l8Px1xEIlIgSmGMam+CoAzx4kGqpLbokgfpaHeP8/Jx3QJ18u9ef/2Qw==}
     engines: {node: '>=18.0.0'}
@@ -4561,6 +4565,10 @@ packages:
   '@rushstack/ts-command-line@5.3.9':
     resolution: {integrity: sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==}
 
+  '@sanity-labs/design-tokens@0.0.2-alpha.2':
+    resolution: {integrity: sha512-rM0+qso6XaE60UaJ7z7v7DWBRlJ57XQUzuL8nTwtub42xGw4jusEhDq7/c4Mrdec98hLykyhe6t5n2mKxf/BVQ==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+
   '@sanity/asset-utils@2.3.0':
     resolution: {integrity: sha512-dlEmALjQ5iyQG0O8ZVmkkE3wUYCKfRmiyMvuuGN5SF9buAHxmseBOKJ/Iy2DU/8ef70mtUXlzeCRSlTN/nmZsg==}
     engines: {node: '>=18'}
@@ -4580,8 +4588,8 @@ packages:
     resolution: {integrity: sha512-6FdEcZMBuxdtfpCikb4l4yqnluxoGj4S75WDNtAXbNVjXJicpFzjwjMeoGtmsKcBbj80Lll1UONydqnYQRbILw==}
     engines: {node: '>=20'}
 
-  '@sanity/blueprints@0.17.1':
-    resolution: {integrity: sha512-gJyoz0YKwph5vpYJPqgd+Eq4GdGGfqKwDsoYpOdPcBJHq/0fU80eUXT6XlAsufpSYTmbQG93ARa1SbWqqYutyQ==}
+  '@sanity/blueprints@0.18.0':
+    resolution: {integrity: sha512-iEFEDtfBt12PiMbqmI4khLVvAhsYDX7OCLnfQ8OvgbhZzrzjsDDzAIrAOoXNmAfW/CgkUMG9qdYqhu1aTAI0dg==}
     engines: {node: '>=20'}
 
   '@sanity/browserslist-config@1.0.5':
@@ -4771,8 +4779,8 @@ packages:
       prismjs:
         optional: true
 
-  '@sanity/runtime-cli@15.0.2':
-    resolution: {integrity: sha512-+4zKz6EXBmdMqStf08SX2mWaYRz/aWD6DVMdJ/mibI2VOV9VT+5TsgVQHeKcn/kIXgaVwEO3Yo+0fbnKdo6lMA==}
+  '@sanity/runtime-cli@15.1.1':
+    resolution: {integrity: sha512-eraFR2KWkPI+bIg7ocfWdzKiQ3jD0Pfs+7UPsTrkZHuUl9GjQ3N6FfIfLEUSgthlfrurCZMMndFMsqhmYUBgxQ==}
     engines: {node: '>=20.19'}
     hasBin: true
 
@@ -9737,6 +9745,46 @@ packages:
       yaml:
         optional: true
 
+  vite@7.3.3:
+    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -13163,6 +13211,10 @@ snapshots:
     dependencies:
       '@oclif/core': 4.10.6
 
+  '@oclif/plugin-help@6.2.49':
+    dependencies:
+      '@oclif/core': 4.11.0
+
   '@oclif/plugin-not-found@3.2.81(@types/node@20.19.39)':
     dependencies:
       '@inquirer/prompts': 7.10.1(@types/node@20.19.39)
@@ -13857,6 +13909,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@sanity-labs/design-tokens@0.0.2-alpha.2': {}
+
   '@sanity/asset-utils@2.3.0': {}
 
   '@sanity/bifur-client@0.4.1':
@@ -13873,7 +13927,7 @@ snapshots:
 
   '@sanity/blueprints@0.15.2': {}
 
-  '@sanity/blueprints@0.17.1': {}
+  '@sanity/blueprints@0.18.0': {}
 
   '@sanity/browserslist-config@1.0.5': {}
 
@@ -13884,7 +13938,7 @@ snapshots:
       nanoid: 3.3.11
       rxjs: 7.8.2
 
-  '@sanity/code-input@7.1.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.23.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.0)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+  '@sanity/code-input@7.1.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.2)(@codemirror/lint@6.9.2)(@codemirror/search@6.7.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.23.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.0)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-java': 6.0.2
@@ -13902,7 +13956,7 @@ snapshots:
       '@sanity/lezer-groq': 1.0.3
       '@sanity/ui': 3.1.14(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@uiw/codemirror-themes': 4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)
-      '@uiw/react-codemirror': 4.25.9(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.40.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@uiw/react-codemirror': 4.25.9(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.2)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.40.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       sanity: 5.23.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.0)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       styled-components: 6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -14285,14 +14339,15 @@ snapshots:
 
   '@sanity/prism-groq@1.1.2': {}
 
-  '@sanity/runtime-cli@15.0.2(@types/node@20.19.39)(esbuild@0.28.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)':
+  '@sanity/runtime-cli@15.1.1(@types/node@20.19.39)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)':
     dependencies:
       '@architect/hydrate': 5.0.2
       '@architect/inventory': 5.0.0
       '@inquirer/prompts': 8.4.2(@types/node@20.19.39)
       '@oclif/core': 4.11.0
-      '@oclif/plugin-help': 6.2.45
-      '@sanity/blueprints': 0.17.1
+      '@oclif/plugin-help': 6.2.49
+      '@sanity-labs/design-tokens': 0.0.2-alpha.2
+      '@sanity/blueprints': 0.18.0
       '@sanity/blueprints-parser': 0.4.0
       '@sanity/client': 7.22.0
       adm-zip: 0.5.17
@@ -14305,18 +14360,17 @@ snapshots:
       mime-types: 3.0.2
       ora: 9.4.0
       tar-stream: 3.2.0
-      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
-      vite-tsconfig-paths: 6.1.1(typescript@5.9.3)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+      vite: 7.3.3(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
+      vite-tsconfig-paths: 6.1.1(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       ws: 8.20.0
       xdg-basedir: 5.1.0
     transitivePeerDependencies:
       - '@types/node'
-      - '@vitejs/devtools'
       - bare-abort-controller
       - bare-buffer
       - bufferutil
-      - esbuild
       - less
+      - lightningcss
       - react-native-b4a
       - sass
       - sass-embedded
@@ -15336,6 +15390,16 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.40.0
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.9(@codemirror/autocomplete@6.20.2)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.2
+      '@codemirror/search': 6.7.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+
   '@uiw/codemirror-themes@4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)':
     dependencies:
       '@codemirror/language': 6.12.3
@@ -15350,6 +15414,23 @@ snapshots:
       '@codemirror/theme-one-dark': 6.1.3
       '@codemirror/view': 6.40.0
       '@uiw/codemirror-extensions-basic-setup': 4.25.9(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)
+      codemirror: 6.0.2
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
+
+  '@uiw/react-codemirror@4.25.9(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.2)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.40.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@codemirror/commands': 6.10.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.40.0
+      '@uiw/codemirror-extensions-basic-setup': 4.25.9(@codemirror/autocomplete@6.20.2)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)
       codemirror: 6.0.2
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -20011,12 +20092,12 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)):
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -20048,6 +20129,23 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.0.10
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      terser: 5.46.0
+      tsx: 4.21.0
+      yaml: 2.8.4
+
+  vite@7.3.3(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.39
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0


### PR DESCRIPTION
### Description

Bumps @sanity/runtime-cli from ^15.0.2 to ^15.1.1 and updates the init update-check tests to stub terminal window size when exercising TTY output.

This isolates the dependency that exposed the oclif screen-width assumption behind the failing Node 22/24 shards.

### What to review

Review the package bump, generated lockfile update, and the checkForUpdates test setup/teardown around stdout/stderr.getWindowSize.

### Testing

- CI=true CLAUDECODE=1 PNPM_CONFIG_IGNORE_WORKSPACE=true pnpm exec vitest run packages/@sanity/cli/src/hooks/init/__tests__/checkForUpdates.test.ts
- Result: 22 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch-level dependency bump; main behavioral impact is improved terminal width detection in non-TTY environments, with test-only stubbing changes to keep update-check tests stable.
> 
> **Overview**
> Updates `@sanity/cli` to use `@sanity/runtime-cli@^15.1.1` (and refreshes `pnpm-lock.yaml`) to address terminal width detection issues in non-TTY environments.
> 
> Adjusts `checkForUpdates` init-hook tests to explicitly stub and later restore `process.stdout/stderr.getWindowSize`, preventing failures when TTY-related screen-width APIs are assumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 480129a83fa91ae705e4831597cfcfe9939e9a19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->