### PR TITLE
chore(cli-test): exclude node_modules on Windows and tolerate dangling symlinks

### DIFF
--- a/packages/@sanity/cli-test/scripts/copy-fixtures.ts
+++ b/packages/@sanity/cli-test/scripts/copy-fixtures.ts
@@ -6,7 +6,7 @@
 
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 import {cp, mkdir, readFile, writeFile} from 'node:fs/promises'
-import {dirname, join, resolve} from 'node:path'
+import {basename, dirname, join, resolve} from 'node:path'
 
 import {parse as parseYaml} from 'yaml'
 
@@ -89,7 +89,7 @@ async function copyFixtures() {
     // Copy the fixture, excluding node_modules, .turbo and (unless specified) dist directories
     await cp(sourceDir, targetDir, {
       filter: (src) => {
-        const name = src.split('/').pop()
+        const name = basename(src)
         return (
           name !== 'node_modules' &&
           name !== '.turbo' &&

--- a/packages/@sanity/cli-test/src/test/testFixture.ts
+++ b/packages/@sanity/cli-test/src/test/testFixture.ts
@@ -158,7 +158,7 @@ export async function testFixture(
       // throws EPERM on stat. Skip dangling symlinks: stat throws ENOENT when
       // the target is missing (can happen with cross-OS turbo cache replay
       // where Windows-absolute symlink targets don't resolve on Linux).
-      let targetStats: {isDirectory: () => boolean} | undefined
+      let targetStats: {isDirectory: () => boolean}
       if (entry.isSymbolicLink()) {
         try {
           targetStats = await stat(srcPath)

--- a/packages/@sanity/cli-test/src/test/testFixture.ts
+++ b/packages/@sanity/cli-test/src/test/testFixture.ts
@@ -155,8 +155,20 @@ export async function testFixture(
       const srcPath = join(srcNodeModules, entry.name)
       // Follow symlinks (e.g. pnpm's `node_modules/<pkg>` → `.pnpm/...`) so
       // they get a 'dir' type on Windows — a file-typed symlink to a directory
-      // throws EPERM on stat.
-      const targetStats = entry.isSymbolicLink() ? await stat(srcPath) : entry
+      // throws EPERM on stat. Skip dangling symlinks: stat throws ENOENT when
+      // the target is missing (can happen with cross-OS turbo cache replay
+      // where Windows-absolute symlink targets don't resolve on Linux).
+      let targetStats: {isDirectory: () => boolean} | undefined
+      if (entry.isSymbolicLink()) {
+        try {
+          targetStats = await stat(srcPath)
+        } catch (err) {
+          if (err instanceof Error && 'code' in err && err.code === 'ENOENT') continue
+          throw err
+        }
+      } else {
+        targetStats = entry
+      }
       await symlink(
         srcPath,
         join(destNodeModules, entry.name),


### PR DESCRIPTION
### Description

Fixes two flaky test failures observed in CI (e.g. [run 26275207771](https://github.com/sanity-io/cli/actions/runs/26275207771/job/77337714668)):
- `build.app.test.ts > should error when @sanity/sdk-react is not installed`
- `build.studio.test.ts > should error when styled-components is not installed`

Both crashed with `ENOENT: no such file or directory, stat '.../packages/@sanity/cli-test/fixtures/basic-app/node_modules/react'` at `testFixture.ts:159`, where `stat()` follows a symlink in the bundled fixtures' `node_modules`.

**Root cause (cross-OS turbo cache corruption):**

1. `copy-fixtures.ts` used `src.split('/').pop()` to filter out `node_modules`/`dist`/`.turbo`. On Windows, paths use `\`, so `split('/')` returns the whole path as a single segment and the filter never matches.
2. On Windows CI, `pnpm install` populates `fixtures/basic-app/node_modules` (workspace install). `copy-fixtures` then copies that `node_modules` into `packages/@sanity/cli-test/fixtures/basic-app/node_modules`, and Node's `fs.cp` resolves symlinks to absolute Windows paths.
3. `turbo.json` declares `fixtures/**` as a build output, so those Windows-absolute symlinks get cached.
4. Linux CI hits the same turbo cache (cache key is content-based, not OS-scoped — confirmed in failing logs where the cache replay shows `C:\a\cli\cli\...` paths). On Linux, the Windows-path symlink targets don't exist → dangling → ENOENT on `stat`.

**Fixes:**
1. `copy-fixtures.ts`: switch the filter to `path.basename(src)` so it's platform-aware.
2. `testFixture.ts`: defensively skip dangling symlinks (ENOENT on `stat`) so cross-OS cache replay or other leftover state can't crash fixture loading again.

### What to review

- The filter change in [copy-fixtures.ts](packages/@sanity/cli-test/scripts/copy-fixtures.ts) — straightforward platform-aware swap.
- The error handling in [testFixture.ts](packages/@sanity/cli-test/src/test/testFixture.ts) — only ENOENT is swallowed (the symlink is skipped); other errors still propagate.

**Worth flagging as a follow-up (not in this PR):** even after fix #1, sharing a turbo cache between Windows and Linux for `@sanity/cli-test:build` is fragile because its output contains resolved symlinks. Consider scoping the turbo cache key per-OS for this task, or dropping `fixtures/**` from `outputs`.

### Testing

- Ran `pnpm check:types` (clean) and `pnpm check:lint` (clean, only pre-existing warnings).
- Ran `pnpm test --changed --bail=1` → 1329/1329 passed.
- Re-ran both previously-failing test files explicitly → 39/39 passed.
- The Windows path-splitting bug is verified locally with `path.win32.basename` returning `node_modules` correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized changes to test/fixture build tooling that only affect how fixtures and `node_modules` symlinks are copied, with narrow error handling (only `ENOENT` is tolerated).
> 
> **Overview**
> Fixes flaky `@sanity/cli-test` runs across Windows/Linux by making fixture bundling and cloning more robust.
> 
> The fixture copy script now uses `path.basename()` when filtering during `fs.cp`, ensuring `node_modules`, `.turbo`, and optional `dist` are correctly excluded on Windows path separators. `testFixture()` now skips dangling `node_modules` symlinks by swallowing `ENOENT` from `stat()` when determining symlink type, preventing cross-OS cache replays from crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 489a86aad4f3b33cb73da8ee4a9785cb00122a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->