### PR TITLE
fix(workbench): sanitize unstable_defineApp icons via the shared manifest allowlist

### DIFF
--- a/.changeset/pr-1146.md
+++ b/.changeset/pr-1146.md
@@ -4,4 +4,4 @@
 '@sanity/cli': minor
 ---
 
-feat(cli): merge app group + priority into the core-app manifest
+feat(workbench): merge app group + priority into the core-app manifest

--- a/.changeset/pr-1146.md
+++ b/.changeset/pr-1146.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+---
+
+feat(cli): merge app group + priority into the core-app manifest

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -4,4 +4,4 @@
 '@sanity/cli': minor
 ---
 
-feat(cli): build app view artifacts and register them on deploy
+feat(workbench): build app view artifacts and register them on deploy

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+---
+
+feat(cli): build app view artifacts and register them on deploy

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -4,4 +4,4 @@
 '@sanity/cli': minor
 ---
 
-feat(workbench): build app view artifacts and register them on deploy
+feat(workbench): build + register app view artifacts; forward the app interface from entry (US3 + US5)

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -1,5 +1,6 @@
 <!-- auto-generated -->
 ---
+'@sanity/cli-build': minor
 '@sanity/cli': minor
 ---
 

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -1,6 +1,5 @@
 <!-- auto-generated -->
 ---
-'@sanity/cli-core': minor
 '@sanity/cli': minor
 ---
 

--- a/.changeset/pr-1182.md
+++ b/.changeset/pr-1182.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): sanitize unstable_defineApp icons via the shared manifest allowlist

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ],
     "overrides": {
       "@sanity/cli": "workspace:*",
-      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d"
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ],
     "overrides": {
       "@sanity/cli": "workspace:*",
-      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450"
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ],
     "overrides": {
       "@sanity/cli": "workspace:*",
-      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091"
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
       "node-pty"
     ],
     "overrides": {
-      "@sanity/cli": "workspace:*"
+      "@sanity/cli": "workspace:*",
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091"
     }
   }
 }

--- a/packages/@sanity/cli-build/src/actions/build/getEntryModule.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getEntryModule.ts
@@ -37,9 +37,21 @@ const element = createElement(App)
 root.render(element)
 `
 
+// A branded app with no \`entry\` (US5) has no navigable app view, so there's no
+// \`App\` to import or render standalone — it contributes panels/services to the
+// workbench instead. The page stays valid (no broken import) for the dev server.
+const noAppViewEntryModule = `
+// This file is auto-generated on 'sanity dev'
+// Modifications to this file is automatically discarded
+const root = document.getElementById('root')
+if (root) {
+  root.textContent = 'This application has no app view.'
+}
+`
+
 export function getEntryModule(options: {
   basePath?: string
-  entry?: string
+  entry?: string | null
   isApp?: boolean
   reactStrictMode: boolean
   relativeConfigLocation: string | null
@@ -47,7 +59,7 @@ export function getEntryModule(options: {
   const {basePath, entry, isApp, reactStrictMode, relativeConfigLocation} = options
 
   if (isApp) {
-    return appEntryModule.replace(/%ENTRY%/, JSON.stringify(entry || './src/App'))
+    return entry ? appEntryModule.replace(/%ENTRY%/, JSON.stringify(entry)) : noAppViewEntryModule
   }
 
   const sourceModule = relativeConfigLocation ? entryModule : noConfigEntryModule

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -37,7 +37,8 @@ interface ViteOptions extends Pick<CliConfig, 'schemaExtraction'> {
 
   entries: {
     relativeConfigLocation: string | null
-    relativeEntry: string
+    // `null` when a branded app declares no `entry` (US5) — no app view.
+    relativeEntry: string | null
   }
 
   /**
@@ -204,7 +205,9 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
             viteFederation({
               ...(isApp
                 ? {
-                    appEntry: entries.relativeEntry,
+                    // `null` relativeEntry (a branded app with no `entry`, US5)
+                    // → omit `appEntry` so the plugin exposes no `./App`.
+                    ...(entries.relativeEntry ? {appEntry: entries.relativeEntry} : {}),
                     isApp: true as const,
                   }
                 : {

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -7,7 +7,7 @@ import {
   readPackageJson,
   type UserViteConfig,
 } from '@sanity/cli-core'
-import {federation as viteFederation} from '@sanity/federation/vite'
+import {type ViewArtifact, federation as viteFederation} from '@sanity/federation/vite'
 import viteReact from '@vitejs/plugin-react'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import debug from 'debug'
@@ -95,6 +95,12 @@ interface ViteOptions extends Pick<CliConfig, 'schemaExtraction'> {
    * Whether or not to enable source maps
    */
   sourceMap?: boolean
+
+  /**
+   * Views the workbench app declares. Built into render-contract artifacts and
+   * exposed through module federation as `./views/<name>`.
+   */
+  views?: readonly ViewArtifact[]
 }
 
 /**
@@ -120,6 +126,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     server,
     // default to `true` when `mode=development`
     sourceMap = options.mode === 'development',
+    views,
   } = options
 
   const basePath = normalizeBasePath(rawBasePath)
@@ -206,6 +213,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
                     studioConfigPath: entries.relativeConfigLocation!,
                   }),
               pkgJson: await readPackageJson(path.join(cwd, 'package.json')),
+              views,
               workDir: cwd,
             }),
           ]

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -7,7 +7,7 @@ import {
   readPackageJson,
   type UserViteConfig,
 } from '@sanity/cli-core'
-import {type ViewArtifact, federation as viteFederation} from '@sanity/federation/vite'
+import {type InterfaceArtifact, federation as viteFederation} from '@sanity/federation/vite'
 import viteReact from '@vitejs/plugin-react'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import debug from 'debug'
@@ -100,7 +100,7 @@ interface ViteOptions extends Pick<CliConfig, 'schemaExtraction'> {
    * Views the workbench app declares. Built into render-contract artifacts and
    * exposed through module federation as `./views/<name>`.
    */
-  views?: readonly ViewArtifact[]
+  views?: readonly InterfaceArtifact[]
 }
 
 /**

--- a/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
+++ b/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
@@ -32,7 +32,7 @@ interface RuntimeOptions {
  * @internal
  */
 export async function writeSanityRuntime(options: RuntimeOptions): Promise<{
-  entries: {relativeConfigLocation: string | null; relativeEntry: string}
+  entries: {relativeConfigLocation: string | null; relativeEntry: string | null}
   watcher: FSWatcher | undefined
 }> {
   const {appTitle, basePath, cwd, entry, isApp, reactStrictMode, watch} = options
@@ -108,7 +108,7 @@ export async function resolveEntries(options: {
   entry?: string
   isApp?: boolean
   runtimeDir?: string
-}): Promise<{relativeConfigLocation: string | null; relativeEntry: string}> {
+}): Promise<{relativeConfigLocation: string | null; relativeEntry: string | null}> {
   const {cwd, entry, isApp} = options
   const runtimeDir = options.runtimeDir ?? path.join(cwd, '.sanity', 'runtime')
 
@@ -120,9 +120,13 @@ export async function resolveEntries(options: {
       : null
   }
 
-  const relativeEntry = toForwardSlashes(
-    path.relative(runtimeDir, path.resolve(cwd, entry || './src/App')),
-  )
+  // A branded app that declares no `entry` has no navigable app view (US5):
+  // `null` entry tells the runtime/federation to skip the `./App` render path.
+  // Studios ignore `relativeEntry`, so the legacy `./src/App` default is fine.
+  const relativeEntry =
+    isApp && !entry
+      ? null
+      : toForwardSlashes(path.relative(runtimeDir, path.resolve(cwd, entry || './src/App')))
 
   return {relativeConfigLocation, relativeEntry}
 }

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -24,6 +24,8 @@ export interface CliConfig {
   app?: {
     /** The entrypoint for your custom app. By default, `src/App.tsx` */
     entry?: string
+    /** Dock group the app renders in. Defaults to `dock.applications`. */
+    group?: 'dock.applications' | 'dock.system' | 'dock.user'
     /**
      * Path to an icon file relative to project root.
      * The file must be an SVG.
@@ -33,6 +35,8 @@ export interface CliConfig {
     id?: string
     /** The ID for the Sanity organization that manages this application */
     organizationId?: string
+    /** Sort position within the dock group, ascending. Defaults to `100`. */
+    priority?: number
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
   }

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -39,21 +39,6 @@ export interface CliConfig {
     priority?: number
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
-    /**
-     * Views the app exposes (e.g. dock panels). Each is built into a render
-     * artifact on `sanity build` and persisted to the application service on
-     * `sanity deploy`. View types may carry extra attributes that are stored
-     * alongside `type`/`name`/`src`.
-     */
-    views?: Array<{
-      [attribute: string]: unknown
-      /** View name, unique within the app. */
-      name: string
-      /** Path to the view src file (default-exports `unstable_defineView`). */
-      src: string
-      /** View type — selects the render contract the build generates. */
-      type: 'panel'
-    }>
   }
 
   /** @deprecated Use deployment.autoUpdates */

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -39,6 +39,21 @@ export interface CliConfig {
     priority?: number
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
+    /**
+     * Views the app exposes (e.g. dock panels). Each is built into a render
+     * artifact on `sanity build` and persisted to the application service on
+     * `sanity deploy`. View types may carry extra attributes that are stored
+     * alongside `type`/`name`/`src`.
+     */
+    views?: Array<{
+      [attribute: string]: unknown
+      /** View name, unique within the app. */
+      name: string
+      /** Path to the view src file (default-exports `unstable_defineView`). */
+      src: string
+      /** View type — selects the render contract the build generates. */
+      type: 'panel'
+    }>
   }
 
   /** @deprecated Use deployment.autoUpdates */

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -45,6 +45,10 @@
       "source": "./src/exports/_internal.ts",
       "default": "./dist/exports/_internal.js"
     },
+    "./runtime": {
+      "source": "./src/exports/runtime.ts",
+      "default": "./dist/exports/runtime.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/@sanity/cli/src/__tests__/exports.test.ts
+++ b/packages/@sanity/cli/src/__tests__/exports.test.ts
@@ -145,7 +145,7 @@ async function getSanityPackageTypeExports() {
 }
 
 // Value exports intentionally added in v6 that the v5 CLI didn't have.
-const NEW_EXPORTS = new Set(['unstable_defineApp', 'unstable_defineView'])
+const NEW_EXPORTS = new Set(['unstable_defineApp'])
 
 test('should match exports of the current cli package', async () => {
   const oldCliExports = await getSanityPackageExports()

--- a/packages/@sanity/cli/src/__tests__/exports.test.ts
+++ b/packages/@sanity/cli/src/__tests__/exports.test.ts
@@ -145,7 +145,7 @@ async function getSanityPackageTypeExports() {
 }
 
 // Value exports intentionally added in v6 that the v5 CLI didn't have.
-const NEW_EXPORTS = new Set(['unstable_defineApp'])
+const NEW_EXPORTS = new Set(['unstable_defineApp', 'unstable_defineView'])
 
 test('should match exports of the current cli package', async () => {
   const oldCliExports = await getSanityPackageExports()

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -43,6 +43,7 @@ interface InternalBuildOptions {
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
+  views: NonNullable<CliConfig['app']>['views']
   vite: UserViteConfig | undefined
   workDir: string
 }
@@ -71,6 +72,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: flags.yes,
+    views: cliConfig && 'app' in cliConfig ? cliConfig.app?.views : undefined,
     vite: cliConfig.vite,
     workDir,
   })
@@ -231,6 +233,7 @@ async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
       reactCompiler: options.reactCompiler,
       schemaExtraction: options.schemaExtraction,
       sourceMap: options.sourceMap,
+      views: options.views,
       vite: options.vite,
     })
 

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -13,7 +13,7 @@ import {
   UserViteConfig,
 } from '@sanity/cli-core'
 import {confirm, logSymbols, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
-import {isWorkbenchApp} from '@sanity/federation'
+import {type DefineAppInput, isWorkbenchApp} from '@sanity/federation'
 import {parse as semverParse} from 'semver'
 
 import {getAppId} from '../../util/appId.js'
@@ -43,7 +43,7 @@ interface InternalBuildOptions {
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
-  views: NonNullable<CliConfig['app']>['views']
+  views: DefineAppInput['views']
   vite: UserViteConfig | undefined
   workDir: string
 }
@@ -56,14 +56,19 @@ interface InternalBuildOptions {
 export async function buildApp(options: BuildOptions): Promise<void> {
   const {cliConfig, flags, outDir, output, workDir} = options
 
+  const app = cliConfig && 'app' in cliConfig ? cliConfig.app : undefined
+  // `views` lives on `unstable_defineApp`'s result, not the legacy `app` config
+  // object — read it off the branded app.
+  const workbenchApp = isWorkbenchApp(app) ? app : undefined
+
   await internalBuildApp({
     appId: getAppId(cliConfig),
-    appTitle: cliConfig && 'app' in cliConfig ? cliConfig.app?.title : undefined,
+    appTitle: app?.title,
     autoUpdatesEnabled: options.autoUpdatesEnabled,
     calledFromDeploy: options.calledFromDeploy,
     determineBasePath: () => determineBasePath(cliConfig, 'app', output),
-    entry: cliConfig && 'app' in cliConfig ? cliConfig.app?.entry : undefined,
-    isWorkbench: isWorkbenchApp(cliConfig && 'app' in cliConfig ? cliConfig.app : undefined),
+    entry: app?.entry,
+    isWorkbench: Boolean(workbenchApp),
     minify: flags.minify,
     outDir,
     output,
@@ -72,7 +77,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: flags.yes,
-    views: cliConfig && 'app' in cliConfig ? cliConfig.app?.views : undefined,
+    views: workbenchApp?.views,
     vite: cliConfig.vite,
     workDir,
   })

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -11,7 +11,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {type CliConfig, type UserViteConfig} from '@sanity/cli-core'
-import {type ViewArtifact} from '@sanity/federation/vite'
+import {type InterfaceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {build, createBuilder} from 'vite'
 
@@ -48,7 +48,7 @@ interface StaticBuildOptions {
   reactCompiler?: ReactCompilerConfig
   schemaExtraction?: CliConfig['schemaExtraction']
   sourceMap?: boolean
-  views?: readonly ViewArtifact[]
+  views?: readonly InterfaceArtifact[]
   vite?: UserViteConfig
 }
 

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -11,6 +11,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {type CliConfig, type UserViteConfig} from '@sanity/cli-core'
+import {type ViewArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {build, createBuilder} from 'vite'
 
@@ -47,6 +48,7 @@ interface StaticBuildOptions {
   reactCompiler?: ReactCompilerConfig
   schemaExtraction?: CliConfig['schemaExtraction']
   sourceMap?: boolean
+  views?: readonly ViewArtifact[]
   vite?: UserViteConfig
 }
 
@@ -72,6 +74,7 @@ export async function buildStaticFiles(
     reactCompiler,
     schemaExtraction,
     sourceMap = false,
+    views,
     vite: extendViteConfig,
   } = options
 
@@ -98,6 +101,7 @@ export async function buildStaticFiles(
       outputDir,
       reactCompiler,
       sourceMap,
+      views,
     })
 
     // Apply the user's Vite config so plugins like `@vanilla-extract/vite-plugin`

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -18,7 +18,7 @@ import {
   UserViteConfig,
 } from '@sanity/cli-core'
 import {confirm, logSymbols, select, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
-import {isWorkbenchApp} from '@sanity/federation'
+import {type DefineAppInput, isWorkbenchApp} from '@sanity/federation'
 import {parse as semverParse} from 'semver'
 
 import {getAppId} from '../../util/appId.js'
@@ -53,6 +53,7 @@ interface InternalBuildOptions {
   stats: boolean
   unattendedMode: boolean
   upgradePackages(options: {packages: [name: string, version: string][]}): Promise<void>
+  views: DefineAppInput['views']
   vite: UserViteConfig | undefined
   workDir: string
 }
@@ -64,6 +65,11 @@ interface InternalBuildOptions {
  */
 export async function buildStudio(options: BuildOptions): Promise<void> {
   const {calledFromDeploy, cliConfig, flags, outDir, output, workDir} = options
+
+  // `views` lives on the branded `unstable_defineApp` result — read it off the
+  // branded app so it's gated on the brand, like the app build.
+  const app = cliConfig?.app
+  const workbenchApp = isWorkbenchApp(app) ? app : undefined
 
   const upgradePkgs = async (options: {
     packages: [name: string, version: string][]
@@ -83,7 +89,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     calledFromDeploy,
     determineBasePath: () => determineBasePath(cliConfig, 'studio', output),
     isApp: determineIsApp(cliConfig),
-    isWorkbench: isWorkbenchApp(cliConfig?.app),
+    isWorkbench: Boolean(workbenchApp),
     minify: Boolean(flags.minify),
     outDir,
     output,
@@ -94,6 +100,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     stats: flags.stats,
     unattendedMode: Boolean(flags.yes),
     upgradePackages: upgradePkgs,
+    views: workbenchApp?.views,
     vite: cliConfig.vite,
     workDir,
   })
@@ -121,6 +128,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     stats,
     unattendedMode,
     upgradePackages,
+    views,
     vite,
     workDir,
   } = options
@@ -303,6 +311,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
       reactCompiler,
       schemaExtraction,
       sourceMap,
+      views,
       vite,
     })
 

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -5,6 +5,7 @@ import {createGzip} from 'node:zlib'
 import {CLIError} from '@oclif/core/errors'
 import {getLocalPackageVersion} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
+import {isWorkbenchApp} from '@sanity/federation'
 import {pack} from 'tar-fs'
 
 import {createDeployment, updateUserApplication} from '../../services/userApplications.js'
@@ -141,7 +142,9 @@ export async function deployApp(options: DeployAppOptions) {
     // Register the app's declared views with the application service. That
     // service doesn't exist yet, so validate the payload and log it (no store);
     // a malformed view declaration fails the deploy before we ship the bundle.
-    const declaredViews = cliConfig.app?.views ?? []
+    // `views` lives on the branded `unstable_defineApp` result, not the legacy
+    // `app` config object.
+    const declaredViews = isWorkbenchApp(cliConfig.app) ? (cliConfig.app.views ?? []) : []
     if (declaredViews.length > 0) {
       try {
         const payload = buildViewDeploymentPayload({

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -20,6 +20,7 @@ import {createUserApplicationForApp} from './createUserApplicationForApp.js'
 import {deployDebug} from './deployDebug.js'
 import {findUserApplicationForApp} from './findUserApplicationForApp.js'
 import {type DeployAppOptions} from './types.js'
+import {buildViewDeploymentPayload} from './viewDeployment.js'
 
 /**
  * Deploy a Sanity application.
@@ -134,6 +135,28 @@ export async function deployApp(options: DeployAppOptions) {
         const message = getErrorMessage(err)
         deployDebug('Error updating application title', {message})
         output.warn(`Error updating application title: ${message}`)
+      }
+    }
+
+    // Register the app's declared views with the application service. That
+    // service doesn't exist yet, so validate the payload and log it (no store);
+    // a malformed view declaration fails the deploy before we ship the bundle.
+    const declaredViews = cliConfig.app?.views ?? []
+    if (declaredViews.length > 0) {
+      try {
+        const payload = buildViewDeploymentPayload({
+          applicationId: userApplication.id,
+          views: declaredViews,
+        })
+        output.log(
+          `Validated ${payload.views.length} view(s) for the application service (not yet persisted):`,
+        )
+        output.log(JSON.stringify(payload, null, 2))
+        deployDebug('View deployment payload', payload)
+      } catch (err) {
+        const message = getErrorMessage(err)
+        output.error(`Invalid view declaration: ${message}`, {exit: 1})
+        return
       }
     }
 

--- a/packages/@sanity/cli/src/actions/deploy/viewDeployment.ts
+++ b/packages/@sanity/cli/src/actions/deploy/viewDeployment.ts
@@ -19,12 +19,12 @@ const viewRecordSchema = z
  * payload is validated and logged only — never sent. Builds the contract the
  * application-service endpoint will accept.
  */
-export const viewDeploymentPayloadSchema = z.object({
+const viewDeploymentPayloadSchema = z.object({
   applicationId: z.string(),
   views: z.array(viewRecordSchema),
 })
 
-export type ViewDeploymentPayload = z.infer<typeof viewDeploymentPayloadSchema>
+type ViewDeploymentPayload = z.infer<typeof viewDeploymentPayloadSchema>
 
 /**
  * Validate an app's declared views into the application-service payload.

--- a/packages/@sanity/cli/src/actions/deploy/viewDeployment.ts
+++ b/packages/@sanity/cli/src/actions/deploy/viewDeployment.ts
@@ -1,0 +1,41 @@
+import {z} from 'zod'
+
+/**
+ * A view record as persisted to the application service: `type`, `name`, `src`,
+ * plus any view-type-specific attributes (passed through for storage).
+ */
+const viewRecordSchema = z
+  .object({
+    name: z.string().regex(/^[a-zA-Z0-9_-]+$/, 'View `name` must match /^[a-zA-Z0-9_-]+$/'),
+    src: z.string(),
+    type: z.enum(['panel']),
+  })
+  .passthrough()
+
+/**
+ * Payload registering an app's views with the application service on deploy.
+ *
+ * Phase 1 stub: the service that stores views does not exist yet, so the
+ * payload is validated and logged only — never sent. Builds the contract the
+ * application-service endpoint will accept.
+ */
+export const viewDeploymentPayloadSchema = z.object({
+  applicationId: z.string(),
+  views: z.array(viewRecordSchema),
+})
+
+export type ViewDeploymentPayload = z.infer<typeof viewDeploymentPayloadSchema>
+
+/**
+ * Validate an app's declared views into the application-service payload.
+ * Throws (via Zod) when a view declaration is malformed.
+ */
+export function buildViewDeploymentPayload(input: {
+  applicationId: string
+  views?: ReadonlyArray<Record<string, unknown>>
+}): ViewDeploymentPayload {
+  return viewDeploymentPayloadSchema.parse({
+    applicationId: input.applicationId,
+    views: input.views ?? [],
+  })
+}

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
@@ -302,4 +302,50 @@ describe('startFederationRegistration', () => {
       expect.objectContaining({exit: 1}),
     )
   })
+
+  // US5 — `entry` declares an SDK app's navigable `app` view.
+  test('forwards an `app` interface derived from `entry` for an SDK app', async () => {
+    await startFederationRegistration({
+      cliConfig: {app: workbenchApp({entry: './src/App.tsx'})},
+      isApp: true,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockRegisterDevServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interfaces: expect.arrayContaining([
+          {entry_point: './src/App.tsx', interface_type: 'app', name: 'test-app'},
+        ]),
+      }),
+    )
+  })
+
+  test('forwards no `app` interface when an SDK app declares no `entry`', async () => {
+    await startFederationRegistration({
+      cliConfig: {app: workbenchApp()},
+      isApp: true,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    const {interfaces} = mockRegisterDevServer.mock.calls[0][0]
+    expect(
+      (interfaces ?? []).some((i: {interface_type: string}) => i.interface_type === 'app'),
+    ).toBe(false)
+  })
+
+  test('rejects a studio that declares `entry` — app views for studios are not implemented yet', async () => {
+    await expect(
+      startFederationRegistration({
+        cliConfig: {app: workbenchApp({entry: './src/App.tsx'})},
+        isApp: false,
+        output: createMockOutput(),
+        server: mockServer({port: 3334}) as any,
+        workDir: '/tmp/sanity-project',
+      }),
+    ).rejects.toThrow('App views for studios are not implemented yet')
+  })
 })

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -34,11 +34,12 @@ const devServerManifestSchema = z.extend(workbenchLockSchema, {
    * Interfaces the app exposes (e.g. dock panels), mapped from the declared
    * views. Carried separately from the manifest — interfaces live in the
    * application service, not the manifest — so the workbench can render local
-   * panels without a deploy. The workbench derives each interface's
-   * `entry_point` from this entry's host/port. Lenient by design; the workbench
-   * is the authority on the interface shape.
+   * panels without a deploy. `entry_point` is the declared `src`. Lenient by
+   * design; the workbench is the authority on the interface shape.
    */
-  interfaces: z.optional(z.array(z.object({interface_type: z.string(), name: z.string()}))),
+  interfaces: z.optional(
+    z.array(z.object({entry_point: z.string(), interface_type: z.string(), name: z.string()})),
+  ),
   /** Inlined manifest — either a {@link StudioManifest} or {@link CoreAppManifest}. */
   manifest: z.optional(z.union([studioManifestSchema, coreAppManifestSchema])),
   /**

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -40,6 +40,13 @@ const devServerManifestSchema = z.extend(workbenchLockSchema, {
   manifestUpdatedAt: z.optional(z.string()),
   projectId: z.optional(z.string()),
   type: z.enum(['coreApp', 'studio']),
+  /**
+   * Views the app declares (e.g. dock panels). Carried separately from the
+   * manifest — views live in the application service, not the manifest — so the
+   * workbench can render local panels without a deploy. Lenient by design;
+   * `@sanity/federation` is the authority on the view shape.
+   */
+  views: z.optional(z.array(z.object({name: z.string(), src: z.string(), type: z.string()}))),
   workDir: z.string(),
 })
 /**

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -30,6 +30,16 @@ const workbenchLockSchema = z.object({
 
 const devServerManifestSchema = z.extend(workbenchLockSchema, {
   id: z.optional(z.string()),
+  /**
+   * Interfaces the app exposes (e.g. dock panels), mapped from the declared
+   * views with the local dev server as their `entry_point`. Carried separately
+   * from the manifest — interfaces live in the application service, not the
+   * manifest — so the workbench can render local panels without a deploy.
+   * Lenient by design; the workbench is the authority on the interface shape.
+   */
+  interfaces: z.optional(
+    z.array(z.object({entry_point: z.string(), interface_type: z.string(), name: z.string()})),
+  ),
   /** Inlined manifest — either a {@link StudioManifest} or {@link CoreAppManifest}. */
   manifest: z.optional(z.union([studioManifestSchema, coreAppManifestSchema])),
   /**
@@ -40,13 +50,6 @@ const devServerManifestSchema = z.extend(workbenchLockSchema, {
   manifestUpdatedAt: z.optional(z.string()),
   projectId: z.optional(z.string()),
   type: z.enum(['coreApp', 'studio']),
-  /**
-   * Views the app declares (e.g. dock panels). Carried separately from the
-   * manifest — views live in the application service, not the manifest — so the
-   * workbench can render local panels without a deploy. Lenient by design;
-   * `@sanity/federation` is the authority on the view shape.
-   */
-  views: z.optional(z.array(z.object({name: z.string(), src: z.string(), type: z.string()}))),
   workDir: z.string(),
 })
 /**

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -32,14 +32,13 @@ const devServerManifestSchema = z.extend(workbenchLockSchema, {
   id: z.optional(z.string()),
   /**
    * Interfaces the app exposes (e.g. dock panels), mapped from the declared
-   * views with the local dev server as their `entry_point`. Carried separately
-   * from the manifest — interfaces live in the application service, not the
-   * manifest — so the workbench can render local panels without a deploy.
-   * Lenient by design; the workbench is the authority on the interface shape.
+   * views. Carried separately from the manifest — interfaces live in the
+   * application service, not the manifest — so the workbench can render local
+   * panels without a deploy. The workbench derives each interface's
+   * `entry_point` from this entry's host/port. Lenient by design; the workbench
+   * is the authority on the interface shape.
    */
-  interfaces: z.optional(
-    z.array(z.object({entry_point: z.string(), interface_type: z.string(), name: z.string()})),
-  ),
+  interfaces: z.optional(z.array(z.object({interface_type: z.string(), name: z.string()}))),
   /** Inlined manifest — either a {@link StudioManifest} or {@link CoreAppManifest}. */
   manifest: z.optional(z.union([studioManifestSchema, coreAppManifestSchema])),
   /**

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -49,6 +49,9 @@ export function getDevServerConfig({
 
   return {
     ...baseConfig,
+    // The app's navigable entry. A branded app that omits `entry` has no app
+    // view (US5): the runtime/federation skip the `./App` render path entirely.
+    entry: app?.entry,
     isWorkbench: isWorkbenchApp(app),
     reactCompiler: cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
     reactStrictMode,

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -36,6 +36,9 @@ export function getDevServerConfig({
 
   const isApp = cliConfig ? determineIsApp(cliConfig) : false
   const reactStrictMode = resolveReactStrictMode(cliConfig)
+  // `views` is declared via `unstable_defineApp`, so read it off the branded
+  // app result rather than the legacy `app` config type.
+  const app = cliConfig?.app
 
   const envBasePath = getSanityEnvVar('BASEPATH', isApp ?? false)
   if (envBasePath && cliConfig?.project?.basePath) {
@@ -46,11 +49,11 @@ export function getDevServerConfig({
 
   return {
     ...baseConfig,
-    isWorkbench: isWorkbenchApp(cliConfig?.app),
+    isWorkbench: isWorkbenchApp(app),
     reactCompiler: cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
     reactStrictMode,
     staticPath: path.join(workDir, 'static'),
     typegen: cliConfig?.typegen,
-    views: cliConfig?.app?.views,
+    views: isWorkbenchApp(app) ? app.views : undefined,
   }
 }

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -51,5 +51,6 @@ export function getDevServerConfig({
     reactStrictMode,
     staticPath: path.join(workDir, 'static'),
     typegen: cliConfig?.typegen,
+    views: cliConfig?.app?.views,
   }
 }

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -38,18 +38,27 @@ export async function startFederationRegistration(
   const addr = server.httpServer?.address()
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
-  // Views live on the branded `unstable_defineApp` result. Forward them on the
+  // Interfaces live on the branded `unstable_defineApp` result as declared
+  // views. Map them to the local interface shape — the dev server is the
+  // `entry_point` the workbench loads each from — and forward them on the
   // registry entry (alongside, not inside, the manifest) so the workbench can
   // render local panels without a deploy.
-  const views = isWorkbenchApp(cliConfig.app) ? cliConfig.app.views : undefined
+  const entryPoint = `http://${appHost}:${appPort}/mf-manifest.json`
+  const interfaces = isWorkbenchApp(cliConfig.app)
+    ? cliConfig.app.views?.map((view) => ({
+        entry_point: entryPoint,
+        interface_type: view.type,
+        name: view.name,
+      }))
+    : undefined
 
   const registration = registerDevServer({
     host: appHost,
     id: getAppId(cliConfig),
+    interfaces,
     port: appPort,
     projectId: cliConfig?.api?.projectId,
     type: isApp ? 'coreApp' : 'studio',
-    views,
     workDir,
   })
 

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -39,12 +39,12 @@ export async function startFederationRegistration(
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
   // Interfaces live on the branded `unstable_defineApp` result as declared
-  // views. Forward each as `{interface_type, name}` on the registry entry
-  // (alongside, not inside, the manifest) so the workbench can render local
-  // panels without a deploy. The workbench derives each interface's
-  // `entry_point` from this entry's host/port.
+  // views. Forward each on the registry entry (alongside, not inside, the
+  // manifest) so the workbench can render local panels without a deploy. The
+  // `entry_point` is the declared `src` — the raw value, not a resolved URL.
   const interfaces = isWorkbenchApp(cliConfig.app)
     ? cliConfig.app.views?.map((view) => ({
+        entry_point: view.src,
         interface_type: view.type,
         name: view.name,
       }))

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -1,4 +1,5 @@
 import {type CliConfig, type Output} from '@sanity/cli-core'
+import {isWorkbenchApp} from '@sanity/federation'
 import {type ViteDevServer} from 'vite'
 
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
@@ -37,12 +38,18 @@ export async function startFederationRegistration(
   const addr = server.httpServer?.address()
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
+  // Views live on the branded `unstable_defineApp` result. Forward them on the
+  // registry entry (alongside, not inside, the manifest) so the workbench can
+  // render local panels without a deploy.
+  const views = isWorkbenchApp(cliConfig.app) ? cliConfig.app.views : undefined
+
   const registration = registerDevServer({
     host: appHost,
     id: getAppId(cliConfig),
     port: appPort,
     projectId: cliConfig?.api?.projectId,
     type: isApp ? 'coreApp' : 'studio',
+    views,
     workDir,
   })
 

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -39,15 +39,41 @@ export async function startFederationRegistration(
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
   // Interfaces live on the branded `unstable_defineApp` result as declared
-  // views. Forward each on the registry entry (alongside, not inside, the
-  // manifest) so the workbench can render local panels without a deploy. The
+  // `views` (panels) and the app's navigable `entry`. Forward each on the
+  // registry entry (alongside, not inside, the manifest) so the workbench can
+  // render local panels and resolve the app view without a deploy. The
   // `entry_point` is the declared `src` — the raw value, not a resolved URL.
-  const interfaces = isWorkbenchApp(cliConfig.app)
-    ? cliConfig.app.views?.map((view) => ({
-        entry_point: view.src,
-        interface_type: view.type,
-        name: view.name,
-      }))
+  const app = isWorkbenchApp(cliConfig.app) ? cliConfig.app : undefined
+
+  // US5 — studio app views are not implemented yet. A studio (not an SDK app)
+  // that declares `entry` reaches the app-view path; reject with a clear error
+  // rather than deriving an `app` interface for it. SDK app views are a later
+  // iteration for studios (FR-026).
+  if (app && !isApp && app.entry !== undefined) {
+    throw new Error('App views for studios are not implemented yet')
+  }
+
+  const interfaces = app
+    ? [
+        ...(app.views?.map((view) => ({
+          entry_point: view.src,
+          interface_type: view.type,
+          name: view.name,
+        })) ?? []),
+        // US5 — an SDK app's `entry` declares its navigable full-page `app`
+        // view. Forward it as an `app` interface so the workbench knows the app
+        // is navigable; with no `entry` the app has no `app` view and is not
+        // reachable as a full-page app.
+        ...(app.entry === undefined
+          ? []
+          : [
+              {
+                entry_point: app.entry,
+                interface_type: 'app' as const,
+                name: app.name,
+              },
+            ]),
+      ]
     : undefined
 
   const registration = registerDevServer({

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -39,14 +39,12 @@ export async function startFederationRegistration(
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
   // Interfaces live on the branded `unstable_defineApp` result as declared
-  // views. Map them to the local interface shape — the dev server is the
-  // `entry_point` the workbench loads each from — and forward them on the
-  // registry entry (alongside, not inside, the manifest) so the workbench can
-  // render local panels without a deploy.
-  const entryPoint = `http://${appHost}:${appPort}/mf-manifest.json`
+  // views. Forward each as `{interface_type, name}` on the registry entry
+  // (alongside, not inside, the manifest) so the workbench can render local
+  // panels without a deploy. The workbench derives each interface's
+  // `entry_point` from this entry's host/port.
   const interfaces = isWorkbenchApp(cliConfig.app)
     ? cliConfig.app.views?.map((view) => ({
-        entry_point: entryPoint,
         interface_type: view.type,
         name: view.name,
       }))

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -21,14 +21,14 @@ import {writeWorkbenchRuntime} from './writeWorkbenchRuntime.js'
 const noop = async () => {}
 
 const toApplicationsPayload = (servers: DevServerManifest[]) => ({
-  applications: servers.map(({host, id, manifest, port, projectId, type, views}) => ({
+  applications: servers.map(({host, id, interfaces, manifest, port, projectId, type}) => ({
     host,
     id,
+    interfaces,
     manifest,
     port,
     projectId,
     type,
-    views,
   })),
 })
 

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -21,13 +21,14 @@ import {writeWorkbenchRuntime} from './writeWorkbenchRuntime.js'
 const noop = async () => {}
 
 const toApplicationsPayload = (servers: DevServerManifest[]) => ({
-  applications: servers.map(({host, id, manifest, port, projectId, type}) => ({
+  applications: servers.map(({host, id, manifest, port, projectId, type, views}) => ({
     host,
     id,
     manifest,
     port,
     projectId,
     type,
+    views,
   })),
 })
 

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -50,6 +50,26 @@ describe('extractCoreAppManifest', () => {
     expect(mockReadFile).not.toHaveBeenCalled()
   })
 
+  test('merges group and priority into the manifest', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: {group: 'dock.system', organizationId: 'org-1', priority: 20, title: 'My App'},
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result).toEqual({group: 'dock.system', priority: 20, title: 'My App', version: '1'})
+  })
+
+  test('keeps priority 0 (not dropped as a falsy value)', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: {organizationId: 'org-1', priority: 0, title: 'My App'},
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result?.priority).toBe(0)
+  })
+
   test('reads icon from file path and inlines in manifest', async () => {
     const workDir = '/project'
     mockGetCliConfig.mockResolvedValue({

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -85,6 +85,20 @@ describe('extractCoreAppManifest', () => {
     expect(result?.title).toBe('My App')
   })
 
+  test('sanitizes the icon SVG before inlining it', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: {icon: 'public/icon.svg', organizationId: 'org-1', title: 'My App'},
+    } as never)
+    mockReadFile.mockResolvedValue(
+      '<svg xmlns="http://www.w3.org/2000/svg"><script>alert("xss")</script><path d="M0 0"/></svg>',
+    )
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result?.icon).not.toContain('<script>')
+    expect(result?.icon).toContain('<path')
+  })
+
   test('rejects icon path that resolves outside project directory', async () => {
     mockGetCliConfig.mockResolvedValue({
       app: {icon: '../../../etc/passwd', organizationId: 'org-1'},

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -78,6 +78,8 @@ export async function extractCoreAppManifest(
       version: '1',
       ...(icon ? {icon} : {}),
       ...(app.title ? {title: app.title} : {}),
+      ...(app.group ? {group: app.group} : {}),
+      ...(app.priority === undefined ? {} : {priority: app.priority}),
     })
 
     spin.succeed(`Extracted manifest`)

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -1,20 +1,38 @@
 import {readFile} from 'node:fs/promises'
 import {relative, resolve} from 'node:path'
 
-import {getCliConfigUncached} from '@sanity/cli-core'
+import {doImport, getCliConfigUncached} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 
 import {getErrorMessage} from '../../util/getErrorMessage.js'
+import {type sanitizeIcon as sanitizeIconFn} from './sanitizeIcon.js'
 import {type CoreAppManifest, coreAppManifestSchema} from './types.js'
 
 interface ExtractCoreAppManifestOptions {
   workDir: string
 }
 
+const sanitizeIconPath = new URL('sanitizeIcon.js', import.meta.url).href
+
+/**
+ * Lazy-load {@link sanitizeIconFn} so `isomorphic-dompurify` (and its jsdom
+ * dependency) stays out of the CLI's eager import graph. The studio manifest
+ * resolver lazy-loads its icon machinery for the same reason; this path runs in
+ * the main process (not the manifest worker), so only an app deploy that
+ * actually has an icon pays the cost.
+ */
+async function lazySanitizeIcon(): Promise<typeof sanitizeIconFn> {
+  const mod = await doImport(sanitizeIconPath)
+  return mod.sanitizeIcon
+}
+
 /**
  * Resolves app.icon from config (a file path) to an SVG string for the manifest.
  * The manifest expects the SVG string inline, not a path.
- * Brett sanitizes SVGs so it's skipped here.
+ *
+ * The file is sanitized through the same allowlist as the studio manifest's
+ * icon resolver (see {@link lazySanitizeIcon}) so both manifest paths inline the
+ * same trusted subset of SVG markup.
  */
 async function readIconFromPath(workDir: string, iconPath: string): Promise<string> {
   const resolvedPath = resolve(workDir, iconPath)
@@ -43,7 +61,8 @@ async function readIconFromPath(workDir: string, iconPath: string): Promise<stri
     )
   }
 
-  return trimmed
+  const sanitizeIcon = await lazySanitizeIcon()
+  return sanitizeIcon(trimmed)
 }
 
 /**

--- a/packages/@sanity/cli/src/actions/manifest/iconResolver.tsx
+++ b/packages/@sanity/cli/src/actions/manifest/iconResolver.tsx
@@ -1,9 +1,8 @@
 import {resolveLocalPackage} from '@sanity/cli-core'
-import DOMPurify from 'isomorphic-dompurify'
 
 import {manifestDebug} from './debug.js'
-import {config} from './purifyConfig.js'
 import {resolveSchemaIcon, type SchemaIconProps} from './resolveSchemaIcon.js'
+import {sanitizeIcon} from './sanitizeIcon.js'
 
 /**
  * Resolves an icon to a sanitized HTML string.
@@ -31,7 +30,7 @@ export const resolveIcon = async (props: SchemaIconProps): Promise<string | null
       chunks.push(value)
     }
     const html = new TextDecoder().decode(Buffer.concat(chunks))
-    return DOMPurify.sanitize(html.trim(), config)
+    return sanitizeIcon(html)
   } catch (error) {
     manifestDebug('Error resolving icon', error)
     return null

--- a/packages/@sanity/cli/src/actions/manifest/sanitizeIcon.ts
+++ b/packages/@sanity/cli/src/actions/manifest/sanitizeIcon.ts
@@ -1,0 +1,14 @@
+import DOMPurify from 'isomorphic-dompurify'
+
+import {config} from './purifyConfig.js'
+
+/**
+ * Sanitize icon markup against the manifest allowlist (see {@link config}).
+ *
+ * Shared by the studio manifest icon resolver and the core app manifest so
+ * every icon we inline — whether rendered from a React component or read from
+ * a file on disk — passes through the exact same trusted subset of SVG/HTML.
+ */
+export function sanitizeIcon(html: string): string {
+  return DOMPurify.sanitize(html.trim(), config)
+}

--- a/packages/@sanity/cli/src/actions/manifest/types.ts
+++ b/packages/@sanity/cli/src/actions/manifest/types.ts
@@ -25,7 +25,9 @@ export interface CreateManifest {
  * since the CLI produces the payload in full.
  */
 export const coreAppManifestSchema = z.object({
+  group: z.optional(z.string()),
   icon: z.optional(z.string()),
+  priority: z.optional(z.number()),
   title: z.optional(z.string()),
   version: z.string(),
 })

--- a/packages/@sanity/cli/src/exports/index.ts
+++ b/packages/@sanity/cli/src/exports/index.ts
@@ -9,4 +9,8 @@ export type {CliConfig, UserViteConfig} from '@sanity/cli-core'
 // Workbench application extension API. Canonical implementation in
 // `@sanity/federation`; re-exported here so `sanity/cli` can surface it to
 // app authors via `import {unstable_defineApp} from 'sanity/cli'`.
-export {type DefineAppInput, unstable_defineApp} from '@sanity/federation'
+// `unstable_defineView` is the runtime view-authoring helper; its long-term
+// home is the `sanity` runtime package, but it's surfaced here for now so view
+// src files can `import {unstable_defineView} from '@sanity/cli'`. Component
+// props are inferred from the view type, so no prop types are re-exported.
+export {type DefineAppInput, unstable_defineApp, unstable_defineView} from '@sanity/federation'

--- a/packages/@sanity/cli/src/exports/index.ts
+++ b/packages/@sanity/cli/src/exports/index.ts
@@ -6,11 +6,10 @@ export {type CliClientOptions, getCliClient} from '../util/cliClient.js'
 export {loadEnv} from '../util/loadEnv.js'
 export type {CliConfig, UserViteConfig} from '@sanity/cli-core'
 
-// Workbench application extension API. Canonical implementation in
-// `@sanity/federation`; re-exported here so `sanity/cli` can surface it to
+// Workbench application extension API (config-time). Canonical implementation
+// in `@sanity/federation`; re-exported here so `sanity/cli` can surface it to
 // app authors via `import {unstable_defineApp} from 'sanity/cli'`.
-// `unstable_defineView` is the runtime view-authoring helper; its long-term
-// home is the `sanity` runtime package, but it's surfaced here for now so view
-// src files can `import {unstable_defineView} from '@sanity/cli'`. Component
-// props are inferred from the view type, so no prop types are re-exported.
-export {type DefineAppInput, unstable_defineApp, unstable_defineView} from '@sanity/federation'
+// The runtime helper `unstable_defineView` is NOT here — it bundles to the
+// browser, so it lives on the browser-safe `@sanity/cli/runtime` entry to keep
+// `cli-core` out of the frontend bundle.
+export {type DefineAppInput, unstable_defineApp} from '@sanity/federation'

--- a/packages/@sanity/cli/src/exports/runtime.ts
+++ b/packages/@sanity/cli/src/exports/runtime.ts
@@ -1,0 +1,11 @@
+// Browser-safe runtime authoring helpers for the workbench extension API.
+//
+// View/service src files bundle to the browser, so this entry re-exports ONLY
+// from `@sanity/federation` (a pure, dependency-light package) — it must never
+// import `@sanity/cli-core` or anything Node-only, or it would drag the CLI
+// into the frontend bundle. The `sanity` runtime package re-exports from here,
+// so the same constraint protects it.
+//
+// `unstable_defineApp` is config-time (Node) and stays on the main `@sanity/cli`
+// entry; only the runtime helpers live here.
+export {unstable_defineView} from '@sanity/federation'

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -4,7 +4,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {CliConfig, getCliTelemetry, type UserViteConfig} from '@sanity/cli-core'
-import {type ViewArtifact} from '@sanity/federation/vite'
+import {type InterfaceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {type FSWatcher} from 'chokidar'
 import {createServer, type InlineConfig, type ViteDevServer} from 'vite'
@@ -36,7 +36,7 @@ export interface DevServerOptions {
   projectName?: string
   schemaExtraction?: CliConfig['schemaExtraction']
   typegen?: CliConfig['typegen']
-  views?: readonly ViewArtifact[]
+  views?: readonly InterfaceArtifact[]
   vite?: UserViteConfig
 }
 

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -4,6 +4,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {CliConfig, getCliTelemetry, type UserViteConfig} from '@sanity/cli-core'
+import {type ViewArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {type FSWatcher} from 'chokidar'
 import {createServer, type InlineConfig, type ViteDevServer} from 'vite'
@@ -35,6 +36,7 @@ export interface DevServerOptions {
   projectName?: string
   schemaExtraction?: CliConfig['schemaExtraction']
   typegen?: CliConfig['typegen']
+  views?: readonly ViewArtifact[]
   vite?: UserViteConfig
 }
 
@@ -59,6 +61,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactStrictMode,
     schemaExtraction,
     typegen,
+    views,
     vite: extendViteConfig,
   } = options
 
@@ -105,6 +108,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactCompiler,
     schemaExtraction,
     server: {host: httpHost, port: httpPort},
+    views,
   })
 
   // Extend Vite configuration with user-provided config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
 
 importers:
 
@@ -265,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: 0.1.0-alpha.9
-        version: 0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -537,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: 0.1.0-alpha.9
-        version: 0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -826,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: 0.1.0-alpha.9
-        version: 0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -962,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: 0.1.0-alpha.9
-        version: 0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4924,8 +4925,9 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@0.1.0-alpha.9':
-    resolution: {integrity: sha512-mSsRVzqSrniPtg50+hhbO2WE8vzX/PGkI123ysS8xrUECV0m/v/9YH3ha159dcuUxG0JzgjAtj1+gVy+TmqANQ==}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091':
+    resolution: {tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091}
+    version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
       vite: ^7.0.0 || ^8.0.0
@@ -14543,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14556,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
-  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
 
 importers:
 
@@ -266,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -538,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -827,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -963,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4925,8 +4925,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091':
-    resolution: {tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d':
+    resolution: {integrity: sha512-YKgES0eH9N7i3b0mLPQHmTd0PhWHMpWL9SxYhRfxV2qTWvIvLINBSpd4PVvm2tv0+4k7cHHatKVD3IWSBjoacw==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d}
     version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
@@ -14545,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14558,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
-  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48
 
 importers:
 
@@ -266,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -538,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -827,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -963,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4925,8 +4925,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450':
-    resolution: {integrity: sha512-hfsw2aIaLD1psykxFF3tPPTm/oQNWclX8yN76IhBtj559huRjpV+NaQLBwRjlghHa/2RdOvmgcARRrHBDpI7MQ==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48':
+    resolution: {integrity: sha512-65aDKytAsZcCn+F5vKmL2h/6WSfPPWNU8QpTAEt54umEaMQQlkDddCo29xhV8+cTxsF5xTYC1RX0vDeo5zlROA==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48}
     version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
@@ -14545,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14558,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
-  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
 
 importers:
 
@@ -266,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -538,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -827,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -963,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4925,8 +4925,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d':
-    resolution: {integrity: sha512-YKgES0eH9N7i3b0mLPQHmTd0PhWHMpWL9SxYhRfxV2qTWvIvLINBSpd4PVvm2tv0+4k7cHHatKVD3IWSBjoacw==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450':
+    resolution: {integrity: sha512-hfsw2aIaLD1psykxFF3tPPTm/oQNWclX8yN76IhBtj559huRjpV+NaQLBwRjlghHa/2RdOvmgcARRrHBDpI7MQ==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450}
     version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
@@ -14545,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14558,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))


### PR DESCRIPTION
Follow-up to #1149.

`unstable_defineApp`'s `icon` is inlined into the core-app manifest verbatim, while the studio manifest runs its icon through a DOMPurify allowlist. This aligns them so every inlined icon passes the same trusted subset of SVG markup, with the existing studio manifest resolver as the source of truth.

- Extract the studio resolver's sanitization into a shared `sanitizeIcon` (the existing `purifyConfig` allowlist) and run the app icon (`readIconFromPath`) through it too.
- Lazy-load `sanitizeIcon` via `doImport`: `isomorphic-dompurify` drags in jsdom, and the core-app manifest runs in the CLI's main process — unlike the studio manifest, which is worker-isolated and already lazy-loads its icon machinery. An eager import would pull jsdom into the deploy command's startup graph; lazy-loading keeps it out, so only a deploy with an app icon pays the cost.

Builds on an in-progress change that started the `sanitizeIcon` extraction; completes it by aligning the load path with the studio resolver.