### PR TITLE
feat(workbench): app-view interface from entry (US5)

### DIFF
--- a/.changeset/pr-1176.md
+++ b/.changeset/pr-1176.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+'@sanity/cli': minor
+---
+
+feat(workbench): thread workbench services through

--- a/.changeset/pr-1215.md
+++ b/.changeset/pr-1215.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(workbench): app-view interface from entry (US5)

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ],
     "overrides": {
       "@sanity/cli": "workspace:*",
-      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283"
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ],
     "overrides": {
       "@sanity/cli": "workspace:*",
-      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d"
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ],
     "overrides": {
       "@sanity/cli": "workspace:*",
-      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75"
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283"
     }
   }
 }

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -7,7 +7,11 @@ import {
   readPackageJson,
   type UserViteConfig,
 } from '@sanity/cli-core'
-import {type InterfaceArtifact, federation as viteFederation} from '@sanity/federation/vite'
+import {
+  type InterfaceArtifact,
+  type ServiceArtifact,
+  federation as viteFederation,
+} from '@sanity/federation/vite'
 import viteReact from '@vitejs/plugin-react'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import debug from 'debug'
@@ -92,6 +96,12 @@ interface ViteOptions extends Pick<CliConfig, 'schemaExtraction'> {
    */
   server?: {host?: string; port?: number}
   /**
+   * Background services the workbench app declares. Built into self-contained
+   * worker bundles and exposed through module federation as `./services/<name>`.
+   */
+  services?: readonly ServiceArtifact[]
+
+  /**
    * Whether or not to enable source maps
    */
   sourceMap?: boolean
@@ -124,6 +134,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     reactCompiler,
     schemaExtraction,
     server,
+    services,
     // default to `true` when `mode=development`
     sourceMap = options.mode === 'development',
     views,
@@ -213,6 +224,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
                     studioConfigPath: entries.relativeConfigLocation!,
                   }),
               pkgJson: await readPackageJson(path.join(cwd, 'package.json')),
+              services,
               views,
               workDir: cwd,
             }),

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -40,6 +40,7 @@ interface InternalBuildOptions {
   output: Output
   reactCompiler: CliConfig['reactCompiler']
   schemaExtraction: CliConfig['schemaExtraction']
+  services: DefineAppInput['services']
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
@@ -74,6 +75,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     output,
     reactCompiler: cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
     schemaExtraction: cliConfig?.schemaExtraction,
+    services: workbenchApp?.services,
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: flags.yes,
@@ -237,6 +239,7 @@ async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
       outputDir,
       reactCompiler: options.reactCompiler,
       schemaExtraction: options.schemaExtraction,
+      services: options.services,
       sourceMap: options.sourceMap,
       views: options.views,
       vite: options.vite,

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -11,7 +11,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {type CliConfig, type UserViteConfig} from '@sanity/cli-core'
-import {type InterfaceArtifact} from '@sanity/federation/vite'
+import {type InterfaceArtifact, type ServiceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {build, createBuilder} from 'vite'
 
@@ -47,6 +47,7 @@ interface StaticBuildOptions {
   profile?: boolean
   reactCompiler?: ReactCompilerConfig
   schemaExtraction?: CliConfig['schemaExtraction']
+  services?: readonly ServiceArtifact[]
   sourceMap?: boolean
   views?: readonly InterfaceArtifact[]
   vite?: UserViteConfig
@@ -73,6 +74,7 @@ export async function buildStaticFiles(
     outputDir,
     reactCompiler,
     schemaExtraction,
+    services,
     sourceMap = false,
     views,
     vite: extendViteConfig,
@@ -100,6 +102,7 @@ export async function buildStaticFiles(
       mode,
       outputDir,
       reactCompiler,
+      services,
       sourceMap,
       views,
     })

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -49,6 +49,7 @@ interface InternalBuildOptions {
   projectId: string | undefined
   reactCompiler: CliConfig['reactCompiler']
   schemaExtraction: CliConfig['schemaExtraction']
+  services: DefineAppInput['services']
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
@@ -96,6 +97,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     projectId: cliConfig?.api?.projectId,
     reactCompiler: cliConfig.reactCompiler,
     schemaExtraction: cliConfig.schemaExtraction,
+    services: workbenchApp?.services,
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: Boolean(flags.yes),
@@ -124,6 +126,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     projectId,
     reactCompiler,
     schemaExtraction,
+    services,
     sourceMap,
     stats,
     unattendedMode,
@@ -310,6 +313,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
       outputDir,
       reactCompiler,
       schemaExtraction,
+      services,
       sourceMap,
       views,
       vite,

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
@@ -302,4 +302,50 @@ describe('startFederationRegistration', () => {
       expect.objectContaining({exit: 1}),
     )
   })
+
+  // US5 — `entry` declares an SDK app's navigable `app` view.
+  test('forwards an `app` interface derived from `entry` for an SDK app', async () => {
+    await startFederationRegistration({
+      cliConfig: {app: workbenchApp({entry: './src/App.tsx'})},
+      isApp: true,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockRegisterDevServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interfaces: expect.arrayContaining([
+          {entry_point: './src/App.tsx', interface_type: 'app', name: 'test-app'},
+        ]),
+      }),
+    )
+  })
+
+  test('forwards no `app` interface when an SDK app declares no `entry`', async () => {
+    await startFederationRegistration({
+      cliConfig: {app: workbenchApp()},
+      isApp: true,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    const {interfaces} = mockRegisterDevServer.mock.calls[0][0]
+    expect(
+      (interfaces ?? []).some((i: {interface_type: string}) => i.interface_type === 'app'),
+    ).toBe(false)
+  })
+
+  test('rejects a studio that declares `entry` — app views for studios are not implemented yet', async () => {
+    await expect(
+      startFederationRegistration({
+        cliConfig: {app: workbenchApp({entry: './src/App.tsx'})},
+        isApp: false,
+        output: createMockOutput(),
+        server: mockServer({port: 3334}) as any,
+        workDir: '/tmp/sanity-project',
+      }),
+    ).rejects.toThrow('App views for studios are not implemented yet')
+  })
 })

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -31,11 +31,14 @@ const workbenchLockSchema = z.object({
 const devServerManifestSchema = z.extend(workbenchLockSchema, {
   id: z.optional(z.string()),
   /**
-   * Interfaces the app exposes (e.g. dock panels), mapped from the declared
-   * views. Carried separately from the manifest — interfaces live in the
-   * application service, not the manifest — so the workbench can render local
-   * panels without a deploy. `entry_point` is the declared `src`. Lenient by
-   * design; the workbench is the authority on the interface shape.
+   * Interfaces the app exposes, mapped from the declared `views` (dock panels,
+   * `interface_type: "panel"`) and `services` (background workers,
+   * `interface_type: "worker"`). A service is just an interface, so both live
+   * in this one list. Carried separately from the manifest — interfaces live in
+   * the application service, not the manifest — so the workbench can render
+   * local panels and run local workers without a deploy. `entry_point` is the
+   * declared `src`. Lenient by design; the workbench is the authority on the
+   * interface shape.
    */
   interfaces: z.optional(
     z.array(z.object({entry_point: z.string(), interface_type: z.string(), name: z.string()})),

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -52,6 +52,7 @@ export function getDevServerConfig({
     isWorkbench: isWorkbenchApp(app),
     reactCompiler: cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
     reactStrictMode,
+    services: isWorkbenchApp(app) ? app.services : undefined,
     staticPath: path.join(workDir, 'static'),
     typegen: cliConfig?.typegen,
     views: isWorkbenchApp(app) ? app.views : undefined,

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -39,15 +39,26 @@ export async function startFederationRegistration(
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
   // Interfaces live on the branded `unstable_defineApp` result as declared
-  // views. Forward each on the registry entry (alongside, not inside, the
-  // manifest) so the workbench can render local panels without a deploy. The
-  // `entry_point` is the declared `src` — the raw value, not a resolved URL.
-  const interfaces = isWorkbenchApp(cliConfig.app)
-    ? cliConfig.app.views?.map((view) => ({
-        entry_point: view.src,
-        interface_type: view.type,
-        name: view.name,
-      }))
+  // `views` (panels) and `services` (workers). A service is just an interface
+  // discriminated by `interface_type`, so map both into a single `interfaces`
+  // list and forward them on the registry entry (alongside, not inside, the
+  // manifest) so the workbench can render local panels and run local workers
+  // without a deploy. `entry_point` is the declared `src` — the raw value, not
+  // a resolved URL.
+  const app = isWorkbenchApp(cliConfig.app) ? cliConfig.app : undefined
+  const interfaces = app
+    ? [
+        ...(app.views?.map((view) => ({
+          entry_point: view.src,
+          interface_type: view.type,
+          name: view.name,
+        })) ?? []),
+        ...(app.services?.map((service) => ({
+          entry_point: service.src,
+          interface_type: service.type,
+          name: service.name,
+        })) ?? []),
+      ]
     : undefined
 
   const registration = registerDevServer({

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -46,6 +46,15 @@ export async function startFederationRegistration(
   // without a deploy. `entry_point` is the declared `src` — the raw value, not
   // a resolved URL.
   const app = isWorkbenchApp(cliConfig.app) ? cliConfig.app : undefined
+
+  // US5 — studio app views are not implemented yet. A studio (not an SDK app)
+  // that declares `entry` reaches the app-view path; reject with a clear error
+  // rather than deriving an `app` interface for it. SDK app views are a later
+  // iteration for studios (FR-026).
+  if (app && !isApp && app.entry !== undefined) {
+    throw new Error('App views for studios are not implemented yet')
+  }
+
   const interfaces = app
     ? [
         ...(app.views?.map((view) => ({
@@ -58,6 +67,19 @@ export async function startFederationRegistration(
           interface_type: service.type,
           name: service.name,
         })) ?? []),
+        // US5 — an SDK app's `entry` declares its navigable full-page `app`
+        // view. Forward it as an `app` interface so the workbench knows the app
+        // is navigable; with no `entry` the app has no `app` view and is not
+        // reachable as a full-page app.
+        ...(app.entry === undefined
+          ? []
+          : [
+              {
+                entry_point: app.entry,
+                interface_type: 'app' as const,
+                name: app.name,
+              },
+            ]),
       ]
     : undefined
 

--- a/packages/@sanity/cli/src/exports/runtime.ts
+++ b/packages/@sanity/cli/src/exports/runtime.ts
@@ -8,4 +8,4 @@
 //
 // `unstable_defineApp` is config-time (Node) and stays on the main `@sanity/cli`
 // entry; only the runtime helpers live here.
-export {unstable_defineView} from '@sanity/federation'
+export {unstable_defineService, unstable_defineView} from '@sanity/federation'

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -4,7 +4,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {CliConfig, getCliTelemetry, type UserViteConfig} from '@sanity/cli-core'
-import {type InterfaceArtifact} from '@sanity/federation/vite'
+import {type InterfaceArtifact, type ServiceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {type FSWatcher} from 'chokidar'
 import {createServer, type InlineConfig, type ViteDevServer} from 'vite'
@@ -35,6 +35,7 @@ export interface DevServerOptions {
   isWorkbench?: boolean
   projectName?: string
   schemaExtraction?: CliConfig['schemaExtraction']
+  services?: readonly ServiceArtifact[]
   typegen?: CliConfig['typegen']
   views?: readonly InterfaceArtifact[]
   vite?: UserViteConfig
@@ -60,6 +61,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactCompiler,
     reactStrictMode,
     schemaExtraction,
+    services,
     typegen,
     views,
     vite: extendViteConfig,
@@ -108,6 +110,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactCompiler,
     schemaExtraction,
     server: {host: httpHost, port: httpPort},
+    services,
     views,
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
-  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3
 
 importers:
 
@@ -266,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -538,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -827,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -963,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4925,8 +4925,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283':
-    resolution: {integrity: sha512-osw0N7YR4F1I63q7kEKnaC4nQg1HrMLWFhDHEYF6cPH+KO0B187i81TN4xPlBUZ5gTyR5S5FLfGxW5CRnHqntQ==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3':
+    resolution: {integrity: sha512-XDF3RdwkdFaSzaTGJCSiqFCQ1zoVVxsRdG7XAQSeahg7hF83Gd3ljoGiTJZQUVOozBKIek7QMn5G34Dtng2K8w==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3}
     version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
@@ -14545,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14558,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@6e9fae3(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
-  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75
 
 importers:
 
@@ -266,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -538,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -827,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -963,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4925,8 +4925,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d':
-    resolution: {integrity: sha512-YKgES0eH9N7i3b0mLPQHmTd0PhWHMpWL9SxYhRfxV2qTWvIvLINBSpd4PVvm2tv0+4k7cHHatKVD3IWSBjoacw==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75':
+    resolution: {integrity: sha512-vOQy1VnNvwYrD2xmxbtBQHcvCpQ8AXt/HPfXUHj9ckYdmdOID39f9gWZ9TuTezKg8NM/r+agoBpYjRcIgmlGjQ==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75}
     version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
@@ -14545,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14558,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
-  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283
 
 importers:
 
@@ -266,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -538,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -827,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -963,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4925,8 +4925,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75':
-    resolution: {integrity: sha512-vOQy1VnNvwYrD2xmxbtBQHcvCpQ8AXt/HPfXUHj9ckYdmdOID39f9gWZ9TuTezKg8NM/r+agoBpYjRcIgmlGjQ==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283':
+    resolution: {integrity: sha512-osw0N7YR4F1I63q7kEKnaC4nQg1HrMLWFhDHEYF6cPH+KO0B187i81TN4xPlBUZ5gTyR5S5FLfGxW5CRnHqntQ==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283}
     version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
@@ -14545,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14558,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@9d49a75(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@2950283(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))


### PR DESCRIPTION
Stacked on #1176. The CLI side of US5 (app views) — the dev path.

An SDK app declares its navigable full-page view via `entry`. `sanity dev` now forwards it as an `app` interface on the dev-server registry (alongside panels and workers), so the workbench can gate navigability on it. An app with no `entry` forwards no `app` interface (not navigable). A studio that declares `entry` reaches the not-yet-implemented studio app-view path and is rejected with a clear error.

Pins the `@sanity/federation` preview carrying the `app` interface model.

Scope / follow-ups:

- The deploy payload (the Phase-1 stub — validated + logged, panel-only schema) does not yet include the app view; that follows when the app-service endpoint lands.
- Studio-extraction CI stays red until the federation `development` export is resolved. That is pre-existing and orthogonal: the SDK-app config path loads via jiti → dist and is unaffected; studios load via vite-node, which trips on federation source. US5 defers studios anyway.

Workbench side: sanity-io/workbench#239.