### PR TITLE
refactor(workbench): drop `reactRefreshHost` plumbing

### DIFF
--- a/.changeset/pr-1028.md
+++ b/.changeset/pr-1028.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(workbench): add `__mf__temp` directory to .gitignore

--- a/fixtures/federated-studio/.gitignore
+++ b/fixtures/federated-studio/.gitignore
@@ -27,5 +27,3 @@
 
 # Dotenv and similar local-only files
 *.local
-
-.__mf__temp

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -80,7 +80,7 @@
     "@sanity/codegen": "catalog:",
     "@sanity/descriptors": "^1.3.0",
     "@sanity/export": "^6.1.0",
-    "@sanity/federation": "0.1.0-alpha.7",
+    "@sanity/federation": "0.1.0-alpha.8",
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/id-utils": "^1.0.0",
     "@sanity/import": "^6.0.1",

--- a/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/getViteConfig.test.ts
@@ -525,46 +525,6 @@ describe('#getViteConfig', () => {
     expect(federationPlugin).toBeUndefined()
   })
 
-  test('should pass reactRefreshHost to viteReact when provided', async () => {
-    const viteReactMock = (await import('@vitejs/plugin-react')).default as unknown as ReturnType<
-      typeof vi.fn
-    >
-
-    const options = {
-      cwd: mockTestCwd,
-      entries: {relativeConfigLocation: '../../sanity.config.ts', relativeEntry: '../../src/App'},
-      federation: {enabled: true},
-      mode: 'development' as const,
-      reactCompiler: undefined,
-      reactRefreshHost: 'http://localhost:3333',
-    }
-
-    await getViteConfig(options)
-
-    expect(viteReactMock).toHaveBeenCalledWith(
-      expect.objectContaining({reactRefreshHost: 'http://localhost:3333'}),
-    )
-  })
-
-  test('should not pass reactRefreshHost to viteReact when not provided', async () => {
-    const viteReactMock = (await import('@vitejs/plugin-react')).default as unknown as ReturnType<
-      typeof vi.fn
-    >
-
-    const options = {
-      cwd: mockTestCwd,
-      entries: mockEntries,
-      mode: 'development' as const,
-      reactCompiler: undefined,
-    }
-
-    await getViteConfig(options)
-
-    expect(viteReactMock).toHaveBeenCalledWith(
-      expect.not.objectContaining({reactRefreshHost: expect.anything()}),
-    )
-  })
-
   test('should not include federation plugin when federation is undefined', async () => {
     const options = {
       cwd: mockTestCwd,

--- a/packages/@sanity/cli/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli/src/actions/build/getViteConfig.ts
@@ -82,12 +82,6 @@ interface ViteOptions extends Pick<CliConfig, 'federation' | 'schemaExtraction' 
    */
   outputDir?: string
   /**
-   * URL of the workbench dev server for react-refresh in federated builds.
-   * Passed as `reactRefreshHost` to `@vitejs/plugin-react` so the refresh
-   * preamble connects to the host application's HMR server.
-   */
-  reactRefreshHost?: string
-  /**
    * HTTP development server configuration
    */
   server?: {host?: string; port?: number}
@@ -116,7 +110,6 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     mode,
     outputDir,
     reactCompiler,
-    reactRefreshHost,
     schemaExtraction,
     server,
     // default to `true` when `mode=development`
@@ -137,17 +130,16 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     : getStudioEnvironmentVariables({jsonEncode: true, prefix: 'process.env.'})
 
   const sharedPlugins: PluginOption = [
-    viteReact({
-      ...(reactCompiler
+    viteReact(
+      reactCompiler
         ? {
             babel: {
               generatorOpts: {compact: true},
               plugins: [['babel-plugin-react-compiler', reactCompiler]],
             },
           }
-        : {}),
-      ...(reactRefreshHost ? {reactRefreshHost} : {}),
-    }),
+        : {},
+    ),
     ...(schemaExtraction?.enabled
       ? [
           sanitySchemaExtractionPlugin({

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -63,6 +63,28 @@ describe('devAction', () => {
     )
   })
 
+  test('logs studio URL on no-workbench branch', async () => {
+    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
+    const output = createMockOutput()
+
+    await devAction(createBaseDevOptions({output}))
+
+    expect(output.log).toHaveBeenCalledWith(
+      expect.stringMatching(/Studio dev server started at .*localhost:3333/),
+    )
+  })
+
+  test('logs app URL on no-workbench branch', async () => {
+    mockStartAppDevServer.mockResolvedValue(mockServer({port: 3333}))
+    const output = createMockOutput()
+
+    await devAction(createBaseDevOptions({isApp: true, output}))
+
+    expect(output.log).toHaveBeenCalledWith(
+      expect.stringMatching(/App dev server started at .*localhost:3333/),
+    )
+  })
+
   test('studio mode with workbench bumps port and logs workbench URL', async () => {
     mockStartWorkbenchDevServer.mockResolvedValue({
       close: vi.fn().mockResolvedValue(undefined),
@@ -78,7 +100,6 @@ describe('devAction', () => {
     expect(mockStartStudioDevServer).toHaveBeenCalledWith(
       expect.objectContaining({
         flags: expect.objectContaining({port: '3334'}),
-        workbenchAvailable: true,
       }),
     )
     expect(output.log).toHaveBeenCalledWith(expect.stringContaining('3333'))
@@ -92,32 +113,6 @@ describe('devAction', () => {
 
     expect(mockStartAppDevServer).toHaveBeenCalled()
     expect(mockStartStudioDevServer).not.toHaveBeenCalled()
-  })
-
-  test('passes reactRefreshHost pointing to workbench when workbench is running', async () => {
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: vi.fn().mockResolvedValue(undefined),
-      httpHost: 'localhost',
-      workbenchAvailable: true,
-      workbenchPort: 3333,
-    })
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-    await devAction(createBaseDevOptions())
-
-    expect(mockStartStudioDevServer).toHaveBeenCalledWith(
-      expect.objectContaining({reactRefreshHost: 'http://localhost:3333'}),
-    )
-  })
-
-  test('does not pass reactRefreshHost when workbench is not running', async () => {
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
-
-    await devAction(createBaseDevOptions())
-
-    expect(mockStartStudioDevServer).toHaveBeenCalledWith(
-      expect.objectContaining({reactRefreshHost: undefined}),
-    )
   })
 
   test('cleans up workbench and re-throws when app/studio startup fails', async () => {
@@ -268,12 +263,9 @@ describe('devAction', () => {
 
     await devAction(createBaseDevOptions({output}))
 
-    // The workbench is running on mydev.local — the URL and reactRefreshHost
-    // should reflect the existing workbench's host, not the caller's.
+    // The workbench is running on mydev.local — the URL should reflect the
+    // existing workbench's host, not the caller's.
     expect(output.log).toHaveBeenCalledWith(expect.stringContaining('mydev.local:3333'))
-    expect(mockStartStudioDevServer).toHaveBeenCalledWith(
-      expect.objectContaining({reactRefreshHost: 'http://mydev.local:3333'}),
-    )
   })
 
   test('returns early with workbench-only close when app server exits without a server', async () => {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -63,28 +63,6 @@ describe('devAction', () => {
     )
   })
 
-  test('logs studio URL on no-workbench branch', async () => {
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
-    const output = createMockOutput()
-
-    await devAction(createBaseDevOptions({output}))
-
-    expect(output.log).toHaveBeenCalledWith(
-      expect.stringMatching(/Studio dev server started at .*localhost:3333/),
-    )
-  })
-
-  test('logs app URL on no-workbench branch', async () => {
-    mockStartAppDevServer.mockResolvedValue(mockServer({port: 3333}))
-    const output = createMockOutput()
-
-    await devAction(createBaseDevOptions({isApp: true, output}))
-
-    expect(output.log).toHaveBeenCalledWith(
-      expect.stringMatching(/App dev server started at .*localhost:3333/),
-    )
-  })
-
   test('studio mode with workbench bumps port and logs workbench URL', async () => {
     mockStartWorkbenchDevServer.mockResolvedValue({
       close: vi.fn().mockResolvedValue(undefined),
@@ -100,6 +78,7 @@ describe('devAction', () => {
     expect(mockStartStudioDevServer).toHaveBeenCalledWith(
       expect.objectContaining({
         flags: expect.objectContaining({port: '3334'}),
+        workbenchAvailable: true,
       }),
     )
     expect(output.log).toHaveBeenCalledWith(expect.stringContaining('3333'))

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startAppDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startAppDevServer.test.ts
@@ -98,6 +98,26 @@ describe('startAppDevServer', () => {
     expect(result.close).toBeDefined()
   })
 
+  test('logs "App dev server started" when workbench is not available', async () => {
+    mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
+    const output = createMockOutput()
+
+    await startAppDevServer(createOptions({output, workbenchAvailable: false}))
+
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('3334'))
+  })
+
+  test('skips the port log line when workbench is available', async () => {
+    mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
+    const output = createMockOutput()
+
+    await startAppDevServer(createOptions({output, workbenchAvailable: true}))
+
+    // 'Starting dev server' is still logged, but the port announcement is not
+    const logCalls = (output.log as ReturnType<typeof vi.fn>).mock.calls.flat()
+    expect(logCalls.some((c) => String(c).includes('App dev server started'))).toBe(false)
+  })
+
   test('wraps startup failures via gracefulServerDeath', async () => {
     const originalErr = Object.assign(new Error('boom'), {code: 'EADDRINUSE'})
     const wrappedErr = new Error('friendly message')

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startAppDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startAppDevServer.test.ts
@@ -98,34 +98,6 @@ describe('startAppDevServer', () => {
     expect(result.close).toBeDefined()
   })
 
-  test('passes reactRefreshHost through to startDevServer', async () => {
-    await startAppDevServer(createOptions({reactRefreshHost: 'http://localhost:3333'}))
-
-    expect(mockStartDevServer).toHaveBeenCalledWith(
-      expect.objectContaining({reactRefreshHost: 'http://localhost:3333'}),
-    )
-  })
-
-  test('logs "App dev server started" when workbench is not available', async () => {
-    mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
-    const output = createMockOutput()
-
-    await startAppDevServer(createOptions({output, workbenchAvailable: false}))
-
-    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('3334'))
-  })
-
-  test('skips the port log line when workbench is available', async () => {
-    mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
-    const output = createMockOutput()
-
-    await startAppDevServer(createOptions({output, workbenchAvailable: true}))
-
-    // 'Starting dev server' is still logged, but the port announcement is not
-    const logCalls = (output.log as ReturnType<typeof vi.fn>).mock.calls.flat()
-    expect(logCalls.some((c) => String(c).includes('App dev server started'))).toBe(false)
-  })
-
   test('wraps startup failures via gracefulServerDeath', async () => {
     const originalErr = Object.assign(new Error('boom'), {code: 'EADDRINUSE'})
     const wrappedErr = new Error('friendly message')

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startStudioDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startStudioDevServer.test.ts
@@ -119,14 +119,6 @@ describe('startStudioDevServer', () => {
     expect(result.server).toBeDefined()
   })
 
-  test('passes reactRefreshHost through to startDevServer', async () => {
-    await startStudioDevServer(createDevOptions({reactRefreshHost: 'http://localhost:3333'}))
-
-    expect(mockStartDevServer).toHaveBeenCalledWith(
-      expect.objectContaining({reactRefreshHost: 'http://localhost:3333'}),
-    )
-  })
-
   test('logs schema-extraction info line when enabled in cliConfig', async () => {
     const output = createMockOutput()
     await startStudioDevServer(

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -38,6 +38,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   const appOptions: DevActionOptions = {
     ...options,
     flags: {...options.flags, port: String(desiredAppPort)},
+    workbenchAvailable,
   }
 
   let closeAppDevServer: () => Promise<void> = noop
@@ -67,18 +68,13 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
       })
     : undefined
 
-  const addr = server.httpServer?.address()
-  const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
-
   if (workbenchAvailable) {
     const workbenchUrl = `http://${workbenchHost || 'localhost'}:${workbenchPort}`
+    const addr = server.httpServer?.address()
+    const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
     output.log(
       `Workbench dev server started at ${styleText(['blue', 'underline'], workbenchUrl)} (app on port ${appPort})`,
     )
-  } else {
-    const appUrl = `http://${httpHost || 'localhost'}:${appPort}`
-    const label = options.isApp ? 'App' : 'Studio'
-    output.log(`${label} dev server started at ${styleText(['blue', 'underline'], appUrl)}`)
   }
 
   const close = async () => {

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -35,15 +35,9 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   // Use workbenchPort + 1 when workbench claims the configured port
   const desiredAppPort = workbenchAvailable ? workbenchPort + 1 : workbenchPort
 
-  const reactRefreshHost = workbenchAvailable
-    ? `http://${workbenchHost || 'localhost'}:${workbenchPort}`
-    : undefined
-
   const appOptions: DevActionOptions = {
     ...options,
     flags: {...options.flags, port: String(desiredAppPort)},
-    reactRefreshHost,
-    workbenchAvailable,
   }
 
   let closeAppDevServer: () => Promise<void> = noop
@@ -73,13 +67,18 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
       })
     : undefined
 
+  const addr = server.httpServer?.address()
+  const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
+
   if (workbenchAvailable) {
     const workbenchUrl = `http://${workbenchHost || 'localhost'}:${workbenchPort}`
-    const addr = server.httpServer?.address()
-    const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
     output.log(
       `Workbench dev server started at ${styleText(['blue', 'underline'], workbenchUrl)} (app on port ${appPort})`,
     )
+  } else {
+    const appUrl = `http://${httpHost || 'localhost'}:${appPort}`
+    const label = options.isApp ? 'App' : 'Studio'
+    output.log(`${label} dev server started at ${styleText(['blue', 'underline'], appUrl)}`)
   }
 
   const close = async () => {

--- a/packages/@sanity/cli/src/actions/dev/startAppDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startAppDevServer.ts
@@ -9,7 +9,7 @@ import {type DevActionOptions} from './types.js'
 export async function startAppDevServer(
   options: DevActionOptions,
 ): Promise<{close?: () => Promise<void>; server?: ViteDevServer}> {
-  const {cliConfig, flags, output, workDir} = options
+  const {cliConfig, flags, output, workbenchAvailable, workDir} = options
 
   let organizationId: string | undefined
   if (cliConfig && 'app' in cliConfig && cliConfig.app?.organizationId) {
@@ -34,6 +34,12 @@ export async function startAppDevServer(
       appTitle,
       isApp: true,
     })
+
+    const {port} = server.config.server
+
+    if (!workbenchAvailable) {
+      output.log(`App dev server started on port ${port}`)
+    }
 
     return {close, server}
   } catch (err) {

--- a/packages/@sanity/cli/src/actions/dev/startAppDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startAppDevServer.ts
@@ -9,7 +9,7 @@ import {type DevActionOptions} from './types.js'
 export async function startAppDevServer(
   options: DevActionOptions,
 ): Promise<{close?: () => Promise<void>; server?: ViteDevServer}> {
-  const {cliConfig, flags, output, workbenchAvailable, workDir} = options
+  const {cliConfig, flags, output, workDir} = options
 
   let organizationId: string | undefined
   if (cliConfig && 'app' in cliConfig && cliConfig.app?.organizationId) {
@@ -33,14 +33,7 @@ export async function startAppDevServer(
       ...config,
       appTitle,
       isApp: true,
-      reactRefreshHost: options.reactRefreshHost,
     })
-
-    const {port} = server.config.server
-
-    if (!workbenchAvailable) {
-      output.log(`App dev server started on port ${port}`)
-    }
 
     return {close, server}
   } catch (err) {

--- a/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
@@ -21,7 +21,7 @@ import {type DevActionOptions} from './types.js'
 export async function startStudioDevServer(
   options: DevActionOptions,
 ): Promise<{close: () => Promise<void>; server: ViteDevServer}> {
-  const {cliConfig, flags, output, workDir} = options
+  const {cliConfig, flags, output, workbenchAvailable, workDir} = options
 
   // Check studio dependency versions
   await checkStudioDependencyVersions(workDir, output)
@@ -104,8 +104,11 @@ export async function startStudioDevServer(
     const {close, server} = await startDevServer(config)
 
     const {info: loggerInfo} = server.config.logger
+    const {port} = server.config.server
+    const httpHost = config.httpHost || 'localhost'
 
     const startupDuration = Date.now() - startTime
+    const url = `http://${httpHost || 'localhost'}:${port}${config.basePath}`
     const appType = 'Sanity Studio'
 
     const viteVersion = await getLocalPackageVersion('vite', import.meta.url)
@@ -114,7 +117,8 @@ export async function startStudioDevServer(
     loggerInfo(
       `${appType} ` +
         `using ${styleText('cyan', `vite@${viteVersion}`)} ` +
-        `ready in ${styleText('cyan', `${Math.ceil(startupDuration)}ms`)}`,
+        `ready in ${styleText('cyan', `${Math.ceil(startupDuration)}ms`)}` +
+        (workbenchAvailable ? '' : ` and running at ${styleText('cyan', url)}`),
     )
 
     return {close, server}

--- a/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startStudioDevServer.ts
@@ -21,7 +21,7 @@ import {type DevActionOptions} from './types.js'
 export async function startStudioDevServer(
   options: DevActionOptions,
 ): Promise<{close: () => Promise<void>; server: ViteDevServer}> {
-  const {cliConfig, flags, output, workbenchAvailable, workDir} = options
+  const {cliConfig, flags, output, workDir} = options
 
   // Check studio dependency versions
   await checkStudioDependencyVersions(workDir, output)
@@ -101,17 +101,11 @@ export async function startStudioDevServer(
   try {
     const startTime = Date.now()
     const spin = spinner('Starting dev server').start()
-    const {close, server} = await startDevServer({
-      ...config,
-      reactRefreshHost: options.reactRefreshHost,
-    })
+    const {close, server} = await startDevServer(config)
 
     const {info: loggerInfo} = server.config.logger
-    const {port} = server.config.server
-    const httpHost = config.httpHost || 'localhost'
 
     const startupDuration = Date.now() - startTime
-    const url = `http://${httpHost || 'localhost'}:${port}${config.basePath}`
     const appType = 'Sanity Studio'
 
     const viteVersion = await getLocalPackageVersion('vite', import.meta.url)
@@ -120,8 +114,7 @@ export async function startStudioDevServer(
     loggerInfo(
       `${appType} ` +
         `using ${styleText('cyan', `vite@${viteVersion}`)} ` +
-        `ready in ${styleText('cyan', `${Math.ceil(startupDuration)}ms`)}` +
-        (workbenchAvailable ? '' : ` and running at ${styleText('cyan', url)}`),
+        `ready in ${styleText('cyan', `${Math.ceil(startupDuration)}ms`)}`,
     )
 
     return {close, server}

--- a/packages/@sanity/cli/src/actions/dev/types.ts
+++ b/packages/@sanity/cli/src/actions/dev/types.ts
@@ -10,4 +10,6 @@ export interface DevActionOptions {
   isApp: boolean
   output: Output
   workDir: string
+
+  workbenchAvailable?: boolean
 }

--- a/packages/@sanity/cli/src/actions/dev/types.ts
+++ b/packages/@sanity/cli/src/actions/dev/types.ts
@@ -10,7 +10,4 @@ export interface DevActionOptions {
   isApp: boolean
   output: Output
   workDir: string
-
-  reactRefreshHost?: string
-  workbenchAvailable?: boolean
 }

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
@@ -125,9 +125,6 @@ describe('bootstrapLocalTemplate (federation)', () => {
 
     const pkgJson = JSON.parse(await readFile(path.join(tmp, 'package.json'), 'utf8'))
     expect(pkgJson.dependencies.sanity).toBe('1.0.0')
-
-    const gitignore = await readFile(path.join(tmp, '.gitignore'), 'utf8')
-    expect(gitignore).toContain('.__mf__temp/')
   })
 
   test('keeps the `sanity` dependency on the `latest` dist-tag when federation is disabled', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/build.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/build.studio.test.ts
@@ -89,6 +89,12 @@ describe('#build studio', {timeout: (platform() === 'win32' ? 120 : 60) * 1000},
     const cwd = await testFixture('federated-studio')
     process.chdir(cwd)
 
+    // `@module-federation/vite` short-circuits to an empty plugin array when
+    // it detects vitest/jest in the env, which leaves the federation env without
+    // its plugins and skips emitting `remote-entry.js` / `mf-manifest.json`.
+    // Opt out of that guard for this in-process build.
+    vi.stubEnv('MFE_VITE_NO_TEST_ENV_CHECK', 'true')
+
     const {error, stderr} = await testCommand(BuildCommand, ['--yes'], {
       config: {root: cwd},
     })

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -26,7 +26,6 @@ export interface DevServerOptions {
   httpHost?: string
   isApp?: boolean
   projectName?: string
-  reactRefreshHost?: string
   schemaExtraction?: CliConfig['schemaExtraction']
   typegen?: CliConfig['typegen']
   vite?: UserViteConfig
@@ -50,7 +49,6 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     httpPort,
     isApp,
     reactCompiler,
-    reactRefreshHost,
     reactStrictMode,
     schemaExtraction,
     typegen,
@@ -91,7 +89,6 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     isApp,
     mode: 'development',
     reactCompiler,
-    reactRefreshHost,
     schemaExtraction,
     server: {host: httpHost, port: httpPort},
   })

--- a/packages/@sanity/cli/templates/shared/gitignore.txt
+++ b/packages/@sanity/cli/templates/shared/gitignore.txt
@@ -27,6 +27,3 @@
 
 # Dotenv and similar local-only files
 *.local
-
-# Module federation temporary files
-.__mf__temp/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,7 +238,7 @@ importers:
     dependencies:
       '@sanity/vision':
         specifier: 'catalog:'
-        version: 5.26.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 5.26.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -285,7 +285,7 @@ importers:
     dependencies:
       '@sanity/vision':
         specifier: 'catalog:'
-        version: 5.26.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 5.26.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -310,7 +310,7 @@ importers:
     dependencies:
       '@sanity/vision':
         specifier: 'catalog:'
-        version: 5.26.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 5.26.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -401,10 +401,10 @@ importers:
     dependencies:
       '@sanity/code-input':
         specifier: ^7.1.0
-        version: 7.1.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 7.1.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@sanity/vision':
         specifier: 'catalog:'
-        version: 5.26.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 5.26.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -416,7 +416,7 @@ importers:
         version: 5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       sanity-plugin-media:
         specifier: ^4.1.1
-        version: 4.1.1(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 4.1.1(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       styled-components:
         specifier: ^6.4.0
         version: 6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -531,8 +531,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0
       '@sanity/federation':
-        specifier: 0.1.0-alpha.7
-        version: 0.1.0-alpha.7(debug@4.4.3)(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: 0.1.0-alpha.8
+        version: 0.1.0-alpha.8(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -800,7 +800,7 @@ importers:
         version: 6.1.3
       sanity:
         specifier: 'catalog:'
-        version: 5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.10.6)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+        version: 5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.10.6)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -988,7 +988,7 @@ importers:
         version: 0.3.18
       sanity:
         specifier: 'catalog:'
-        version: 5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.10.6)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+        version: 5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.10.6)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -3440,8 +3440,8 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@module-federation/dts-plugin@2.3.1':
-    resolution: {integrity: sha512-6BJvu+dLDtW/ngpyuOLgpKOgtOnMUTZY51JUyargVckerKRbe7Ul+414YaHj32mu2FpsiHVMl4ig1XnxgnRg2Q==}
+  '@module-federation/dts-plugin@2.5.0':
+    resolution: {integrity: sha512-q7KDhJ5tn2HrUV7uMuh/L3TaaztUosE+4LAb90sxx0pPPqWRwlpBpxu1REubv5BWXmU1K/Ozn14u6jRbjLVaGA==}
     peerDependencies:
       typescript: ^4.9.0 || ^5.0.0
       vue-tsc: '>=1.0.24'
@@ -3449,48 +3449,31 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/error-codes@2.3.1':
-    resolution: {integrity: sha512-s3IjT2OYrSBNNmxdTmmrWBpsFfeNszdL6BSqjXLHb1CgXWUYLNXpb05IopnzMhRLcur6MTGuKR0ZSjJbmvQBbg==}
+  '@module-federation/error-codes@2.5.0':
+    resolution: {integrity: sha512-sq05/8Gp3csy1nr2/f76K3vLy0/xRqVtP71ibGy8BiLg7h1UxWN7G4EwAKSrPZ4FnsERGeFlIszg5Z+MqlwhFg==}
 
-  '@module-federation/error-codes@2.3.3':
-    resolution: {integrity: sha512-UVtKBoKnRDcHgByIDvPRZSxQqjqbNH7NvJm1KHLoce33+EDiIdZYs0HvvUQv43RgESpB9s7HjrqFlq3bEcAgfQ==}
+  '@module-federation/managers@2.5.0':
+    resolution: {integrity: sha512-9b5mU/7OYbKrYUJmhZ1kkfeJCZqR7qX6/FWp+oOfZMzUynN7Rb41dwoUs3TdnOKzbZ3CCwtZ2WsR4pF9ZNvuJA==}
 
-  '@module-federation/managers@2.3.1':
-    resolution: {integrity: sha512-kK/4FkoaIxbJbN+R6+cq+igv095hPox8oheZOKkrYA9P6Xv5FiHza+gHlCntiWTMrU8bzqJHH4VYm6gq1RB+dQ==}
+  '@module-federation/runtime-core@2.5.0':
+    resolution: {integrity: sha512-STmhQ3c6/hunba2FMP6GrHazXU/8GuN7Gk4dOkWNRpnqYIoD8Wx4MNl76j3HdCzBESC7uSMXTniksVaM1+xxyA==}
 
-  '@module-federation/runtime-core@2.3.1':
-    resolution: {integrity: sha512-E0WgaCn32AWzD0n6SCH7VQ+kxk46XyX432PQWARgyQzCX/wyLkaT+We3A18RVNUevRT85YHLrrVIhMKJJVHgjA==}
+  '@module-federation/runtime@2.5.0':
+    resolution: {integrity: sha512-dOc7pFEf8aruHBk5hoJLnvwkCa5ELT78q3o9dqcdaa/TT74X5z0FT0BsaGaRBPcse/iP6czK3fWd7RLv5ZKP5g==}
 
-  '@module-federation/runtime-core@2.3.3':
-    resolution: {integrity: sha512-B07LDH9KxhBO3GbULGW64mQFVQBtrEd3PoaCBm7XR1IbU8rMQUJQjDNVZgXYcyhRPBVP+3KWZuiaKFRiNb6PQw==}
-
-  '@module-federation/runtime@2.3.1':
-    resolution: {integrity: sha512-NiKelHKzOf1Vz8oqcxC/XRUAW224O6lKj9xD0cfp5Bp343iu6s58RlLvX1ypF+UpCl3jA4JM8npGax/3jjyifw==}
-
-  '@module-federation/runtime@2.3.3':
-    resolution: {integrity: sha512-JYJ3qv9V85DtBtT/ppDuJNwBTUrYqqZDYcyiTzwY5+44dC5QPvgJ//F+BOhAhZ02WkZV0b4jsKTyLOC3vXKGqQ==}
-
-  '@module-federation/sdk@2.3.1':
-    resolution: {integrity: sha512-lgWxFZyLRKDXWRGlV6ROjFJ6MRaJTxs0bBnS6hS9ONfr/0TkeW4JzDbsfzrB8g4p6IgSKB+wQ9XfibJCGBI5OQ==}
+  '@module-federation/sdk@2.5.0':
+    resolution: {integrity: sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==}
     peerDependencies:
-      node-fetch: ^3.3.2
+      node-fetch: ^2.7.0 || ^3.3.2
     peerDependenciesMeta:
       node-fetch:
         optional: true
 
-  '@module-federation/sdk@2.3.3':
-    resolution: {integrity: sha512-mwCS+LQdqiSc6fM5iz/S60ibaFNSH6kNqlZkCRIuS4yjdZ+jgnihz+6xp1QzppvfFgKLhEHBiXOmcYOdk3Ckew==}
-    peerDependencies:
-      node-fetch: ^3.3.2
-    peerDependenciesMeta:
-      node-fetch:
-        optional: true
+  '@module-federation/third-party-dts-extractor@2.5.0':
+    resolution: {integrity: sha512-5di43LGk2ies86Cj8QyzYr540Ijc+nyPqYziyFotL6Pparnu+uf3b3ERfEyQfBmEcyGk1MpitQIO2J3bd9BcNw==}
 
-  '@module-federation/third-party-dts-extractor@2.3.1':
-    resolution: {integrity: sha512-YpTLzM7H9damh31JX7eFBiCCR1mbibzS4i4JEa4fZ5ICT4hfNIuaAx1OeICGDOzSdl35TYegegCjk91oX6xCJQ==}
-
-  '@module-federation/vite@1.14.0':
-    resolution: {integrity: sha512-RBUbUrCrpsjteNYAw21tKRLvTtAtKYkJz4GZKF2R5vEuVR1zQ42l4PC3c9b6ERj9wVfkKDHNWUdXfR5NAZ92Gw==}
+  '@module-federation/vite@1.16.0':
+    resolution: {integrity: sha512-xgEcAj00A+1fGNLOg88FbJJjyLGqQQMM4qvTEGgw1bkVT1l8Bv2hqhjfk0UNs86EPPYfBbZxC2dR2rLxIljMQw==}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
@@ -4876,8 +4859,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@0.1.0-alpha.7':
-    resolution: {integrity: sha512-4N7BkgxyjmdTMX3dLGq3F+XJFN7O9qY75m/Ns487eeQrLWyKBtCl+3Ct37a9FeEVdAiDvfSv2TzanbySo1vsyA==}
+  '@sanity/federation@0.1.0-alpha.8':
+    resolution: {integrity: sha512-FMVXDu9XM8+I6XO1jXE3AIfL399CP9aVDotL3KWipPppTuq7iexo0wuD6d7mcYOwrhMukET7Pooy2+Z3WwQ3Iw==}
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
       vite: ^7.0.0 || ^8.0.0
@@ -6084,9 +6067,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.16:
-    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.5.10:
+    resolution: {integrity: sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==}
+    engines: {node: '>=6.0'}
 
   adm-zip@0.5.17:
     resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
@@ -6204,19 +6187,12 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  at-least-node@1.0.0:
-    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
-    engines: {node: '>= 4.0.0'}
-
   attr-accept@2.2.5:
     resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
     engines: {node: '>=4'}
 
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
-
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -6817,9 +6793,6 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
-  defu@6.1.7:
-    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
-
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -7346,15 +7319,6 @@ packages:
     resolution: {integrity: sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==}
     engines: {node: '>=10'}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
@@ -7397,10 +7361,6 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
-
-  fs-extra@9.1.0:
-    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
-    engines: {node: '>=10'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -8943,9 +8903,6 @@ packages:
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   publint@0.3.18:
     resolution: {integrity: sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==}
     engines: {node: '>=18'}
@@ -9911,6 +9868,10 @@ packages:
   undici@6.24.1:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -13294,95 +13255,67 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@module-federation/dts-plugin@2.3.1(debug@4.4.3)(typescript@5.9.3)':
+  '@module-federation/dts-plugin@2.5.0(typescript@5.9.3)':
     dependencies:
-      '@module-federation/error-codes': 2.3.1
-      '@module-federation/managers': 2.3.1
-      '@module-federation/sdk': 2.3.1
-      '@module-federation/third-party-dts-extractor': 2.3.1
-      adm-zip: 0.5.16
+      '@module-federation/error-codes': 2.5.0
+      '@module-federation/managers': 2.5.0
+      '@module-federation/sdk': 2.5.0
+      '@module-federation/third-party-dts-extractor': 2.5.0
+      adm-zip: 0.5.10
       ansi-colors: 4.1.3
-      axios: 1.13.5(debug@4.4.3)
-      fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
       node-schedule: 2.1.1
       typescript: 5.9.3
+      undici: 7.24.7
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/error-codes@2.3.1': {}
+  '@module-federation/error-codes@2.5.0': {}
 
-  '@module-federation/error-codes@2.3.3': {}
-
-  '@module-federation/managers@2.3.1':
+  '@module-federation/managers@2.5.0':
     dependencies:
-      '@module-federation/sdk': 2.3.1
+      '@module-federation/sdk': 2.5.0
       find-pkg: 2.0.0
-      fs-extra: 9.1.0
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/runtime-core@2.3.1':
+  '@module-federation/runtime-core@2.5.0':
     dependencies:
-      '@module-federation/error-codes': 2.3.1
-      '@module-federation/sdk': 2.3.1
+      '@module-federation/error-codes': 2.5.0
+      '@module-federation/sdk': 2.5.0
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/runtime-core@2.3.3':
+  '@module-federation/runtime@2.5.0':
     dependencies:
-      '@module-federation/error-codes': 2.3.3
-      '@module-federation/sdk': 2.3.3
+      '@module-federation/error-codes': 2.5.0
+      '@module-federation/runtime-core': 2.5.0
+      '@module-federation/sdk': 2.5.0
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/runtime@2.3.1':
-    dependencies:
-      '@module-federation/error-codes': 2.3.1
-      '@module-federation/runtime-core': 2.3.1
-      '@module-federation/sdk': 2.3.1
-    transitivePeerDependencies:
-      - node-fetch
+  '@module-federation/sdk@2.5.0': {}
 
-  '@module-federation/runtime@2.3.3':
-    dependencies:
-      '@module-federation/error-codes': 2.3.3
-      '@module-federation/runtime-core': 2.3.3
-      '@module-federation/sdk': 2.3.3
-    transitivePeerDependencies:
-      - node-fetch
-
-  '@module-federation/sdk@2.3.1': {}
-
-  '@module-federation/sdk@2.3.3': {}
-
-  '@module-federation/third-party-dts-extractor@2.3.1':
+  '@module-federation/third-party-dts-extractor@2.5.0':
     dependencies:
       find-pkg: 2.0.0
-      fs-extra: 9.1.0
       resolve: 1.22.8
 
-  '@module-federation/vite@1.14.0(debug@4.4.3)(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@module-federation/vite@1.16.0(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@module-federation/dts-plugin': 2.3.1(debug@4.4.3)(typescript@5.9.3)
-      '@module-federation/runtime': 2.3.1
-      '@module-federation/sdk': 2.3.1
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
-      defu: 6.1.7
+      '@module-federation/dts-plugin': 2.5.0(typescript@5.9.3)
+      '@module-federation/runtime': 2.5.0
+      '@module-federation/sdk': 2.5.0
       es-module-lexer: 2.0.0
       estree-walker: 3.0.3
-      magic-string: 0.30.21
       pathe: 2.0.3
       vite: 7.3.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - node-fetch
-      - rollup
       - typescript
       - utf-8-validate
       - vue-tsc
@@ -14437,7 +14370,7 @@ snapshots:
       nanoid: 3.3.11
       rxjs: 7.8.2
 
-  '@sanity/code-input@7.1.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+  '@sanity/code-input@7.1.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-java': 6.0.2
@@ -14553,16 +14486,14 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@0.1.0-alpha.7(debug@4.4.3)(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@0.1.0-alpha.8(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@module-federation/runtime': 2.3.3
-      '@module-federation/vite': 1.14.0(debug@4.4.3)(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+      '@module-federation/runtime': 2.5.0
+      '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       vite: 7.3.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - node-fetch
-      - rollup
       - typescript
       - utf-8-validate
       - vue-tsc
@@ -15072,7 +15003,7 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/vision@5.26.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+  '@sanity/vision@5.26.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/commands': 6.10.3
@@ -16305,7 +16236,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  adm-zip@0.5.16: {}
+  adm-zip@0.5.10: {}
 
   adm-zip@0.5.17: {}
 
@@ -16400,19 +16331,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  at-least-node@1.0.0: {}
-
   attr-accept@2.2.5: {}
 
   aws4@1.13.2: {}
-
-  axios@1.13.5(debug@4.4.3):
-    dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   b4a@1.7.3: {}
 
@@ -17006,8 +16927,6 @@ snapshots:
       gopd: 1.2.0
 
   define-lazy-prop@3.0.0: {}
-
-  defu@6.1.7: {}
 
   delayed-stream@1.0.0: {}
 
@@ -17633,10 +17552,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  follow-redirects@1.16.0(debug@4.4.3):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-
   form-data-encoder@2.1.4: {}
 
   form-data-encoder@4.1.0: {}
@@ -17680,13 +17595,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
-
-  fs-extra@9.1.0:
-    dependencies:
-      at-least-node: 1.0.0
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
 
   fsevents@2.3.3:
     optional: true
@@ -19280,8 +19188,6 @@ snapshots:
 
   protocols@2.0.2: {}
 
-  proxy-from-env@1.1.0: {}
-
   publint@0.3.18:
     dependencies:
       '@publint/pack': 0.1.4
@@ -19747,7 +19653,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity-plugin-media@4.1.1(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
+  sanity-plugin-media@4.1.1(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.3)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3))(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
       '@hookform/resolvers': 3.10.0(react-hook-form@7.71.2(react@19.2.5))
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)
@@ -19785,7 +19691,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.10.6)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3):
+  sanity@5.26.0(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.10.6)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3):
     dependencies:
       '@algorithm.ts/lcs': 4.0.5
       '@date-fns/tz': 1.4.1
@@ -20573,6 +20479,8 @@ snapshots:
   undici-types@7.22.0: {}
 
   undici@6.24.1: {}
+
+  undici@7.24.7: {}
 
   undici@7.25.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,3 +94,5 @@ minimumReleaseAgeExclude:
   - 'jiti@2.7.0'
   # Renovate security update: turbo@2.9.14
   - turbo@2.9.14
+  # Required by @sanity/federation@0.1.0-alpha.8
+  - '@module-federation/vite@1.16.0'


### PR DESCRIPTION
## Description

With `dev.remoteHmr: true` landing in `@module-federation/vite` (via workbench PR sanity-io/workbench#208), the federation plugin wires Fast Refresh through the host automatically. The workbench port no longer needs to leak from `devAction` down through `start{Studio,App}DevServer` → `startDevServer` → `getViteConfig` into `@vitejs/plugin-react`.

Also drops the `.__mf__temp` ignore entries from templates and fixtures — federation no longer writes that directory at build time, so the entries are stale.

Net: the build pipeline has zero awareness of whether a workbench host exists.

Depends on a `@sanity/federation` release containing sanity-io/workbench#208 before merging.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches federated dev HMR wiring and bumps @sanity/federation; behavior depends on the new federation release being present before merge.
> 
> **Overview**
> Removes **`reactRefreshHost`** from the dev/build Vite path (`devAction` → `startStudioDevServer` / `startAppDevServer` → `startDevServer` → `getViteConfig`), so `@vitejs/plugin-react` is no longer pointed at the workbench URL for federated HMR—that behavior is expected from **`@sanity/federation` `0.1.0-alpha.8`** and **`@module-federation/vite@1.16.0`** (`dev.remoteHmr`).
> 
> Cleans up **stale module-federation ignores**: drops `.__mf__temp/` from shared gitignore templates, the federated fixture, and related init/bootstrap tests; removes the old changeset that only documented that ignore.
> 
> **Tests / lockfile:** deletes `reactRefreshHost` assertions; federated build test sets **`MFE_VITE_NO_TEST_ENV_CHECK`** so federation plugins still run under Vitest; **`pnpm-lock.yaml`** and workspace catalog pin the new federation stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe7fb52a3356a2abdc59d5e6642e8d6312eba97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->