### PR TITLE
feat(workbench): thread workbench services through, re-run live in dev (US4)

### DIFF
--- a/.changeset/pr-1176.md
+++ b/.changeset/pr-1176.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+'@sanity/cli': minor
+---
+
+feat(workbench): thread workbench services through, re-run live in dev (US4)

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -7,7 +7,11 @@ import {
   readPackageJson,
   type UserViteConfig,
 } from '@sanity/cli-core'
-import {type InterfaceArtifact, federation as viteFederation} from '@sanity/federation/vite'
+import {
+  type InterfaceArtifact,
+  type ServiceArtifact,
+  federation as viteFederation,
+} from '@sanity/federation/vite'
 import viteReact from '@vitejs/plugin-react'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import debug from 'debug'
@@ -93,6 +97,12 @@ interface ViteOptions extends Pick<CliConfig, 'schemaExtraction'> {
    */
   server?: {host?: string; port?: number}
   /**
+   * Background services the workbench app declares. Built into self-contained
+   * worker bundles and exposed through module federation as `./services/<name>`.
+   */
+  services?: readonly ServiceArtifact[]
+
+  /**
    * Whether or not to enable source maps
    */
   sourceMap?: boolean
@@ -125,6 +135,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     reactCompiler,
     schemaExtraction,
     server,
+    services,
     // default to `true` when `mode=development`
     sourceMap = options.mode === 'development',
     views,
@@ -216,6 +227,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
                     studioConfigPath: entries.relativeConfigLocation!,
                   }),
               pkgJson: await readPackageJson(path.join(cwd, 'package.json')),
+              services,
               views,
               workDir: cwd,
             }),

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -41,6 +41,7 @@ interface InternalBuildOptions {
   output: Output
   reactCompiler: CliConfig['reactCompiler']
   schemaExtraction: CliConfig['schemaExtraction']
+  services: DefineAppInput['services']
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
@@ -75,6 +76,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     output,
     reactCompiler: cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
     schemaExtraction: cliConfig?.schemaExtraction,
+    services: workbenchApp?.services,
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: flags.yes,
@@ -238,6 +240,7 @@ async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
       outputDir,
       reactCompiler: options.reactCompiler,
       schemaExtraction: options.schemaExtraction,
+      services: options.services,
       sourceMap: options.sourceMap,
       views: options.views,
       vite: options.vite,

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -11,7 +11,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {type CliConfig, type UserViteConfig} from '@sanity/cli-core'
-import {type InterfaceArtifact} from '@sanity/federation/vite'
+import {type InterfaceArtifact, type ServiceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {build, createBuilder} from 'vite'
 
@@ -47,6 +47,7 @@ interface StaticBuildOptions {
   profile?: boolean
   reactCompiler?: ReactCompilerConfig
   schemaExtraction?: CliConfig['schemaExtraction']
+  services?: readonly ServiceArtifact[]
   sourceMap?: boolean
   views?: readonly InterfaceArtifact[]
   vite?: UserViteConfig
@@ -73,6 +74,7 @@ export async function buildStaticFiles(
     outputDir,
     reactCompiler,
     schemaExtraction,
+    services,
     sourceMap = false,
     views,
     vite: extendViteConfig,
@@ -100,6 +102,7 @@ export async function buildStaticFiles(
       mode,
       outputDir,
       reactCompiler,
+      services,
       sourceMap,
       views,
     })

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -50,6 +50,7 @@ interface InternalBuildOptions {
   projectId: string | undefined
   reactCompiler: CliConfig['reactCompiler']
   schemaExtraction: CliConfig['schemaExtraction']
+  services: DefineAppInput['services']
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
@@ -97,6 +98,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     projectId: cliConfig?.api?.projectId,
     reactCompiler: cliConfig.reactCompiler,
     schemaExtraction: cliConfig.schemaExtraction,
+    services: workbenchApp?.services,
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: Boolean(flags.yes),
@@ -125,6 +127,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     projectId,
     reactCompiler,
     schemaExtraction,
+    services,
     sourceMap,
     stats,
     unattendedMode,
@@ -311,6 +314,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
       outputDir,
       reactCompiler,
       schemaExtraction,
+      services,
       sourceMap,
       views,
       vite,

--- a/packages/@sanity/cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -17,6 +17,15 @@ describe('deriveInterfaces', () => {
     ])
   })
 
+  test('maps services to worker interfaces', () => {
+    const app = workbenchApp({
+      services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread'},
+    ])
+  })
+
   test('derives an app interface from entry for an SDK app', () => {
     const app = workbenchApp({entry: './src/App.tsx', name: 'my-app'})
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
@@ -30,14 +39,16 @@ describe('deriveInterfaces', () => {
     expect(result?.some((iface) => iface.interface_type === 'app')).toBe(false)
   })
 
-  test('combines views and the app view (in that order)', () => {
+  test('combines views, services, and the app view (in that order)', () => {
     const app = workbenchApp({
       entry: './src/App.tsx',
       name: 'my-app',
+      services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
       {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread'},
       {entry_point: './src/App.tsx', interface_type: 'app', name: 'my-app'},
     ])
   })
@@ -49,7 +60,7 @@ describe('deriveInterfaces', () => {
     )
   })
 
-  test('a studio without entry still derives its panels', () => {
+  test('a studio without entry still derives its panels/workers', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     expect(deriveInterfaces(app, {isApp: false})).toEqual([
       {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},

--- a/packages/@sanity/cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/cli/src/actions/dev/deriveInterfaces.ts
@@ -7,18 +7,17 @@ export type DevServerInterface = NonNullable<DevServerManifest['interfaces']>[nu
 
 /**
  * Derive the workbench `interfaces[]` an app forwards to the dev-server
- * registry from its `unstable_defineApp` config: `views` → `panel`s and (SDK
- * apps) `entry` → the navigable `app` view. `entry_point` is the declared `src`
- * — the raw value, not a resolved URL. (Background `services` → `worker`s are
- * layered on in sanity-io/workbench spec 002-workbench-extension-api, US4.)
+ * registry from its `unstable_defineApp` config: `views` → `panel`s,
+ * `services` → `worker`s, and (SDK apps) `entry` → the navigable `app` view.
+ * `entry_point` is the declared `src` — the raw value, not a resolved URL.
  *
  * Returns `undefined` for a non-branded app (no `unstable_defineApp`). A studio
  * that declares `entry` reaches the not-yet-implemented studio app-view path and
  * is rejected (FR-026).
  *
  * Shared by the initial registration and the dev config watcher so editing
- * `views`/`entry` in `sanity.cli.ts` re-pushes the same shape live, the way
- * `title`/`icon` already re-sync (FR-024).
+ * `views`/`services`/`entry` in `sanity.cli.ts` re-pushes the same shape live,
+ * the way `title`/`icon` already re-sync (FR-024).
  */
 export function deriveInterfaces(
   app: CliConfig['app'],
@@ -38,6 +37,11 @@ export function deriveInterfaces(
       entry_point: view.src,
       interface_type: view.type,
       name: view.name,
+    })) ?? []),
+    ...(app.services?.map((service) => ({
+      entry_point: service.src,
+      interface_type: service.type,
+      name: service.name,
     })) ?? []),
     // sanity-io/workbench spec 002-workbench-extension-api, US5 — with no `entry` the app has no `app` view and isn't reachable as a
     // full-page app; with one, forward it so the workbench gates navigability.

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -31,11 +31,14 @@ const workbenchLockSchema = z.object({
 const devServerManifestSchema = z.extend(workbenchLockSchema, {
   id: z.optional(z.string()),
   /**
-   * Interfaces the app exposes (e.g. dock panels), mapped from the declared
-   * views. Carried separately from the manifest — interfaces live in the
-   * application service, not the manifest — so the workbench can render local
-   * panels without a deploy. `entry_point` is the declared `src`. Lenient by
-   * design; the workbench is the authority on the interface shape.
+   * Interfaces the app exposes, mapped from the declared `views` (dock panels,
+   * `interface_type: "panel"`) and `services` (background workers,
+   * `interface_type: "worker"`). A service is just an interface, so both live
+   * in this one list. Carried separately from the manifest — interfaces live in
+   * the application service, not the manifest — so the workbench can render
+   * local panels and run local workers without a deploy. `entry_point` is the
+   * declared `src`. Lenient by design; the workbench is the authority on the
+   * interface shape.
    */
   interfaces: z.optional(
     z.array(z.object({entry_point: z.string(), interface_type: z.string(), name: z.string()})),

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -54,6 +54,7 @@ export function getDevServerConfig({
     isWorkbenchApp: isWorkbenchApp(app),
     reactCompiler: cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
     reactStrictMode,
+    services: isWorkbenchApp(app) ? app.services : undefined,
     staticPath: path.join(workDir, 'static'),
     typegen: cliConfig?.typegen,
     views: isWorkbenchApp(app) ? app.views : undefined,

--- a/packages/@sanity/cli/src/exports/runtime.ts
+++ b/packages/@sanity/cli/src/exports/runtime.ts
@@ -8,4 +8,4 @@
 //
 // `unstable_defineApp` is config-time (Node) and stays on the main `@sanity/cli`
 // entry; only the runtime helpers live here.
-export {unstable_defineView} from '@sanity/federation'
+export {unstable_defineService, unstable_defineView} from '@sanity/federation'

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -4,7 +4,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {CliConfig, getCliTelemetry, type UserViteConfig} from '@sanity/cli-core'
-import {type InterfaceArtifact} from '@sanity/federation/vite'
+import {type InterfaceArtifact, type ServiceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {type FSWatcher} from 'chokidar'
 import {createServer, type InlineConfig, type ViteDevServer} from 'vite'
@@ -35,6 +35,7 @@ export interface DevServerOptions {
   isWorkbenchApp?: boolean
   projectName?: string
   schemaExtraction?: CliConfig['schemaExtraction']
+  services?: readonly ServiceArtifact[]
   typegen?: CliConfig['typegen']
   views?: readonly InterfaceArtifact[]
   vite?: UserViteConfig
@@ -60,6 +61,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactCompiler,
     reactStrictMode,
     schemaExtraction,
+    services,
     typegen,
     views,
     vite: extendViteConfig,
@@ -108,6 +110,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactCompiler,
     schemaExtraction,
     server: {host: httpHost, port: httpPort},
+    services,
     views,
   })
 


### PR DESCRIPTION
Stacked on #1149. Threads an app's declared `services` through the build (federation worker-bundle codegen) and dev server (local service records on the registry, forwarded to the workbench), mirroring how `views`/interfaces are threaded. Adds `unstable_defineService` to the browser-safe `@sanity/cli/runtime` entry.

## Live re-sync (shared with #1149)

A service is just another interface, so it rides the same re-sync + remote-rebuild path: adding or removing a `services` worker in `sanity.cli.ts` during `sanity dev` rebuilds the remote and reloads the page, so the worker (re)runs without a restart. A worker *source* edit full-reloads — workers have no HMR boundary. (FR-024)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the workbench federation build path and dev-server interface forwarding; scope is additive and mirrors existing `views` behavior, but incorrect worker bundling could affect local dev and production federation output.
> 
> **Overview**
> Workbench apps can declare **`services`** (background workers) alongside **`views`**, using the same plumbing as dock panels.
> 
> **Build & dev:** `services` from `unstable_defineApp` are passed through app/studio build, static file build, and `sanity dev` into `getViteConfig` / module federation so each service becomes a worker bundle exposed as `./services/<name>`.
> 
> **Dev registry:** `deriveInterfaces` now maps `services` to `interface_type: "worker"` entries on the dev-server registry (with panels and the app view), so the workbench can run local workers without deploy; editing `services` in `sanity.cli.ts` re-syncs like `views` (FR-024).
> 
> **Authoring:** `@sanity/cli/runtime` re-exports **`unstable_defineService`** from `@sanity/federation` for browser-safe worker source files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e87a1fea8be04dffb6429e12052e8a738ed243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->