### PR TITLE
fix: ensure babel-plugin-react-compiler is a peer dependency

### DIFF
--- a/.changeset/chilly-walls-repeat.md
+++ b/.changeset/chilly-walls-repeat.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli-core": patch
+---
+
+Fixes an issue where `babel-plugin-react-compiler` were a regular dependency, when it should've been a peer dependency

--- a/.changeset/happy-knives-call.md
+++ b/.changeset/happy-knives-call.md
@@ -1,0 +1,6 @@
+---
+"@sanity/cli": patch
+"@sanity/cli-build": patch
+---
+
+Fixes an issue where `babel-plugin-react-compiler` typings were bundled, instead of following peer dependency lookups

--- a/fixtures/worst-case-studio/package.json
+++ b/fixtures/worst-case-studio/package.json
@@ -28,6 +28,6 @@
     "@sanity/color": "^3.0.6",
     "@types/react": "^19.2.14",
     "typescript": "^5.9.3",
-    "vite": "^7.3.2"
+    "vite": "catalog:"
   }
 }

--- a/packages/@sanity/cli-build/package.json
+++ b/packages/@sanity/cli-build/package.json
@@ -91,13 +91,21 @@
     "@types/react-dom": "^19.2.3",
     "@types/semver": "^7.7.1",
     "@vitest/coverage-istanbul": "catalog:",
-    "babel-plugin-react-compiler": "^1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "eslint": "catalog:",
     "jsdom": "catalog:",
     "publint": "catalog:",
     "sanity": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "babel-plugin-react-compiler": "*"
+  },
+  "peerDependenciesMeta": {
+    "babel-plugin-react-compiler": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=20.19.1 <22 || >=22.12"

--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -66,7 +66,6 @@
     "@inquirer/prompts": "^8.3.0",
     "@oclif/core": "catalog:",
     "@sanity/client": "catalog:",
-    "babel-plugin-react-compiler": "^1.0.0",
     "boxen": "^8.0.1",
     "debug": "catalog:",
     "get-it": "^8.7.2",
@@ -81,7 +80,7 @@
     "rxjs": "catalog:",
     "tsx": "catalog:",
     "vite": "catalog:",
-    "vite-node": "^5.3.0",
+    "vite-node": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
@@ -96,11 +95,20 @@
     "@types/debug": "catalog:",
     "@types/jsdom": "catalog:",
     "@types/node": "catalog:",
+    "babel-plugin-react-compiler": "catalog:",
     "eslint": "catalog:",
     "publint": "catalog:",
     "sanity": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "babel-plugin-react-compiler": "*"
+  },
+  "peerDependenciesMeta": {
+    "babel-plugin-react-compiler": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=20.19.1 <22 || >=22.12"

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -162,7 +162,7 @@
     "@types/tar-stream": "^3.1.4",
     "@types/which": "^3.0.4",
     "@vitest/coverage-istanbul": "catalog:",
-    "babel-plugin-react-compiler": "^1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "eslint": "catalog:",
     "jsdom": "catalog:",
     "nock": "catalog:",
@@ -173,6 +173,14 @@
     "typescript": "catalog:",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "babel-plugin-react-compiler": "*"
+  },
+  "peerDependenciesMeta": {
+    "babel-plugin-react-compiler": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=20.19.1 <22 || >=22.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ catalogs:
     '@vitest/coverage-istanbul':
       specifier: ^4.1.7
       version: 4.1.7
+    babel-plugin-react-compiler:
+      specifier: ^1.0.0
+      version: 1.0.0
     debug:
       specifier: ^4.4.3
       version: 4.4.3
@@ -129,6 +132,9 @@ catalogs:
     vite:
       specifier: ^7.3.3
       version: 7.3.3
+    vite-node:
+      specifier: ^5.3.0
+      version: 5.3.0
     vitest:
       specifier: ^4.1.7
       version: 4.1.7
@@ -415,7 +421,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
-        specifier: ^7.3.2
+        specifier: 'catalog:'
         version: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   packages/@repo/coverage-delta:
@@ -753,7 +759,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.7(vitest@4.1.7)
       babel-plugin-react-compiler:
-        specifier: ^1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       eslint:
         specifier: 'catalog:'
@@ -895,7 +901,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.7(vitest@4.1.7)
       babel-plugin-react-compiler:
-        specifier: ^1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       eslint:
         specifier: 'catalog:'
@@ -927,9 +933,6 @@ importers:
       '@sanity/client':
         specifier: ^7.22.1
         version: 7.22.1
-      babel-plugin-react-compiler:
-        specifier: ^1.0.0
-        version: 1.0.0
       boxen:
         specifier: ^8.0.1
         version: 8.0.1
@@ -973,7 +976,7 @@ importers:
         specifier: 'catalog:'
         version: 7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-node:
-        specifier: ^5.3.0
+        specifier: 'catalog:'
         version: 5.3.0(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       zod:
         specifier: 'catalog:'
@@ -1012,6 +1015,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.41
+      babel-plugin-react-compiler:
+        specifier: 'catalog:'
+        version: 1.0.0
       eslint:
         specifier: 'catalog:'
         version: 10.4.1(jiti@2.7.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,10 +31,12 @@ catalog:
   '@sanity/telemetry': ^1.1.0
 
   # Build & Development Tools
+  babel-plugin-react-compiler: ^1.0.0
   typescript: ^5.9.3
   vite: ^7.3.3
-  tsx: ^4.22.4
+  vite-node: ^5.3.0
   '@vitejs/plugin-react': ^5.2.0
+  tsx: ^4.22.4
 
   # Testing
   vitest: ^4.1.7


### PR DESCRIPTION
### Description

> Split out from #1150 (`vite` v8 / `@vitejs/plugin-react` v6 / `vite-node` v6 upgrade) — this PR isolates the `babel-plugin-react-compiler` peer-dependency fix and the related catalog cleanup so it can land independently.

`babel-plugin-react-compiler` must always be an **optional peer dependency** — never a regular `dependency`. This PR fixes the Sanity CLI packages to follow that convention.

**Why this matters**

Both `@sanity/cli-core` (`CliConfig['reactCompiler']` and `cliConfigSchema`) and `@sanity/cli-build` (`getViteConfig`) expose `babel-plugin-react-compiler`'s `PluginOptions` type as part of their public API:

```ts
import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
```

Because `babel-plugin-react-compiler` was a regular dependency (in `@sanity/cli-core`) rather than a peer, the declaration build **inlined and bundled those typings** into the published packages. For example, `@sanity/cli-build@0.2.1`'s `dist/_exports/_internal/build.d.ts` ships a frozen copy of the whole compiler type surface — `CompilerMode`, `EnvironmentConfig`, `EnvironmentConfigSchema`, `PluginOptions`, `ParsedPluginOptions`, etc.:

- https://npmx.dev/package-code/@sanity/cli-build/v/0.2.1/dist%2F_exports%2F_internal%2Fbuild.d.ts

This is the wrong behavior:

- Our own docs instruct userland to **always install `babel-plugin-react-compiler` in their own project**: https://www.sanity.io/docs/help/react-compiler
- For that to work — i.e. for userland to control which version of the compiler is used — it **must always be a peer dependency**.
- Frameworks and libraries follow exactly this convention. **Next.js** declares it as an optional peer:
  - https://github.com/vercel/next.js/blob/ddc4093aabfe80f2075cd6edf4c234403481fa28/packages/next/package.json#L114
  - https://github.com/vercel/next.js/blob/ddc4093aabfe80f2075cd6edf4c234403481fa28/packages/next/package.json#L120-L122
- So does **`@sanity/pkg-utils`**, which is used to build all of our React libraries and Sanity plugins:
  - https://github.com/sanity-io/pkg-utils/blob/2526d6ec0bfba11ab1389beeff28cf41d816c4a0/packages/%40sanity/pkg-utils/package.json#L121
  - https://github.com/sanity-io/pkg-utils/blob/2526d6ec0bfba11ab1389beeff28cf41d816c4a0/packages/%40sanity/pkg-utils/package.json#L125-L127

Inlining the typings also actively breaks users who opt into newer/experimental compiler versions: they get our frozen v1 types instead of the version they actually installed. The compiler's `PluginOptions` / `EnvironmentConfig` surface changes substantially between releases (fields added/removed/renamed, `CompilerMode` → `CompilerOutputMode`, `zod` → `zod/v4`, etc.), as seen comparing `1.0.0` against a recent experimental build:

- https://npmdiff.dev/babel-plugin-react-compiler/1.0.0/0.0.0-experimental-a1856f3-20260507/package/dist/index.d.ts/

**Changes**

- Declare `babel-plugin-react-compiler` as an **optional peer dependency** (`peerDependencies: "*"` + `peerDependenciesMeta.optional`) in `@sanity/cli`, `@sanity/cli-core`, and `@sanity/cli-build`.
- Remove `babel-plugin-react-compiler` from `@sanity/cli-core`'s runtime `dependencies` (it was the only package shipping it at runtime).
- Keep it as a `devDependency` in each package so the workspace still typechecks/builds.

With the package no longer a regular dependency, the emitted `.d.ts` references the consumer-installed `babel-plugin-react-compiler` via a peer lookup instead of bundling a frozen copy.

**Dependency cleanup (catalog)**

While here, a few dependencies that were still pinned inline were moved into the pnpm `catalog` so there's a single source of version truth (these were originally part of #1150):

- `babel-plugin-react-compiler` — added to the catalog (`^1.0.0`); `@sanity/cli`, `@sanity/cli-core`, and `@sanity/cli-build` now reference it via `catalog:` instead of inline `^1.0.0`.
- `vite-node` — added to the catalog (`^5.3.0`); `@sanity/cli-core` now references it via `catalog:` instead of inline `^5.3.0`.
- `fixtures/worst-case-studio` — `vite` switched from inline `^7.3.2` to the existing `catalog:` entry.

### What to review

- Mostly a manifest-only change — there are no runtime/source changes.
- All three published packages (`@sanity/cli`, `@sanity/cli-core`, `@sanity/cli-build`) declare `babel-plugin-react-compiler` as `peerDependencies: "*"` with `peerDependenciesMeta.optional: true`, matching the Next.js / `@sanity/pkg-utils` convention.
- `babel-plugin-react-compiler` is removed from `@sanity/cli-core`'s `dependencies`.
- Catalog wiring in `pnpm-workspace.yaml` (and the resulting `pnpm-lock.yaml`) resolves cleanly, and the inlined dependencies (`babel-plugin-react-compiler`, `vite-node`, fixture `vite`) now resolve through `catalog:`.
- After building, the published declarations (e.g. `@sanity/cli-build`'s `_internal/build.d.ts`) no longer inline `PluginOptions` / `EnvironmentConfig` and instead `import(...)` from `babel-plugin-react-compiler`.

### Testing

No automated tests added — this is dependency/manifest wiring with no behavioral change. Verified via type-checking, build, lint, `publint`, and a clean install/resolve of the catalog + optional peer dependency. The fix is confirmed by inspecting the emitted `.d.ts`, which now defers to the peer-installed `babel-plugin-react-compiler` typings rather than bundling them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest and lockfile-only; no runtime or source logic changes, with low install/typing resolution risk for consumers who opt into the React compiler.
> 
> **Overview**
> Treats **`babel-plugin-react-compiler`** as an **optional peer** on `@sanity/cli`, `@sanity/cli-core`, and `@sanity/cli-build` instead of shipping it as a runtime dependency (removed from `@sanity/cli-core` **dependencies**; kept under **devDependencies** for workspace builds). Published `.d.ts` should **import** compiler types from the consumer’s install instead of **inlining** frozen `PluginOptions` / related types.
> 
> Centralizes versions in the pnpm **catalog**: adds **`babel-plugin-react-compiler`** and **`vite-node`**, switches those packages (and **`fixtures/worst-case-studio`**’s `vite`) from inline pins to **`catalog:`**, with lockfile updates and patch changesets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6bef8d4b1323102e7060633e6a45d1e725c7b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->