### PR TITLE
fix(mcp): use oauth for codex cli config

### DIFF
--- a/.changeset/codex-mcp-oauth-only.md
+++ b/.changeset/codex-mcp-oauth-only.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+`sanity mcp configure` now uses OAuth for Codex CLI.

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
@@ -71,7 +71,16 @@ describe('buildServerConfig', () => {
     })
   })
 
-  test('Codex CLI uses http_headers instead of headers', () => {
+  test('Codex CLI config uses OAuth (no http_headers)', () => {
+    const config = EDITOR_CONFIGS['Codex CLI'].buildServerConfig()
+
+    expect(config).toStrictEqual({
+      type: 'http',
+      url: 'https://mcp.sanity.io',
+    })
+  })
+
+  test('Codex CLI uses http_headers instead of headers when given a token', () => {
     const config = EDITOR_CONFIGS['Codex CLI'].buildServerConfig(testToken)
 
     expect(config).toStrictEqual({
@@ -81,12 +90,11 @@ describe('buildServerConfig', () => {
     })
   })
 
-  test('all editors except Cursor and Claude Code include auth credentials', () => {
+  test('all editors except OAuth-only ones include auth credentials', () => {
     const editorsWithToken = [
       'Antigravity',
       'Cline',
       'Cline CLI',
-      'Codex CLI',
       'Gemini CLI',
       'GitHub Copilot CLI',
       'MCPorter',

--- a/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
+++ b/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
@@ -253,12 +253,17 @@ function buildClineServerConfig(token: string): Record<string, unknown> {
   }
 }
 
-function buildCodexCliServerConfig(token: string): Record<string, unknown> {
-  return {
-    http_headers: {Authorization: `Bearer ${token}`},
+function buildCodexCliServerConfig(token?: string): Record<string, unknown> {
+  const config: Record<string, unknown> = {
     type: 'http',
     url: MCP_SERVER_URL,
   }
+
+  if (token) {
+    config.http_headers = {Authorization: `Bearer ${token}`}
+  }
+
+  return config
 }
 
 function buildGitHubCopilotCliServerConfig(token: string): Record<string, unknown> {
@@ -334,6 +339,7 @@ export const EDITOR_CONFIGS = {
     configKey: 'mcp_servers',
     detect: detectCodexCli,
     format: 'toml' as const,
+    oauthOnly: true,
     readToken: readTokenFromHttpHeaders,
     skillsCliAgent: 'codex',
   },

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -328,8 +328,9 @@ const editorTestCases: EditorTestCase[] = [
   {
     detect: {cliCommands: ['codex']},
     expectedConfigPath: '.codex/config.toml',
-    expectedContentChecks: ['[mcp_servers.Sanity]', '[mcp_servers.Sanity.http_headers]'],
+    expectedContentChecks: ['[mcp_servers.Sanity]'],
     name: 'Codex CLI',
+    oauthOnly: true,
   },
   {
     detect: {
@@ -343,6 +344,7 @@ const editorTestCases: EditorTestCase[] = [
     },
     expectedConfigPath: convertToSystemPath('/tmp/custom-codex-home/config.toml'),
     name: 'Codex CLI',
+    oauthOnly: true,
   },
   {
     detect: {


### PR DESCRIPTION
### Description

Makes `Codex CLI` an OAuth-only editor in `sanity mcp configure`, so it no longer embeds a Sanity API token and instead relies on Codex's own OAuth flow (which now has improved auth messaging). Mirrors the same change made for Claude Code in #1118.

Resolves [AIGRO-5053](https://linear.app/sanity/issue/AIGRO-5053/use-oauth-only-auth-text-in-mcp-configure).

### What to review

- `editorConfigs.ts`: `Codex CLI` now has `oauthOnly: true`; `buildCodexCliServerConfig` only writes `http_headers` when a token is actually present (matching `defaultHttpConfig`'s empty-token handling).

### Testing

Updated unit tests in `editorConfigs.test.ts` and `configure.test.ts` to cover the OAuth-only Codex path. Tests, typecheck, and lint pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows auth to OAuth for one editor using an existing oauthOnly pattern; reduces stored tokens in local config with no changes to core auth services.
> 
> **Overview**
> **Codex CLI** is now treated as an **OAuth-only** editor in `sanity mcp configure`, matching **Cursor** and **Claude Code**. Configure will write only the HTTP MCP server URL/type to `~/.codex/config.toml` (or `CODEX_HOME`) and will **not** mint or embed a Sanity API token in `http_headers` for fresh setups.
> 
> `buildCodexCliServerConfig` now accepts an optional token and only adds `http_headers` when a token is explicitly provided (e.g. reusing auth from another editor). Tests and the changeset were updated to assert the OAuth-only Codex path and that configure output no longer includes `[mcp_servers.Sanity.http_headers]` by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba6ca2bdbe4116aa4dcb789dde4d3119e918900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->