### PR TITLE
fix(cli): add organizations list command and improve unattended init

### DIFF
--- a/.github/workflows/2027-eval.yml
+++ b/.github/workflows/2027-eval.yml
@@ -1,0 +1,121 @@
+name: 2027 eval
+on:
+  pull_request:
+    types: [labeled, synchronize, opened, reopened]
+  issue_comment:
+    types: [created]
+
+# Concurrency note: GitHub evaluates concurrency BEFORE the job's `if:`,
+# so keying off issue.number means unrelated bot comments on the same PR
+# (e.g. claude[bot], dependabot) cancel an in-flight eval even when their
+# bodies fail the @2027dev filter. Key on comment.id instead so each
+# comment is its own group; pull_request events still group by head_ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.comment.id || github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  statuses: write
+  contents: read
+
+env:
+  PROMPT_ID: 1d8004c6-d00c-432e-998b-e868a957807c
+
+jobs:
+  eval:
+    # Fires on:
+    # - any labeled/synchronize/opened/reopened PR that carries the
+    #   `trigger: preview` label (existing behavior)
+    # - any PR comment that mentions @2027dev (new — issue_comment loads
+    #   the workflow from the default branch, so this YAML must be on main)
+    if: >-
+      (github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'trigger: preview')) ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@2027dev'))
+    runs-on: ubuntu-latest
+    steps:
+      # Resolve the PR head sha. pull_request payloads carry it directly;
+      # issue_comment doesn't, so fetch via pulls.get. Downstream steps key
+      # off steps.pr.outputs.sha so they stay event-agnostic.
+      - name: Resolve PR head sha
+        id: pr
+        uses: actions/github-script@v9
+        with:
+          script: |
+            if (context.eventName === 'pull_request') {
+              core.setOutput('sha', context.payload.pull_request.head.sha)
+              core.setOutput('number', String(context.payload.pull_request.number))
+              return
+            }
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.payload.issue.number,
+            })
+            core.setOutput('sha', pr.head.sha)
+            core.setOutput('number', String(pr.number))
+
+      - name: Wait for pkg-pr-new on this SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.pr.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Poll pkg-pr-new's "Continuous Releases" commit status. This is
+          # pkg-pr-new's authoritative "package is uploaded and reachable"
+          # signal — stronger than our internal publish workflow exiting 0.
+          # success wins, hard failure aborts, anything else keeps polling.
+          for i in $(seq 1 30); do
+            STATE=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/check-runs" \
+              --jq '
+                [.check_runs[] | select(.name == "Continuous Releases")] as $c
+                | if any($c[]; .conclusion == "success") then "success"
+                  elif any($c[]; .conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") then "hard_fail"
+                  else "pending" end
+              ')
+            case "$STATE" in
+              success)
+                echo "pkg-pr-new succeeded on $SHA"
+                exit 0
+                ;;
+              hard_fail)
+                echo "::error::pkg-pr-new failed on $SHA — aborting eval"
+                exit 1
+                ;;
+            esac
+            echo "waiting for Continuous Releases on $SHA (attempt $i/30, state: $STATE)..."
+            sleep 20
+          done
+          echo "::error::Timed out waiting for Continuous Releases — is the pkg-pr-new GitHub App installed on $GITHUB_REPOSITORY?"
+          exit 1
+
+      - name: Compute cliInstall + url-map target
+        id: cli
+        env:
+          SHA: ${{ steps.pr.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # url-map preserves path, so the agent's package suffix gets appended
+          # to the url-map target. Keep target as the org/repo root; the
+          # agent's `/@sanity/cli@<sha>` path completes the real URL.
+          # Agent sees a sanity.io subdomain instead of pkg.pr.new/<org>/<repo>.
+          echo "install=npm i -g https://preview.sanity.io/@sanity/cli@${SHA:0:7}" >> "$GITHUB_OUTPUT"
+          echo "pkg_url=https://pkg.pr.new/${GITHUB_REPOSITORY}" >> "$GITHUB_OUTPUT"
+
+      - name: Run 2027 eval
+        # team2027/evals-action@v0.7.0 — SHA-pinned per GitHub's hardening
+        # guidance for third-party actions that handle secrets.
+        uses: team2027/evals-action@f322589b36320fcbc0ea4756686d240bc7fcda88
+        with:
+          api-key: ${{ secrets.EVALS_API_KEY }}
+          prompt-id: ${{ env.PROMPT_ID }}
+          # preview.sanity.io is a stand-in domain; the eval sandbox's URL_MAP
+          # rewrites it to the per-PR pkg.pr.new tarball so the agent sees a
+          # clean install URL without a branch/sha pinning tell.
+          url-map: |
+            { "preview.sanity.io": "${{ steps.cli.outputs.pkg_url }}" }
+          template-vars: |
+            { "cliInstall": "${{ steps.cli.outputs.install }}" }
+          wait-timeout-minutes: 60

--- a/packages/@sanity/cli/oclif.config.js
+++ b/packages/@sanity/cli/oclif.config.js
@@ -25,6 +25,7 @@ export default {
     mcp: {description: 'Configure Sanity MCP server for AI editors'},
     media: {description: 'Manage media assets and aspect definitions'},
     openapi: {description: 'Manage OpenAPI specifications'},
+    organizations: {description: 'Manage Sanity organizations'},
     projects: {description: 'Manage Sanity projects'},
     schemas: {description: 'Manage and validate schemas'},
     telemetry: {description: 'Manage telemetry consent'},

--- a/packages/@sanity/cli/src/actions/deploy/deployStudioSchemasAndManifests.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudioSchemasAndManifests.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
-import {SchemaExtractionError} from '@sanity/cli-build/_internal'
 import {ux} from '@oclif/core/ux'
+import {SchemaExtractionError} from '@sanity/cli-build/_internal'
 import {getCliTelemetry, studioWorkerTask, subdebug} from '@sanity/cli-core'
 import {type SchemaValidationProblemGroup} from '@sanity/types'
 import {type StudioManifest} from 'sanity'

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -1,8 +1,14 @@
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import path from 'node:path'
+
 import {createTestClient, mockApi} from '@sanity/cli-test'
 import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
+import {ORGANIZATIONS_API_VERSION} from '../../../services/organizations.js'
+import {CREATE_PROJECT_API_VERSION} from '../../../services/projects.js'
 import {initAction} from '../initAction.js'
 import {InitError} from '../initError.js'
 import {type InitContext, type InitOptions} from '../types.js'
@@ -49,6 +55,7 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
 
       return {
         datasets: {
+          create: vi.fn().mockResolvedValue(undefined),
           list: vi.fn().mockResolvedValue([{aclMode: 'public', name: 'production'}]),
         },
         request: client.request,
@@ -82,7 +89,7 @@ const defaultOptions: InitOptions = {
   unattended: false,
 }
 
-function createTestContext(): InitContext {
+function createTestContext(workDir = '/tmp/test-work-dir'): InitContext {
   return {
     output: {
       // output.error has a `never` return type in the Output interface, but
@@ -101,7 +108,7 @@ function createTestContext(): InitContext {
         start: vi.fn(),
       }),
     } as unknown as InitContext['telemetry'],
-    workDir: '/tmp/test-work-dir',
+    workDir,
   }
 }
 
@@ -203,5 +210,195 @@ describe('initAction (direct)', () => {
       'Must be logged in to run this command in unattended mode, run `sanity login`',
     )
     expect(initError.exitCode).toBe(1)
+  })
+
+  test('unattended --project-name with single org with attach grant auto-picks org', async () => {
+    mockValidateSession.mockResolvedValue({
+      email: 'test@example.com',
+      id: 'user-123',
+      name: 'Test User',
+      provider: 'google',
+    })
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [{id: 'org-1', name: 'Only Org', slug: 'only-org'}])
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations/org-1/grants',
+    }).reply(200, {
+      'sanity.organization.projects': [{grants: [{name: 'attach'}]}],
+    })
+
+    mockApi({
+      apiVersion: CREATE_PROJECT_API_VERSION,
+      method: 'post',
+      uri: '/projects',
+    }).reply(200, {displayName: 'My New Project', projectId: 'test-project'})
+
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      uri: '/features',
+    }).reply(200, ['privateDataset'])
+
+    const context = createTestContext()
+    const options: InitOptions = {
+      ...defaultOptions,
+      bare: true,
+      projectName: 'My New Project',
+      unattended: true,
+    }
+
+    await initAction(options, context)
+
+    const logCalls = vi.mocked(context.output.log).mock.calls.map((call) => call[0])
+    const combined = logCalls.join('\n')
+
+    expect(combined).toContain('test-project')
+  })
+
+  test('unattended --project-name with zero orgs throws descriptive error pointing to organizations list', async () => {
+    mockValidateSession.mockResolvedValue({
+      email: 'test@example.com',
+      id: 'user-123',
+      name: 'Test User',
+      provider: 'google',
+    })
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [])
+
+    const context = createTestContext()
+    const options: InitOptions = {
+      ...defaultOptions,
+      bare: true,
+      projectName: 'My New Project',
+      unattended: true,
+    }
+
+    let caughtError: unknown
+    try {
+      await initAction(options, context)
+    } catch (error) {
+      caughtError = error
+    }
+
+    expect(caughtError).toBeInstanceOf(InitError)
+    const initError = caughtError as InitError
+    expect(initError.message).toContain('No organization found for new project')
+    expect(initError.message).toContain('sanity organizations list')
+    expect(initError.exitCode).toBe(1)
+  })
+
+  test('unattended without --project/--project-name derives projectName from package.json name', async () => {
+    mockValidateSession.mockResolvedValue({
+      email: 'test@example.com',
+      id: 'user-123',
+      name: 'Test User',
+      provider: 'google',
+    })
+
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'sanity-init-test-'))
+    writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: 'my-pkg-name', version: '1.0.0'}),
+    )
+
+    try {
+      mockApi({
+        apiVersion: ORGANIZATIONS_API_VERSION,
+        uri: '/organizations',
+      }).reply(200, [{id: 'org-1', name: 'Only Org', slug: 'only-org'}])
+
+      mockApi({
+        apiVersion: ORGANIZATIONS_API_VERSION,
+        uri: '/organizations/org-1/grants',
+      }).reply(200, {
+        'sanity.organization.projects': [{grants: [{name: 'attach'}]}],
+      })
+
+      mockApi({
+        apiVersion: CREATE_PROJECT_API_VERSION,
+        method: 'post',
+        uri: '/projects',
+      }).reply(200, (_uri, body: Record<string, unknown>) => {
+        expect(body.displayName).toBe('my-pkg-name')
+        return {displayName: 'my-pkg-name', projectId: 'test-project'}
+      })
+
+      mockApi({
+        apiVersion: PROJECT_FEATURES_API_VERSION,
+        method: 'get',
+        uri: '/features',
+      }).reply(200, ['privateDataset'])
+
+      const context = createTestContext(tmpDir)
+      const options: InitOptions = {
+        ...defaultOptions,
+        bare: true,
+        unattended: true,
+      }
+
+      await initAction(options, context)
+    } finally {
+      rmSync(tmpDir, {force: true, recursive: true})
+    }
+  })
+
+  test('unattended without --project/--project-name and no package.json derives projectName from basename(cwd)', async () => {
+    mockValidateSession.mockResolvedValue({
+      email: 'test@example.com',
+      id: 'user-123',
+      name: 'Test User',
+      provider: 'google',
+    })
+
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'my-folder-name-'))
+    const expectedName = path.basename(tmpDir)
+
+    try {
+      mockApi({
+        apiVersion: ORGANIZATIONS_API_VERSION,
+        uri: '/organizations',
+      }).reply(200, [{id: 'org-1', name: 'Only Org', slug: 'only-org'}])
+
+      mockApi({
+        apiVersion: ORGANIZATIONS_API_VERSION,
+        uri: '/organizations/org-1/grants',
+      }).reply(200, {
+        'sanity.organization.projects': [{grants: [{name: 'attach'}]}],
+      })
+
+      mockApi({
+        apiVersion: CREATE_PROJECT_API_VERSION,
+        method: 'post',
+        uri: '/projects',
+      }).reply(200, (_uri, body: Record<string, unknown>) => {
+        expect(body.displayName).toBe(expectedName)
+        return {displayName: expectedName, projectId: 'test-project'}
+      })
+
+      mockApi({
+        apiVersion: PROJECT_FEATURES_API_VERSION,
+        method: 'get',
+        uri: '/features',
+      }).reply(200, ['privateDataset'])
+
+      const context = createTestContext(tmpDir)
+      const options: InitOptions = {
+        ...defaultOptions,
+        bare: true,
+        unattended: true,
+      }
+
+      await initAction(options, context)
+    } finally {
+      rmSync(tmpDir, {force: true, recursive: true})
+    }
   })
 })

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -1,3 +1,5 @@
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
 import {styleText} from 'node:util'
 
 import {type SanityOrgUser, subdebug, type TelemetryUserProperties} from '@sanity/cli-core'
@@ -83,6 +85,14 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
 
   const isAppTemplate = options.template ? determineAppTemplate(options.template) : false
 
+  if (options.unattended && !isAppTemplate && !options.project && !options.projectName) {
+    const derived = await deriveProjectName(workDir)
+    if (derived) {
+      debug('Deriving --project-name from %s: %s', derived.source, derived.name)
+      options.projectName = derived.name
+    }
+  }
+
   if (options.unattended) {
     checkFlagsInUnattendedMode(options, {isAppTemplate, isNextJs})
   }
@@ -124,6 +134,7 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
       dataset: options.dataset,
       organization: options.organization,
       planId,
+      unattended: options.unattended,
       user,
       visibility: options.visibility,
     })
@@ -282,10 +293,6 @@ function checkFlagsInUnattendedMode(
 ): void {
   debug('Unattended mode, validating required options')
 
-  if (options.projectName && !options.organization) {
-    throw new InitError('`--project-name` requires `--organization <id>` in unattended mode', 1)
-  }
-
   if (isAppTemplate) {
     if (!options.outputPath) {
       throw new InitError('`--output-path` must be specified in unattended mode', 1)
@@ -314,6 +321,33 @@ function checkFlagsInUnattendedMode(
       1,
     )
   }
+}
+
+async function deriveProjectName(
+  workDir: string,
+): Promise<{name: string; source: 'directory' | 'package.json'} | undefined> {
+  try {
+    const raw = await readFile(path.join(workDir, 'package.json'), 'utf8')
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'name' in parsed &&
+      typeof parsed.name === 'string' &&
+      parsed.name.trim().length > 0
+    ) {
+      return {name: parsed.name.trim(), source: 'package.json'}
+    }
+  } catch {
+    // package.json missing or unreadable — fall through to basename
+  }
+
+  const basename = path.basename(workDir)
+  if (basename) {
+    return {name: basename, source: 'directory'}
+  }
+
+  return undefined
 }
 
 async function ensureAuthenticated(

--- a/packages/@sanity/cli/src/actions/init/project/createProjectFromName.ts
+++ b/packages/@sanity/cli/src/actions/init/project/createProjectFromName.ts
@@ -5,6 +5,8 @@ import {type DatasetAclMode} from '@sanity/client'
 import {createDataset as createDatasetService} from '../../../services/datasets.js'
 import {listOrganizations} from '../../../services/organizations.js'
 import {createProject} from '../../../services/projects.js'
+import {getOrganizationsWithAttachGrantInfo} from '../../organizations/getOrganizationsWithAttachGrantInfo.js'
+import {InitError} from '../initError.js'
 import {promptUserForOrganization} from './promptUserForOrganization.js'
 
 const debug = subdebug('init')
@@ -15,6 +17,7 @@ export async function createProjectFromName({
   dataset,
   organization,
   planId,
+  unattended,
   user,
   visibility,
 }: {
@@ -23,6 +26,7 @@ export async function createProjectFromName({
   dataset: string | undefined
   organization: string | undefined
   planId: string | undefined
+  unattended: boolean | undefined
   user: SanityOrgUser
   visibility: 'private' | 'public' | undefined
 }): Promise<string> {
@@ -33,10 +37,24 @@ export async function createProjectFromName({
   if (!orgForCreateProjectFlag) {
     debug('no organization specified, selecting one')
     const organizations = await listOrganizations()
-    orgForCreateProjectFlag = await promptUserForOrganization({
-      organizations,
-      user,
-    })
+
+    if (unattended) {
+      const withGrantInfo = await getOrganizationsWithAttachGrantInfo(organizations)
+      const withAttach = withGrantInfo.filter(({hasAttachGrant}) => hasAttachGrant)
+      if (withAttach.length === 0) {
+        throw new InitError(
+          "No organization found for new project. Run 'sanity organizations list' to find your organization ID, or create one at https://sanity.io/manage",
+          1,
+        )
+      }
+      orgForCreateProjectFlag = withAttach[0].organization.id
+      debug('unattended mode: picked first org with attach grant: %s', orgForCreateProjectFlag)
+    } else {
+      orgForCreateProjectFlag = await promptUserForOrganization({
+        organizations,
+        user,
+      })
+    }
   }
 
   debug('creating a new project')

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -1,7 +1,9 @@
-import {testCommand} from '@sanity/cli-test'
+import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
+import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {selectTemplate} from '../../../actions/init/scaffoldTemplate.js'
+import {ORGANIZATIONS_API_VERSION} from '../../../services/organizations.js'
 import {InitCommand} from '../../init.js'
 
 const mocks = vi.hoisted(() => ({
@@ -27,9 +29,15 @@ vi.mock('../../../prompts/init/promptForTypescript.js', () => ({
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
+  const globalTestClient = createTestClient({
+    apiVersion: 'v2025-05-14',
+    token: 'test-token',
+  })
+
   return {
     ...actual,
     getGlobalCliClient: vi.fn().mockResolvedValue({
+      request: globalTestClient.request,
       users: {
         getById: mocks.getById,
       } as never,
@@ -57,6 +65,9 @@ const defaultMocks = {
 describe('#init: oclif command setup', () => {
   afterEach(() => {
     vi.clearAllMocks()
+    const pending = pendingMocks()
+    cleanAll()
+    expect(pending, 'pending mocks').toEqual([])
   })
 
   test.each([
@@ -230,11 +241,19 @@ describe('#init: oclif command setup', () => {
     )
   })
 
-  test('throws error when in unattended mode and `project` and `project-name` not set', async () => {
+  test('does not throw when project flags omitted in unattended mode — project name is derived', async () => {
     mocks.detectFrameworkRecord.mockResolvedValueOnce({
       name: 'Next.js',
       slug: 'nextjs',
     })
+
+    // With derived projectName, init proceeds to org resolution. We don't need to mock
+    // the full happy path — empty orgs returns the new descriptive error from task #2,
+    // which proves the original "must be specified" throw is gone.
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [])
 
     const {error} = await testCommand(
       InitCommand,
@@ -250,17 +269,21 @@ describe('#init: oclif command setup', () => {
       },
     )
 
-    expect(error?.message).toContain(
+    expect(error?.message ?? '').not.toContain(
       '`--project <id>` or `--project-name <name>` must be specified in unattended mode',
     )
-    expect(error?.oclif?.exit).toBe(1)
   })
 
-  test('throws error when in unattended mode and `project-name` set without `organization`', async () => {
+  test('throws descriptive error when in unattended mode, `project-name` is set, and user has no organizations', async () => {
     mocks.detectFrameworkRecord.mockResolvedValueOnce({
       name: 'Next.js',
       slug: 'nextjs',
     })
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [])
 
     const {error} = await testCommand(
       InitCommand,
@@ -272,9 +295,8 @@ describe('#init: oclif command setup', () => {
       },
     )
 
-    expect(error?.message).toContain(
-      '`--project-name` requires `--organization <id>` in unattended mode',
-    )
+    expect(error?.message).toContain('No organization found for new project')
+    expect(error?.message).toContain('sanity organizations list')
     expect(error?.oclif?.exit).toBe(1)
   })
 

--- a/packages/@sanity/cli/src/commands/organizations/__tests__/__snapshots__/list.test.ts.snap
+++ b/packages/@sanity/cli/src/commands/organizations/__tests__/__snapshots__/list.test.ts.snap
@@ -1,0 +1,8 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`#list > displays organizations correctly 1`] = `
+"id      name        slug 
+org-a   Alpha Org   alpha
+org-b   Beta Org    beta 
+"
+`;

--- a/packages/@sanity/cli/src/commands/organizations/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/organizations/__tests__/list.test.ts
@@ -1,0 +1,110 @@
+import {mockApi, testCommand} from '@sanity/cli-test'
+import {cleanAll, pendingMocks} from 'nock'
+import {afterEach, describe, expect, test} from 'vitest'
+
+import {ORGANIZATIONS_API_VERSION} from '../../../services/organizations.js'
+import {List} from '../list.js'
+
+describe('#list', () => {
+  afterEach(() => {
+    const pending = pendingMocks()
+    cleanAll()
+    expect(pending, 'pending mocks').toEqual([])
+  })
+
+  test('displays organizations correctly', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [
+      {id: 'org-b', name: 'Beta Org', slug: 'beta'},
+      {id: 'org-a', name: 'Alpha Org', slug: 'alpha'},
+    ])
+
+    const {stdout} = await testCommand(List)
+
+    expect(stdout).toMatchSnapshot()
+  })
+
+  test('outputs JSON when --json is specified', async () => {
+    const organizations = [
+      {id: 'org-1', name: 'First Org', slug: 'first'},
+      {id: 'org-2', name: 'Second Org', slug: 'second'},
+    ]
+
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, organizations)
+
+    const {stdout} = await testCommand(List, ['--json'])
+
+    const parsed = JSON.parse(stdout)
+    expect(parsed).toEqual(organizations)
+  })
+
+  test('sorts by name when --sort name is specified', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [
+      {id: 'org-1', name: 'Charlie', slug: 'charlie'},
+      {id: 'org-2', name: 'Alpha', slug: 'alpha'},
+      {id: 'org-3', name: 'Bravo', slug: 'bravo'},
+    ])
+
+    const {stdout} = await testCommand(List, ['--sort', 'name'])
+
+    const lines = stdout.split('\n').filter(Boolean)
+
+    const alphaIndex = lines.findIndex((line) => line.includes('Alpha'))
+    const bravoIndex = lines.findIndex((line) => line.includes('Bravo'))
+    const charlieIndex = lines.findIndex((line) => line.includes('Charlie'))
+
+    expect(alphaIndex).toBeGreaterThan(0)
+    expect(bravoIndex).toBeGreaterThan(0)
+    expect(charlieIndex).toBeGreaterThan(0)
+
+    expect(alphaIndex).toBeLessThan(bravoIndex)
+    expect(bravoIndex).toBeLessThan(charlieIndex)
+  })
+
+  test('sorts in descending order when --order desc is specified', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(200, [
+      {id: 'org-a', name: 'Alpha', slug: 'alpha'},
+      {id: 'org-b', name: 'Bravo', slug: 'bravo'},
+      {id: 'org-c', name: 'Charlie', slug: 'charlie'},
+    ])
+
+    const {stdout} = await testCommand(List, ['--order', 'desc'])
+
+    const lines = stdout.split('\n').filter(Boolean)
+
+    const orgAIndex = lines.findIndex((line) => line.includes('org-a'))
+    const orgBIndex = lines.findIndex((line) => line.includes('org-b'))
+    const orgCIndex = lines.findIndex((line) => line.includes('org-c'))
+
+    expect(orgAIndex).toBeGreaterThan(0)
+    expect(orgBIndex).toBeGreaterThan(0)
+    expect(orgCIndex).toBeGreaterThan(0)
+
+    expect(orgCIndex).toBeLessThan(orgBIndex)
+    expect(orgBIndex).toBeLessThan(orgAIndex)
+  })
+
+  test('displays an error if the API request fails', async () => {
+    mockApi({
+      apiVersion: ORGANIZATIONS_API_VERSION,
+      uri: '/organizations',
+    }).reply(500, {message: 'Internal Server Error'})
+
+    const {error} = await testCommand(List)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Failed to list organizations')
+    expect(error?.oclif?.exit).toBe(1)
+  })
+})

--- a/packages/@sanity/cli/src/commands/organizations/list.ts
+++ b/packages/@sanity/cli/src/commands/organizations/list.ts
@@ -1,0 +1,87 @@
+import {styleText} from 'node:util'
+
+import {Flags} from '@oclif/core'
+import {SanityCommand, subdebug} from '@sanity/cli-core'
+import size from 'lodash-es/size.js'
+import sortBy from 'lodash-es/sortBy.js'
+
+import {listOrganizations} from '../../services/organizations.js'
+
+const sortFields = ['id', 'name', 'slug']
+
+const organizationsDebug = subdebug('organizations')
+
+export class List extends SanityCommand<typeof List> {
+  static override description = 'List your organizations'
+  static override examples = [
+    {
+      command: '<%= config.bin %> <%= command.id %>',
+      description: 'List organizations',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --json',
+      description: 'List organizations in JSON format',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --sort=name --order=asc',
+      description: 'List organizations sorted by name, ascending',
+    },
+  ]
+
+  static override flags = {
+    json: Flags.boolean({
+      default: false,
+      description: 'Output organizations in JSON format',
+    }),
+    order: Flags.string({
+      default: 'asc',
+      description: 'Sort direction',
+      options: ['asc', 'desc'],
+    }),
+    sort: Flags.string({
+      default: 'id',
+      description: 'Sort field',
+      options: sortFields,
+    }),
+  }
+
+  static override hiddenAliases: string[] = ['organization:list']
+
+  public async run() {
+    const {json, order, sort} = this.flags
+
+    let organizations
+    try {
+      organizations = await listOrganizations()
+    } catch (error) {
+      organizationsDebug('Error listing organizations', error)
+      this.error('Failed to list organizations', {exit: 1})
+    }
+
+    if (json) {
+      this.log(JSON.stringify(organizations, null, 2))
+      return
+    }
+
+    const ordered = sortBy(
+      organizations.map(({id, name, slug}) => [id, name, slug].map(String)),
+      [sortFields.indexOf(sort)],
+    )
+
+    const rows = order === 'asc' ? ordered : ordered.toReversed()
+
+    const maxWidths = sortFields.map((str) => size(str))
+
+    for (const row of rows) {
+      for (const [i, element] of row.entries()) {
+        maxWidths[i] = Math.max(size(element), maxWidths[i])
+      }
+    }
+
+    const printRow = (row: string[]) =>
+      row.map((col, i) => `${col}`.padEnd(maxWidths[i])).join('   ')
+
+    this.log(styleText('cyan', printRow(sortFields)))
+    for (const row of rows) this.log(printRow(row))
+  }
+}

--- a/packages/@sanity/cli/src/commands/schemas/deploy.ts
+++ b/packages/@sanity/cli/src/commands/schemas/deploy.ts
@@ -1,8 +1,8 @@
 import {styleText} from 'node:util'
 
-import {SchemaExtractionError} from '@sanity/cli-build/_internal'
 import {Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
+import {SchemaExtractionError} from '@sanity/cli-build/_internal'
 import {SanityCommand} from '@sanity/cli-core'
 
 import {deploySchemas} from '../../actions/schema/deploySchemas.js'

--- a/packages/@sanity/cli/src/topicAliases.ts
+++ b/packages/@sanity/cli/src/topicAliases.ts
@@ -23,6 +23,7 @@ export const topicAliases: Record<string, string[]> = {
   documents: ['document'],
   functions: ['function'],
   hooks: ['hook'],
+  organizations: ['organization'],
   projects: ['project'],
   schemas: ['schema'],
   tokens: ['token'],


### PR DESCRIPTION
### Description

Add `sanity organizations list` command and fix unattended `sanity init` to work headlessly without requiring `--organization <id>`.

**Motivation:** [2027 eval trace `sanity-94b5a32e`](https://2027.dev/evals/sanity.io/reports/sanity-94b5a32e/trace) — an AI agent tried `npx sanity init --mcp --yes` in a headless container and got stuck because:
1. `--project-name` required `--organization <id>` in unattended mode with no way to discover org IDs
2. `sanity organizations list` didn't exist as a command
3. The agent resorted to `curl` against the REST API to find its org ID — a ~30s detour

**Changes:**
- **New command: `sanity organizations list`** — columns: `id`, `name`, `slug`; flags: `--json`, `--sort`, `--order`. Hidden alias `organization:list`, topic alias `organization` → `organizations`
- **Auto-pick org in unattended mode** — when `--project-name` is set without `--organization`, auto-pick the first org with attach grant (matches interactive behavior). Descriptive error when zero orgs found, pointing at `sanity organizations list`
- **Derive project name from folder** — when `--yes` is set without `--project` or `--project-name`, derive from `package.json:name` or `basename(cwd)`. This makes `npx sanity init --mcp --yes` a working one-shot command

### What to review

- `packages/@sanity/cli/src/commands/organizations/list.ts` — new command, mirrors `projects/list.ts`
- `packages/@sanity/cli/src/actions/init/initAction.ts` — `deriveProjectName()` function, removed hard throw for missing `--organization`
- `packages/@sanity/cli/src/actions/init/project/createProjectFromName.ts` — unattended org auto-pick logic
- `packages/@sanity/cli/oclif.config.js` + `src/topicAliases.ts` — wiring

### Testing

All 260 CLI tests pass. Added:
- `organizations list` tests: tabular output, `--json` parsing, sort/order, error handling (5 tests)
- `initAction` tests: single-org auto-pick in unattended mode, zero-org descriptive error, derive from `package.json`, derive from `basename(cwd)` (4 tests)
- Updated oclif-level `init.setup.test.ts`: old error messages replaced with new ones (2 updated tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)