### PR TITLE
fix(init): migrate page-builder template to @sanity/presets v0.5

### DIFF
--- a/.changeset/pr-1217.md
+++ b/.changeset/pr-1217.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(init): migrate page-builder template to @sanity/presets v0.5

--- a/packages/@sanity/cli-e2e/__tests__/init/init.studio.shared.ts
+++ b/packages/@sanity/cli-e2e/__tests__/init/init.studio.shared.ts
@@ -67,30 +67,33 @@ export function registerStudioInitTests(yFlag: string[]): void {
     expect(existsSync(`${tmp.path}/sanity.config.js`)).toBe(false)
   })
 
-  test.each(['clean', 'blog'])('creates studio with %s template', async (template) => {
-    const {error} = await runCli({
-      args: [
-        'init',
-        ...yFlag,
-        '--project',
-        projectId,
-        '--dataset',
-        'production',
-        '--output-path',
-        tmp.path,
-        '--template',
-        template,
-        '--typescript',
-      ],
-    })
+  test.each(['clean', 'blog', 'page-builder'])(
+    'creates studio with %s template',
+    async (template) => {
+      const {error} = await runCli({
+        args: [
+          'init',
+          ...yFlag,
+          '--project',
+          projectId,
+          '--dataset',
+          'production',
+          '--output-path',
+          tmp.path,
+          '--template',
+          template,
+          '--typescript',
+        ],
+      })
 
-    if (error) throw error
-    expect(existsSync(`${tmp.path}/sanity.config.ts`)).toBe(true)
-    expect(existsSync(`${tmp.path}/package.json`)).toBe(true)
-    if (template === 'blog') {
-      expect(existsSync(`${tmp.path}/schemaTypes`)).toBe(true)
-    }
-  })
+      if (error) throw error
+      expect(existsSync(`${tmp.path}/sanity.config.ts`)).toBe(true)
+      expect(existsSync(`${tmp.path}/package.json`)).toBe(true)
+      if (template === 'blog' || template === 'page-builder') {
+        expect(existsSync(`${tmp.path}/schemaTypes`)).toBe(true)
+      }
+    },
+  )
 
   test('creates TypeScript project with correct config files', async () => {
     const {error} = await runCli({

--- a/packages/@sanity/cli/src/actions/init/templates/pageBuilder.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/pageBuilder.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 const pageBuilderTemplate: ProjectTemplate = {
   configTemplate,
   dependencies: {
-    '@sanity/presets': '^0.4.1',
+    '@sanity/presets': '^0.5.0',
   },
 }
 

--- a/packages/@sanity/cli/templates/page-builder/schemaTypes/index.js
+++ b/packages/@sanity/cli/templates/page-builder/schemaTypes/index.js
@@ -3,7 +3,7 @@ import {createPresetsRegistry} from '@sanity/presets'
 import hero from './hero'
 
 const {defineCta, defineImage, definePage, defineRichText} = createPresetsRegistry({
-  link: {internalTypes: ['page']},
+  link: {to: ['page']},
 })
 
 export const schemaTypes = [


### PR DESCRIPTION
### Description

The page-builder template depends on `@sanity/presets`, and version 0.5.0 ships minor breaking changes. The `link.internalTypes` option was renamed to `link.to`, and under 0.5.0 the old `internalTypes` key is silently ignored - the internal link's reference target is dropped entirely.

This PR migrates the page-builder template to `@sanity/presets` 0.5.0: it bumps the declared dependency to `^0.5.0` and renames `link.internalTypes` to `link.to` in the template's schema. The other 0.5.0 breaking changes do not affect this template - `defineImage` is used without `altText`, `caption`, `hotspot`, or `map` config, and the template contains no GROQ queries referencing image asset, hotspot, or crop paths.

### What to review

- `templates/page-builder/schemaTypes/index.js` - the `link.to` rename. `to` accepts the same `['page']` string shorthand, so the value is unchanged.
- `templates/pageBuilder.ts` - dependency bump only.
- `cli-e2e/__tests__/init/init.studio.shared.ts` - adds `page-builder` to the existing studio init parity test, matching the `clean` and `blog` coverage.

### Testing

Verified the migrated schema against `@sanity/presets@0.5.0` from npm: `createPresetsRegistry({link: {to: ['page']}})` builds the schema and correctly wires the `page` reference target, whereas the old `internalTypes` form drops it. The existing `pageBuilder.test.ts` unit test passes.

Adds `page-builder` to the studio init e2e suite, which scaffolds the template and installs its dependencies alongside `clean` and `blog`. This matches the existing parity pattern: it asserts the scaffolded files exist, not that the studio builds.
