### PR TITLE
fix(turbo): bust cli-test build cache when fixtures change

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,11 @@
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**", ".sanity/**", "lib/**", "fixtures/**"]
     },
+    "@sanity/cli-test#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/fixtures/**", "$TURBO_ROOT$/pnpm-workspace.yaml"],
+      "outputs": ["dist/**", "fixtures/**"]
+    },
     "build:types": {
       "dependsOn": ["^build", "^build:types", "build"],
       "outputs": ["dist/**/*.d.ts"]


### PR DESCRIPTION
`@sanity/cli-test` bundles its test fixtures by copying them from the repo-root `fixtures/` via `copy:fixtures` at build time.

The generic `build` task only keys its cache on files inside the package, so editing a repo-root fixture leaves cli-test's cache key unchanged. turbo then replays a stale bundled copy and tests run against an outdated fixture — a silent, confusing failure mode (the test reads a fixture that no longer matches what's on disk).

Fix: give `@sanity/cli-test#build` an explicit input set that includes `$TURBO_ROOT$/fixtures` and `pnpm-workspace.yaml` (the catalog `copy:fixtures` also reads), so fixture edits invalidate the cache.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/cache configuration only; no runtime product or security behavior changes.
> 
> **Overview**
> Adds a **Turbo** override for `@sanity/cli-test#build` so cache keys include repo-root `fixtures/**` and `pnpm-workspace.yaml`, not only files inside the package.
> 
> That way edits to shared fixtures (copied in at build via `copy:fixtures`) invalidate the build cache instead of reusing a stale bundled copy during CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d22456c3744864c91deef7d2fa90525ad2684511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->