### PR TITLE
feat(workbench): merge app group + priority into the core-app manifest

### DIFF
--- a/.changeset/pr-1146.md
+++ b/.changeset/pr-1146.md
@@ -4,4 +4,4 @@
 '@sanity/cli': minor
 ---
 
-feat(cli): merge app group + priority into the core-app manifest
+feat(workbench): merge app group + priority into the core-app manifest

--- a/.changeset/pr-1146.md
+++ b/.changeset/pr-1146.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+---
+
+feat(cli): merge app group + priority into the core-app manifest

--- a/.changeset/pr-1146.md
+++ b/.changeset/pr-1146.md
@@ -1,5 +1,6 @@
 <!-- auto-generated -->
 ---
+'@sanity/cli-build': minor
 '@sanity/cli-core': minor
 '@sanity/cli': minor
 ---

--- a/.changeset/pr-1146.md
+++ b/.changeset/pr-1146.md
@@ -1,6 +1,5 @@
 <!-- auto-generated -->
 ---
-'@sanity/cli-build': minor
 '@sanity/cli-core': minor
 '@sanity/cli': minor
 ---

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -24,6 +24,8 @@ export interface CliConfig {
   app?: {
     /** The entrypoint for your custom app. By default, `src/App.tsx` */
     entry?: string
+    /** Dock group the app renders in. Defaults to `dock.applications`. */
+    group?: 'dock.applications' | 'dock.system' | 'dock.user'
     /**
      * Path to an icon file relative to project root.
      * The file must be an SVG.
@@ -33,6 +35,8 @@ export interface CliConfig {
     id?: string
     /** The ID for the Sanity organization that manages this application */
     organizationId?: string
+    /** Sort position within the dock group, ascending. Defaults to `100`. */
+    priority?: number
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
   }

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -50,6 +50,26 @@ describe('extractCoreAppManifest', () => {
     expect(mockReadFile).not.toHaveBeenCalled()
   })
 
+  test('merges group and priority into the manifest', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: {group: 'dock.system', organizationId: 'org-1', priority: 20, title: 'My App'},
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result).toEqual({group: 'dock.system', priority: 20, title: 'My App', version: '1'})
+  })
+
+  test('keeps priority 0 (not dropped as a falsy value)', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: {organizationId: 'org-1', priority: 0, title: 'My App'},
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result?.priority).toBe(0)
+  })
+
   test('reads icon from file path and inlines in manifest', async () => {
     const workDir = '/project'
     mockGetCliConfig.mockResolvedValue({

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -97,6 +97,8 @@ export async function extractCoreAppManifest(
       version: '1',
       ...(icon ? {icon} : {}),
       ...(app.title ? {title: app.title} : {}),
+      ...(app.group ? {group: app.group} : {}),
+      ...(app.priority === undefined ? {} : {priority: app.priority}),
     })
 
     spin.succeed(`Extracted manifest`)

--- a/packages/@sanity/cli/src/actions/manifest/types.ts
+++ b/packages/@sanity/cli/src/actions/manifest/types.ts
@@ -25,7 +25,9 @@ export interface CreateManifest {
  * since the CLI produces the payload in full.
  */
 export const coreAppManifestSchema = z.object({
+  group: z.optional(z.string()),
   icon: z.optional(z.string()),
+  priority: z.optional(z.number()),
   title: z.optional(z.string()),
   version: z.string(),
 })


### PR DESCRIPTION
The CLI side of **US2 — dock placement** (`002-workbench-extension-api`), stacked on #1143. Companion to workbench PR #235.

Carries `group`/`priority` from `unstable_defineApp` into the core-app manifest:
- `coreAppManifestSchema` + `CliConfig.app` type gain `group`/`priority`.
- `extractCoreAppManifest` merges them alongside `title`/`icon` (`priority: 0` preserved, not dropped as falsy).

For **local `sanity dev` apps** this rides the existing path with no new wiring: the config watcher re-extracts the manifest on `sanity.cli.ts` edits → `registration.update` rewrites the dev-server registry entry → `watchRegistry` → `ws.send('sanity:workbench:local-applications')`. So editing group/priority live re-sorts the dock without a restart (FR-024). The registry validates against the same extended `coreAppManifestSchema`, so the fields aren't stripped.

Added unit coverage in `extractCoreAppManifest.test.ts` (merge + `priority: 0`).

**Note:** the workbench canaries declaring `group`/`priority` (and clean cross-repo types) need this CLI to ship its `@sanity/federation` bump first — until then the workbench side keeps that as local WIP.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive manifest fields and extraction logic with unit tests; no auth, security, or breaking changes to existing manifest consumers.
> 
> **Overview**
> Extends **dock placement** for custom apps by flowing `group` and `priority` from `sanity.cli` / `CliConfig.app` into the **core-app manifest** the CLI emits for the workbench.
> 
> `CliConfig.app` gains typed `group` (`dock.applications` | `dock.system` | `dock.user`) and `priority` (sort order within the group). `coreAppManifestSchema` adds optional `group` and `priority`; `extractCoreAppManifest` merges them with existing `title`/`icon`, using an explicit `priority === undefined` check so **`priority: 0` is kept** (not treated as falsy). Unit tests cover merge behavior and `priority: 0`.
> 
> Minor bumps for `@sanity/cli` and `@sanity/cli-core` in the changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06258768352c08ba53c383715ebf766e95ad05d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->