### PR TITLE
fix(login): allow ctrl-c to cancel browser login

### DIFF
--- a/.changeset/pr-1126.md
+++ b/.changeset/pr-1126.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(login): allow ctrl-c to cancel browser login

--- a/packages/@sanity/cli/src/actions/auth/login/login.ts
+++ b/packages/@sanity/cli/src/actions/auth/login/login.ts
@@ -85,7 +85,10 @@ export async function login(options: LoginOptions) {
 
   output.log(`\n${actionText} ${loginUrl.href}\n`)
 
-  const spin = spinner('Waiting for browser login to complete... Press Ctrl + C to cancel').start()
+  const spin = spinner({
+    discardStdin: false, // dont swallow ctrl-c
+    text: 'Waiting for browser login to complete... Press Ctrl + C to cancel',
+  }).start()
 
   if (shouldLaunchBrowser) {
     open(loginUrl.href)


### PR DESCRIPTION
### Description

`sanity login` (browser-callback flow) used a spinner with ora's default `discardStdin: true`. The spinner text invites the user to cancel ("Press Ctrl + C to cancel"), but Ctrl+C did nothing.

This is a [documented ora gotcha](https://github.com/sindresorhus/ora/blob/main/readme.md). From the ora README:

> Note: `discardStdin` puts stdin into raw mode. In raw mode, `Ctrl+C` no longer generates `SIGINT` from the terminal. Ora re-emits `Ctrl+C` from stdin input, but if your code blocks the event loop with synchronous work, `Ctrl+C` handling is delayed until the blocking work ends. Use async APIs, a worker thread, or a child process to keep `Ctrl+C` responsive, or set `discardStdin` to `false`.

`discardStdin: false` is one of the two officially recommended workarounds. See also [ora#156 — ctrl + c not working](https://github.com/sindresorhus/ora/issues/156) (closed with no clean fix; the README note above is effectively the resolution).

In our specific case the re-emit path also breaks for a more interesting reason: `getProvider()` runs its own spinner immediately before this one (packages/@sanity/cli/src/actions/auth/login/getProvider.ts:44). Both spinners drive the same `stdin-discarder` singleton, and the back-to-back `start → stop → start` cycle leaves stdin in a state where the second spinner's data listener never sees the `0x03` byte. Adding any `process.stdin.on('data', …)` listener after the second spinner starts unsticks it — which is consistent with the TTY-state-corruption family of bugs around raw-mode toggling. Untangling that is out of scope here; `discardStdin: false` sidesteps the whole thing for this call site.

The same pattern (sequential spinners) likely affects other commands; we should sweep them in a follow-up.

### What to review

- `packages/@sanity/cli/src/actions/auth/login/login.ts` — one option added to the spinner.

### Testing

Manual:
1. `pnpm build:cli`
2. `./packages/@sanity/cli/bin/run.js login --provider google` (with or without `--no-open` — both reproduce)
3. Press Ctrl+C while the spinner is running → process exits cleanly.

Reverting the change reproduces the hang.

No new automated test — the bug depends on TTY/stdin raw-mode interaction that's awkward to simulate in unit tests.