### PR TITLE
fix(mcp): use oauth for claude code config

### DIFF
--- a/.changeset/claude-code-mcp-oauth-only.md
+++ b/.changeset/claude-code-mcp-oauth-only.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+`sanity mcp configure` now uses OAuth for Claude Code.

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
@@ -52,11 +52,10 @@ describe('buildServerConfig', () => {
     })
   })
 
-  test('Claude Code config includes Authorization header with token', () => {
-    const config = EDITOR_CONFIGS['Claude Code'].buildServerConfig(testToken)
+  test('Claude Code config uses OAuth (no Authorization header)', () => {
+    const config = EDITOR_CONFIGS['Claude Code'].buildServerConfig()
 
     expect(config).toStrictEqual({
-      headers: {Authorization: `Bearer ${testToken}`},
       type: 'http',
       url: 'https://mcp.sanity.io',
     })
@@ -82,10 +81,9 @@ describe('buildServerConfig', () => {
     })
   })
 
-  test('all editors except Cursor include auth credentials', () => {
+  test('all editors except Cursor and Claude Code include auth credentials', () => {
     const editorsWithToken = [
       'Antigravity',
-      'Claude Code',
       'Cline',
       'Cline CLI',
       'Codex CLI',

--- a/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
+++ b/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
@@ -298,7 +298,7 @@ export const EDITOR_CONFIGS = {
   },
   // Doc: https://docs.anthropic.com/en/docs/claude-code/mcp
   // Path: ~/.claude.json  Key: mcpServers
-  'Claude Code': {...EDITOR_DEFAULTS, detect: detectClaudeCode},
+  'Claude Code': {...EDITOR_DEFAULTS, detect: detectClaudeCode, oauthOnly: true},
   // Doc: https://github.com/cline/cline — VS Code extension (saoudrizwan.claude-dev)
   // Path: <VS Code User>/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json
   Cline: {...EDITOR_DEFAULTS, buildServerConfig: buildClineServerConfig, detect: detectCline},

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -701,7 +701,7 @@ describe('#mcp:configure', () => {
     mockIsInteractive.mockReturnValue(false)
 
     mockExeca.mockImplementation((async (command: string | URL) => {
-      if (command === 'claude') return EXECA_SUCCESS
+      if (command === 'opencode') return EXECA_SUCCESS
       throw new Error('Not installed')
     }) as never)
 
@@ -722,11 +722,11 @@ describe('#mcp:configure', () => {
 
     expect(mockCheckbox).not.toHaveBeenCalled()
     expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining('.claude.json'),
+      expect.stringContaining(convertToSystemPath('.config/opencode/opencode.json')),
       expect.stringContaining('test-token-ci'),
       'utf8',
     )
-    expect(stdout).toContain('MCP configured for Claude Code')
+    expect(stdout).toContain('MCP configured for OpenCode')
   })
 
   // -------------------------------------------------------------------------
@@ -735,11 +735,11 @@ describe('#mcp:configure', () => {
 
   test('handles token creation error gracefully', async () => {
     mockExeca.mockImplementation((async (command: string | URL) => {
-      if (command === 'claude') return EXECA_SUCCESS
+      if (command === 'opencode') return EXECA_SUCCESS
       throw new Error('Not installed')
     }) as never)
 
-    mockCheckbox.mockResolvedValue(['Claude Code'])
+    mockCheckbox.mockResolvedValue(['OpenCode'])
 
     mockApi({
       apiVersion: MCP_API_VERSION,
@@ -756,11 +756,11 @@ describe('#mcp:configure', () => {
 
   test('handles file write error gracefully', async () => {
     mockExeca.mockImplementation((async (command: string | URL) => {
-      if (command === 'claude') return EXECA_SUCCESS
+      if (command === 'opencode') return EXECA_SUCCESS
       throw new Error('Not installed')
     }) as never)
 
-    mockCheckbox.mockResolvedValue(['Claude Code'])
+    mockCheckbox.mockResolvedValue(['OpenCode'])
 
     mockApi({
       apiVersion: MCP_API_VERSION,
@@ -812,17 +812,17 @@ describe('#mcp:configure', () => {
 
   test('merges with existing config file', async () => {
     mockExeca.mockImplementation((async (command: string | URL) => {
-      if (command === 'claude') return EXECA_SUCCESS
+      if (command === 'opencode') return EXECA_SUCCESS
       throw new Error('Not installed')
     }) as never)
 
     mockExistsSync.mockImplementation((p: PathLike) => {
-      return String(p).endsWith('.claude.json')
+      return String(p).endsWith('opencode.json')
     })
 
     mockReadFile.mockResolvedValue(
       JSON.stringify({
-        mcpServers: {
+        mcp: {
           OtherServer: {
             type: 'stdio',
           },
@@ -830,7 +830,7 @@ describe('#mcp:configure', () => {
       }),
     )
 
-    mockCheckbox.mockResolvedValue(['Claude Code'])
+    mockCheckbox.mockResolvedValue(['OpenCode'])
 
     mockApi({
       apiVersion: MCP_API_VERSION,

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -245,6 +245,7 @@ const editorTestCases: EditorTestCase[] = [
     detect: {cliCommands: ['claude']},
     expectedConfigPath: '.claude.json',
     name: 'Claude Code',
+    oauthOnly: true,
   },
   {
     detect: {


### PR DESCRIPTION
### Description

Marks Claude Code as an OAuth-only MCP client (`oauthOnly: true`), so `sanity mcp configure` no longer embeds a Bearer token in the generated Claude Code config.

### What to review

One-line change in `editorConfigs.ts` and minimal test adjustments to match.

### Testing

Existing tests updated to reflect the new OAuth-only behavior for Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change that stops embedding Bearer tokens in the generated Claude Code MCP config, with test updates to validate the new OAuth-only behavior.
> 
> **Overview**
> **Claude Code MCP configuration is now OAuth-only.** `sanity mcp configure` marks `Claude Code` as `oauthOnly`, so generated configs no longer include an `Authorization: Bearer ...` header.
> 
> Tests were updated to reflect the new behavior (Claude Code now treated like Cursor for no-token configs), and configure-flow tests were adjusted to use another CLI editor where a token is still required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee742cbab2731851ffa458810de0bb5f2002205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->