### PR TITLE
fix: Allow MCP and skills auto-install in all interactive environments, not just production

### DIFF
--- a/.changeset/pr-1211.md
+++ b/.changeset/pr-1211.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix: auto install in staging

--- a/.changeset/pr-1211.md
+++ b/.changeset/pr-1211.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-fix: auto install in staging
+Allow MCP and skills auto-install in all interactive environments, not just production

--- a/.changeset/pr-1211.md
+++ b/.changeset/pr-1211.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-fix: auto install in staging
+fix: Allow MCP and skills auto-install in all interactive environments, not just production

--- a/.changeset/pr-1211.md
+++ b/.changeset/pr-1211.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-Allow MCP and skills auto-install in all interactive environments, not just production
+fix: auto install in staging

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/promptForMCPSetup.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/promptForMCPSetup.test.ts
@@ -33,13 +33,13 @@ describe('promptForMCPSetup', () => {
 
     await promptForMCPSetup({
       choices: [choice(makeEditor({name: 'Cursor'}), 'mcp-and-skill')],
-      message: 'Configure Sanity MCP and install agent skills for these editors?',
+      message: 'Configure Sanity MCP and agent skill for these editors?',
     })
 
     expect(mockCheckbox).toHaveBeenCalledWith(
       expect.objectContaining({
         choices: [{checked: true, name: 'Cursor', value: 'Cursor'}],
-        message: 'Configure Sanity MCP and install agent skills for these editors?',
+        message: 'Configure Sanity MCP and agent skill for these editors?',
       }),
     )
   })

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts
@@ -259,7 +259,7 @@ describe('setupMCP', () => {
 
     expect(mockPromptForMCPSetup).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: 'Configure Sanity MCP and install agent skills for these editors?',
+        message: 'Configure Sanity MCP and agent skill for these editors?',
       }),
     )
   })

--- a/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
+++ b/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
@@ -142,7 +142,7 @@ function applyMasking(
 function getPromptMessage(mcpMode: Mode, skillsMode: Mode): string {
   if (mcpMode === 'skip') return 'Install Sanity agent skills for these editors?'
   if (skillsMode === 'skip') return 'Configure Sanity MCP server?'
-  return 'Configure Sanity MCP and install agent skills for these editors?'
+  return 'Configure Sanity MCP and agent skill for these editors?'
 }
 
 /**

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.command.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.command.test.ts
@@ -132,7 +132,7 @@ describe('skillsMode resolution', () => {
     )
   })
 
-  test('sets skillsMode to "skip" in non-production Sanity env (e2e / UI tests)', async () => {
+  test('sets skillsMode to "auto" in staging Sanity env when interactive', async () => {
     const previous = process.env.SANITY_INTERNAL_ENV
     process.env.SANITY_INTERNAL_ENV = 'staging'
     mockInitAction.mockResolvedValue(undefined)
@@ -144,7 +144,7 @@ describe('skillsMode resolution', () => {
 
       if (error) throw error
       expect(mockInitAction).toHaveBeenCalledWith(
-        expect.objectContaining({skillsMode: 'skip'}),
+        expect.objectContaining({skillsMode: 'auto'}),
         expect.any(Object),
       )
     } finally {

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.staging-env.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.staging-env.test.ts
@@ -326,7 +326,7 @@ describe('#init: staging env propagation', () => {
     expect(mocks.createOrAppendEnvVars).not.toHaveBeenCalled()
   })
 
-  test('skips MCP setup when in staging environment', async () => {
+  test('prompts for MCP and auto-installs skills in staging environment', async () => {
     mocks.getSanityEnv.mockReturnValue('staging')
     setupInitSuccessMocks()
 
@@ -349,6 +349,6 @@ describe('#init: staging env propagation', () => {
       },
     )
 
-    expect(setupMCP).toHaveBeenCalledWith({editors: [], mode: 'skip', skillsMode: 'skip'})
+    expect(setupMCP).toHaveBeenCalledWith({editors: [], mode: 'prompt', skillsMode: 'auto'})
   })
 })

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -5,7 +5,6 @@ import {SanityCommand} from '@sanity/cli-core'
 import {initAction} from '../actions/init/initAction.js'
 import {InitError} from '../actions/init/initError.js'
 import {flagsToInitOptions} from '../actions/init/types.js'
-import {getSanityEnv} from '../util/getSanityEnv.js'
 
 export class InitCommand extends SanityCommand<typeof InitCommand> {
   static override args = {type: Args.string({hidden: true})}
@@ -216,16 +215,16 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
 
   public async run(): Promise<void> {
     let mcpMode: 'auto' | 'prompt' | 'skip' = 'prompt'
-    if (!this.flags.mcp || !this.resolveIsInteractive() || getSanityEnv() !== 'production') {
+    if (!this.flags.mcp || !this.resolveIsInteractive()) {
       mcpMode = 'skip'
     } else if (this.flags.yes) {
       mcpMode = 'auto'
     }
 
-    // Mirror MCP's environment gating: skip skills install in non-production
-    // Sanity envs so e2e / UI tests don't run the bundled skills CLI.
+    // Mirror MCP's environment gating: skip install in test environments
+    // ensure e2e / CI tests don't run the bundled skills CLI.
     let skillsMode: 'auto' | 'prompt' | 'skip' = 'auto'
-    if (!this.flags.skills || !this.resolveIsInteractive() || getSanityEnv() !== 'production') {
+    if (!this.flags.skills || !this.resolveIsInteractive()) {
       skillsMode = 'skip'
     }
 


### PR DESCRIPTION
### Description

Previously, `sanity init` gated MCP server setup and agent skills auto-install behind `getSanityEnv() === 'production'`, which meant developers running in staging (or any non-production internal environment) never got the MCP/skills prompts. This PR removes that environment check so the only gates are `--no-mcp` / `--no-skills` flags and `resolveIsInteractive()` — the same rules production already uses.

### What to review

- **Environment gate removal in `init.ts`**: The `getSanityEnv() !== 'production'` check is removed from both the `mcpMode` and `skillsMode` resolution blocks. The remaining gates (`--no-mcp`, `--no-skills`, non-interactive detection, `--yes` for auto mode) are unchanged. Verify these are sufficient to keep CI/e2e tests safe from unintended auto-installs.
- **Prompt copy tweak in `setupMCP.ts`**: "agent skills" changed to "agent skill" (singular) in the combined MCP + skills prompt message.
- **Test updates**: Both `init.command.test.ts` and `init.staging-env.test.ts` now assert that staging environments receive `skillsMode: 'auto'` and `mode: 'prompt'` instead of `'skip'` for both.

### Testing

Existing unit tests updated to reflect the new behavior — staging environment tests now expect `skillsMode: 'auto'` and MCP `mode: 'prompt'` instead of both being skipped. See `init.command.test.ts` and `init.staging-env.test.ts`.