### PR TITLE
feat(dataset export): add no-strict-asset-verification flag

### DIFF
--- a/.changeset/pr-1135.md
+++ b/.changeset/pr-1135.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(dataset export): add no-strict-asset-verification flag

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -79,7 +79,7 @@
     "@sanity/client": "catalog:",
     "@sanity/codegen": "catalog:",
     "@sanity/descriptors": "^1.3.0",
-    "@sanity/export": "^6.1.0",
+    "@sanity/export": "^6.2.0",
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/id-utils": "^1.0.0",
     "@sanity/import": "^6.0.1",

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
@@ -176,6 +176,7 @@ describe('#dataset:export', () => {
             onProgress: expect.any(Function),
             outputPath: expect.stringMatching(expectedPathPattern),
             raw: false,
+            strictAssetVerification: true,
             types: undefined,
           }),
         )
@@ -461,6 +462,22 @@ describe('#dataset:export', () => {
       expect(mockExportDataset).toHaveBeenCalledWith(
         expect.objectContaining({
           raw: true,
+        }),
+      )
+    })
+
+    test('sets strictAssetVerification:false when --no-strict-asset-verification flag is used', async () => {
+      const {mocks} = createTestContext({datasets: [{name: 'production'}]})
+
+      await testCommand(
+        DatasetExportCommand,
+        ['production', TEST_OUTPUTS.TAR_GZ, '--no-strict-asset-verification'],
+        {mocks},
+      )
+
+      expect(mockExportDataset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strictAssetVerification: false,
         }),
       )
     })

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -51,6 +51,11 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
       command: '<%= config.bin %> <%= command.id %> staging staging.tar.gz --types products,shops',
       description: 'Export specific document types',
     },
+    {
+      command:
+        '<%= config.bin %> <%= command.id %> moviedb moviedb.tar.gz --no-strict-asset-verification',
+      description: 'Export dataset without aborting on asset verification failures',
+    },
   ]
 
   static override flags = {
@@ -83,7 +88,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
     'no-strict-asset-verification': Flags.boolean({
       default: false,
       description:
-        'Skip aborting the export when an asset fails hash/content-length verification (keeps the asset with a warning)',
+        'Do not abort the export when an asset fails hash or content-length verification',
     }),
     overwrite: Flags.boolean({
       default: false,

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -80,6 +80,11 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
       default: false,
       description: 'Export only published versions of documents',
     }),
+    'no-strict-asset-verification': Flags.boolean({
+      default: false,
+      description:
+        'Skip aborting the export when an asset fails hash/content-length verification (keeps the asset with a warning)',
+    }),
     overwrite: Flags.boolean({
       default: false,
       description: 'Overwrite any file with the same name',
@@ -193,6 +198,7 @@ dataset: ${dataset.padEnd(46)}`,
       onProgress,
       outputPath,
       raw: flags.raw,
+      strictAssetVerification: !flags['no-strict-asset-verification'],
       types: flags.types ? flags.types.split(',') : undefined,
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,8 +506,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       '@sanity/export':
-        specifier: ^6.1.0
-        version: 6.1.0
+        specifier: ^6.2.0
+        version: 6.2.0
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -4660,8 +4660,8 @@ packages:
   '@sanity/eventsource@5.0.2':
     resolution: {integrity: sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==}
 
-  '@sanity/export@6.1.0':
-    resolution: {integrity: sha512-lbBm5DnpFMDnbxoARU8ig0wZqe/mWyTtDu08z9OXDGyDl2dZJxAZt3DWxx1ndiWzEIoNKIyLFjpaNc2CazuK0w==}
+  '@sanity/export@6.2.0':
+    resolution: {integrity: sha512-qu/I3EZIjj36lBQ2FLhBJSPqYZF2t2UO7/jtfYJQ0Qi5LBqVrtlVFOZ/niNg8gu4FUFoOuKTOxXY+V76xw/19Q==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
@@ -14042,14 +14042,14 @@ snapshots:
       event-source-polyfill: 1.0.31
       eventsource: 2.0.2
 
-  '@sanity/export@6.1.0':
+  '@sanity/export@6.2.0':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       get-it: 8.7.2
       json-stream-stringify: 3.1.6
       p-queue: 9.1.0
       tar: 7.5.13
-      tar-stream: 3.1.8
+      tar-stream: 3.2.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer


### PR DESCRIPTION
Adds a new flag `--no-strict-asset-verification` to `sanity dataset export` to disable strict validation of asset hashes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI flag plumbing and dependency bump only; default export behavior remains strict verification unless the flag is set.
> 
> **Overview**
> Adds **`--no-strict-asset-verification`** to `sanity dataset export` so exports can continue when downloaded assets fail hash or content-length checks. By default, **`strictAssetVerification` stays `true`** and is passed through to `@sanity/export` (bumped to **^6.2.0**).
> 
> The command wires the new oclif flag, documents it in examples, and extends tests to assert the option is forwarded to `exportDataset`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 477c2369cae5cb954d45029ced252f6fe2495c74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->