### PR TITLE
refactor(cli): pass through reactStrictMode to let studio default take effect

### DIFF
--- a/.changeset/strict-mode-default-dev.md
+++ b/.changeset/strict-mode-default-dev.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': minor
+---
+
+Enable React StrictMode by default in `sanity dev`. Opt out with `reactStrictMode: false` in `sanity.cli.ts` or by setting `SANITY_STUDIO_REACT_STRICT_MODE=false`.

--- a/.changeset/strict-mode-default-dev.md
+++ b/.changeset/strict-mode-default-dev.md
@@ -2,4 +2,4 @@
 '@sanity/cli': minor
 ---
 
-Enable React StrictMode by default in `sanity dev`. Opt out with `reactStrictMode: false` in `sanity.cli.ts` or by setting `SANITY_STUDIO_REACT_STRICT_MODE=false`.
+Defer the `reactStrictMode` default for `sanity dev` to the `sanity` package. When `reactStrictMode` is unset in `sanity.cli.ts` and the `SANITY_STUDIO_REACT_STRICT_MODE` env var is absent, the CLI no longer forces a value; `renderStudio`'s own default decides instead. That default is off in Studio v5 and on in Studio v6. Explicit config and the env var still take effect. Opt out with `reactStrictMode: false` in `sanity.cli.ts` or by setting `SANITY_STUDIO_REACT_STRICT_MODE=false`.

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getEntryModule.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getEntryModule.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, test} from 'vitest'
+
+import {getEntryModule} from '../getEntryModule'
+
+describe('getEntryModule', () => {
+  test('emits reactStrictMode: undefined when the option is undefined, deferring to the studio default', () => {
+    const output = getEntryModule({
+      reactStrictMode: undefined,
+      relativeConfigLocation: './sanity.config',
+    })
+
+    expect(output).toContain('reactStrictMode: undefined')
+  })
+
+  test('emits reactStrictMode: undefined for the no-config template too', () => {
+    const output = getEntryModule({
+      reactStrictMode: undefined,
+      relativeConfigLocation: null,
+    })
+
+    expect(output).toContain('reactStrictMode: undefined')
+    expect(output).toContain('missingConfigFile: true')
+  })
+
+  test('emits a concrete reactStrictMode: true when explicitly enabled', () => {
+    const output = getEntryModule({
+      reactStrictMode: true,
+      relativeConfigLocation: './sanity.config',
+    })
+
+    expect(output).toContain('reactStrictMode: true')
+  })
+
+  test('emits a concrete reactStrictMode: false when explicitly disabled', () => {
+    const output = getEntryModule({
+      reactStrictMode: false,
+      relativeConfigLocation: './sanity.config',
+    })
+
+    expect(output).toContain('reactStrictMode: false')
+  })
+
+  test('never references reactStrictMode for the app entry module', () => {
+    const output = getEntryModule({
+      isApp: true,
+      reactStrictMode: undefined,
+      relativeConfigLocation: null,
+    })
+
+    expect(output).not.toContain('reactStrictMode')
+    expect(output).toContain('createRoot')
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/getEntryModule.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getEntryModule.ts
@@ -41,7 +41,7 @@ export function getEntryModule(options: {
   basePath?: string
   entry?: string
   isApp?: boolean
-  reactStrictMode: boolean
+  reactStrictMode: boolean | undefined
   relativeConfigLocation: string | null
 }): string {
   const {basePath, entry, isApp, reactStrictMode, relativeConfigLocation} = options
@@ -53,7 +53,10 @@ export function getEntryModule(options: {
   const sourceModule = relativeConfigLocation ? entryModule : noConfigEntryModule
 
   return sourceModule
-    .replace(/%STUDIO_REACT_STRICT_MODE%/, JSON.stringify(Boolean(reactStrictMode)))
+    .replace(
+      /%STUDIO_REACT_STRICT_MODE%/,
+      reactStrictMode === undefined ? 'undefined' : JSON.stringify(reactStrictMode),
+    )
     .replace(/%STUDIO_CONFIG_LOCATION%/, JSON.stringify(relativeConfigLocation))
     .replace(/%STUDIO_BASE_PATH%/, JSON.stringify(basePath || '/'))
 }

--- a/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
+++ b/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
@@ -14,7 +14,7 @@ import {renderDocument} from './renderDocument.js'
 
 interface RuntimeOptions {
   cwd: string
-  reactStrictMode: boolean
+  reactStrictMode: boolean | undefined
   watch: boolean
 
   appTitle?: string

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -85,7 +85,7 @@ export interface CliConfig {
   /** Configuration options for React Compiler */
   reactCompiler?: ReactCompilerConfig
 
-  /** Wraps the Studio in \<React.StrictMode\> root to aid in flagging potential problems related to concurrent features (startTransition, useTransition, useDeferredValue, Suspense). Can also be enabled by setting SANITY_STUDIO_REACT_STRICT_MODE="true"|"false". It only applies to sanity dev in development mode and is ignored in sanity build and in production. Defaults to false. */
+  /** Wraps the Studio in \<React.StrictMode\> root to aid in flagging potential problems related to concurrent features (startTransition, useTransition, useDeferredValue, Suspense). Can also be enabled by setting SANITY_STUDIO_REACT_STRICT_MODE="true"|"false". It only applies to sanity dev in development mode and is ignored in sanity build and in production. Defaults to true. */
   reactStrictMode?: boolean
 
   /**

--- a/packages/@sanity/cli/src/actions/dev/__tests__/getDevServerConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/getDevServerConfig.test.ts
@@ -150,7 +150,21 @@ describe('getDevServerConfig', () => {
     expect(config.reactStrictMode).toBe(false)
   })
 
-  test('should resolve reactStrictMode to true by default when env var is absent and cliConfig is unset', () => {
+  test('should resolve reactStrictMode to true when env var is absent and cliConfig opts in explicitly', () => {
+    const output = createMockOutput()
+    const cliConfig: CliConfig = {reactStrictMode: true}
+
+    const config = getDevServerConfig({
+      cliConfig,
+      flags: FLAGS,
+      output,
+      workDir: '/tmp',
+    })
+
+    expect(config.reactStrictMode).toBe(true)
+  })
+
+  test('should leave reactStrictMode undefined when env var is absent and cliConfig is unset, deferring to the studio default', () => {
     const output = createMockOutput()
 
     const config = getDevServerConfig({
@@ -160,6 +174,6 @@ describe('getDevServerConfig', () => {
       workDir: '/tmp',
     })
 
-    expect(config.reactStrictMode).toBe(true)
+    expect(config.reactStrictMode).toBeUndefined()
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/getDevServerConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/getDevServerConfig.test.ts
@@ -107,4 +107,59 @@ describe('getDevServerConfig', () => {
 
     expect(output.warn).not.toHaveBeenCalled()
   })
+
+  test('should resolve reactStrictMode to true when SANITY_STUDIO_REACT_STRICT_MODE env var is "true"', () => {
+    vi.stubEnv('SANITY_STUDIO_REACT_STRICT_MODE', 'true')
+    const output = createMockOutput()
+
+    const config = getDevServerConfig({
+      cliConfig: {},
+      flags: FLAGS,
+      output,
+      workDir: '/tmp',
+    })
+
+    expect(config.reactStrictMode).toBe(true)
+  })
+
+  test('should resolve reactStrictMode to false when SANITY_STUDIO_REACT_STRICT_MODE env var is "false"', () => {
+    vi.stubEnv('SANITY_STUDIO_REACT_STRICT_MODE', 'false')
+    const output = createMockOutput()
+
+    const config = getDevServerConfig({
+      cliConfig: {},
+      flags: FLAGS,
+      output,
+      workDir: '/tmp',
+    })
+
+    expect(config.reactStrictMode).toBe(false)
+  })
+
+  test('should resolve reactStrictMode to false when env var is absent and cliConfig opts out explicitly', () => {
+    const output = createMockOutput()
+    const cliConfig: CliConfig = {reactStrictMode: false}
+
+    const config = getDevServerConfig({
+      cliConfig,
+      flags: FLAGS,
+      output,
+      workDir: '/tmp',
+    })
+
+    expect(config.reactStrictMode).toBe(false)
+  })
+
+  test('should resolve reactStrictMode to true by default when env var is absent and cliConfig is unset', () => {
+    const output = createMockOutput()
+
+    const config = getDevServerConfig({
+      cliConfig: {},
+      flags: FLAGS,
+      output,
+      workDir: '/tmp',
+    })
+
+    expect(config.reactStrictMode).toBe(true)
+  })
 })

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -35,7 +35,7 @@ export function getDevServerConfig({
   const env = process.env
   const reactStrictMode = env.SANITY_STUDIO_REACT_STRICT_MODE
     ? env.SANITY_STUDIO_REACT_STRICT_MODE === 'true'
-    : (cliConfig?.reactStrictMode ?? true)
+    : cliConfig?.reactStrictMode
 
   const envBasePath = getSanityEnvVar('BASEPATH', isApp ?? false)
   if (envBasePath && cliConfig?.project?.basePath) {

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -35,7 +35,7 @@ export function getDevServerConfig({
   const env = process.env
   const reactStrictMode = env.SANITY_STUDIO_REACT_STRICT_MODE
     ? env.SANITY_STUDIO_REACT_STRICT_MODE === 'true'
-    : Boolean(cliConfig?.reactStrictMode)
+    : (cliConfig?.reactStrictMode ?? true)
 
   const envBasePath = getSanityEnvVar('BASEPATH', isApp ?? false)
   if (envBasePath && cliConfig?.project?.basePath) {

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -23,7 +23,7 @@ export interface DevServerOptions {
   httpPort: number
 
   reactCompiler: ReactCompilerConfig | undefined
-  reactStrictMode: boolean
+  reactStrictMode: boolean | undefined
 
   staticPath: string
 


### PR DESCRIPTION
### Description

Defers the `reactStrictMode` default for `sanity dev` to the `sanity` package instead of having the CLI decide it. `getDevServerConfig` no longer forces a value when `reactStrictMode` is unset, and `getEntryModule` emits `reactStrictMode: undefined` so `renderStudio`'s own destructuring default applies. That default is off in Studio v5 and on in Studio v6, so the on-by-default behavior now lives entirely in `sanity@6` and reaches users only when they upgrade the Studio. Explicit config (`reactStrictMode: false` or `true`) and the `SANITY_STUDIO_REACT_STRICT_MODE` env var still take precedence. Production builds (`sanity build`) are unaffected. Part of [SAPP-3841](https://linear.app/sanity/issue/SAPP-3841).

This reverses the earlier approach on this branch. Previously the CLI flipped the default itself (`cliConfig?.reactStrictMode ?? true`), but because `sanity@5` depends on `@sanity/cli` via `^6.x`, a minor CLI release would have leaked StrictMode-on to existing `sanity@5` users running `sanity dev`. Making the CLI a pass-through keeps this change non-breaking for current `sanity@5` users and confines the breaking default to the `sanity@6` major (sanity-io/sanity#12916), which also covers the component audit.

### What to review

- `getDevServerConfig.ts` - drops the `?? true` fallback; the resolved value is now `boolean | undefined`.
- `getEntryModule.ts` - emits the literal `undefined` instead of coercing with `Boolean()` when `reactStrictMode` is unset, so the generated entry lets `renderStudio`'s default decide.
- `DevServerOptions` / `RuntimeOptions` - `reactStrictMode` widened to `boolean | undefined` (internal types, not part of the public export surface).
- Confirm the opt-out paths are intact: explicit config and the env var still emit concrete booleans, and `sanity build` still passes a literal `false`.

### Testing

Updated `getDevServerConfig` tests: the unset case now resolves to `undefined` (deferring to the studio), with an added explicit `reactStrictMode: true` config case; the env-var-true, env-var-false, and explicit-false cases are unchanged. Added a new `getEntryModule` test asserting the generated entry contains `reactStrictMode: undefined` when unset (for both the config and no-config templates), concrete `true`/`false` when set, and never references `reactStrictMode` for the app entry. All pass; types and format clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default dev behavior when neither config nor env is set (now follows Studio major version), though explicit overrides remain; avoids turning StrictMode on for existing sanity@5 projects via a CLI-only default.
> 
> **Overview**
> For **`sanity dev`**, the CLI stops choosing a default for **`reactStrictMode`** when it is omitted from `sanity.cli.ts` and **`SANITY_STUDIO_REACT_STRICT_MODE`** is not set. **`getDevServerConfig`** now passes through `cliConfig?.reactStrictMode` (including `undefined`) instead of coercing with `Boolean()`, and **`getEntryModule`** writes the literal `reactStrictMode: undefined` in the generated runtime entry instead of `false`, so **`renderStudio`** in the installed **`sanity`** package applies its own default (off on v5, on on v6).
> 
> Explicit **`reactStrictMode: true|false`** in CLI config and the env var still resolve to concrete booleans. Internal types (`DevServerOptions`, `RuntimeOptions`, `getEntryModule`) accept **`boolean | undefined`**. **`CliConfig`** JSDoc now documents default **true** for the option when documented at the config layer. New tests cover dev resolution and generated entry output; a changeset records the **`@sanity/cli`** minor behavior note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb3bedb2af2a669cc4eff544dc4628276b34cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->