### PR TITLE
[DIAGNOSTIC, do not merge] Capture Windows worker crash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,12 +116,22 @@ jobs:
         shell: bash
         env:
           SANITY_AUTH_TOKEN: 'test-token'
+          # Windows worker crash diagnostics: write Node diagnostic reports on
+          # fatal errors / uncaught exceptions / signals, and bump heap to
+          # rule out OOM. Vitest forks inherit NODE_OPTIONS.
+          NODE_OPTIONS: ${{ matrix.os == 'windows-8core' && '--report-on-fatalerror --report-uncaught-exception --report-on-signal --report-directory=node-reports --max-old-space-size=8192' || '' }}
         run: |
+          mkdir -p node-reports
           ARGS="--test-timeout=60000 --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
           # We only gather coverage from Node 20 on Ubuntu
           if [ "${{ matrix.node-version }}" == "20" ] && [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
             # We pass in `--reporter=blob` so that we can combine the results from all shards.
             ARGS="$ARGS --coverage --reporter=default --reporter=blob"
+          fi
+          # Verbose reporter on Windows so we can see which test file the worker
+          # was on when it died (default reporter only prints completed files).
+          if [ "${{ matrix.os }}" == "windows-8core" ]; then
+            ARGS="$ARGS --reporter=verbose"
           fi
           pnpm test $ARGS
 
@@ -133,6 +143,17 @@ jobs:
           path: '.vitest-reports/*'
           include-hidden-files: true
           retention-days: 1
+
+      - name: Upload Windows diagnostic reports
+        if: ${{ failure() && matrix.os == 'windows-8core' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: win-diag-${{ matrix.node-version }}-${{ matrix.shardIndex }}
+          path: |
+            node-reports/
+            **/report.*.json
+          if-no-files-found: warn
+          retention-days: 7
 
   report-coverage:
     needs: [changes, test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
           # Windows worker crash diagnostics: write Node diagnostic reports on
           # fatal errors / uncaught exceptions / signals, and bump heap to
           # rule out OOM. Vitest forks inherit NODE_OPTIONS.
-          NODE_OPTIONS: ${{ matrix.os == 'windows-8core' && '--report-on-fatalerror --report-uncaught-exception --report-on-signal --report-directory=node-reports --max-old-space-size=8192' || '' }}
+          NODE_OPTIONS: ${{ matrix.os == 'windows-8core' && '--report-on-fatalerror --report-uncaught-exception --report-on-signal --report-directory=node-reports' || '' }}
         run: |
           mkdir -p node-reports
           ARGS="--test-timeout=60000 --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"

--- a/packages/@sanity/cli/test/setup.ts
+++ b/packages/@sanity/cli/test/setup.ts
@@ -1,5 +1,38 @@
 import {vi} from 'vitest'
 
+// Diagnostic listeners for the Windows worker-crash investigation.
+// Vitest's "Worker exited unexpectedly" doesn't tell us *why* a fork died.
+// These log to stderr (vitest tees to the job log) so a failing CI run will
+// show the actual cause. Remove after the root cause is found.
+if (process.platform === 'win32') {
+  process.on('uncaughtException', (err) => {
+    // eslint-disable-next-line no-console
+    console.error('[win-diag] uncaughtException:', err?.stack || err)
+  })
+  process.on('unhandledRejection', (reason) => {
+    // eslint-disable-next-line no-console
+    console.error('[win-diag] unhandledRejection:', reason)
+  })
+  process.on('warning', (warning) => {
+    // eslint-disable-next-line no-console
+    console.error('[win-diag] warning:', warning.name, warning.message)
+  })
+  for (const sig of ['SIGTERM', 'SIGINT', 'SIGBREAK', 'SIGHUP'] as const) {
+    process.on(sig, () => {
+      // eslint-disable-next-line no-console
+      console.error(`[win-diag] received signal: ${sig}`)
+    })
+  }
+  process.on('beforeExit', (code) => {
+    // eslint-disable-next-line no-console
+    console.error(`[win-diag] beforeExit code=${code}`)
+  })
+  process.on('exit', (code) => {
+    // eslint-disable-next-line no-console
+    console.error(`[win-diag] exit code=${code}`)
+  })
+}
+
 /**
  * Default mocks
  */


### PR DESCRIPTION
Diagnostic-only branch to capture details about the Windows vitest worker crash hit on PR #1109.

Adds (Windows-only):
- `NODE_OPTIONS` with `--report-on-fatalerror --report-uncaught-exception --report-on-signal --report-directory=node-reports --max-old-space-size=8192` — Node writes a JSON diagnostic report on fatal errors / OOM / signals.
- `--reporter=verbose` so we can see which test file the worker was on when it died.
- Process listeners in `packages/@sanity/cli/test/setup.ts` that log `uncaughtException`, `unhandledRejection`, `warning`, signals, `beforeExit`, `exit`.
- Uploads `node-reports/` + any `report.*.json` as artifacts when a Windows shard fails.

Once we capture diagnostics on a failing shard, root cause this and close. Do not merge.