### PR TITLE
chore(cli-test): isolate Vite cache per fixture instance

### DIFF
--- a/.changeset/pr-1112.md
+++ b/.changeset/pr-1112.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-test': patch
+'@sanity/cli': patch
+---
+
+fix(cli-test): isolate Vite cache per fixture instance

--- a/.changeset/pr-1112.md
+++ b/.changeset/pr-1112.md
@@ -1,7 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli-test': patch
-'@sanity/cli': patch
----
-
-fix(cli-test): isolate Vite cache per fixture instance

--- a/packages/@sanity/cli-test/src/test/testFixture.ts
+++ b/packages/@sanity/cli-test/src/test/testFixture.ts
@@ -137,8 +137,34 @@ export async function testFixture(
   // Copy the fixture to the temp directory
   await testCopyDirectory(tempFixturePath, tempPath, skipDirs)
 
-  // Symlink the node_modules directory for performance
-  await symlink(join(tempFixturePath, 'node_modules'), join(tempPath, 'node_modules'))
+  // Mirror node_modules as a directory of per-entry symlinks (instead of a
+  // single symlink to the source). This preserves the perf benefit of not
+  // copying installed deps, while letting us shadow specific subpaths per
+  // fixture. `.sanity` is excluded so each fixture instance gets its own
+  // Vite dep cache — sharing the cache across parallel tests causes
+  // dependency-optimization races ("Cannot read properties of undefined
+  // (reading 'imports')").
+  // If the source has no node_modules yet (test will install fresh), skip
+  // the mirroring entirely.
+  const srcNodeModules = join(tempFixturePath, 'node_modules')
+  const destNodeModules = join(tempPath, 'node_modules')
+  let srcEntries
+  try {
+    srcEntries = await readdir(srcNodeModules, {withFileTypes: true})
+  } catch (err) {
+    if (!(err instanceof Error && 'code' in err && err.code === 'ENOENT')) throw err
+  }
+  if (srcEntries) {
+    await mkdir(destNodeModules, {recursive: true})
+    for (const entry of srcEntries) {
+      if (entry.name === '.sanity') continue
+      await symlink(
+        join(srcNodeModules, entry.name),
+        join(destNodeModules, entry.name),
+        entry.isDirectory() ? 'dir' : 'file',
+      )
+    }
+  }
 
   // Replace the package.json name with a temp name
   const packageJsonPath = join(tempPath, 'package.json')

--- a/packages/@sanity/cli-test/src/test/testFixture.ts
+++ b/packages/@sanity/cli-test/src/test/testFixture.ts
@@ -137,15 +137,9 @@ export async function testFixture(
   // Copy the fixture to the temp directory
   await testCopyDirectory(tempFixturePath, tempPath, skipDirs)
 
-  // Mirror node_modules as a directory of per-entry symlinks (instead of a
-  // single symlink to the source). This preserves the perf benefit of not
-  // copying installed deps, while letting us shadow specific subpaths per
-  // fixture. `.sanity` is excluded so each fixture instance gets its own
-  // Vite dep cache — sharing the cache across parallel tests causes
-  // dependency-optimization races ("Cannot read properties of undefined
-  // (reading 'imports')").
-  // If the source has no node_modules yet (test will install fresh), skip
-  // the mirroring entirely.
+  // Mirror node_modules as per-entry symlinks excluding `.sanity` so each fixture
+  // gets its own Vite dep cache — sharing it across parallel tests races on
+  // dependency optimization.
   const srcNodeModules = join(tempFixturePath, 'node_modules')
   const destNodeModules = join(tempPath, 'node_modules')
   let srcEntries
@@ -158,10 +152,15 @@ export async function testFixture(
     await mkdir(destNodeModules, {recursive: true})
     for (const entry of srcEntries) {
       if (entry.name === '.sanity') continue
+      const srcPath = join(srcNodeModules, entry.name)
+      // Follow symlinks (e.g. pnpm's `node_modules/<pkg>` → `.pnpm/...`) so
+      // they get a 'dir' type on Windows — a file-typed symlink to a directory
+      // throws EPERM on stat.
+      const targetStats = entry.isSymbolicLink() ? await stat(srcPath) : entry
       await symlink(
-        join(srcNodeModules, entry.name),
+        srcPath,
         join(destNodeModules, entry.name),
-        entry.isDirectory() ? 'dir' : 'file',
+        targetStats.isDirectory() ? 'dir' : 'file',
       )
     }
   }

--- a/packages/@sanity/cli/src/commands/__tests__/build.app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/build.app.test.ts
@@ -1,5 +1,5 @@
 import {exec} from 'node:child_process'
-import {readdir, readFile, rm, unlink, writeFile} from 'node:fs/promises'
+import {readdir, readFile, rm, writeFile} from 'node:fs/promises'
 import {platform, tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {promisify} from 'node:util'
@@ -123,7 +123,7 @@ describe('#build app', {timeout: (platform() === 'win32' ? 120 : 60) * 1000}, ()
     await writeFile(join(cwd, 'package.json'), JSON.stringify(packageJsonData, null, 2))
 
     // Remove node_modules so the package can't be found
-    await unlink(join(cwd, 'node_modules'))
+    await rm(join(cwd, 'node_modules'), {force: true, recursive: true})
     // Install from pnpm
     await execAsync(`pnpm install --prefer-offline --config.minimum-release-age=0`, {
       cwd,

--- a/packages/@sanity/cli/src/commands/__tests__/build.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/build.studio.test.ts
@@ -1,5 +1,5 @@
 import {exec} from 'node:child_process'
-import {readdir, readFile, rm, unlink, writeFile} from 'node:fs/promises'
+import {readdir, readFile, rm, writeFile} from 'node:fs/promises'
 import {platform, tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {promisify} from 'node:util'
@@ -150,7 +150,7 @@ describe('#build studio', {timeout: (platform() === 'win32' ? 120 : 60) * 1000},
     await writeFile(join(cwd, 'package.json'), JSON.stringify(packageJsonData, null, 2))
 
     // Remove node_modules so the package can't be found
-    await unlink(join(cwd, 'node_modules'))
+    await rm(join(cwd, 'node_modules'), {force: true, recursive: true})
     // Install from pnpm without updating the lockfile
     await execAsync(`pnpm install --prefer-offline --config.minimum-release-age=0`, {
       cwd,


### PR DESCRIPTION
### Why

`testFixture` symlinked `node_modules` from a shared source directory into each test's temp dir. The CLI's dev server uses Vite with `cacheDir: node_modules/.sanity/vite`, so every parallel test instance using the same fixture also shared the same Vite dep cache through the symlink. Concurrent runs raced on `_metadata.json`, surfacing as:

```
TypeError: Error during dependency optimization:
Cannot read properties of undefined (reading 'imports')
  ❯ vite/dist/node/chunks/config.js:32022:82
```

This is what's been flaking `dev.test.ts` in CI (see e.g. [job 76931524284](https://github.com/sanity-io/cli/actions/runs/26154869890/job/76931524284)).

### What

Mirror `node_modules` as a directory of per-entry symlinks instead of a single top-level symlink, excluding `.sanity`. Each fixture instance now gets its own Vite cache while still avoiding a full copy of the installed deps.

Also switches the two existing `unlink(node_modules)` callsites in build tests to `rm(..., {recursive: true, force: true})` so they keep working with the directory layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `testFixture` materializes `node_modules` using many symlinks instead of one, which could behave differently across platforms/filesystems and impact a large portion of the test suite. The intent is test-stability, but it touches shared test infrastructure used broadly.
> 
> **Overview**
> Fixes CI flakiness in CLI fixtures by changing `testFixture` to **mirror `node_modules` as per-entry symlinks** and exclude `node_modules/.sanity`, ensuring each temp fixture gets its own Vite dependency cache instead of sharing it via a single `node_modules` symlink.
> 
> Updates build command tests to remove `node_modules` via `rm(..., {recursive: true, force: true})` (instead of `unlink`) so they continue to work with the new `node_modules` layout, and adds a changeset for patch releases of `@sanity/cli-test` and `@sanity/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba3d7f71fb7235cd0ad3b111bf70b7c79f457092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->