### PR TITLE
fix(dev): canonicalize watch dirs to long path on Windows

### DIFF
--- a/.changeset/pr-1156.md
+++ b/.changeset/pr-1156.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(dev): canonicalize watch dirs to long path on Windows

--- a/packages/@sanity/cli/src/actions/dev/__tests__/canonicalizeWatchDir.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/canonicalizeWatchDir.test.ts
@@ -1,0 +1,29 @@
+import {mkdirSync, realpathSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {afterEach, describe, expect, test} from 'vitest'
+
+import {canonicalizeWatchDir} from '../canonicalizeWatchDir.js'
+
+describe('canonicalizeWatchDir', () => {
+  const created: string[] = []
+
+  afterEach(() => {
+    created.length = 0
+  })
+
+  test('resolves an existing directory to its canonical real path', () => {
+    const dir = join(tmpdir(), `sanity-canon-test-${process.pid}-${Date.now()}`)
+    mkdirSync(dir, {recursive: true})
+    created.push(dir)
+
+    expect(canonicalizeWatchDir(dir)).toBe(realpathSync.native(dir))
+  })
+
+  test('falls back to the input path when it cannot be resolved', () => {
+    const missing = join(tmpdir(), `sanity-canon-missing-${process.pid}-${Date.now()}`)
+
+    expect(canonicalizeWatchDir(missing)).toBe(missing)
+  })
+})

--- a/packages/@sanity/cli/src/actions/dev/canonicalizeWatchDir.ts
+++ b/packages/@sanity/cli/src/actions/dev/canonicalizeWatchDir.ts
@@ -1,0 +1,23 @@
+import {realpathSync} from 'node:fs'
+
+/**
+ * Resolve a directory to its canonical (long) form before handing it to
+ * `fs.watch`.
+ *
+ * On Windows, `fs.watch` aborts with a libuv assertion
+ * (`!_wcsnicmp(filename, dir, dirlen)` in `fs-event.c`) when the watched path
+ * is an 8.3 short name — e.g. temp dirs under `RUNNER~1` — because the OS
+ * reports long-form filenames that fail libuv's prefix check.
+ * `realpathSync.native` expands short names to their long form so the
+ * prefixes match.
+ *
+ * Falls back to the original path when it can't be resolved (e.g. it doesn't
+ * exist yet), which is no worse than watching it directly.
+ */
+export function canonicalizeWatchDir(dir: string): string {
+  try {
+    return realpathSync.native(dir)
+  } catch {
+    return dir
+  }
+}

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -14,6 +14,7 @@ import {getSanityDataDir} from '@sanity/cli-core'
 import {z} from 'zod/mini'
 
 import {coreAppManifestSchema, studioManifestSchema} from '../manifest/types.js'
+import {canonicalizeWatchDir} from './canonicalizeWatchDir.js'
 import {devDebug} from './devDebug.js'
 
 /** Bump when the manifest/lock shape changes in a breaking way. */
@@ -411,6 +412,10 @@ export function watchRegistry(callback: (servers: DevServerManifest[]) => void):
   const registryDir = getRegistryDir()
   mkdirSync(registryDir, {recursive: true})
 
+  // Canonicalize to the real long path so `fs.watch` doesn't abort on Windows
+  // short-path dirs. See `canonicalizeWatchDir`.
+  const watchDir = canonicalizeWatchDir(registryDir)
+
   let debounceTimer: ReturnType<typeof setTimeout> | undefined
 
   const notify = () => {
@@ -420,7 +425,7 @@ export function watchRegistry(callback: (servers: DevServerManifest[]) => void):
     }, 50)
   }
 
-  const watcher = watch(registryDir, notify)
+  const watcher = watch(watchDir, notify)
 
   return {
     close() {

--- a/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
@@ -3,6 +3,7 @@ import {basename, dirname} from 'node:path'
 
 import {findProjectRoot, type Output} from '@sanity/cli-core'
 
+import {canonicalizeWatchDir} from './canonicalizeWatchDir.js'
 import {devDebug} from './devDebug.js'
 
 /**
@@ -100,7 +101,9 @@ export async function startDevManifestWatcher<T>({
   // Watching the file itself is unreliable across editors that perform
   // atomic-save (delete + rename) — the watcher loses its target once the
   // inode changes. Directory watches survive those transitions.
-  const configDir = dirname(configPath)
+  // Canonicalize to the real long path so `fs.watch` doesn't abort on Windows
+  // short-path dirs. See `canonicalizeWatchDir`.
+  const configDir = canonicalizeWatchDir(dirname(configPath))
   const configFilename = basename(configPath)
 
   let debounceTimer: ReturnType<typeof setTimeout> | undefined


### PR DESCRIPTION
### Description

Stacked on #1155. Fixes the one persistent CI failure there: `test (windows-8core, 24, 2, 4)` crashing every run.

It's not a flake. `fs.watch` aborts the process on Windows when the watched path is an 8.3 short name — libuv's `fs-event.c` assertion `!_wcsnicmp(filename, dir, dirlen)` fires because the OS reports long-form filenames that don't prefix-match the short watched path. CI's Windows runners trip it because temp dirs resolve through `RUNNER~1`, and the dev-server registry + manifest watchers watch those dirs, killing the vitest worker fork.

`feat/workbench` never saw this because its last CI predates the current Windows test matrix — the watcher code only meets these shards on the rebased branches.

Fix: resolve the directory with `realpathSync.native` (expands short → long) before handing it to `fs.watch`, via a shared `canonicalizeWatchDir` helper. Falls back to the raw path if it can't be resolved, so it's no worse than before anywhere else.

### What to review

`canonicalizeWatchDir` and its two call sites (`devServerRegistry.ts`, `startDevManifestWatcher.ts`). The real signal is the Windows shard going green here.

### Testing

Added a unit test for the helper (resolve + fallback). Existing registry/manifest watcher suites pass. The Windows shard is what CI confirms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow dev-server file-watcher path normalization with safe fallback; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **Windows CI crashes** where `fs.watch` on 8.3 short paths (e.g. `RUNNER~1`) triggers a libuv assertion and aborts the Vitest worker.
> 
> Adds **`canonicalizeWatchDir`**, which resolves directories with `realpathSync.native` to their long canonical path before watching, and **falls back** to the original path if resolution fails. **`watchRegistry`** and **`startDevManifestWatcher`** now pass canonicalized dirs into `fs.watch` instead of raw paths. Includes a small **unit test** for resolve and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c6b04b8cb0e18efc03ad5252c36d6ff463aae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->