### PR TITLE
feat(cli-core): expand isCi detection coverage via ci-info

### DIFF
--- a/.changeset/pr-1138.md
+++ b/.changeset/pr-1138.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': minor
+---
+
+feat(cli-core): expand isCi detection coverage via ci-info

--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -68,6 +68,7 @@
     "@sanity/client": "catalog:",
     "babel-plugin-react-compiler": "^1.0.0",
     "boxen": "^8.0.1",
+    "ci-info": "^4.3.1",
     "debug": "catalog:",
     "get-it": "^8.7.0",
     "get-tsconfig": "catalog:",

--- a/packages/@sanity/cli-core/src/util/isCi.ts
+++ b/packages/@sanity/cli-core/src/util/isCi.ts
@@ -1,6 +1,3 @@
-import {isTrueish} from './isTrueish.js'
+import {isCI} from 'ci-info'
 
-export const isCi = (): boolean =>
-  isTrueish(process.env.CI) || // Travis CI, CircleCI, Gitlab CI, Appveyor, CodeShip
-  isTrueish(process.env.CONTINUOUS_INTEGRATION) || // Travis CI
-  isTrueish(process.env.BUILD_NUMBER) // Jenkins, TeamCity
+export const isCi = (): boolean => isCI

--- a/packages/@sanity/cli-core/src/util/isTrueish.ts
+++ b/packages/@sanity/cli-core/src/util/isTrueish.ts
@@ -1,8 +1,0 @@
-export function isTrueish(value: string | undefined) {
-  if (value === undefined) return false
-  if (value.toLowerCase() === 'true') return true
-  if (value.toLowerCase() === 'false') return false
-  const number = Number.parseInt(value, 10)
-  if (Number.isNaN(number)) return false
-  return number > 0
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -876,6 +876,9 @@ importers:
       boxen:
         specifier: ^8.0.1
         version: 8.0.1
+      ci-info:
+        specifier: ^4.3.1
+        version: 4.3.1
       debug:
         specifier: 'catalog:'
         version: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
### Description

Replaces the hand-rolled three-env-var CI check with [`ci-info`](https://github.com/watson/ci-info), which detects ~80 CI providers (GitHub Actions, GitLab CI, CircleCI, Vercel, Buildkite, Azure Pipelines, etc.).

Resolves [AIGRO-5015](https://linear.app/sanity/issue/AIGRO-5015/detect-when-cli-is-running-in-ci).

### What to review

- `packages/@sanity/cli-core/src/util/isCi.ts` — now a 3-line pass-through to `ci-info`'s `isCI`.
- `packages/@sanity/cli-core/package.json` — adds `ci-info: ^4.3.1` as a direct dep.

`isCi()` is consumed by the update notifier, telemetry disclosure, telemetry consent resolution, and telemetry status — all already mock `isCi` directly in their tests, so the change is transparent to them.

### Testing

No new tests — `isCi` is now a trivial wrapper around `ci-info`, and testing it would only verify the mock returns what we set. The existing consumers continue to mock `isCi` directly.

Verified: `pnpm check:types`, `pnpm check:lint`, `pnpm check:deps` pass.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small utility swap; public `isCi()` API unchanged and downstream code already mocks it in tests.
> 
> **Overview**
> **`isCi()`** in `@sanity/cli-core` no longer checks a few env vars (`CI`, `CONTINUOUS_INTEGRATION`, `BUILD_NUMBER`) via a local **`isTrueish`** helper. It now returns **`ci-info`**’s **`isCI`**, which recognizes many more CI environments (e.g. GitHub Actions, Vercel, Buildkite).
> 
> The **`isTrueish`** module is removed. **`ci-info`** `^4.3.1` is added as a direct dependency, with a **minor** changeset entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 106e55990d6a9525c59d7a838986e46131edf48b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->