### PR TITLE
test(cli): stop checkForUpdates from crashing test workers

### DIFF
--- a/packages/@sanity/cli/test/setup.ts
+++ b/packages/@sanity/cli/test/setup.ts
@@ -5,3 +5,18 @@ import {vi} from 'vitest'
  */
 // Mock open, to prevent it from opening a browser
 vi.mock('open')
+
+// `@oclif/core/lib/screen.js` reads `process.stdout.getWindowSize()` at module
+// init when `process.stdout.isTTY` is truthy. Vitest's stdout proxy doesn't
+// implement `getWindowSize`, so any test that flips `isTTY = true` before oclif
+// is loaded (e.g. `checkForUpdates.test.ts`) crashes the whole worker.
+// Provide a no-op shim once per worker so the eventual load is safe.
+for (const stream of [process.stdout, process.stderr] as const) {
+  if (typeof stream.getWindowSize !== 'function') {
+    Object.defineProperty(stream, 'getWindowSize', {
+      configurable: true,
+      value: () => [80, 24],
+      writable: true,
+    })
+  }
+}


### PR DESCRIPTION
### Why

`checkForUpdates.test.ts` flips `process.stdout.isTTY = true` in `beforeEach` to simulate an interactive terminal. The first time anything in that worker touches `@oclif/core` after that, `@oclif/core/lib/screen.js` runs its module-init code, sees `isTTY = true`, and calls `process.stdout.getWindowSize()`. Vitest's stdout proxy doesn't implement `getWindowSize`, so the whole worker crashes with:

```
TypeError: stream.getWindowSize is not a function
  ❯ termwidth @oclif/core/lib/screen.js:9:26
  ❯ Object.<anonymous> @oclif/core/lib/screen.js:19:35
```

It's order-dependent — only the shard where `checkForUpdates.test.ts` happens to be the first file to drag in `@oclif/core` flakes, which is why different individual tests fail across shards (see the failing jobs on [#1110](https://github.com/sanity-io/cli/pull/1110): shard 4/6 on ubuntu, shard 3/4 on Windows).

### What

Install a `getWindowSize` shim once per worker in `test/setup.ts`. Now screen.js can load safely whether `isTTY` is true or false at the time.

Minimal, test-only, no production code touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `dev`/`build` orchestration, Vite config generation, and adds a new on-disk dev-server registry/lock mechanism; regressions could affect local development startup/port handling across platforms (notably Windows).
> 
> **Overview**
> Adds an experimental `federation.enabled` CLI config option and wires it through `dev` and `build` flows.
> 
> When federation is enabled, `sanity dev` now tries to start a shared workbench server (singleton lock + registry under `~/.sanity{-staging}/dev-servers/`), bumps the app/studio port, enables cross-server React refresh via `reactRefreshHost`, and registers running dev servers plus extracted manifests for workbench discovery.
> 
> Builds gain a federation mode that skips runtime/static asset steps, applies user Vite config to federation builds, and injects the `@sanity/federation/vite` plugin; auto-updates import-map generation is disabled for federation builds. Also adds uncached CLI config loading for long-lived processes, centralizes config/data dir resolution, and updates CI snapshot release tagging plus new `federated-studio` fixture/test coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 159d36a6b9699ced6124ca24feaf7bd757319fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->