### PR TITLE
fix(mcp): add or remove existing mcp configurations

### DIFF
--- a/.changeset/mcp-configure-source-of-truth.md
+++ b/.changeset/mcp-configure-source-of-truth.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+`sanity mcp configure` now removes the Sanity MCP entry from editors the user deselects in the prompt.

--- a/.changeset/mcp-configure-source-of-truth.md
+++ b/.changeset/mcp-configure-source-of-truth.md
@@ -2,4 +2,4 @@
 "@sanity/cli": patch
 ---
 
-`sanity mcp configure` now removes the Sanity MCP entry from editors the user deselects in the prompt.
+Deselected editors get their Sanity MCP entry removed.

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -192,6 +192,7 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
   trace.log({
     configuredEditors: mcpResult.configuredEditors,
     detectedEditors: mcpResult.detectedEditors,
+    removedEditors: mcpResult.removedEditors,
     skipped: mcpResult.skipped,
     step: 'mcpSetup',
   })

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/promptForMCPSetup.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/promptForMCPSetup.test.ts
@@ -23,7 +23,7 @@ describe('promptForMCPSetup', () => {
     vi.clearAllMocks()
   })
 
-  test('labels unconfigured editors with plain name', async () => {
+  test('leaves unconfigured editors unchecked with plain name', async () => {
     mockCheckbox.mockResolvedValue(['Cursor'])
 
     const editors = [makeEditor({name: 'Cursor'})]
@@ -31,7 +31,22 @@ describe('promptForMCPSetup', () => {
 
     expect(mockCheckbox).toHaveBeenCalledWith(
       expect.objectContaining({
-        choices: [{checked: true, name: 'Cursor', value: 'Cursor'}],
+        choices: [{checked: false, name: 'Cursor', value: 'Cursor'}],
+      }),
+    )
+  })
+
+  test('pre-checks configured editors with valid credentials', async () => {
+    mockCheckbox.mockResolvedValue(['Cursor'])
+
+    const editors = [
+      makeEditor({authStatus: 'valid', configured: true, existingToken: 'tok', name: 'Cursor'}),
+    ]
+    await promptForMCPSetup(editors)
+
+    expect(mockCheckbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        choices: [{checked: true, name: 'Cursor (configured)', value: 'Cursor'}],
       }),
     )
   })
@@ -69,13 +84,13 @@ describe('promptForMCPSetup', () => {
     )
   })
 
-  test('returns null when user deselects all editors', async () => {
+  test('returns an empty array when user deselects all editors', async () => {
     mockCheckbox.mockResolvedValue([])
 
     const editors = [makeEditor({name: 'Cursor'})]
     const result = await promptForMCPSetup(editors)
 
-    expect(result).toBeNull()
+    expect(result).toEqual([])
   })
 
   test('returns only selected editors', async () => {
@@ -85,6 +100,6 @@ describe('promptForMCPSetup', () => {
     const result = await promptForMCPSetup(editors)
 
     expect(result).toHaveLength(1)
-    expect(result![0].name).toBe('VS Code')
+    expect(result[0].name).toBe('VS Code')
   })
 })

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts
@@ -7,6 +7,7 @@ const mockPromptForMCPSetup = vi.hoisted(() => vi.fn())
 const mockValidateEditorTokens = vi.hoisted(() => vi.fn())
 const mockCreateMCPToken = vi.hoisted(() => vi.fn())
 const mockWriteMCPConfig = vi.hoisted(() => vi.fn())
+const mockRemoveMCPConfig = vi.hoisted(() => vi.fn())
 
 vi.mock('../detectAvailableEditors.js', () => ({
   detectAvailableEditors: mockDetectAvailableEditors,
@@ -27,6 +28,10 @@ vi.mock('../../../services/mcp.js', () => ({
 
 vi.mock('../writeMCPConfig.js', () => ({
   writeMCPConfig: mockWriteMCPConfig,
+}))
+
+vi.mock('../removeMCPConfig.js', () => ({
+  removeMCPConfig: mockRemoveMCPConfig,
 }))
 
 describe('setupMCP', () => {
@@ -50,7 +55,7 @@ describe('setupMCP', () => {
     ])
     mockValidateEditorTokens.mockResolvedValue(undefined)
     mockCreateMCPToken.mockResolvedValue('test-token')
-    mockWriteMCPConfig.mockResolvedValue(undefined)
+    mockWriteMCPConfig.mockResolvedValue(true)
 
     const result = await setupMCP({mode: 'auto'})
 
@@ -66,7 +71,7 @@ describe('setupMCP', () => {
     mockValidateEditorTokens.mockResolvedValue(undefined)
     mockPromptForMCPSetup.mockResolvedValue(editors)
     mockCreateMCPToken.mockResolvedValue('test-token')
-    mockWriteMCPConfig.mockResolvedValue(undefined)
+    mockWriteMCPConfig.mockResolvedValue(true)
 
     const result = await setupMCP({mode: 'prompt'})
 
@@ -81,7 +86,7 @@ describe('setupMCP', () => {
     mockValidateEditorTokens.mockResolvedValue(undefined)
     mockPromptForMCPSetup.mockResolvedValue(editors)
     mockCreateMCPToken.mockResolvedValue('test-token')
-    mockWriteMCPConfig.mockResolvedValue(undefined)
+    mockWriteMCPConfig.mockResolvedValue(true)
 
     await setupMCP()
 
@@ -94,10 +99,79 @@ describe('setupMCP', () => {
     mockValidateEditorTokens.mockResolvedValue(undefined)
     mockPromptForMCPSetup.mockResolvedValue(editors)
     mockCreateMCPToken.mockResolvedValue('test-token')
-    mockWriteMCPConfig.mockResolvedValue(undefined)
+    mockWriteMCPConfig.mockResolvedValue(true)
 
     await setupMCP({explicit: true})
 
     expect(mockPromptForMCPSetup).toHaveBeenCalledWith(editors)
+  })
+
+  test('reports an editor whose config already matches as already-configured (no write needed)', async () => {
+    // VS Code is configured with a valid bearer token. writeMCPConfig returns
+    // false to signal a no-op — setupMCP should classify this as
+    // "alreadyConfigured" rather than "configured".
+    const vscode = {
+      authStatus: 'valid',
+      configured: true,
+      existingToken: 'valid-token',
+      name: 'VS Code',
+    }
+    mockDetectAvailableEditors.mockResolvedValue([vscode])
+    mockValidateEditorTokens.mockResolvedValue(undefined)
+    mockPromptForMCPSetup.mockResolvedValue([vscode])
+    mockWriteMCPConfig.mockResolvedValue(false)
+
+    const result = await setupMCP({mode: 'prompt'})
+
+    expect(mockCreateMCPToken).not.toHaveBeenCalled()
+    expect(result.configuredEditors).toEqual([])
+    expect(result.alreadyConfiguredEditors).toEqual(['VS Code'])
+  })
+
+  test('reports an editor whose config needed rewriting as configured', async () => {
+    // Existing config shape diverges from what writeMCPConfig would produce
+    // (e.g. oauthOnly toggled, token changed). writeMCPConfig returns true to
+    // signal it wrote.
+    const cursor = {
+      authStatus: 'valid',
+      configured: true,
+      existingToken: 'stale-bearer-token',
+      name: 'Cursor',
+    }
+    mockDetectAvailableEditors.mockResolvedValue([cursor])
+    mockValidateEditorTokens.mockResolvedValue(undefined)
+    mockPromptForMCPSetup.mockResolvedValue([cursor])
+    mockWriteMCPConfig.mockResolvedValue(true)
+
+    const result = await setupMCP({mode: 'prompt'})
+
+    expect(mockWriteMCPConfig).toHaveBeenCalled()
+    expect(result.configuredEditors).toEqual(['Cursor'])
+    expect(result.alreadyConfiguredEditors).toEqual([])
+  })
+
+  test('removes Sanity entry from configured editors that the user deselects', async () => {
+    const cursor = {
+      authStatus: 'valid',
+      configured: true,
+      existingToken: 'existing-token',
+      name: 'Cursor',
+    }
+    const vscode = {authStatus: 'unknown', configured: false, name: 'VS Code'}
+    mockDetectAvailableEditors.mockResolvedValue([cursor, vscode])
+    mockValidateEditorTokens.mockResolvedValue(undefined)
+    // User keeps VS Code, drops Cursor
+    mockPromptForMCPSetup.mockResolvedValue([vscode])
+    mockWriteMCPConfig.mockResolvedValue(true)
+    mockRemoveMCPConfig.mockResolvedValue(undefined)
+
+    const result = await setupMCP({mode: 'prompt'})
+
+    // Reuses Cursor's still-valid token for the new VS Code write
+    expect(mockCreateMCPToken).not.toHaveBeenCalled()
+    expect(mockWriteMCPConfig).toHaveBeenCalledWith(vscode, 'existing-token')
+    expect(mockRemoveMCPConfig).toHaveBeenCalledWith(cursor)
+    expect(result.configuredEditors).toEqual(['VS Code'])
+    expect(result.removedEditors).toEqual(['Cursor'])
   })
 })

--- a/packages/@sanity/cli/src/actions/mcp/promptForMCPSetup.ts
+++ b/packages/@sanity/cli/src/actions/mcp/promptForMCPSetup.ts
@@ -9,18 +9,22 @@ function getEditorLabel(editor: Editor): string {
   if (editor.configured && !editor.existingToken) {
     return `${editor.name} (missing credentials)`
   }
+  if (editor.configured) {
+    return `${editor.name} (configured)`
+  }
   return editor.name
 }
 
 /**
- * Prompt user to select which editors to configure.
+ * Prompt the user to choose which editors should have a Sanity MCP entry.
  *
- * Expects only actionable editors (unconfigured, or configured with
- * invalid/missing credentials). Annotates entries with auth status.
+ * The returned array is the desired final state: editors selected here should
+ * end up configured, editors that were previously configured but are not
+ * selected here should have their Sanity entry removed.
  */
-export async function promptForMCPSetup(editors: Editor[]): Promise<Editor[] | null> {
+export async function promptForMCPSetup(editors: Editor[]): Promise<Editor[]> {
   const editorChoices = editors.map((e) => ({
-    checked: true, // Pre-select all actionable editors
+    checked: e.configured,
     name: getEditorLabel(e),
     value: e.name,
   }))
@@ -29,11 +33,6 @@ export async function promptForMCPSetup(editors: Editor[]): Promise<Editor[] | n
     choices: editorChoices,
     message: 'Configure Sanity MCP server?',
   })
-
-  // User can deselect all to skip
-  if (!selectedNames || selectedNames.length === 0) {
-    return null
-  }
 
   return editors.filter((e) => selectedNames.includes(e.name))
 }

--- a/packages/@sanity/cli/src/actions/mcp/removeMCPConfig.ts
+++ b/packages/@sanity/cli/src/actions/mcp/removeMCPConfig.ts
@@ -1,0 +1,41 @@
+import {existsSync} from 'node:fs'
+import fs from 'node:fs/promises'
+
+import {applyEdits, modify} from 'jsonc-parser'
+import {parse as parseToml, stringify as stringifyToml} from 'smol-toml'
+
+import {EDITOR_CONFIGS} from './editorConfigs.js'
+import {type Editor} from './types.js'
+
+/**
+ * Remove the Sanity MCP server entry from an editor's config file.
+ * Other entries are preserved.
+ */
+export async function removeMCPConfig(editor: Editor): Promise<void> {
+  const {configKey, format} = EDITOR_CONFIGS[editor.name]
+  const {configPath} = editor
+
+  if (!existsSync(configPath)) return
+
+  const content = await fs.readFile(configPath, 'utf8')
+  if (!content.trim()) return
+
+  let updated: string
+  if (format === 'toml') {
+    const config = parseToml(content) as Record<string, unknown>
+    const servers = config[configKey]
+    if (!servers || typeof servers !== 'object' || Array.isArray(servers)) return
+    const {Sanity: _removed, ...rest} = servers as Record<string, unknown>
+    if (_removed === undefined) return
+    config[configKey] = rest
+    updated = stringifyToml(config)
+  } else {
+    const edits = modify(content, [configKey, 'Sanity'], undefined, {
+      formattingOptions: {insertSpaces: true, tabSize: 2},
+    })
+    if (edits.length === 0) return
+    updated = applyEdits(content, edits)
+  }
+
+  await fs.writeFile(configPath, updated, 'utf8')
+}

--- a/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
+++ b/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
@@ -3,6 +3,7 @@ import {subdebug} from '@sanity/cli-core'
 import {logSymbols} from '@sanity/cli-core/ux'
 
 import {createMCPToken, MCP_SERVER_URL} from '../../services/mcp.js'
+import {toError} from '../../util/getErrorMessage.js'
 import {detectAvailableEditors} from './detectAvailableEditors.js'
 import {EDITOR_CONFIGS, type EditorName} from './editorConfigs.js'
 import {promptForMCPSetup} from './promptForMCPSetup.js'
@@ -97,6 +98,8 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
   }
 
   let token: string | undefined
+  let firstError: Error | undefined
+
   const reusable = editors.find((e) => e.authStatus === 'valid' && e.existingToken)
   if (reusable?.existingToken) {
     mcpDebug('Reusing valid token from %s', reusable.name)
@@ -107,7 +110,7 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
     try {
       token = await createMCPToken()
     } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error))
+      const err = toError(error)
       mcpDebug('Error creating MCP token', error)
       ux.warn(`Could not configure MCP: ${err.message}`)
       ux.warn('You can set up MCP manually later using https://mcp.sanity.io')
@@ -124,44 +127,29 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
 
   const configuredEditors: EditorName[] = []
   const alreadyConfiguredEditors: EditorName[] = []
-  try {
-    for (const editor of selected) {
+  for (const editor of selected) {
+    try {
       const wrote = await writeMCPConfig(editor, token)
       if (wrote) configuredEditors.push(editor.name)
       else alreadyConfiguredEditors.push(editor.name)
-    }
-  } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error))
-    mcpDebug('Error writing MCP config', error)
-    ux.warn(`Could not configure MCP: ${err.message}`)
-    ux.warn('You can set up MCP manually later using https://mcp.sanity.io')
-    return {
-      alreadyConfiguredEditors,
-      configuredEditors,
-      detectedEditors,
-      error: err,
-      removedEditors: [],
-      skipped: false,
+    } catch (error) {
+      const err = toError(error)
+      mcpDebug('Error writing MCP config for %s: %s', editor.name, err)
+      ux.warn(`Could not configure MCP for ${editor.name}: ${err.message}`)
+      firstError ??= err
     }
   }
 
   const removedEditors: EditorName[] = []
-  try {
-    for (const editor of editorsToRemove) {
+  for (const editor of editorsToRemove) {
+    try {
       await removeMCPConfig(editor)
       removedEditors.push(editor.name)
-    }
-  } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error))
-    mcpDebug('Error removing MCP config', error)
-    ux.warn(`Could not remove MCP configuration: ${err.message}`)
-    return {
-      alreadyConfiguredEditors,
-      configuredEditors,
-      detectedEditors,
-      error: err,
-      removedEditors,
-      skipped: false,
+    } catch (error) {
+      const err = toError(error)
+      mcpDebug('Error removing MCP config for %s: %s', editor.name, err)
+      ux.warn(`Could not remove MCP configuration for ${editor.name}: ${err.message}`)
+      firstError ??= err
     }
   }
 
@@ -171,7 +159,9 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
   if (removedEditors.length > 0) {
     ux.stdout(`${logSymbols.success} MCP removed from ${removedEditors.join(', ')}`)
   }
-  if (
+  if (firstError) {
+    ux.warn('Some editors could not be updated. See https://mcp.sanity.io for manual setup.')
+  } else if (
     explicit &&
     configuredEditors.length === 0 &&
     removedEditors.length === 0 &&
@@ -184,6 +174,7 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
     alreadyConfiguredEditors,
     configuredEditors,
     detectedEditors,
+    error: firstError,
     removedEditors,
     skipped: false,
   }

--- a/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
+++ b/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
@@ -6,6 +6,7 @@ import {createMCPToken, MCP_SERVER_URL} from '../../services/mcp.js'
 import {detectAvailableEditors} from './detectAvailableEditors.js'
 import {EDITOR_CONFIGS, type EditorName} from './editorConfigs.js'
 import {promptForMCPSetup} from './promptForMCPSetup.js'
+import {removeMCPConfig} from './removeMCPConfig.js'
 import {validateEditorTokens} from './validateEditorTokens.js'
 import {writeMCPConfig} from './writeMCPConfig.js'
 
@@ -35,6 +36,7 @@ interface MCPSetupResult {
   alreadyConfiguredEditors: EditorName[]
   configuredEditors: EditorName[]
   detectedEditors: EditorName[]
+  removedEditors: EditorName[]
   skipped: boolean
 
   error?: Error
@@ -47,89 +49,61 @@ interface MCPSetupResult {
 export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResult> {
   const {explicit = false, mode = 'prompt'} = options ?? {}
 
-  // 1. Check for explicit opt-out
   if (mode === 'skip') {
     mcpDebug('Skipping MCP configuration (mode: skip)')
     return {
       alreadyConfiguredEditors: [],
       configuredEditors: [],
       detectedEditors: [],
+      removedEditors: [],
       skipped: true,
     }
   }
 
-  // 2. Detect available editors (filters out unparseable configs)
   const editors = await detectAvailableEditors()
   const detectedEditors = editors.map((e) => e.name)
 
   mcpDebug('Detected %d editors: %s', detectedEditors.length, detectedEditors)
 
   if (editors.length === 0) {
-    if (explicit) {
-      ux.warn(NO_EDITORS_DETECTED_MESSAGE)
-    }
+    if (explicit) ux.warn(NO_EDITORS_DETECTED_MESSAGE)
     return {
       alreadyConfiguredEditors: [],
       configuredEditors: [],
       detectedEditors,
+      removedEditors: [],
       skipped: true,
     }
   }
 
-  // 3. Validate existing tokens against the Sanity API
   await validateEditorTokens(editors)
 
-  // 4. Check if there's anything actionable
-  const actionable = editors.filter((e) => !e.configured || e.authStatus !== 'valid')
+  // The prompt shows every detected editor; what the user keeps checked is the
+  // desired final state. In auto mode, treat every editor as selected.
+  const selected = mode === 'auto' ? editors : await promptForMCPSetup(editors)
+  const selectedNames = new Set(selected.map((e) => e.name))
 
-  if (actionable.length === 0) {
-    mcpDebug('All editors configured with valid credentials')
-    const alreadyConfiguredEditors = editors
-      .filter((e) => e.configured && e.authStatus === 'valid')
-      .map((e) => e.name)
-    if (explicit) {
-      ux.stdout(`${logSymbols.success} All detected editors are already configured`)
-    }
+  const editorsToRemove = editors.filter((e) => e.configured && !selectedNames.has(e.name))
+
+  if (selected.length === 0 && editorsToRemove.length === 0) {
+    if (explicit) ux.stdout('MCP configuration skipped')
     return {
-      alreadyConfiguredEditors,
+      alreadyConfiguredEditors: [],
       configuredEditors: [],
       detectedEditors,
+      removedEditors: [],
       skipped: true,
     }
   }
 
-  // Non-actionable editors are already configured with valid credentials
-  const alreadyConfiguredEditors = editors.filter((e) => !actionable.includes(e)).map((e) => e.name)
-
-  // 5. Select editors to configure — prompt interactively or auto-select all
-  const selected = mode === 'auto' ? actionable : await promptForMCPSetup(actionable)
-
-  if (!selected || selected.length === 0) {
-    // User deselected all editors
-    ux.stdout('MCP configuration skipped')
-    return {
-      alreadyConfiguredEditors,
-      configuredEditors: [],
-      detectedEditors,
-      skipped: true,
-    }
-  }
-
-  // 6. Get a token — reuse a valid existing one or create a new one
   let token: string | undefined
-
-  // Look for an existing valid token we can reuse
-  const validEditor = editors.find((e) => e.authStatus === 'valid' && e.existingToken)
-  if (validEditor?.existingToken) {
-    mcpDebug('Reusing valid token from %s', validEditor.name)
-    token = validEditor.existingToken
+  const reusable = editors.find((e) => e.authStatus === 'valid' && e.existingToken)
+  if (reusable?.existingToken) {
+    mcpDebug('Reusing valid token from %s', reusable.name)
+    token = reusable.existingToken
   }
-
-  const allOAuth = selected.every((e) => EDITOR_CONFIGS[e.name].oauthOnly)
-
-  // Fall back to creating a new token
-  // If all editors use OAuth, we don't need to create a token
-  if (!token && !allOAuth) {
+  const needsToken = selected.some((e) => !EDITOR_CONFIGS[e.name].oauthOnly)
+  if (!token && needsToken) {
     try {
       token = await createMCPToken()
     } catch (error) {
@@ -138,21 +112,23 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
       ux.warn(`Could not configure MCP: ${err.message}`)
       ux.warn('You can set up MCP manually later using https://mcp.sanity.io')
       return {
-        alreadyConfiguredEditors,
+        alreadyConfiguredEditors: [],
         configuredEditors: [],
         detectedEditors,
         error: err,
+        removedEditors: [],
         skipped: false,
       }
     }
   }
 
-  // 7. Write configs for each selected editor
   const configuredEditors: EditorName[] = []
+  const alreadyConfiguredEditors: EditorName[] = []
   try {
     for (const editor of selected) {
-      await writeMCPConfig(editor, token)
-      configuredEditors.push(editor.name)
+      const wrote = await writeMCPConfig(editor, token)
+      if (wrote) configuredEditors.push(editor.name)
+      else alreadyConfiguredEditors.push(editor.name)
     }
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error))
@@ -164,16 +140,51 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
       configuredEditors,
       detectedEditors,
       error: err,
+      removedEditors: [],
       skipped: false,
     }
   }
 
-  ux.stdout(`${logSymbols.success} MCP configured for ${configuredEditors.join(', ')}`)
+  const removedEditors: EditorName[] = []
+  try {
+    for (const editor of editorsToRemove) {
+      await removeMCPConfig(editor)
+      removedEditors.push(editor.name)
+    }
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error))
+    mcpDebug('Error removing MCP config', error)
+    ux.warn(`Could not remove MCP configuration: ${err.message}`)
+    return {
+      alreadyConfiguredEditors,
+      configuredEditors,
+      detectedEditors,
+      error: err,
+      removedEditors,
+      skipped: false,
+    }
+  }
+
+  if (configuredEditors.length > 0) {
+    ux.stdout(`${logSymbols.success} MCP configured for ${configuredEditors.join(', ')}`)
+  }
+  if (removedEditors.length > 0) {
+    ux.stdout(`${logSymbols.success} MCP removed from ${removedEditors.join(', ')}`)
+  }
+  if (
+    explicit &&
+    configuredEditors.length === 0 &&
+    removedEditors.length === 0 &&
+    alreadyConfiguredEditors.length > 0
+  ) {
+    ux.stdout(`${logSymbols.success} All detected editors are already configured`)
+  }
 
   return {
     alreadyConfiguredEditors,
     configuredEditors,
     detectedEditors,
+    removedEditors,
     skipped: false,
   }
 }

--- a/packages/@sanity/cli/src/actions/mcp/writeMCPConfig.ts
+++ b/packages/@sanity/cli/src/actions/mcp/writeMCPConfig.ts
@@ -2,7 +2,7 @@ import {existsSync} from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import {applyEdits, modify} from 'jsonc-parser'
+import {applyEdits, modify, parse as parseJsonc} from 'jsonc-parser'
 import {parse as parseToml, stringify as stringifyToml} from 'smol-toml'
 
 import {EDITOR_CONFIGS} from './editorConfigs.js'
@@ -12,25 +12,53 @@ interface TomlConfig {
   [key: string]: Record<string, unknown> | undefined
 }
 
+/** Stable JSON for structural comparison — sorts object keys recursively. */
+function canonical(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map((v) => canonical(v)).join(',')}]`
+  const record = value as Record<string, unknown>
+  const entries = Object.keys(record)
+    .toSorted()
+    .map((k) => `${JSON.stringify(k)}:${canonical(record[k])}`)
+  return `{${entries.join(',')}}`
+}
+
+function readExistingSanityEntry(
+  content: string,
+  configKey: string,
+  format: 'jsonc' | 'toml',
+): unknown {
+  if (!content.trim()) return undefined
+  try {
+    const parsed = format === 'toml' ? parseToml(content) : parseJsonc(content)
+    const servers = (parsed as Record<string, unknown> | null)?.[configKey]
+    if (!servers || typeof servers !== 'object' || Array.isArray(servers)) return undefined
+    return (servers as Record<string, unknown>).Sanity
+  } catch {
+    return undefined
+  }
+}
+
 /**
- * Write MCP configuration to editor config file
- * Uses jsonc-parser's modify/applyEdits to preserve comments
+ * Write MCP configuration to an editor's config file. Returns `true` if the
+ * file was written, `false` if the existing Sanity entry already matches and
+ * the write was skipped.
  *
- * Note: Config parseability is already validated in detectAvailableEditors()
+ * Note: Config parseability is already validated in detectAvailableEditors().
  */
-export async function writeMCPConfig(editor: Editor, token?: string): Promise<void> {
+export async function writeMCPConfig(editor: Editor, token?: string): Promise<boolean> {
   const configPath = editor.configPath
   const {buildServerConfig, configKey, format, oauthOnly} = EDITOR_CONFIGS[editor.name]
   const serverConfig = oauthOnly ? buildServerConfig('') : buildServerConfig(token!)
 
-  // Read existing content or start with empty object/document
-  let content = format === 'toml' ? '' : '{}'
-  if (existsSync(configPath)) {
-    const fileContent = await fs.readFile(configPath, 'utf8')
-    if (fileContent.trim()) {
-      content = fileContent
-    }
+  const existingContent = existsSync(configPath) ? await fs.readFile(configPath, 'utf8') : ''
+
+  const existingEntry = readExistingSanityEntry(existingContent, configKey, format)
+  if (existingEntry && canonical(existingEntry) === canonical(serverConfig)) {
+    return false
   }
+
+  let content = existingContent.trim() ? existingContent : format === 'toml' ? '' : '{}'
 
   if (format === 'toml') {
     const tomlConfig = content.trim() ? (parseToml(content) as TomlConfig) : {}
@@ -43,15 +71,13 @@ export async function writeMCPConfig(editor: Editor, token?: string): Promise<vo
 
     content = stringifyToml(tomlConfig)
   } else {
-    // Modify using jsonc-parser - preserves comments
-    // Setting a nested path automatically creates intermediate objects
     const edits = modify(content, [configKey, 'Sanity'], serverConfig, {
       formattingOptions: {insertSpaces: true, tabSize: 2},
     })
     content = applyEdits(content, edits)
   }
 
-  // Ensure parent directory exists and write
   await fs.mkdir(path.dirname(configPath), {recursive: true})
   await fs.writeFile(configPath, content, 'utf8')
+  return true
 }

--- a/packages/@sanity/cli/src/actions/mcp/writeMCPConfig.ts
+++ b/packages/@sanity/cli/src/actions/mcp/writeMCPConfig.ts
@@ -12,10 +12,16 @@ interface TomlConfig {
   [key: string]: Record<string, unknown> | undefined
 }
 
-/** Stable JSON for structural comparison — sorts object keys recursively. */
+/**
+ * Stable JSON for structural comparison — sorts object keys recursively.
+ *
+ * Scope: only handles strings and plain nested objects. That is the entire
+ * shape produced by `buildServerConfig` across every editor in
+ * `EDITOR_CONFIGS` (type/url/headers/etc — no arrays, no null, no numbers).
+ * If a future server config grows new value types, extend this here.
+ */
 function canonical(value: unknown): string {
-  if (value === null || typeof value !== 'object') return JSON.stringify(value)
-  if (Array.isArray(value)) return `[${value.map((v) => canonical(v)).join(',')}]`
+  if (typeof value !== 'object' || value === null) return JSON.stringify(value)
   const record = value as Record<string, unknown>
   const entries = Object.keys(record)
     .toSorted()

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.create-new-project.test.ts
@@ -350,6 +350,7 @@ describe('#init: create new project', () => {
       alreadyConfiguredEditors: ['VS Code'],
       configuredEditors: [],
       detectedEditors: ['VS Code'],
+      removedEditors: [],
       skipped: true,
     })
 
@@ -401,6 +402,7 @@ describe('#init: create new project', () => {
       alreadyConfiguredEditors: ['VS Code', 'Cursor'],
       configuredEditors: [],
       detectedEditors: ['VS Code', 'Cursor'],
+      removedEditors: [],
       skipped: true,
     })
 

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -496,11 +496,14 @@ describe('#mcp:configure', () => {
   // Token lifecycle
   // -------------------------------------------------------------------------
 
-  test('skips prompt when all configured editors have valid auth', async () => {
+  test('rewrites an oauthOnly editor whose existing config still has a stale bearer header', async () => {
     mockExistsSync.mockImplementation((path: PathLike) => {
       return String(path).includes('.cursor')
     })
 
+    // Cursor is oauthOnly today, but the existing config has a stale bearer
+    // header from a previous CLI version. The shape no longer matches what
+    // we'd write, so the file should be rewritten without the header.
     mockReadFile.mockResolvedValue(
       JSON.stringify({
         mcpServers: {
@@ -521,14 +524,19 @@ describe('#mcp:configure', () => {
       name: 'Test User',
     })
 
+    mockCheckbox.mockResolvedValue(['Cursor'])
+
     const {stdout} = await testCommand(ConfigureMcpCommand, [])
 
-    // Should NOT prompt the user — everything is already configured
-    expect(mockCheckbox).not.toHaveBeenCalled()
-    expect(stdout).toContain('All detected editors are already configured')
+    expect(mockCheckbox).toHaveBeenCalled()
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    const written = mockWriteFile.mock.calls[0]?.[1] as string
+    expect(written).not.toContain('Bearer')
+    expect(written).not.toContain('Authorization')
+    expect(stdout).toContain('MCP configured for Cursor')
   })
 
-  test('skips prompt for oauthOnly editor configured without a bearer token', async () => {
+  test('leaves an oauthOnly configured editor untouched when user accepts the default selection', async () => {
     mockExistsSync.mockImplementation((path: PathLike) => {
       return String(path).includes('.cursor')
     })
@@ -547,9 +555,12 @@ describe('#mcp:configure', () => {
 
     // No /users/me mock — oauthOnly editors with no token skip validation entirely
 
+    mockCheckbox.mockResolvedValue(['Cursor'])
+
     const {stdout} = await testCommand(ConfigureMcpCommand, [])
 
-    expect(mockCheckbox).not.toHaveBeenCalled()
+    expect(mockCheckbox).toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
     expect(stdout).toContain('All detected editors are already configured')
   })
 

--- a/packages/@sanity/cli/src/commands/mcp/configure.ts
+++ b/packages/@sanity/cli/src/commands/mcp/configure.ts
@@ -45,6 +45,7 @@ export class ConfigureMcpCommand extends SanityCommand<typeof ConfigureMcpComman
       trace.log({
         configuredEditors: mcpResult.configuredEditors,
         detectedEditors: mcpResult.detectedEditors,
+        removedEditors: mcpResult.removedEditors,
       })
 
       if (mcpResult.error) {

--- a/packages/@sanity/cli/src/telemetry/init.telemetry.ts
+++ b/packages/@sanity/cli/src/telemetry/init.telemetry.ts
@@ -83,6 +83,7 @@ interface SelectPackageManagerStep {
 interface MCPSetupStep {
   configuredEditors: EditorName[]
   detectedEditors: EditorName[]
+  removedEditors: EditorName[]
   skipped: boolean
   step: 'mcpSetup'
 }

--- a/packages/@sanity/cli/src/telemetry/mcp.telemetry.ts
+++ b/packages/@sanity/cli/src/telemetry/mcp.telemetry.ts
@@ -5,6 +5,7 @@ import {type EditorName} from '../actions/mcp/editorConfigs.js'
 interface MCPConfigureTraceData {
   configuredEditors: EditorName[]
   detectedEditors: EditorName[]
+  removedEditors: EditorName[]
 }
 
 export const MCPConfigureTrace = defineTrace<MCPConfigureTraceData>({


### PR DESCRIPTION
### Description

MCP setup treats the user's selection as the desired final state. The prompt shows every detected editor, pre-checked when already configured. Selected editors get written, deselected editors that previously had a Sanity entry get it removed. Auto mode behaves the same with everything selected.

`writeMCPConfig` returns whether it wrote. Same-shape configs are skipped (structural comparison), including stale bearer headers on editors that are now `oauthOnly`. Per-editor failures log a warning and the loop continues. `removedEditors` is added to init and `mcp configure` telemetry.

Closes AIGRO-4989.

### Testing

- `CLAUDECODE=1 pnpm test packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts`
- `CLAUDECODE=1 pnpm test packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts`
- `pnpm check:types`
- `pnpm check:lint`
- `pnpm check:deps`
- `pnpm build:cli`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes MCP setup orchestration to rewrite and delete editor config entries, which could inadvertently modify user config files if edge cases in JSON/TOML parsing or config-key handling are missed.
> 
> **Overview**
> **MCP configuration is now source-of-truth driven by the user’s selection.** The MCP prompt shows *all* detected editors, pre-checks those already configured, returns an empty selection instead of `null`, and `setupMCP` now removes the Sanity MCP entry from editors that were previously configured but are deselected.
> 
> `writeMCPConfig` now returns whether it actually wrote, skipping no-op rewrites via a structural comparison of the existing Sanity entry; `setupMCP` reports these as `alreadyConfiguredEditors` and continues on per-editor write/remove failures while collecting a first error.
> 
> Adds `removedEditors` to init + `mcp configure` telemetry/tracing, introduces `removeMCPConfig` for JSONC/TOML config removal, and includes a changeset for the CLI patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43a2b68f638c453a21ca62913c6c5323c864799f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->