### PR TITLE
fix(mcp): use oauth for client configs

### DIFF
--- a/.changeset/mcp-configure-oauth-only.md
+++ b/.changeset/mcp-configure-oauth-only.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+`sanity mcp configure` now writes OAuth MCP configs without bearer tokens.

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
@@ -52,6 +52,17 @@ describe('buildServerConfig', () => {
     })
   })
 
+  test('all editors use OAuth config without auth credentials by default', () => {
+    for (const name of Object.keys(EDITOR_CONFIGS) as Array<keyof typeof EDITOR_CONFIGS>) {
+      const config = EDITOR_CONFIGS[name].buildServerConfig()
+      const hasAuth =
+        (config.headers as Record<string, string> | undefined)?.Authorization ||
+        (config.http_headers as Record<string, string> | undefined)?.Authorization
+
+      expect(hasAuth, `${name} should not include auth credentials`).toBeUndefined()
+    }
+  })
+
   test('Claude Code config includes Authorization header with token', () => {
     const config = EDITOR_CONFIGS['Claude Code'].buildServerConfig(testToken)
 
@@ -82,13 +93,14 @@ describe('buildServerConfig', () => {
     })
   })
 
-  test('all editors except Cursor include auth credentials', () => {
+  test('all editors can include auth credentials when a token is provided', () => {
     const editorsWithToken = [
       'Antigravity',
       'Claude Code',
       'Cline',
       'Cline CLI',
       'Codex CLI',
+      'Cursor',
       'Gemini CLI',
       'GitHub Copilot CLI',
       'MCPorter',

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/promptForMCPSetup.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/promptForMCPSetup.test.ts
@@ -36,8 +36,8 @@ describe('promptForMCPSetup', () => {
     )
   })
 
-  test('preselects editors that are already configured', async () => {
-    mockCheckbox.mockResolvedValue(['Cursor'])
+  test('preselects configured editors and labels them as configured', async () => {
+    mockCheckbox.mockResolvedValue(['Cursor', 'VS Code', 'Claude Code'])
 
     const editors = [
       makeEditor({
@@ -46,6 +46,13 @@ describe('promptForMCPSetup', () => {
         existingToken: 'token',
         name: 'Cursor',
       }),
+      makeEditor({
+        authStatus: 'unauthorized',
+        configured: true,
+        existingToken: 'old',
+        name: 'VS Code',
+      }),
+      makeEditor({configured: true, name: 'Claude Code'}),
     ]
     await promptForMCPSetup(editors)
 
@@ -58,52 +65,17 @@ describe('promptForMCPSetup', () => {
             name: 'Cursor',
             value: 'Cursor',
           },
-        ],
-      }),
-    )
-  })
-
-  test('labels editors with expired auth as "(auth expired)"', async () => {
-    mockCheckbox.mockResolvedValue(['Cursor'])
-
-    const editors = [
-      makeEditor({
-        authStatus: 'unauthorized',
-        configured: true,
-        existingToken: 'old',
-        name: 'Cursor',
-      }),
-    ]
-    await promptForMCPSetup(editors)
-
-    expect(mockCheckbox).toHaveBeenCalledWith(
-      expect.objectContaining({
-        choices: [
           {
             checked: true,
-            description: 'Auth expired. Keep selected to refresh the configuration.',
-            name: 'Cursor (auth expired)',
-            value: 'Cursor',
-          },
-        ],
-      }),
-    )
-  })
-
-  test('labels configured editors without token as "(missing credentials)"', async () => {
-    mockCheckbox.mockResolvedValue(['VS Code'])
-
-    const editors = [makeEditor({configured: true, name: 'VS Code'})]
-    await promptForMCPSetup(editors)
-
-    expect(mockCheckbox).toHaveBeenCalledWith(
-      expect.objectContaining({
-        choices: [
-          {
-            checked: true,
-            description: 'Missing credentials. Keep selected to update the configuration.',
-            name: 'VS Code (missing credentials)',
+            description: 'Configured',
+            name: 'VS Code',
             value: 'VS Code',
+          },
+          {
+            checked: true,
+            description: 'Configured',
+            name: 'Claude Code',
+            value: 'Claude Code',
           },
         ],
       }),

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts
@@ -5,7 +5,6 @@ import {setupMCP} from '../setupMCP.js'
 const mockDetectAvailableEditors = vi.hoisted(() => vi.fn())
 const mockPromptForMCPSetup = vi.hoisted(() => vi.fn())
 const mockValidateEditorTokens = vi.hoisted(() => vi.fn())
-const mockCreateMCPToken = vi.hoisted(() => vi.fn())
 const mockWriteMCPConfig = vi.hoisted(() => vi.fn())
 const mockRemoveMCPConfig = vi.hoisted(() => vi.fn())
 
@@ -22,7 +21,6 @@ vi.mock('../validateEditorTokens.js', () => ({
 }))
 
 vi.mock('../../../services/mcp.js', () => ({
-  createMCPToken: mockCreateMCPToken,
   MCP_SERVER_URL: 'https://mcp.sanity.io',
 }))
 
@@ -38,7 +36,6 @@ function setupPromptedEditors(editors: unknown[]): void {
   mockDetectAvailableEditors.mockResolvedValue(editors)
   mockValidateEditorTokens.mockResolvedValue(undefined)
   mockPromptForMCPSetup.mockResolvedValue(editors)
-  mockCreateMCPToken.mockResolvedValue('test-token')
   mockWriteMCPConfig.mockResolvedValue(undefined)
 }
 
@@ -73,10 +70,9 @@ describe('setupMCP', () => {
     const result = await setupMCP({mode: 'auto'})
 
     expect(mockPromptForMCPSetup).not.toHaveBeenCalled()
-    expect(mockCreateMCPToken).not.toHaveBeenCalled()
     expect(mockWriteMCPConfig).toHaveBeenCalledTimes(2)
-    expect(mockWriteMCPConfig).toHaveBeenCalledWith(editors[0], 'existing-token')
-    expect(mockWriteMCPConfig).toHaveBeenCalledWith(editors[1], 'existing-token')
+    expect(mockWriteMCPConfig).toHaveBeenCalledWith(editors[0])
+    expect(mockWriteMCPConfig).toHaveBeenCalledWith(editors[1])
     expect(result.configuredEditors).toEqual(['Claude Code', 'VS Code'])
     expect(result.skipped).toBe(false)
   })
@@ -128,10 +124,9 @@ describe('setupMCP', () => {
     const result = await setupMCP({mode: 'prompt'})
 
     expect(mockPromptForMCPSetup).toHaveBeenCalledWith(editors)
-    expect(mockCreateMCPToken).not.toHaveBeenCalled()
     expect(mockWriteMCPConfig).toHaveBeenCalledTimes(2)
-    expect(mockWriteMCPConfig).toHaveBeenCalledWith(editors[0], 'reusable-token')
-    expect(mockWriteMCPConfig).toHaveBeenCalledWith(editors[1], 'reusable-token')
+    expect(mockWriteMCPConfig).toHaveBeenCalledWith(editors[0])
+    expect(mockWriteMCPConfig).toHaveBeenCalledWith(editors[1])
     expect(mockRemoveMCPConfig).not.toHaveBeenCalled()
     expect(result.configuredEditors).toEqual(['VS Code', 'Gemini CLI'])
   })
@@ -148,14 +143,12 @@ describe('setupMCP', () => {
     mockDetectAvailableEditors.mockResolvedValue(editors)
     mockValidateEditorTokens.mockResolvedValue(undefined)
     mockPromptForMCPSetup.mockResolvedValue([vscode])
-    mockCreateMCPToken.mockResolvedValue('new-token')
     mockWriteMCPConfig.mockResolvedValue(undefined)
     mockRemoveMCPConfig.mockResolvedValue(undefined)
 
     const result = await setupMCP({mode: 'prompt'})
 
-    expect(mockCreateMCPToken).toHaveBeenCalledTimes(1)
-    expect(mockWriteMCPConfig).toHaveBeenCalledWith(vscode, 'new-token')
+    expect(mockWriteMCPConfig).toHaveBeenCalledWith(vscode)
     expect(mockRemoveMCPConfig).toHaveBeenCalledWith(cursor)
     expect(result.configuredEditors).toEqual(['VS Code'])
     expect(result.removedEditors).toEqual(['Cursor'])

--- a/packages/@sanity/cli/src/actions/mcp/detectAvailableEditors.ts
+++ b/packages/@sanity/cli/src/actions/mcp/detectAvailableEditors.ts
@@ -19,6 +19,26 @@ interface MCPConfig {
   [key: string]: Record<string, unknown> | undefined
 }
 
+function isConfigObject(value: unknown): value is MCPConfig {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseTomlConfig(content: string): MCPConfig | null {
+  try {
+    const parsed = parseToml(content)
+    return isConfigObject(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function parseJsoncConfig(content: string): MCPConfig | null {
+  const errors: ParseError[] = []
+  const parsed = parseJsonc(content, errors, {allowTrailingComma: true})
+
+  return errors.length === 0 && isConfigObject(parsed) ? parsed : null
+}
+
 /**
  * Safely parse config file content
  * Returns parsed config or null if unparseable
@@ -29,27 +49,32 @@ function parseConfig(content: string, format: 'jsonc' | 'toml'): MCPConfig | nul
     return {} // Empty file - safe to write, treat as empty config
   }
 
-  if (format === 'toml') {
-    try {
-      const parsed = parseToml(content)
-      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-        return null
-      }
+  return format === 'toml' ? parseTomlConfig(content) : parseJsoncConfig(content)
+}
 
-      return parsed as MCPConfig
-    } catch {
-      return null
+async function readConfig(
+  name: EditorName,
+  configPath: string,
+  format: 'jsonc' | 'toml',
+): Promise<MCPConfig | null> {
+  try {
+    const content = await fs.readFile(configPath, 'utf8')
+    const config = parseConfig(content, format)
+    if (config === null) {
+      debug('Skipping %s: could not parse %s', name, configPath)
     }
+    return config
+  } catch (err) {
+    debug('Skipping %s: could not read %s: %s', name, configPath, err)
+    return null
   }
+}
 
-  const errors: ParseError[] = []
-  const parsed = parseJsonc(content, errors, {allowTrailingComma: true})
-
-  if (errors.length > 0 || typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-    return null // Parse failed
-  }
-
-  return parsed as MCPConfig
+function readExistingToken(
+  sanityConfig: unknown,
+  readToken: (serverConfig: Record<string, unknown>) => string | undefined,
+): string | undefined {
+  return isConfigObject(sanityConfig) ? readToken(sanityConfig) : undefined
 }
 
 /**
@@ -60,41 +85,23 @@ function parseConfig(content: string, format: 'jsonc' | 'toml'): MCPConfig | nul
 async function checkEditorConfig(name: EditorName, configPath: string): Promise<Editor | null> {
   const {configKey, format, readToken} = EDITOR_CONFIGS[name]
 
-  // Config file doesn't exist - can create it
   if (!existsSync(configPath)) {
     return {configPath, configured: false, name}
   }
 
-  // Config exists - try to parse it
-  try {
-    const content = await fs.readFile(configPath, 'utf8')
-    const config = parseConfig(content, format)
-
-    if (config === null) {
-      debug('Skipping %s: could not parse %s', name, configPath)
-      return null // Can't parse - skip this editor
-    }
-
-    // Check if Sanity MCP is already configured
-    const sanityConfig = config[configKey]?.Sanity
-    const configured = Boolean(sanityConfig)
-
-    // Extract existing token if configured
-    let existingToken: string | undefined
-    if (configured && typeof sanityConfig === 'object' && sanityConfig !== null) {
-      existingToken = readToken(sanityConfig as Record<string, unknown>)
-    }
-
-    const {oauthOnly} = EDITOR_CONFIGS[name]
-    if (configured && !existingToken && oauthOnly) {
-      return {authStatus: 'valid', configPath, configured, name}
-    }
-
-    return {configPath, configured, existingToken, name}
-  } catch (err) {
-    debug('Skipping %s: could not read %s: %s', name, configPath, err)
+  const config = await readConfig(name, configPath, format)
+  if (config === null) {
     return null
   }
+
+  const sanityConfig = config[configKey]?.Sanity
+  const configured = Boolean(sanityConfig)
+  const existingToken = readExistingToken(sanityConfig, readToken)
+  if (configured && !existingToken) {
+    return {authStatus: 'valid', configPath, configured, name}
+  }
+
+  return {configPath, configured, existingToken, name}
 }
 
 /**

--- a/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
+++ b/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
@@ -33,17 +33,14 @@ export function createDetectionEnv(): DetectionEnv {
 }
 
 interface EditorConfig {
-  /** Builds the server config with API token. If oauthOnly is true, the token is not used */
-  buildServerConfig: (token: string) => Record<string, unknown>
+  /** Builds the server config, optionally with an API token. */
+  buildServerConfig: (token?: string) => Record<string, unknown>
   configKey: string
   /** Returns the config file path if editor is detected, null otherwise */
   detect: (env: DetectionEnv) => Promise<string | null>
   format: 'jsonc' | 'toml'
   /** Extracts the auth token from a parsed Sanity server config block */
   readToken: (serverConfig: Record<string, unknown>) => string | undefined
-
-  /** If true, this editor uses OAuth natively and does not need an embedded API token */
-  oauthOnly?: boolean
 }
 
 /**
@@ -228,57 +225,70 @@ const EDITOR_DEFAULTS = {
   buildServerConfig: defaultHttpConfig,
   configKey: 'mcpServers',
   format: 'jsonc' as const,
-  oauthOnly: false,
   readToken: readTokenFromHeaders,
 }
 
-function buildAntigravityServerConfig(token: string): Record<string, unknown> {
-  return {
-    headers: {Authorization: `Bearer ${token}`},
-    serverUrl: MCP_SERVER_URL,
-  }
+function buildAntigravityServerConfig(token?: string): Record<string, unknown> {
+  return token
+    ? {headers: {Authorization: `Bearer ${token}`}, serverUrl: MCP_SERVER_URL}
+    : {serverUrl: MCP_SERVER_URL}
 }
 
-function buildClineServerConfig(token: string): Record<string, unknown> {
-  return {
+function buildClineServerConfig(token?: string): Record<string, unknown> {
+  const config: Record<string, unknown> = {
     disabled: false,
-    headers: {Authorization: `Bearer ${token}`},
     type: 'streamableHttp',
     url: MCP_SERVER_URL,
   }
+  if (token) {
+    config.headers = {Authorization: `Bearer ${token}`}
+  }
+  return config
 }
 
-function buildCodexCliServerConfig(token: string): Record<string, unknown> {
-  return {
-    http_headers: {Authorization: `Bearer ${token}`},
+function buildCodexCliServerConfig(token?: string): Record<string, unknown> {
+  const config: Record<string, unknown> = {
     type: 'http',
     url: MCP_SERVER_URL,
   }
+  if (token) {
+    config.http_headers = {Authorization: `Bearer ${token}`}
+  }
+  return config
 }
 
-function buildGitHubCopilotCliServerConfig(token: string): Record<string, unknown> {
-  return {
-    headers: {Authorization: `Bearer ${token}`},
+function buildGitHubCopilotCliServerConfig(token?: string): Record<string, unknown> {
+  const config: Record<string, unknown> = {
     tools: ['*'],
     type: 'http',
     url: MCP_SERVER_URL,
   }
+  if (token) {
+    config.headers = {Authorization: `Bearer ${token}`}
+  }
+  return config
 }
 
-function buildOpenCodeServerConfig(token: string): Record<string, unknown> {
-  return {
-    headers: {Authorization: `Bearer ${token}`},
+function buildOpenCodeServerConfig(token?: string): Record<string, unknown> {
+  const config: Record<string, unknown> = {
     type: 'remote',
     url: MCP_SERVER_URL,
   }
+  if (token) {
+    config.headers = {Authorization: `Bearer ${token}`}
+  }
+  return config
 }
 
-function buildZedServerConfig(token: string): Record<string, unknown> {
-  return {
-    headers: {Authorization: `Bearer ${token}`},
+function buildZedServerConfig(token?: string): Record<string, unknown> {
+  const config: Record<string, unknown> = {
     settings: {},
     url: MCP_SERVER_URL,
   }
+  if (token) {
+    config.headers = {Authorization: `Bearer ${token}`}
+  }
+  return config
 }
 
 /**
@@ -321,11 +331,7 @@ export const EDITOR_CONFIGS = {
   },
   // Doc: https://docs.cursor.com/context/model-context-protocol
   // Path: ~/.cursor/mcp.json  Key: mcpServers
-  Cursor: {
-    ...EDITOR_DEFAULTS,
-    detect: detectCursor,
-    oauthOnly: true,
-  },
+  Cursor: {...EDITOR_DEFAULTS, detect: detectCursor},
   // Doc: https://googlegemini.wiki/gemini-cli/mcp-servers
   // Path: ~/.gemini/settings.json  Key: mcpServers
   'Gemini CLI': {...EDITOR_DEFAULTS, detect: detectGeminiCli},

--- a/packages/@sanity/cli/src/actions/mcp/promptForMCPSetup.ts
+++ b/packages/@sanity/cli/src/actions/mcp/promptForMCPSetup.ts
@@ -1,27 +1,14 @@
 import {checkbox} from '@sanity/cli-core/ux'
 
-import {EDITOR_CONFIGS} from './editorConfigs.js'
 import {type Editor} from './types.js'
 
 function getEditorLabel(editor: Editor): string {
-  if (editor.configured && editor.authStatus === 'unauthorized') {
-    return `${editor.name} (auth expired)`
-  }
-  if (editor.configured && !editor.existingToken && !EDITOR_CONFIGS[editor.name].oauthOnly) {
-    return `${editor.name} (missing credentials)`
-  }
   return editor.name
 }
 
 function getEditorDescription(editor: Editor): string {
   if (!editor.configured) {
     return 'Not configured'
-  }
-  if (editor.authStatus === 'unauthorized') {
-    return 'Auth expired. Keep selected to refresh the configuration.'
-  }
-  if (!editor.existingToken && !EDITOR_CONFIGS[editor.name].oauthOnly) {
-    return 'Missing credentials. Keep selected to update the configuration.'
   }
   return 'Configured'
 }

--- a/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
+++ b/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
@@ -2,10 +2,10 @@ import {ux} from '@oclif/core'
 import {subdebug} from '@sanity/cli-core'
 import {logSymbols} from '@sanity/cli-core/ux'
 
-import {createMCPToken, MCP_SERVER_URL} from '../../services/mcp.js'
+import {MCP_SERVER_URL} from '../../services/mcp.js'
 import {toError} from '../../util/getErrorMessage.js'
 import {detectAvailableEditors} from './detectAvailableEditors.js'
-import {EDITOR_CONFIGS, type EditorName} from './editorConfigs.js'
+import {type EditorName} from './editorConfigs.js'
 import {promptForMCPSetup} from './promptForMCPSetup.js'
 import {removeMCPConfig} from './removeMCPConfig.js'
 import {type Editor} from './types.js'
@@ -43,25 +43,10 @@ interface MCPSetupResult {
   removedEditors?: EditorName[]
 }
 
-async function getTokenForConfiguration(editorsToConfigure: Editor[]): Promise<string | undefined> {
-  const validEditor = editorsToConfigure.find((e) => e.authStatus === 'valid' && e.existingToken)
-  if (validEditor?.existingToken) {
-    mcpDebug('Reusing valid token from %s', validEditor.name)
-    return validEditor.existingToken
-  }
-
-  const allOAuth = editorsToConfigure.every((e) => EDITOR_CONFIGS[e.name].oauthOnly)
-  if (editorsToConfigure.length === 0 || allOAuth) {
-    return undefined
-  }
-
-  return createMCPToken()
-}
-
-async function writeMCPConfigs(editors: Editor[], token?: string): Promise<EditorName[]> {
+async function writeMCPConfigs(editors: Editor[]): Promise<EditorName[]> {
   const configuredEditors: EditorName[] = []
   for (const editor of editors) {
-    await writeMCPConfig(editor, token)
+    await writeMCPConfig(editor)
     configuredEditors.push(editor.name)
   }
   return configuredEditors
@@ -133,26 +118,9 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
     }
   }
 
-  let token: string | undefined
-  try {
-    token = await getTokenForConfiguration(editorsToConfigure)
-  } catch (error) {
-    const err = toError(error)
-    mcpDebug('Error creating MCP token', error)
-    ux.warn(`Could not configure MCP: ${err.message}`)
-    ux.warn('You can set up MCP manually later using https://mcp.sanity.io')
-    return {
-      configuredEditors: [],
-      detectedEditors,
-      error: err,
-      removedEditors: [],
-      skipped: false,
-    }
-  }
-
   let configuredEditors: EditorName[] = []
   try {
-    configuredEditors = await writeMCPConfigs(editorsToConfigure, token)
+    configuredEditors = await writeMCPConfigs(editorsToConfigure)
   } catch (error) {
     const err = toError(error)
     mcpDebug('Error writing MCP config', error)

--- a/packages/@sanity/cli/src/actions/mcp/writeMCPConfig.ts
+++ b/packages/@sanity/cli/src/actions/mcp/writeMCPConfig.ts
@@ -20,8 +20,8 @@ interface TomlConfig {
  */
 export async function writeMCPConfig(editor: Editor, token?: string): Promise<void> {
   const configPath = editor.configPath
-  const {buildServerConfig, configKey, format, oauthOnly} = EDITOR_CONFIGS[editor.name]
-  const serverConfig = oauthOnly ? buildServerConfig('') : buildServerConfig(token!)
+  const {buildServerConfig, configKey, format} = EDITOR_CONFIGS[editor.name]
+  const serverConfig = buildServerConfig(token)
 
   // Read existing content or start with empty object/document
   let content = format === 'toml' ? '' : '{}'

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -85,10 +85,8 @@ interface EditorTestCase {
   /** Editor name as it appears in EDITOR_CONFIGS */
   name: string
 
-  /** Extra substrings the written content must contain (beyond the token) */
+  /** Extra substrings the written content must contain */
   expectedContentChecks?: string[]
-  /** If true, this editor uses OAuth natively and does not need an embedded API token */
-  oauthOnly?: boolean
   /** Only run on this platform (skipped otherwise) */
   platform?: NodeJS.Platform
 }
@@ -129,84 +127,22 @@ function mockClaudeCodeDetected(): void {
   }) as never)
 }
 
-/** Shared helper: sets up mocks, runs command, asserts outputs for a single editor. */
-async function runEditorTest(tc: EditorTestCase): Promise<void> {
+function applyPlatformOverride(platform?: NodeJS.Platform): () => void {
+  if (!platform) return () => undefined
   const originalPlatform = process.platform
+  Object.defineProperty(process, 'platform', {value: platform})
+  return () => Object.defineProperty(process, 'platform', {value: originalPlatform})
+}
+
+function applyEnvOverrides(env?: Record<string, string>): () => void {
   const envBackups: Record<string, string | undefined> = {}
 
-  try {
-    // Platform override
-    if (tc.detect.overridePlatform) {
-      Object.defineProperty(process, 'platform', {value: tc.detect.overridePlatform})
-    }
+  for (const [key, value] of Object.entries(env ?? {})) {
+    envBackups[key] = process.env[key]
+    process.env[key] = value
+  }
 
-    // Env var overrides
-    if (tc.detect.env) {
-      for (const [key, value] of Object.entries(tc.detect.env)) {
-        envBackups[key] = process.env[key]
-        process.env[key] = value
-      }
-    }
-
-    // existsSync mock
-    if (tc.detect.existsSync) {
-      const predicate = tc.detect.existsSync
-      mockExistsSync.mockImplementation((p: PathLike) => predicate(String(p)))
-    }
-
-    // CLI mock — resolve for specific commands, reject for everything else
-    if (tc.detect.cliCommands) {
-      const commands = tc.detect.cliCommands
-      mockExeca.mockImplementation((async (command: string | URL) => {
-        if (commands.includes(String(command))) return EXECA_SUCCESS
-        throw new Error('Not installed')
-      }) as never)
-    }
-
-    mockCheckbox.mockResolvedValue([tc.name])
-
-    const sessionId = `session-${tc.name.toLowerCase().replaceAll(/\s+/g, '-')}`
-    const token = `test-token-${tc.name.toLowerCase().replaceAll(/\s+/g, '-')}`
-
-    if (!tc.oauthOnly) {
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'post',
-        uri: '/auth/session/create',
-      }).reply(200, {id: sessionId, sid: sessionId})
-
-      mockApi({
-        apiVersion: MCP_API_VERSION,
-        method: 'get',
-        query: {sid: sessionId},
-        uri: '/auth/fetch',
-      }).reply(200, {label: 'MCP Token', token})
-    }
-
-    const {stdout} = await testCommand(ConfigureMcpCommand, [])
-
-    // Assert config was written to the expected path with the token
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining(convertToSystemPath(tc.expectedConfigPath)),
-      tc.oauthOnly ? expect.not.stringContaining(token) : expect.stringContaining(token),
-      'utf8',
-    )
-
-    // Assert extra content checks
-    if (tc.expectedContentChecks) {
-      const writtenContent = mockWriteFile.mock.calls[0]?.[1] as string
-      for (const check of tc.expectedContentChecks) {
-        expect(writtenContent, `written content should contain "${check}"`).toContain(check)
-      }
-    }
-
-    expect(stdout).toContain(`MCP configured for ${tc.name}`)
-  } finally {
-    // Restore platform
-    if (tc.detect.overridePlatform) {
-      Object.defineProperty(process, 'platform', {value: originalPlatform})
-    }
-    // Restore env vars
+  return () => {
     for (const [key, original] of Object.entries(envBackups)) {
       if (original === undefined) {
         delete process.env[key]
@@ -214,6 +150,55 @@ async function runEditorTest(tc: EditorTestCase): Promise<void> {
         process.env[key] = original
       }
     }
+  }
+}
+
+function mockEditorDetection(detect: EditorTestCase['detect']): void {
+  if (detect.existsSync) {
+    const predicate = detect.existsSync
+    mockExistsSync.mockImplementation((p: PathLike) => predicate(String(p)))
+  }
+
+  if (detect.cliCommands) {
+    const commands = detect.cliCommands
+    mockExeca.mockImplementation((async (command: string | URL) => {
+      if (commands.includes(String(command))) return EXECA_SUCCESS
+      throw new Error('Not installed')
+    }) as never)
+  }
+}
+
+function expectEditorConfigWritten(tc: EditorTestCase): void {
+  expect(mockWriteFile).toHaveBeenCalledWith(
+    expect.stringContaining(convertToSystemPath(tc.expectedConfigPath)),
+    expect.not.stringContaining('Authorization'),
+    'utf8',
+  )
+}
+
+function expectContentChecks(tc: EditorTestCase): void {
+  const writtenContent = mockWriteFile.mock.calls[0]?.[1] as string
+  for (const check of tc.expectedContentChecks ?? []) {
+    expect(writtenContent, `written content should contain "${check}"`).toContain(check)
+  }
+}
+
+/** Shared helper: sets up mocks, runs command, asserts outputs for a single editor. */
+async function runEditorTest(tc: EditorTestCase): Promise<void> {
+  const restorePlatform = applyPlatformOverride(tc.detect.overridePlatform)
+  const restoreEnv = applyEnvOverrides(tc.detect.env)
+
+  try {
+    mockEditorDetection(tc.detect)
+    mockCheckbox.mockResolvedValue([tc.name])
+    const {stdout} = await testCommand(ConfigureMcpCommand, [])
+
+    expectEditorConfigWritten(tc)
+    expectContentChecks(tc)
+    expect(stdout).toContain(`MCP configured for ${tc.name}`)
+  } finally {
+    restorePlatform()
+    restoreEnv()
   }
 }
 
@@ -226,7 +211,6 @@ const editorTestCases: EditorTestCase[] = [
     detect: {existsSync: (p) => p.endsWith('.cursor')},
     expectedConfigPath: '.cursor/mcp.json',
     name: 'Cursor',
-    oauthOnly: true,
   },
   {
     detect: {
@@ -350,7 +334,7 @@ const editorTestCases: EditorTestCase[] = [
   {
     detect: {cliCommands: ['codex']},
     expectedConfigPath: '.codex/config.toml',
-    expectedContentChecks: ['[mcp_servers.Sanity]', '[mcp_servers.Sanity.http_headers]'],
+    expectedContentChecks: ['[mcp_servers.Sanity]'],
     name: 'Codex CLI',
   },
   {
@@ -387,6 +371,16 @@ const editorTestCases: EditorTestCase[] = [
   },
 ]
 
+function existsForMCPorterFiles(options: {json: boolean; jsonc: boolean}): (p: string) => boolean {
+  return (p) => {
+    const n = p.replaceAll('\\', '/')
+    if (n.endsWith('/.mcporter')) return true
+    if (n.endsWith('/.mcporter/mcporter.json')) return options.json
+    if (n.endsWith('/.mcporter/mcporter.jsonc')) return options.jsonc
+    return false
+  }
+}
+
 // MCPorter has three variants for file format detection
 const mcporterTestCases: Array<{
   existsSync: (p: string) => boolean
@@ -394,35 +388,17 @@ const mcporterTestCases: Array<{
   label: string
 }> = [
   {
-    existsSync: (p) => {
-      const n = p.replaceAll('\\', '/')
-      if (n.endsWith('/.mcporter')) return true
-      if (n.endsWith('/.mcporter/mcporter.json')) return false
-      if (n.endsWith('/.mcporter/mcporter.jsonc')) return true
-      return false
-    },
+    existsSync: existsForMCPorterFiles({json: false, jsonc: true}),
     expectedConfigPath: '.mcporter/mcporter.jsonc',
     label: 'existing jsonc config',
   },
   {
-    existsSync: (p) => {
-      const n = p.replaceAll('\\', '/')
-      if (n.endsWith('/.mcporter')) return true
-      if (n.endsWith('/.mcporter/mcporter.json')) return true
-      if (n.endsWith('/.mcporter/mcporter.jsonc')) return false
-      return false
-    },
+    existsSync: existsForMCPorterFiles({json: true, jsonc: false}),
     expectedConfigPath: '.mcporter/mcporter.json',
     label: 'existing json config',
   },
   {
-    existsSync: (p) => {
-      const n = p.replaceAll('\\', '/')
-      if (n.endsWith('/.mcporter')) return true
-      if (n.endsWith('/.mcporter/mcporter.json')) return false
-      if (n.endsWith('/.mcporter/mcporter.jsonc')) return false
-      return false
-    },
+    existsSync: existsForMCPorterFiles({json: false, jsonc: false}),
     expectedConfigPath: '.mcporter/mcporter.json',
     label: 'fresh install (defaults to json)',
   },
@@ -555,13 +531,18 @@ describe('#mcp:configure', () => {
     expectConfiguredPrompt('Claude Code')
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining(convertToSystemPath('.claude.json')),
-      expect.stringContaining('existing-token'),
+      expect.not.stringContaining('existing-token'),
+      'utf8',
+    )
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining(convertToSystemPath('.claude.json')),
+      expect.not.stringContaining('Authorization'),
       'utf8',
     )
     expect(stdout).toContain('MCP configured for Claude Code')
   })
 
-  test('shows oauthOnly editor configured without a bearer token in the prompt', async () => {
+  test('shows OAuth editor configured without a bearer token in the prompt', async () => {
     mockExistsSync.mockImplementation((path: PathLike) => {
       return String(path).includes('.cursor')
     })
@@ -578,7 +559,7 @@ describe('#mcp:configure', () => {
       }),
     )
 
-    // No /users/me mock — oauthOnly editors with no token skip validation entirely
+    // No /users/me mock — OAuth configs with no token skip validation entirely
 
     mockCheckbox.mockResolvedValue(['Cursor'])
 
@@ -593,7 +574,7 @@ describe('#mcp:configure', () => {
     expect(stdout).toContain('MCP configured for Cursor')
   })
 
-  test('shows auth expired annotation when configured token is invalid', async () => {
+  test('shows legacy token configs as configured when token is invalid', async () => {
     mockExistsSync.mockImplementation((path: PathLike) => {
       return String(path).includes('.cursor')
     })
@@ -621,16 +602,14 @@ describe('#mcp:configure', () => {
 
     mockCheckbox.mockResolvedValue(['Cursor'])
 
-    // Cursor is oauthOnly so no new token is created — config is rewritten without a token
-
     await testCommand(ConfigureMcpCommand, [])
 
     expect(mockCheckbox).toHaveBeenCalledWith({
       choices: [
         {
           checked: true,
-          description: 'Auth expired. Keep selected to refresh the configuration.',
-          name: 'Cursor (auth expired)',
+          description: 'Configured',
+          name: 'Cursor',
           value: 'Cursor',
         },
       ],
@@ -674,7 +653,7 @@ describe('#mcp:configure', () => {
     expect(stdout).toContain('MCP removed from Cursor')
   })
 
-  test('reuses valid token from another editor instead of creating new one', async () => {
+  test('does not reuse a valid legacy token when configuring OAuth clients', async () => {
     mockClaudeCodeDetected()
 
     // Detect both Claude Code (configured with valid token) and Gemini (unconfigured)
@@ -708,14 +687,16 @@ describe('#mcp:configure', () => {
     // User keeps Claude Code selected and adds Gemini CLI
     mockCheckbox.mockResolvedValue(['Claude Code', 'Gemini CLI'])
 
-    // NO /auth/session/create or /auth/fetch mocks — token should be reused
-
     const {stdout} = await testCommand(ConfigureMcpCommand, [])
 
-    // Should write config with the reused token
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining(convertToSystemPath('.gemini/settings.json')),
-      expect.stringContaining('valid-reusable-token'),
+      expect.not.stringContaining('valid-reusable-token'),
+      'utf8',
+    )
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining(convertToSystemPath('.gemini/settings.json')),
+      expect.not.stringContaining('Authorization'),
       'utf8',
     )
 
@@ -744,31 +725,18 @@ describe('#mcp:configure', () => {
 
     mockCheckbox.mockResolvedValue(['Cursor', 'VS Code'])
 
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-multi', sid: 'session-multi'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-multi'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'multi-token-123'})
-
     const {stdout} = await testCommand(ConfigureMcpCommand, [])
 
     expect(mockWriteFile).toHaveBeenCalledTimes(2)
 
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining(convertToSystemPath('.cursor/mcp.json')),
-      expect.not.stringContaining('multi-token-123'),
+      expect.not.stringContaining('Authorization'),
       'utf8',
     )
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining(convertToSystemPath('Code/User/mcp.json')),
-      expect.stringContaining('multi-token-123'),
+      expect.not.stringContaining('Authorization'),
       'utf8',
     )
 
@@ -780,25 +748,12 @@ describe('#mcp:configure', () => {
 
     mockClaudeCodeDetected()
 
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-ci', sid: 'session-ci'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-ci'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'test-token-ci'})
-
     const {stdout} = await testCommand(ConfigureMcpCommand, [])
 
     expect(mockCheckbox).not.toHaveBeenCalled()
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining('.claude.json'),
-      expect.stringContaining('test-token-ci'),
+      expect.not.stringContaining('Authorization'),
       'utf8',
     )
     expect(stdout).toContain('MCP configured for Claude Code')
@@ -808,41 +763,25 @@ describe('#mcp:configure', () => {
   // Error handling
   // -------------------------------------------------------------------------
 
-  test('handles token creation error gracefully', async () => {
+  test('configures OAuth clients without creating a token', async () => {
     mockClaudeCodeDetected()
 
     mockCheckbox.mockResolvedValue(['Claude Code'])
 
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(401, {message: 'Not authenticated'})
+    const {stdout} = await testCommand(ConfigureMcpCommand, [])
 
-    const {stderr} = await testCommand(ConfigureMcpCommand, [])
-
-    expect(stderr).toContain('Could not configure MCP')
-    expect(stderr).toContain('https://mcp.sanity.io')
-    expect(mockWriteFile).not.toHaveBeenCalled()
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining('.claude.json'),
+      expect.not.stringContaining('Authorization'),
+      'utf8',
+    )
+    expect(stdout).toContain('MCP configured for Claude Code')
   })
 
   test('handles file write error gracefully', async () => {
     mockClaudeCodeDetected()
 
     mockCheckbox.mockResolvedValue(['Claude Code'])
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-write-error', sid: 'session-write-error'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-write-error'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'token-write-error'})
 
     mockWriteFile.mockRejectedValue(new Error('Permission denied'))
 
@@ -898,19 +837,6 @@ describe('#mcp:configure', () => {
 
     mockCheckbox.mockResolvedValue(['Claude Code'])
 
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'post',
-      uri: '/auth/session/create',
-    }).reply(200, {id: 'session-merge', sid: 'session-merge'})
-
-    mockApi({
-      apiVersion: MCP_API_VERSION,
-      method: 'get',
-      query: {sid: 'session-merge'},
-      uri: '/auth/fetch',
-    }).reply(200, {label: 'MCP Token', token: 'merge-token-123'})
-
     await testCommand(ConfigureMcpCommand, [])
 
     expect(mockWriteFile).toHaveBeenCalledWith(
@@ -921,6 +847,11 @@ describe('#mcp:configure', () => {
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('Sanity'),
+      'utf8',
+    )
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.stringContaining('Authorization'),
       'utf8',
     )
   })

--- a/packages/@sanity/cli/src/services/mcp.ts
+++ b/packages/@sanity/cli/src/services/mcp.ts
@@ -12,38 +12,6 @@ interface PostInitPromptResponse {
 }
 
 /**
- * Create a child token for MCP usage
- * This token is tied to the parent CLI token and will be invalidated
- * when the parent token is invalidated (e.g., on logout)
- *
- * @returns The MCP token string
- * @internal
- */
-export async function createMCPToken(): Promise<string> {
-  const client = await getGlobalCliClient({
-    apiVersion: MCP_API_VERSION,
-    requireUser: true,
-  })
-
-  const sessionResponse = await client.request<{id: string; sid: string}>({
-    body: {
-      sourceId: 'sanity-mcp',
-      withStamp: false,
-    },
-    method: 'POST',
-    uri: '/auth/session/create',
-  })
-
-  const tokenResponse = await client.request<{label: string; token: string}>({
-    method: 'GET',
-    query: {sid: sessionResponse.sid},
-    uri: '/auth/fetch',
-  })
-
-  return tokenResponse.token
-}
-
-/**
  * Validate an MCP token by checking it against the Sanity API.
  *
  * MCP tokens are standard Sanity session tokens (`sk…`), so we validate


### PR DESCRIPTION
### Description

Updates `sanity mcp configure` to write OAuth MCP configs without bearer tokens. The config builders and `writeMCPConfig(editor, token?)` still support token-based configs if a future path needs to pass one explicitly, but the current configure flow no longer creates or passes bearer tokens.

### What to review

Review the MCP setup and config-writing path, especially that selected clients are written without `Authorization` headers while legacy token configs are overwritten with OAuth config.

### Testing

- `CLAUDECODE=1 pnpm test packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts packages/@sanity/cli/src/actions/mcp/__tests__/promptForMCPSetup.test.ts packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts`
- `CLAUDECODE=1 pnpm test packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts packages/@sanity/cli/src/actions/mcp/__tests__/validateEditorTokens.test.ts`
- `pnpm dlx fallow audit --base HEAD`
- `pnpm check:types`
- `pnpm check:lint`
- `pnpm build:cli`
- `pnpm check:deps`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `sanity mcp configure` flow to stop minting/reusing bearer tokens and to overwrite existing token-based configs with OAuth-only configs, which could affect users relying on embedded credentials. Risk is limited to MCP editor configuration files and related CLI UX/test logic.
> 
> **Overview**
> `sanity mcp configure` now **always writes OAuth MCP server configs without `Authorization` headers**, removing the token creation/reuse path and stripping legacy bearer-token configs when rewriting editor settings.
> 
> Editor config builders were updated to accept an *optional* token (only adding auth headers when explicitly provided), editor detection treats configured entries without tokens as valid, and the setup prompt was simplified to just "Configured" vs "Not configured" (no expired/missing-credentials annotations). Tests were updated accordingly, and the unused `createMCPToken` service was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4680bad16f9378ac6700efe48232238d5052935f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->