### PR TITLE
chore: update nextjs tsconfig.json with defaults

### DIFF
--- a/fixtures/nextjs-app/tsconfig.json
+++ b/fixtures/nextjs-app/tsconfig.json
@@ -11,11 +11,11 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [{"name": "next"}],
     "paths": {"@/*": ["./*"]}
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Split from #1150, nextjs regenerates the tsconfig.json as it doesn't like `jsx: preserve` anymore, it wants `jsx: react-jsx`: https://github.com/vercel/next.js/blob/fbff9945a75ad5b65c3db23437393679df2dee67/packages/next/src/lib/typescript/writeConfigurationDefaults.ts#L50
It also wants `.next/types` and `.next/dev/types` patterns in its include array

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Fixture-only TypeScript config; no runtime or production code paths.
> 
> **Overview**
> Updates the **Next.js test fixture** `tsconfig.json` so it matches what current Next.js writes by default, avoiding drift when Next regenerates or validates config.
> 
> **`compilerOptions.jsx`** moves from `preserve` to **`react-jsx`**, matching Next’s TypeScript defaults. **`include`** now also picks up **`.next/types/**/*.ts`** and **`.next/dev/types/**/*.ts`** so generated route/types from the dev server are part of the project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb561dae1fbbbbca9575e4668a842e651518aa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->