### PR TITLE
feat(workbench): re-sync workbench interfaces on config change

### DIFF
--- a/.changeset/pr-1216.md
+++ b/.changeset/pr-1216.md
@@ -3,4 +3,4 @@
 '@sanity/cli': minor
 ---
 
-feat(dev): re-sync workbench interfaces (views/services) on config change
+feat(workbench): re-sync workbench interfaces on config change

--- a/.changeset/pr-1216.md
+++ b/.changeset/pr-1216.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(dev): re-sync workbench interfaces (views/services) on config change

--- a/packages/@sanity/cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -1,0 +1,69 @@
+import {type CliConfig} from '@sanity/cli-core'
+import {describe, expect, test} from 'vitest'
+
+import {deriveInterfaces} from '../deriveInterfaces.js'
+import {workbenchApp} from './testHelpers.js'
+
+describe('deriveInterfaces', () => {
+  test('returns undefined for a non-branded app (no unstable_defineApp)', () => {
+    expect(deriveInterfaces({title: 'Plain'} as CliConfig['app'], {isApp: true})).toBeUndefined()
+    expect(deriveInterfaces(undefined, {isApp: true})).toBeUndefined()
+  })
+
+  test('maps views to panel interfaces', () => {
+    const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+    ])
+  })
+
+  test('maps services to worker interfaces', () => {
+    const app = workbenchApp({
+      services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread'},
+    ])
+  })
+
+  test('derives an app interface from entry for an SDK app', () => {
+    const app = workbenchApp({entry: './src/App.tsx', name: 'my-app'})
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {entry_point: './src/App.tsx', interface_type: 'app', name: 'my-app'},
+    ])
+  })
+
+  test('omits the app interface for a dock-only app (no entry)', () => {
+    const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
+    const result = deriveInterfaces(app, {isApp: true})
+    expect(result?.some((iface) => iface.interface_type === 'app')).toBe(false)
+  })
+
+  test('combines views, services, and the app view (in that order)', () => {
+    const app = workbenchApp({
+      entry: './src/App.tsx',
+      name: 'my-app',
+      services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+      views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread'},
+      {entry_point: './src/App.tsx', interface_type: 'app', name: 'my-app'},
+    ])
+  })
+
+  test('rejects a studio that declares entry (FR-026)', () => {
+    const app = workbenchApp({entry: './src/App.tsx'})
+    expect(() => deriveInterfaces(app, {isApp: false})).toThrow(
+      'App views for studios are not implemented yet',
+    )
+  })
+
+  test('a studio without entry still derives its panels/workers', () => {
+    const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
+    expect(deriveInterfaces(app, {isApp: false})).toEqual([
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+    ])
+  })
+})

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -44,12 +44,17 @@ const STUDIO_CONFIG_PATH = '/tmp/studio/sanity.config.ts'
 
 describe('startDevManifestWatcher', () => {
   let fakeWatcher: FakeFsWatcher
-  let mockExtract: Mock<(params: {configPath: string; workDir: string}) => Promise<unknown>>
+  let mockExtract: Mock<
+    (params: {configPath: string; workDir: string}) => Promise<{
+      interfaces?: {entry_point: string; interface_type: string; name: string}[] | undefined
+      manifest: unknown
+    }>
+  >
   const studioManifest = {createdAt: '2026-01-01', version: 3, workspaces: []}
 
   beforeEach(() => {
     fakeWatcher = new FakeFsWatcher()
-    mockExtract = vi.fn(async () => studioManifest)
+    mockExtract = vi.fn(async () => ({interfaces: undefined, manifest: studioManifest}))
     mockFindProjectRoot.mockResolvedValue({
       directory: WORK_DIR,
       path: STUDIO_CONFIG_PATH,
@@ -87,6 +92,7 @@ describe('startDevManifestWatcher', () => {
       workDir: WORK_DIR,
     })
     expect(update).toHaveBeenCalledWith({
+      interfaces: undefined,
       manifest: studioManifest,
       manifestUpdatedAt: expect.any(String),
     })
@@ -98,14 +104,16 @@ describe('startDevManifestWatcher', () => {
     // Block the first extraction until we say otherwise. This simulates the
     // user editing sanity.config.ts while the worker is still producing the
     // initial manifest — the watcher must not run a parallel extraction.
-    let resolveFirst: ((value: typeof studioManifest) => void) | undefined
+    let resolveFirst:
+      | ((value: {interfaces: undefined; manifest: typeof studioManifest}) => void)
+      | undefined
     mockExtract
       .mockReturnValueOnce(
         new Promise((resolve) => {
           resolveFirst = resolve
         }),
       )
-      .mockResolvedValueOnce(studioManifest)
+      .mockResolvedValueOnce({interfaces: undefined, manifest: studioManifest})
 
     const update = vi.fn()
     const watcher = await startDevManifestWatcher({
@@ -124,7 +132,7 @@ describe('startDevManifestWatcher', () => {
 
     // Release the initial extraction; the pending change-triggered run now
     // starts, serialized behind it.
-    resolveFirst!(studioManifest)
+    resolveFirst!({interfaces: undefined, manifest: studioManifest})
     await vi.advanceTimersByTimeAsync(0)
 
     expect(mockExtract).toHaveBeenCalledTimes(2)
@@ -186,7 +194,9 @@ describe('startDevManifestWatcher', () => {
   test('logs a warning and keeps running when extraction fails', async () => {
     const output = createMockOutput()
     const update = vi.fn()
-    mockExtract.mockRejectedValueOnce(new Error('bad schema')).mockResolvedValueOnce(studioManifest)
+    mockExtract
+      .mockRejectedValueOnce(new Error('bad schema'))
+      .mockResolvedValueOnce({interfaces: undefined, manifest: studioManifest})
 
     const watcher = await startDevManifestWatcher({
       extract: mockExtract,
@@ -233,12 +243,17 @@ describe('startDevManifestWatcher', () => {
     const APP_WORK_DIR = '/tmp/sdk-app'
     const APP_CONFIG_PATH = '/tmp/sdk-app/sanity.cli.ts'
     const appManifest = {icon: '<svg/>', title: 'My App', version: '1'}
+    // Interfaces ride alongside the manifest (not inside it) and re-sync on
+    // every config edit — FR-024.
+    const appInterfaces = [
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+    ]
     mockFindProjectRoot.mockResolvedValue({
       directory: APP_WORK_DIR,
       path: APP_CONFIG_PATH,
       type: 'app',
     })
-    mockExtract.mockResolvedValue(appManifest)
+    mockExtract.mockResolvedValue({interfaces: appInterfaces, manifest: appManifest})
     const update = vi.fn()
 
     const watcher = await startDevManifestWatcher({
@@ -254,6 +269,7 @@ describe('startDevManifestWatcher', () => {
       workDir: APP_WORK_DIR,
     })
     expect(update).toHaveBeenCalledWith({
+      interfaces: appInterfaces,
       manifest: appManifest,
       manifestUpdatedAt: expect.any(String),
     })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
@@ -9,7 +9,13 @@ const mockExtractCoreAppManifest = vi.hoisted(() => vi.fn())
 const mockExtractStudioManifest = vi.hoisted(() => vi.fn())
 const mockCheckForDeprecatedAppId = vi.hoisted(() => vi.fn())
 const mockGetAppId = vi.hoisted(() => vi.fn())
+const mockGetCliConfigUncached = vi.hoisted(() => vi.fn())
 
+// The core-app watcher re-reads the config to re-derive interfaces on each edit.
+vi.mock('@sanity/cli-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
+  getCliConfigUncached: mockGetCliConfigUncached,
+}))
 vi.mock('../devServerRegistry.js', () => ({
   registerDevServer: mockRegisterDevServer,
 }))
@@ -39,6 +45,7 @@ describe('startFederationRegistration', () => {
     mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
     mockStartDevManifestWatcher.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
     mockExtractCoreAppManifest.mockResolvedValue(undefined)
+    mockGetCliConfigUncached.mockResolvedValue({app: workbenchApp()})
     mockGetAppId.mockReturnValue(undefined)
   })
 
@@ -199,9 +206,13 @@ describe('startFederationRegistration', () => {
     )
   })
 
-  test('wires extractCoreAppManifest into the core-app watcher', async () => {
+  test('wires extractCoreAppManifest into the core-app watcher and re-derives interfaces', async () => {
     const appManifest = {icon: '<svg><path d="M0 0"/></svg>', title: 'My App', version: '1'}
     mockExtractCoreAppManifest.mockResolvedValue(appManifest)
+    // A fresh config read with a panel → the watcher re-derives + forwards it.
+    mockGetCliConfigUncached.mockResolvedValue({
+      app: workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]}),
+    })
 
     await startFederationRegistration({
       cliConfig: workbenchCliConfig(),
@@ -212,13 +223,20 @@ describe('startFederationRegistration', () => {
     })
 
     const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
+    // The manifest stays pure; interfaces ride alongside as a separate field.
     await expect(
       extract({configPath: '/tmp/sanity-project/sanity.cli.ts', workDir: '/tmp/sanity-project'}),
-    ).resolves.toEqual(appManifest)
+    ).resolves.toEqual({
+      interfaces: [{entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'}],
+      manifest: appManifest,
+    })
     expect(mockExtractCoreAppManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
   })
 
-  test('wires extractStudioManifest into the studio watcher', async () => {
+  test('wires extractStudioManifest into the studio watcher (no interfaces)', async () => {
+    const studioManifest = {version: 3, workspaces: []}
+    mockExtractStudioManifest.mockResolvedValue(studioManifest)
+
     await startFederationRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: false,
@@ -228,7 +246,10 @@ describe('startFederationRegistration', () => {
     })
 
     const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
-    expect(extract).toBe(mockExtractStudioManifest)
+    await expect(
+      extract({configPath: '/tmp/sanity-project/sanity.config.ts', workDir: '/tmp/sanity-project'}),
+    ).resolves.toEqual({interfaces: undefined, manifest: studioManifest})
+    expect(mockExtractStudioManifest).toHaveBeenCalled()
   })
 
   test('calls manifest cleanup on close', async () => {

--- a/packages/@sanity/cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/cli/src/actions/dev/deriveInterfaces.ts
@@ -1,0 +1,53 @@
+import {type CliConfig} from '@sanity/cli-core'
+import {isWorkbenchApp} from '@sanity/federation'
+
+import {type DevServerManifest} from './devServerRegistry.js'
+
+/** One forwarded interface record on the dev-server registry entry. */
+export type DevServerInterface = NonNullable<DevServerManifest['interfaces']>[number]
+
+/**
+ * Derive the workbench `interfaces[]` an app forwards to the dev-server
+ * registry from its `unstable_defineApp` config: `views` → `panel`s,
+ * `services` → `worker`s, and (SDK apps) `entry` → the navigable `app` view.
+ * `entry_point` is the declared `src` — the raw value, not a resolved URL.
+ *
+ * Returns `undefined` for a non-branded app (no `unstable_defineApp`). A studio
+ * that declares `entry` reaches the not-yet-implemented studio app-view path and
+ * is rejected (FR-026).
+ *
+ * Shared by the initial registration and the dev config watcher so editing
+ * `views`/`services`/`entry` in `sanity.cli.ts` re-pushes the same shape live,
+ * the way `title`/`icon` already re-sync (FR-024).
+ */
+export function deriveInterfaces(
+  app: CliConfig['app'],
+  options: {isApp: boolean},
+): DevServerInterface[] | undefined {
+  if (!isWorkbenchApp(app)) return undefined
+
+  // US5 — studio app views are not implemented yet. A studio (not an SDK app)
+  // that declares `entry` reaches the app-view path; reject with a clear error
+  // rather than deriving an `app` interface for it.
+  if (!options.isApp && app.entry !== undefined) {
+    throw new Error('App views for studios are not implemented yet')
+  }
+
+  return [
+    ...(app.views?.map((view) => ({
+      entry_point: view.src,
+      interface_type: view.type,
+      name: view.name,
+    })) ?? []),
+    ...(app.services?.map((service) => ({
+      entry_point: service.src,
+      interface_type: service.type,
+      name: service.name,
+    })) ?? []),
+    // US5 — with no `entry` the app has no `app` view and isn't reachable as a
+    // full-page app; with one, forward it so the workbench gates navigability.
+    ...(app.entry === undefined
+      ? []
+      : [{entry_point: app.entry, interface_type: 'app' as const, name: app.name}]),
+  ]
+}

--- a/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
@@ -4,6 +4,7 @@ import {basename, dirname} from 'node:path'
 import {findProjectRoot, type Output} from '@sanity/cli-core'
 
 import {canonicalizeWatchDir} from './canonicalizeWatchDir.js'
+import {type DevServerInterface} from './deriveInterfaces.js'
 import {devDebug} from './devDebug.js'
 
 /**
@@ -21,17 +22,29 @@ interface DevManifestWatcher {
 interface ManifestPatch<T> {
   manifest: T | undefined
   manifestUpdatedAt: string
+
+  /**
+   * Workbench interfaces (views/services/app view) re-derived from the config
+   * on each change, so editing `views`/`services`/`entry` in `sanity.cli.ts`
+   * re-syncs live like `title`/`icon` (FR-024). `undefined` for project types
+   * that don't declare interfaces (e.g. studios).
+   */
+  interfaces?: DevServerInterface[] | undefined
 }
 
 interface StartDevManifestWatcherOptions<T> {
   /**
-   * Run the project-specific manifest extraction and resolve to the inlined
-   * manifest. Receives the resolved config path (e.g. `sanity.config.ts` for
-   * studios, `sanity.cli.ts` for core-apps) and the working directory.
+   * Run the project-specific extraction and resolve to the inlined manifest
+   * plus the workbench `interfaces[]` (when the project declares them).
+   * Receives the resolved config path (e.g. `sanity.config.ts` for studios,
+   * `sanity.cli.ts` for core-apps) and the working directory.
    */
-  extract: (params: {configPath: string; workDir: string}) => Promise<T | undefined>
+  extract: (params: {
+    configPath: string
+    workDir: string
+  }) => Promise<{interfaces?: DevServerInterface[] | undefined; manifest: T | undefined}>
   output: Output
-  /** Called after every successful extraction with the inlined manifest. */
+  /** Called after every successful extraction with the inlined manifest + interfaces. */
   update: (patch: ManifestPatch<T>) => void
   workDir: string
 }
@@ -72,9 +85,9 @@ export async function startDevManifestWatcher<T>({
     }
     running = true
     try {
-      const manifest = await extract({configPath, workDir})
+      const {interfaces, manifest} = await extract({configPath, workDir})
       if (closed) return
-      update({manifest, manifestUpdatedAt: new Date().toISOString()})
+      update({interfaces, manifest, manifestUpdatedAt: new Date().toISOString()})
     } catch (err) {
       // Extractors print their own spinner failure; log the reason here so
       // the user sees what went wrong alongside the spinner indicator.

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -1,9 +1,9 @@
-import {type CliConfig, type Output} from '@sanity/cli-core'
-import {isWorkbenchApp} from '@sanity/federation'
+import {type CliConfig, getCliConfigUncached, type Output} from '@sanity/cli-core'
 import {type ViteDevServer} from 'vite'
 
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
 import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
+import {deriveInterfaces} from './deriveInterfaces.js'
 import {registerDevServer} from './devServerRegistry.js'
 import {extractStudioManifest} from './extractDevServerManifest.js'
 import {startDevManifestWatcher} from './startDevManifestWatcher.js'
@@ -38,50 +38,13 @@ export async function startFederationRegistration(
   const addr = server.httpServer?.address()
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
-  // Interfaces live on the branded `unstable_defineApp` result as declared
-  // `views` (panels), `services` (workers), and the app's navigable `entry`. A
-  // service is just an interface discriminated by `interface_type`, so map them
-  // into a single `interfaces` list and forward them on the registry entry
-  // (alongside, not inside, the manifest) so the workbench can render local
-  // panels, run local workers, and resolve the app view without a deploy.
-  // `entry_point` is the declared `src` — the raw value, not a resolved URL.
-  const app = isWorkbenchApp(cliConfig.app) ? cliConfig.app : undefined
-
-  // US5 — studio app views are not implemented yet. A studio (not an SDK app)
-  // that declares `entry` reaches the app-view path; reject with a clear error
-  // rather than deriving an `app` interface for it. SDK app views are a later
-  // iteration for studios (FR-026).
-  if (app && !isApp && app.entry !== undefined) {
-    throw new Error('App views for studios are not implemented yet')
-  }
-
-  const interfaces = app
-    ? [
-        ...(app.views?.map((view) => ({
-          entry_point: view.src,
-          interface_type: view.type,
-          name: view.name,
-        })) ?? []),
-        ...(app.services?.map((service) => ({
-          entry_point: service.src,
-          interface_type: service.type,
-          name: service.name,
-        })) ?? []),
-        // US5 — an SDK app's `entry` declares its navigable full-page `app`
-        // view. Forward it as an `app` interface so the workbench knows the app
-        // is navigable; with no `entry` the app has no `app` view and is not
-        // reachable as a full-page app.
-        ...(app.entry === undefined
-          ? []
-          : [
-              {
-                entry_point: app.entry,
-                interface_type: 'app' as const,
-                name: app.name,
-              },
-            ]),
-      ]
-    : undefined
+  // Interfaces (panels/workers/app view) are derived from the branded
+  // `unstable_defineApp` config and forwarded on the registry entry (alongside,
+  // not inside, the manifest) so the workbench renders local panels, runs local
+  // workers, and resolves the app view without a deploy. The watcher below
+  // re-derives them on every `sanity.cli.ts` edit so adding/removing a view or
+  // service re-syncs live (FR-024) — the way `title`/`icon` already do.
+  const interfaces = deriveInterfaces(cliConfig.app, {isApp})
 
   const registration = registerDevServer({
     host: appHost,
@@ -95,8 +58,15 @@ export async function startFederationRegistration(
 
   const watcher = await startDevManifestWatcher({
     extract: isApp
-      ? ({workDir: wd}) => extractCoreAppManifest({workDir: wd})
-      : extractStudioManifest,
+      ? async ({workDir: wd}) => ({
+          // Interfaces are NOT part of the manifest — they're re-derived from the
+          // same config edit and forwarded as a separate registry field, so a
+          // `views`/`services`/`entry` change re-syncs live (FR-024).
+          interfaces: deriveInterfaces((await getCliConfigUncached(wd)).app, {isApp}),
+          manifest: await extractCoreAppManifest({workDir: wd}),
+        })
+      : (params) =>
+          extractStudioManifest(params).then((manifest) => ({interfaces: undefined, manifest})),
     output,
     update: registration.update,
     workDir,


### PR DESCRIPTION
Editing `views`/`services`/`entry` in `unstable_defineApp` didn't take effect without a `sanity dev` restart — only `title`/`icon` re-synced live. The dev config watcher now re-derives the interfaces on each `sanity.cli.ts` edit and forwards them on the registry entry, so the workbench reconciles panels/workers/app view without a restart (FR-024).

Interfaces stay a **separate** registry field — the manifest keeps carrying only `title`/`icon`/`group`/`priority`. The `views`/`services`/`entry` → interface mapping moved into a shared `deriveInterfaces` helper so initial registration and the watcher produce the same shape.

Stacked on #1176. Pairs with the workbench-side reconcile (stop a worker when its declaration is removed) — sanity-io/workbench follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dev-server federation registration and live registry updates that drive workbench panels/workers; behavior is well-covered by tests but incorrect derivation could desync local workbench UI until restart.
> 
> **Overview**
> **Workbench panels/workers/app view now re-sync on `sanity.cli.ts` edits** without restarting `sanity dev`, matching how manifest metadata like `title`/`icon` already updates live (FR-024).
> 
> Interface mapping from `unstable_defineApp` (`views` → panels, `services` → workers, SDK `entry` → `app` view) is moved into shared **`deriveInterfaces`**, used at initial federation registration and on every config-driven regeneration. **`startDevManifestWatcher`** now expects extractors to return **`{ manifest, interfaces }`** and forwards both on registry updates; core-app extraction **re-reads config** via `getCliConfigUncached` so interface lists stay in sync with edits. **Interfaces remain a separate registry field**, not part of the inlined manifest; studios continue with `interfaces: undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a521a85b3797bc541131db8ef881eed639b719da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->