### PR TITLE
fix(cli-build): publish SchemaExtractionError export

### DIFF
--- a/.changeset/cli-build-schema-extraction-error.md
+++ b/.changeset/cli-build-schema-extraction-error.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli-build": minor
+---
+
+Export `SchemaExtractionError` and related schema-extraction utilities from `_internal`. Without this, `@sanity/cli` fails at runtime on `sanity dev` because the published `cli-build` does not yet have the symbols that #1120 moved into it.


### PR DESCRIPTION
### Description

PR #1120 moved `SchemaExtractionError` (and the surrounding schema-extraction utilities) from `@sanity/cli` into `@sanity/cli-build/_internal`, but didn't include a changeset for `cli-build`. The next snapshot publish from `feat/workbench` therefore shipped a new `@sanity/cli@workbench` that imports `SchemaExtractionError` from a `cli-build` version that doesn't export it yet:

\`\`\`
SyntaxError: The requested module '@sanity/cli-build/_internal' does not provide an export named 'SchemaExtractionError'
\`\`\`

This reproduces on `sanity dev` in any workbench-host app and currently blocks workbench PR sanity-io/workbench#208.

Adding a changeset so the next snapshot publishes a fresh `@sanity/cli-build@workbench` with the missing exports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only (changeset); no runtime code changes in this PR.
> 
> **Overview**
> Adds a **minor** changeset for `@sanity/cli-build` so the next publish includes `SchemaExtractionError` and related schema-extraction utilities on `_internal`.
> 
> That release is required because #1120 already moved those symbols into `cli-build` and `@sanity/cli` imports them; without a bumped `cli-build`, `sanity dev` fails with a missing named export. This unblocks workbench snapshot consumers (e.g. workbench-host apps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd922780aa8a3349cc6077a747d8427fb78cc2f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->