### PR TITLE
feat(workbench): rebuild the app remote when the declared interface set changes

### DIFF
--- a/.changeset/pr-1146.md
+++ b/.changeset/pr-1146.md
@@ -4,4 +4,4 @@
 '@sanity/cli': minor
 ---
 
-feat(cli): merge app group + priority into the core-app manifest
+feat(workbench): merge app group + priority into the core-app manifest

--- a/.changeset/pr-1146.md
+++ b/.changeset/pr-1146.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+---
+
+feat(cli): merge app group + priority into the core-app manifest

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -4,4 +4,4 @@
 '@sanity/cli': minor
 ---
 
-feat(cli): build app view artifacts and register them on deploy
+feat(workbench): build app view artifacts and register them on deploy

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+---
+
+feat(cli): build app view artifacts and register them on deploy

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -4,4 +4,4 @@
 '@sanity/cli': minor
 ---
 
-feat(workbench): build app view artifacts and register them on deploy
+feat(workbench): build + register app view artifacts; forward the app interface from entry (US3 + US5)

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -1,5 +1,6 @@
 <!-- auto-generated -->
 ---
+'@sanity/cli-build': minor
 '@sanity/cli': minor
 ---
 

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -1,6 +1,5 @@
 <!-- auto-generated -->
 ---
-'@sanity/cli-core': minor
 '@sanity/cli': minor
 ---
 

--- a/.changeset/pr-1176.md
+++ b/.changeset/pr-1176.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+'@sanity/cli': minor
+---
+
+feat(workbench): thread workbench services through

--- a/.changeset/pr-1216.md
+++ b/.changeset/pr-1216.md
@@ -3,4 +3,4 @@
 '@sanity/cli': minor
 ---
 
-feat(dev): re-sync workbench interfaces (views/services) on config change
+feat(workbench): re-sync workbench interfaces on config change

--- a/.changeset/pr-1216.md
+++ b/.changeset/pr-1216.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(dev): re-sync workbench interfaces (views/services) on config change

--- a/.changeset/pr-1218.md
+++ b/.changeset/pr-1218.md
@@ -3,4 +3,4 @@
 '@sanity/cli': minor
 ---
 
-feat(dev): rebuild the app remote when the declared interface set changes
+feat(workbench): rebuild the app remote when the declared interface set changes

--- a/.changeset/pr-1218.md
+++ b/.changeset/pr-1218.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(dev): rebuild the app remote when the declared interface set changes

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ],
     "overrides": {
       "@sanity/cli": "workspace:*",
-      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d"
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ],
     "overrides": {
       "@sanity/cli": "workspace:*",
-      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450"
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ],
     "overrides": {
       "@sanity/cli": "workspace:*",
-      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091"
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
       "node-pty"
     ],
     "overrides": {
-      "@sanity/cli": "workspace:*"
+      "@sanity/cli": "workspace:*",
+      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091"
     }
   }
 }

--- a/packages/@sanity/cli-build/src/actions/build/getEntryModule.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getEntryModule.ts
@@ -37,9 +37,21 @@ const element = createElement(App)
 root.render(element)
 `
 
+// A branded app with no \`entry\` (US5) has no navigable app view, so there's no
+// \`App\` to import or render standalone — it contributes panels/services to the
+// workbench instead. The page stays valid (no broken import) for the dev server.
+const noAppViewEntryModule = `
+// This file is auto-generated on 'sanity dev'
+// Modifications to this file is automatically discarded
+const root = document.getElementById('root')
+if (root) {
+  root.textContent = 'This application has no app view.'
+}
+`
+
 export function getEntryModule(options: {
   basePath?: string
-  entry?: string
+  entry?: string | null
   isApp?: boolean
   reactStrictMode: boolean
   relativeConfigLocation: string | null
@@ -47,7 +59,7 @@ export function getEntryModule(options: {
   const {basePath, entry, isApp, reactStrictMode, relativeConfigLocation} = options
 
   if (isApp) {
-    return appEntryModule.replace(/%ENTRY%/, JSON.stringify(entry || './src/App'))
+    return entry ? appEntryModule.replace(/%ENTRY%/, JSON.stringify(entry)) : noAppViewEntryModule
   }
 
   const sourceModule = relativeConfigLocation ? entryModule : noConfigEntryModule

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -37,7 +37,8 @@ interface ViteOptions extends Pick<CliConfig, 'schemaExtraction'> {
 
   entries: {
     relativeConfigLocation: string | null
-    relativeEntry: string
+    // `null` when a branded app declares no `entry` (US5) — no app view.
+    relativeEntry: string | null
   }
 
   /**
@@ -204,7 +205,9 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
             viteFederation({
               ...(isApp
                 ? {
-                    appEntry: entries.relativeEntry,
+                    // `null` relativeEntry (a branded app with no `entry`, US5)
+                    // → omit `appEntry` so the plugin exposes no `./App`.
+                    ...(entries.relativeEntry ? {appEntry: entries.relativeEntry} : {}),
                     isApp: true as const,
                   }
                 : {

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -7,7 +7,7 @@ import {
   readPackageJson,
   type UserViteConfig,
 } from '@sanity/cli-core'
-import {federation as viteFederation} from '@sanity/federation/vite'
+import {type ViewArtifact, federation as viteFederation} from '@sanity/federation/vite'
 import viteReact from '@vitejs/plugin-react'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import debug from 'debug'
@@ -95,6 +95,12 @@ interface ViteOptions extends Pick<CliConfig, 'schemaExtraction'> {
    * Whether or not to enable source maps
    */
   sourceMap?: boolean
+
+  /**
+   * Views the workbench app declares. Built into render-contract artifacts and
+   * exposed through module federation as `./views/<name>`.
+   */
+  views?: readonly ViewArtifact[]
 }
 
 /**
@@ -120,6 +126,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     server,
     // default to `true` when `mode=development`
     sourceMap = options.mode === 'development',
+    views,
   } = options
 
   const basePath = normalizeBasePath(rawBasePath)
@@ -206,6 +213,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
                     studioConfigPath: entries.relativeConfigLocation!,
                   }),
               pkgJson: await readPackageJson(path.join(cwd, 'package.json')),
+              views,
               workDir: cwd,
             }),
           ]

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -7,7 +7,11 @@ import {
   readPackageJson,
   type UserViteConfig,
 } from '@sanity/cli-core'
-import {type InterfaceArtifact, federation as viteFederation} from '@sanity/federation/vite'
+import {
+  type InterfaceArtifact,
+  type ServiceArtifact,
+  federation as viteFederation,
+} from '@sanity/federation/vite'
 import viteReact from '@vitejs/plugin-react'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import debug from 'debug'
@@ -93,6 +97,12 @@ interface ViteOptions extends Pick<CliConfig, 'schemaExtraction'> {
    */
   server?: {host?: string; port?: number}
   /**
+   * Background services the workbench app declares. Built into self-contained
+   * worker bundles and exposed through module federation as `./services/<name>`.
+   */
+  services?: readonly ServiceArtifact[]
+
+  /**
    * Whether or not to enable source maps
    */
   sourceMap?: boolean
@@ -125,6 +135,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     reactCompiler,
     schemaExtraction,
     server,
+    services,
     // default to `true` when `mode=development`
     sourceMap = options.mode === 'development',
     views,
@@ -216,6 +227,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
                     studioConfigPath: entries.relativeConfigLocation!,
                   }),
               pkgJson: await readPackageJson(path.join(cwd, 'package.json')),
+              services,
               views,
               workDir: cwd,
             }),

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -7,7 +7,7 @@ import {
   readPackageJson,
   type UserViteConfig,
 } from '@sanity/cli-core'
-import {type ViewArtifact, federation as viteFederation} from '@sanity/federation/vite'
+import {type InterfaceArtifact, federation as viteFederation} from '@sanity/federation/vite'
 import viteReact from '@vitejs/plugin-react'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import debug from 'debug'
@@ -100,7 +100,7 @@ interface ViteOptions extends Pick<CliConfig, 'schemaExtraction'> {
    * Views the workbench app declares. Built into render-contract artifacts and
    * exposed through module federation as `./views/<name>`.
    */
-  views?: readonly ViewArtifact[]
+  views?: readonly InterfaceArtifact[]
 }
 
 /**

--- a/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
+++ b/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
@@ -32,7 +32,7 @@ interface RuntimeOptions {
  * @internal
  */
 export async function writeSanityRuntime(options: RuntimeOptions): Promise<{
-  entries: {relativeConfigLocation: string | null; relativeEntry: string}
+  entries: {relativeConfigLocation: string | null; relativeEntry: string | null}
   watcher: FSWatcher | undefined
 }> {
   const {appTitle, basePath, cwd, entry, isApp, reactStrictMode, watch} = options
@@ -108,7 +108,7 @@ export async function resolveEntries(options: {
   entry?: string
   isApp?: boolean
   runtimeDir?: string
-}): Promise<{relativeConfigLocation: string | null; relativeEntry: string}> {
+}): Promise<{relativeConfigLocation: string | null; relativeEntry: string | null}> {
   const {cwd, entry, isApp} = options
   const runtimeDir = options.runtimeDir ?? path.join(cwd, '.sanity', 'runtime')
 
@@ -120,9 +120,13 @@ export async function resolveEntries(options: {
       : null
   }
 
-  const relativeEntry = toForwardSlashes(
-    path.relative(runtimeDir, path.resolve(cwd, entry || './src/App')),
-  )
+  // A branded app that declares no `entry` has no navigable app view (US5):
+  // `null` entry tells the runtime/federation to skip the `./App` render path.
+  // Studios ignore `relativeEntry`, so the legacy `./src/App` default is fine.
+  const relativeEntry =
+    isApp && !entry
+      ? null
+      : toForwardSlashes(path.relative(runtimeDir, path.resolve(cwd, entry || './src/App')))
 
   return {relativeConfigLocation, relativeEntry}
 }

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -24,6 +24,8 @@ export interface CliConfig {
   app?: {
     /** The entrypoint for your custom app. By default, `src/App.tsx` */
     entry?: string
+    /** Dock group the app renders in. Defaults to `dock.applications`. */
+    group?: 'dock.applications' | 'dock.system' | 'dock.user'
     /**
      * Path to an icon file relative to project root.
      * The file must be an SVG.
@@ -33,6 +35,8 @@ export interface CliConfig {
     id?: string
     /** The ID for the Sanity organization that manages this application */
     organizationId?: string
+    /** Sort position within the dock group, ascending. Defaults to `100`. */
+    priority?: number
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
   }

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -39,21 +39,6 @@ export interface CliConfig {
     priority?: number
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
-    /**
-     * Views the app exposes (e.g. dock panels). Each is built into a render
-     * artifact on `sanity build` and persisted to the application service on
-     * `sanity deploy`. View types may carry extra attributes that are stored
-     * alongside `type`/`name`/`src`.
-     */
-    views?: Array<{
-      [attribute: string]: unknown
-      /** View name, unique within the app. */
-      name: string
-      /** Path to the view src file (default-exports `unstable_defineView`). */
-      src: string
-      /** View type — selects the render contract the build generates. */
-      type: 'panel'
-    }>
   }
 
   /** @deprecated Use deployment.autoUpdates */

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -39,6 +39,21 @@ export interface CliConfig {
     priority?: number
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
+    /**
+     * Views the app exposes (e.g. dock panels). Each is built into a render
+     * artifact on `sanity build` and persisted to the application service on
+     * `sanity deploy`. View types may carry extra attributes that are stored
+     * alongside `type`/`name`/`src`.
+     */
+    views?: Array<{
+      [attribute: string]: unknown
+      /** View name, unique within the app. */
+      name: string
+      /** Path to the view src file (default-exports `unstable_defineView`). */
+      src: string
+      /** View type — selects the render contract the build generates. */
+      type: 'panel'
+    }>
   }
 
   /** @deprecated Use deployment.autoUpdates */

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -45,6 +45,10 @@
       "source": "./src/exports/_internal.ts",
       "default": "./dist/exports/_internal.js"
     },
+    "./runtime": {
+      "source": "./src/exports/runtime.ts",
+      "default": "./dist/exports/runtime.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/@sanity/cli/src/__tests__/exports.test.ts
+++ b/packages/@sanity/cli/src/__tests__/exports.test.ts
@@ -145,7 +145,7 @@ async function getSanityPackageTypeExports() {
 }
 
 // Value exports intentionally added in v6 that the v5 CLI didn't have.
-const NEW_EXPORTS = new Set(['unstable_defineApp', 'unstable_defineView'])
+const NEW_EXPORTS = new Set(['unstable_defineApp'])
 
 test('should match exports of the current cli package', async () => {
   const oldCliExports = await getSanityPackageExports()

--- a/packages/@sanity/cli/src/__tests__/exports.test.ts
+++ b/packages/@sanity/cli/src/__tests__/exports.test.ts
@@ -145,7 +145,7 @@ async function getSanityPackageTypeExports() {
 }
 
 // Value exports intentionally added in v6 that the v5 CLI didn't have.
-const NEW_EXPORTS = new Set(['unstable_defineApp'])
+const NEW_EXPORTS = new Set(['unstable_defineApp', 'unstable_defineView'])
 
 test('should match exports of the current cli package', async () => {
   const oldCliExports = await getSanityPackageExports()

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -43,6 +43,7 @@ interface InternalBuildOptions {
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
+  views: NonNullable<CliConfig['app']>['views']
   vite: UserViteConfig | undefined
   workDir: string
 }
@@ -71,6 +72,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: flags.yes,
+    views: cliConfig && 'app' in cliConfig ? cliConfig.app?.views : undefined,
     vite: cliConfig.vite,
     workDir,
   })
@@ -231,6 +233,7 @@ async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
       reactCompiler: options.reactCompiler,
       schemaExtraction: options.schemaExtraction,
       sourceMap: options.sourceMap,
+      views: options.views,
       vite: options.vite,
     })
 

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -40,6 +40,7 @@ interface InternalBuildOptions {
   output: Output
   reactCompiler: CliConfig['reactCompiler']
   schemaExtraction: CliConfig['schemaExtraction']
+  services: DefineAppInput['services']
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
@@ -74,6 +75,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     output,
     reactCompiler: cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
     schemaExtraction: cliConfig?.schemaExtraction,
+    services: workbenchApp?.services,
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: flags.yes,
@@ -237,6 +239,7 @@ async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
       outputDir,
       reactCompiler: options.reactCompiler,
       schemaExtraction: options.schemaExtraction,
+      services: options.services,
       sourceMap: options.sourceMap,
       views: options.views,
       vite: options.vite,

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -13,7 +13,7 @@ import {
   UserViteConfig,
 } from '@sanity/cli-core'
 import {confirm, logSymbols, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
-import {isWorkbenchApp} from '@sanity/federation'
+import {type DefineAppInput, isWorkbenchApp} from '@sanity/federation'
 import {parse as semverParse} from 'semver'
 
 import {getAppId} from '../../util/appId.js'
@@ -43,7 +43,7 @@ interface InternalBuildOptions {
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
-  views: NonNullable<CliConfig['app']>['views']
+  views: DefineAppInput['views']
   vite: UserViteConfig | undefined
   workDir: string
 }
@@ -56,14 +56,19 @@ interface InternalBuildOptions {
 export async function buildApp(options: BuildOptions): Promise<void> {
   const {cliConfig, flags, outDir, output, workDir} = options
 
+  const app = cliConfig && 'app' in cliConfig ? cliConfig.app : undefined
+  // `views` lives on `unstable_defineApp`'s result, not the legacy `app` config
+  // object — read it off the branded app.
+  const workbenchApp = isWorkbenchApp(app) ? app : undefined
+
   await internalBuildApp({
     appId: getAppId(cliConfig),
-    appTitle: cliConfig && 'app' in cliConfig ? cliConfig.app?.title : undefined,
+    appTitle: app?.title,
     autoUpdatesEnabled: options.autoUpdatesEnabled,
     calledFromDeploy: options.calledFromDeploy,
     determineBasePath: () => determineBasePath(cliConfig, 'app', output),
-    entry: cliConfig && 'app' in cliConfig ? cliConfig.app?.entry : undefined,
-    isWorkbench: isWorkbenchApp(cliConfig && 'app' in cliConfig ? cliConfig.app : undefined),
+    entry: app?.entry,
+    isWorkbench: Boolean(workbenchApp),
     minify: flags.minify,
     outDir,
     output,
@@ -72,7 +77,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: flags.yes,
-    views: cliConfig && 'app' in cliConfig ? cliConfig.app?.views : undefined,
+    views: workbenchApp?.views,
     vite: cliConfig.vite,
     workDir,
   })

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -11,7 +11,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {type CliConfig, type UserViteConfig} from '@sanity/cli-core'
-import {type ViewArtifact} from '@sanity/federation/vite'
+import {type InterfaceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {build, createBuilder} from 'vite'
 
@@ -48,7 +48,7 @@ interface StaticBuildOptions {
   reactCompiler?: ReactCompilerConfig
   schemaExtraction?: CliConfig['schemaExtraction']
   sourceMap?: boolean
-  views?: readonly ViewArtifact[]
+  views?: readonly InterfaceArtifact[]
   vite?: UserViteConfig
 }
 

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -11,6 +11,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {type CliConfig, type UserViteConfig} from '@sanity/cli-core'
+import {type ViewArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {build, createBuilder} from 'vite'
 
@@ -47,6 +48,7 @@ interface StaticBuildOptions {
   reactCompiler?: ReactCompilerConfig
   schemaExtraction?: CliConfig['schemaExtraction']
   sourceMap?: boolean
+  views?: readonly ViewArtifact[]
   vite?: UserViteConfig
 }
 
@@ -72,6 +74,7 @@ export async function buildStaticFiles(
     reactCompiler,
     schemaExtraction,
     sourceMap = false,
+    views,
     vite: extendViteConfig,
   } = options
 
@@ -98,6 +101,7 @@ export async function buildStaticFiles(
       outputDir,
       reactCompiler,
       sourceMap,
+      views,
     })
 
     // Apply the user's Vite config so plugins like `@vanilla-extract/vite-plugin`

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -11,7 +11,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {type CliConfig, type UserViteConfig} from '@sanity/cli-core'
-import {type InterfaceArtifact} from '@sanity/federation/vite'
+import {type InterfaceArtifact, type ServiceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {build, createBuilder} from 'vite'
 
@@ -47,6 +47,7 @@ interface StaticBuildOptions {
   profile?: boolean
   reactCompiler?: ReactCompilerConfig
   schemaExtraction?: CliConfig['schemaExtraction']
+  services?: readonly ServiceArtifact[]
   sourceMap?: boolean
   views?: readonly InterfaceArtifact[]
   vite?: UserViteConfig
@@ -73,6 +74,7 @@ export async function buildStaticFiles(
     outputDir,
     reactCompiler,
     schemaExtraction,
+    services,
     sourceMap = false,
     views,
     vite: extendViteConfig,
@@ -100,6 +102,7 @@ export async function buildStaticFiles(
       mode,
       outputDir,
       reactCompiler,
+      services,
       sourceMap,
       views,
     })

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -49,6 +49,7 @@ interface InternalBuildOptions {
   projectId: string | undefined
   reactCompiler: CliConfig['reactCompiler']
   schemaExtraction: CliConfig['schemaExtraction']
+  services: DefineAppInput['services']
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
@@ -96,6 +97,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     projectId: cliConfig?.api?.projectId,
     reactCompiler: cliConfig.reactCompiler,
     schemaExtraction: cliConfig.schemaExtraction,
+    services: workbenchApp?.services,
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: Boolean(flags.yes),
@@ -124,6 +126,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     projectId,
     reactCompiler,
     schemaExtraction,
+    services,
     sourceMap,
     stats,
     unattendedMode,
@@ -310,6 +313,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
       outputDir,
       reactCompiler,
       schemaExtraction,
+      services,
       sourceMap,
       views,
       vite,

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -18,7 +18,7 @@ import {
   UserViteConfig,
 } from '@sanity/cli-core'
 import {confirm, logSymbols, select, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
-import {isWorkbenchApp} from '@sanity/federation'
+import {type DefineAppInput, isWorkbenchApp} from '@sanity/federation'
 import {parse as semverParse} from 'semver'
 
 import {getAppId} from '../../util/appId.js'
@@ -53,6 +53,7 @@ interface InternalBuildOptions {
   stats: boolean
   unattendedMode: boolean
   upgradePackages(options: {packages: [name: string, version: string][]}): Promise<void>
+  views: DefineAppInput['views']
   vite: UserViteConfig | undefined
   workDir: string
 }
@@ -64,6 +65,11 @@ interface InternalBuildOptions {
  */
 export async function buildStudio(options: BuildOptions): Promise<void> {
   const {calledFromDeploy, cliConfig, flags, outDir, output, workDir} = options
+
+  // `views` lives on the branded `unstable_defineApp` result — read it off the
+  // branded app so it's gated on the brand, like the app build.
+  const app = cliConfig?.app
+  const workbenchApp = isWorkbenchApp(app) ? app : undefined
 
   const upgradePkgs = async (options: {
     packages: [name: string, version: string][]
@@ -83,7 +89,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     calledFromDeploy,
     determineBasePath: () => determineBasePath(cliConfig, 'studio', output),
     isApp: determineIsApp(cliConfig),
-    isWorkbench: isWorkbenchApp(cliConfig?.app),
+    isWorkbench: Boolean(workbenchApp),
     minify: Boolean(flags.minify),
     outDir,
     output,
@@ -94,6 +100,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     stats: flags.stats,
     unattendedMode: Boolean(flags.yes),
     upgradePackages: upgradePkgs,
+    views: workbenchApp?.views,
     vite: cliConfig.vite,
     workDir,
   })
@@ -121,6 +128,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     stats,
     unattendedMode,
     upgradePackages,
+    views,
     vite,
     workDir,
   } = options
@@ -303,6 +311,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
       reactCompiler,
       schemaExtraction,
       sourceMap,
+      views,
       vite,
     })
 

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -5,6 +5,7 @@ import {createGzip} from 'node:zlib'
 import {CLIError} from '@oclif/core/errors'
 import {getLocalPackageVersion} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
+import {isWorkbenchApp} from '@sanity/federation'
 import {pack} from 'tar-fs'
 
 import {createDeployment, updateUserApplication} from '../../services/userApplications.js'
@@ -141,7 +142,9 @@ export async function deployApp(options: DeployAppOptions) {
     // Register the app's declared views with the application service. That
     // service doesn't exist yet, so validate the payload and log it (no store);
     // a malformed view declaration fails the deploy before we ship the bundle.
-    const declaredViews = cliConfig.app?.views ?? []
+    // `views` lives on the branded `unstable_defineApp` result, not the legacy
+    // `app` config object.
+    const declaredViews = isWorkbenchApp(cliConfig.app) ? (cliConfig.app.views ?? []) : []
     if (declaredViews.length > 0) {
       try {
         const payload = buildViewDeploymentPayload({

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -20,6 +20,7 @@ import {createUserApplicationForApp} from './createUserApplicationForApp.js'
 import {deployDebug} from './deployDebug.js'
 import {findUserApplicationForApp} from './findUserApplicationForApp.js'
 import {type DeployAppOptions} from './types.js'
+import {buildViewDeploymentPayload} from './viewDeployment.js'
 
 /**
  * Deploy a Sanity application.
@@ -134,6 +135,28 @@ export async function deployApp(options: DeployAppOptions) {
         const message = getErrorMessage(err)
         deployDebug('Error updating application title', {message})
         output.warn(`Error updating application title: ${message}`)
+      }
+    }
+
+    // Register the app's declared views with the application service. That
+    // service doesn't exist yet, so validate the payload and log it (no store);
+    // a malformed view declaration fails the deploy before we ship the bundle.
+    const declaredViews = cliConfig.app?.views ?? []
+    if (declaredViews.length > 0) {
+      try {
+        const payload = buildViewDeploymentPayload({
+          applicationId: userApplication.id,
+          views: declaredViews,
+        })
+        output.log(
+          `Validated ${payload.views.length} view(s) for the application service (not yet persisted):`,
+        )
+        output.log(JSON.stringify(payload, null, 2))
+        deployDebug('View deployment payload', payload)
+      } catch (err) {
+        const message = getErrorMessage(err)
+        output.error(`Invalid view declaration: ${message}`, {exit: 1})
+        return
       }
     }
 

--- a/packages/@sanity/cli/src/actions/deploy/viewDeployment.ts
+++ b/packages/@sanity/cli/src/actions/deploy/viewDeployment.ts
@@ -19,12 +19,12 @@ const viewRecordSchema = z
  * payload is validated and logged only — never sent. Builds the contract the
  * application-service endpoint will accept.
  */
-export const viewDeploymentPayloadSchema = z.object({
+const viewDeploymentPayloadSchema = z.object({
   applicationId: z.string(),
   views: z.array(viewRecordSchema),
 })
 
-export type ViewDeploymentPayload = z.infer<typeof viewDeploymentPayloadSchema>
+type ViewDeploymentPayload = z.infer<typeof viewDeploymentPayloadSchema>
 
 /**
  * Validate an app's declared views into the application-service payload.

--- a/packages/@sanity/cli/src/actions/deploy/viewDeployment.ts
+++ b/packages/@sanity/cli/src/actions/deploy/viewDeployment.ts
@@ -1,0 +1,41 @@
+import {z} from 'zod'
+
+/**
+ * A view record as persisted to the application service: `type`, `name`, `src`,
+ * plus any view-type-specific attributes (passed through for storage).
+ */
+const viewRecordSchema = z
+  .object({
+    name: z.string().regex(/^[a-zA-Z0-9_-]+$/, 'View `name` must match /^[a-zA-Z0-9_-]+$/'),
+    src: z.string(),
+    type: z.enum(['panel']),
+  })
+  .passthrough()
+
+/**
+ * Payload registering an app's views with the application service on deploy.
+ *
+ * Phase 1 stub: the service that stores views does not exist yet, so the
+ * payload is validated and logged only — never sent. Builds the contract the
+ * application-service endpoint will accept.
+ */
+export const viewDeploymentPayloadSchema = z.object({
+  applicationId: z.string(),
+  views: z.array(viewRecordSchema),
+})
+
+export type ViewDeploymentPayload = z.infer<typeof viewDeploymentPayloadSchema>
+
+/**
+ * Validate an app's declared views into the application-service payload.
+ * Throws (via Zod) when a view declaration is malformed.
+ */
+export function buildViewDeploymentPayload(input: {
+  applicationId: string
+  views?: ReadonlyArray<Record<string, unknown>>
+}): ViewDeploymentPayload {
+  return viewDeploymentPayloadSchema.parse({
+    applicationId: input.applicationId,
+    views: input.views ?? [],
+  })
+}

--- a/packages/@sanity/cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -1,0 +1,69 @@
+import {type CliConfig} from '@sanity/cli-core'
+import {describe, expect, test} from 'vitest'
+
+import {deriveInterfaces} from '../deriveInterfaces.js'
+import {workbenchApp} from './testHelpers.js'
+
+describe('deriveInterfaces', () => {
+  test('returns undefined for a non-branded app (no unstable_defineApp)', () => {
+    expect(deriveInterfaces({title: 'Plain'} as CliConfig['app'], {isApp: true})).toBeUndefined()
+    expect(deriveInterfaces(undefined, {isApp: true})).toBeUndefined()
+  })
+
+  test('maps views to panel interfaces', () => {
+    const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+    ])
+  })
+
+  test('maps services to worker interfaces', () => {
+    const app = workbenchApp({
+      services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread'},
+    ])
+  })
+
+  test('derives an app interface from entry for an SDK app', () => {
+    const app = workbenchApp({entry: './src/App.tsx', name: 'my-app'})
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {entry_point: './src/App.tsx', interface_type: 'app', name: 'my-app'},
+    ])
+  })
+
+  test('omits the app interface for a dock-only app (no entry)', () => {
+    const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
+    const result = deriveInterfaces(app, {isApp: true})
+    expect(result?.some((iface) => iface.interface_type === 'app')).toBe(false)
+  })
+
+  test('combines views, services, and the app view (in that order)', () => {
+    const app = workbenchApp({
+      entry: './src/App.tsx',
+      name: 'my-app',
+      services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+      views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread'},
+      {entry_point: './src/App.tsx', interface_type: 'app', name: 'my-app'},
+    ])
+  })
+
+  test('rejects a studio that declares entry (FR-026)', () => {
+    const app = workbenchApp({entry: './src/App.tsx'})
+    expect(() => deriveInterfaces(app, {isApp: false})).toThrow(
+      'App views for studios are not implemented yet',
+    )
+  })
+
+  test('a studio without entry still derives its panels/workers', () => {
+    const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
+    expect(deriveInterfaces(app, {isApp: false})).toEqual([
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+    ])
+  })
+})

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -8,7 +8,14 @@ const mockStartAppDevServer = vi.hoisted(() => vi.fn())
 const mockStartStudioDevServer = vi.hoisted(() => vi.fn())
 const mockStartFederationRegistration = vi.hoisted(() => vi.fn())
 const mockGetSharedServerConfig = vi.hoisted(() => vi.fn())
+const mockGetCliConfigUncached = vi.hoisted(() => vi.fn())
 
+// The rebuild hook re-reads the config so the recreated app server picks up the
+// new view/service set.
+vi.mock('@sanity/cli-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
+  getCliConfigUncached: mockGetCliConfigUncached,
+}))
 vi.mock('../startWorkbenchDevServer.js', () => ({
   startWorkbenchDevServer: mockStartWorkbenchDevServer,
 }))
@@ -184,6 +191,39 @@ describe('devAction', () => {
 
       await result.close()
       expect(mockFederationClose).toHaveBeenCalled()
+    })
+
+    test('rebuilds the app server with a freshly-loaded config when interfaces change', async () => {
+      const firstClose = vi.fn().mockResolvedValue(undefined)
+      const secondClose = vi.fn().mockResolvedValue(undefined)
+      mockStartAppDevServer
+        .mockResolvedValueOnce({...mockServer({port: 3334}), close: firstClose})
+        .mockResolvedValueOnce({...mockServer({port: 3334}), close: secondClose})
+      const freshConfig = workbenchCliConfig()
+      mockGetCliConfigUncached.mockResolvedValue(freshConfig)
+
+      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}))
+
+      const {onInterfacesChange} = mockStartFederationRegistration.mock.calls[0][0]
+      expect(onInterfacesChange).toBeInstanceOf(Function)
+
+      await onInterfacesChange()
+
+      // Old app server torn down, a new one started with the re-read config.
+      expect(firstClose).toHaveBeenCalledTimes(1)
+      expect(mockStartAppDevServer).toHaveBeenCalledTimes(2)
+      expect(mockStartAppDevServer).toHaveBeenLastCalledWith(
+        expect.objectContaining({cliConfig: freshConfig}),
+      )
+    })
+
+    test('wires no rebuild hook for studios (they declare no interfaces)', async () => {
+      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: false}))
+
+      const {onInterfacesChange} = mockStartFederationRegistration.mock.calls[0][0]
+      expect(onInterfacesChange).toBeUndefined()
     })
   })
 

--- a/packages/@sanity/cli/src/actions/dev/__tests__/interfacesChanged.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/interfacesChanged.test.ts
@@ -1,0 +1,63 @@
+import {describe, expect, test} from 'vitest'
+
+import {type DevServerInterface} from '../deriveInterfaces.js'
+import {interfacesChanged, serializeInterfaces} from '../interfacesChanged.js'
+
+const panel = (name: string, src = `./src/${name}.tsx`): DevServerInterface => ({
+  entry_point: src,
+  interface_type: 'panel',
+  name,
+})
+const worker = (name: string, src = `./src/${name}.ts`): DevServerInterface => ({
+  entry_point: src,
+  interface_type: 'worker',
+  name,
+})
+
+describe('serializeInterfaces', () => {
+  test('undefined and empty both key to the empty set', () => {
+    expect(serializeInterfaces(undefined)).toBe('')
+    expect(serializeInterfaces([])).toBe('')
+    expect(serializeInterfaces(undefined)).toBe(serializeInterfaces([]))
+  })
+
+  test('is order-independent', () => {
+    expect(serializeInterfaces([panel('a'), worker('b')])).toBe(
+      serializeInterfaces([worker('b'), panel('a')]),
+    )
+  })
+
+  test('distinguishes type, name, and entry point', () => {
+    expect(serializeInterfaces([panel('a')])).not.toBe(serializeInterfaces([worker('a')]))
+    expect(serializeInterfaces([panel('a')])).not.toBe(serializeInterfaces([panel('b')]))
+    expect(serializeInterfaces([panel('a', './x.tsx')])).not.toBe(
+      serializeInterfaces([panel('a', './y.tsx')]),
+    )
+  })
+})
+
+describe('interfacesChanged', () => {
+  test('no change when the set is identical (any order)', () => {
+    expect(interfacesChanged([panel('a'), worker('b')], [worker('b'), panel('a')])).toBe(false)
+  })
+
+  test('detects an added view', () => {
+    expect(interfacesChanged([panel('a')], [panel('a'), panel('b')])).toBe(true)
+  })
+
+  test('detects a removed service', () => {
+    expect(interfacesChanged([panel('a'), worker('b')], [panel('a')])).toBe(true)
+  })
+
+  test('detects a repointed source (the same name, different entry)', () => {
+    expect(interfacesChanged([panel('a', './old.tsx')], [panel('a', './new.tsx')])).toBe(true)
+  })
+
+  test('undefined ↔ empty is not a change', () => {
+    expect(interfacesChanged(undefined, [])).toBe(false)
+  })
+
+  test('gaining the first interface is a change', () => {
+    expect(interfacesChanged(undefined, [panel('a')])).toBe(true)
+  })
+})

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -44,12 +44,17 @@ const STUDIO_CONFIG_PATH = '/tmp/studio/sanity.config.ts'
 
 describe('startDevManifestWatcher', () => {
   let fakeWatcher: FakeFsWatcher
-  let mockExtract: Mock<(params: {configPath: string; workDir: string}) => Promise<unknown>>
+  let mockExtract: Mock<
+    (params: {configPath: string; workDir: string}) => Promise<{
+      interfaces?: {entry_point: string; interface_type: string; name: string}[] | undefined
+      manifest: unknown
+    }>
+  >
   const studioManifest = {createdAt: '2026-01-01', version: 3, workspaces: []}
 
   beforeEach(() => {
     fakeWatcher = new FakeFsWatcher()
-    mockExtract = vi.fn(async () => studioManifest)
+    mockExtract = vi.fn(async () => ({interfaces: undefined, manifest: studioManifest}))
     mockFindProjectRoot.mockResolvedValue({
       directory: WORK_DIR,
       path: STUDIO_CONFIG_PATH,
@@ -87,6 +92,7 @@ describe('startDevManifestWatcher', () => {
       workDir: WORK_DIR,
     })
     expect(update).toHaveBeenCalledWith({
+      interfaces: undefined,
       manifest: studioManifest,
       manifestUpdatedAt: expect.any(String),
     })
@@ -98,14 +104,16 @@ describe('startDevManifestWatcher', () => {
     // Block the first extraction until we say otherwise. This simulates the
     // user editing sanity.config.ts while the worker is still producing the
     // initial manifest — the watcher must not run a parallel extraction.
-    let resolveFirst: ((value: typeof studioManifest) => void) | undefined
+    let resolveFirst:
+      | ((value: {interfaces: undefined; manifest: typeof studioManifest}) => void)
+      | undefined
     mockExtract
       .mockReturnValueOnce(
         new Promise((resolve) => {
           resolveFirst = resolve
         }),
       )
-      .mockResolvedValueOnce(studioManifest)
+      .mockResolvedValueOnce({interfaces: undefined, manifest: studioManifest})
 
     const update = vi.fn()
     const watcher = await startDevManifestWatcher({
@@ -124,7 +132,7 @@ describe('startDevManifestWatcher', () => {
 
     // Release the initial extraction; the pending change-triggered run now
     // starts, serialized behind it.
-    resolveFirst!(studioManifest)
+    resolveFirst!({interfaces: undefined, manifest: studioManifest})
     await vi.advanceTimersByTimeAsync(0)
 
     expect(mockExtract).toHaveBeenCalledTimes(2)
@@ -186,7 +194,9 @@ describe('startDevManifestWatcher', () => {
   test('logs a warning and keeps running when extraction fails', async () => {
     const output = createMockOutput()
     const update = vi.fn()
-    mockExtract.mockRejectedValueOnce(new Error('bad schema')).mockResolvedValueOnce(studioManifest)
+    mockExtract
+      .mockRejectedValueOnce(new Error('bad schema'))
+      .mockResolvedValueOnce({interfaces: undefined, manifest: studioManifest})
 
     const watcher = await startDevManifestWatcher({
       extract: mockExtract,
@@ -233,12 +243,17 @@ describe('startDevManifestWatcher', () => {
     const APP_WORK_DIR = '/tmp/sdk-app'
     const APP_CONFIG_PATH = '/tmp/sdk-app/sanity.cli.ts'
     const appManifest = {icon: '<svg/>', title: 'My App', version: '1'}
+    // Interfaces ride alongside the manifest (not inside it) and re-sync on
+    // every config edit — FR-024.
+    const appInterfaces = [
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+    ]
     mockFindProjectRoot.mockResolvedValue({
       directory: APP_WORK_DIR,
       path: APP_CONFIG_PATH,
       type: 'app',
     })
-    mockExtract.mockResolvedValue(appManifest)
+    mockExtract.mockResolvedValue({interfaces: appInterfaces, manifest: appManifest})
     const update = vi.fn()
 
     const watcher = await startDevManifestWatcher({
@@ -254,6 +269,7 @@ describe('startDevManifestWatcher', () => {
       workDir: APP_WORK_DIR,
     })
     expect(update).toHaveBeenCalledWith({
+      interfaces: appInterfaces,
       manifest: appManifest,
       manifestUpdatedAt: expect.any(String),
     })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
@@ -302,4 +302,50 @@ describe('startFederationRegistration', () => {
       expect.objectContaining({exit: 1}),
     )
   })
+
+  // US5 — `entry` declares an SDK app's navigable `app` view.
+  test('forwards an `app` interface derived from `entry` for an SDK app', async () => {
+    await startFederationRegistration({
+      cliConfig: {app: workbenchApp({entry: './src/App.tsx'})},
+      isApp: true,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(mockRegisterDevServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interfaces: expect.arrayContaining([
+          {entry_point: './src/App.tsx', interface_type: 'app', name: 'test-app'},
+        ]),
+      }),
+    )
+  })
+
+  test('forwards no `app` interface when an SDK app declares no `entry`', async () => {
+    await startFederationRegistration({
+      cliConfig: {app: workbenchApp()},
+      isApp: true,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+
+    const {interfaces} = mockRegisterDevServer.mock.calls[0][0]
+    expect(
+      (interfaces ?? []).some((i: {interface_type: string}) => i.interface_type === 'app'),
+    ).toBe(false)
+  })
+
+  test('rejects a studio that declares `entry` — app views for studios are not implemented yet', async () => {
+    await expect(
+      startFederationRegistration({
+        cliConfig: {app: workbenchApp({entry: './src/App.tsx'})},
+        isApp: false,
+        output: createMockOutput(),
+        server: mockServer({port: 3334}) as any,
+        workDir: '/tmp/sanity-project',
+      }),
+    ).rejects.toThrow('App views for studios are not implemented yet')
+  })
 })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
@@ -369,4 +369,59 @@ describe('startFederationRegistration', () => {
       }),
     ).rejects.toThrow('App views for studios are not implemented yet')
   })
+
+  // FR-024 — adding/removing a view or service must rebuild the federation
+  // remote so the new interface gets an expose + artifact. The watcher drives it.
+  const feed = {entry_point: './src/Feed.tsx', interface_type: 'panel', name: 'feed'}
+
+  test('rebuilds the remote when the interface set changes, then keeps quiet on a repeat', async () => {
+    const onInterfacesChange = vi.fn().mockResolvedValue(undefined)
+    const update = vi.fn()
+    mockRegisterDevServer.mockReturnValue({release: vi.fn(), update})
+
+    await startFederationRegistration({
+      cliConfig: {app: workbenchApp()}, // no interfaces yet
+      isApp: true,
+      onInterfacesChange,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+    const watcherUpdate = mockStartDevManifestWatcher.mock.calls[0][0].update
+
+    // A panel appears → rebuild, then patch the registry.
+    await watcherUpdate({interfaces: [feed], manifest: undefined, manifestUpdatedAt: 'a'})
+    expect(onInterfacesChange).toHaveBeenCalledTimes(1)
+    expect(update).toHaveBeenCalledTimes(1)
+
+    // Same set on the next pass → no rebuild, registry still patched.
+    await watcherUpdate({interfaces: [feed], manifest: undefined, manifestUpdatedAt: 'b'})
+    expect(onInterfacesChange).toHaveBeenCalledTimes(1)
+    expect(update).toHaveBeenCalledTimes(2)
+  })
+
+  test('does not rebuild when only the manifest changes (same interface set)', async () => {
+    const onInterfacesChange = vi.fn().mockResolvedValue(undefined)
+    mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
+
+    await startFederationRegistration({
+      cliConfig: {
+        app: workbenchApp({views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}]}),
+      },
+      isApp: true,
+      onInterfacesChange,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+    const watcherUpdate = mockStartDevManifestWatcher.mock.calls[0][0].update
+
+    // Same interfaces as the initial registration; only title/icon moved.
+    await watcherUpdate({
+      interfaces: [feed],
+      manifest: {title: 'Renamed', version: '1'},
+      manifestUpdatedAt: 'a',
+    })
+    expect(onInterfacesChange).not.toHaveBeenCalled()
+  })
 })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startFederationRegistration.test.ts
@@ -9,7 +9,13 @@ const mockExtractCoreAppManifest = vi.hoisted(() => vi.fn())
 const mockExtractStudioManifest = vi.hoisted(() => vi.fn())
 const mockCheckForDeprecatedAppId = vi.hoisted(() => vi.fn())
 const mockGetAppId = vi.hoisted(() => vi.fn())
+const mockGetCliConfigUncached = vi.hoisted(() => vi.fn())
 
+// The core-app watcher re-reads the config to re-derive interfaces on each edit.
+vi.mock('@sanity/cli-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
+  getCliConfigUncached: mockGetCliConfigUncached,
+}))
 vi.mock('../devServerRegistry.js', () => ({
   registerDevServer: mockRegisterDevServer,
 }))
@@ -39,6 +45,7 @@ describe('startFederationRegistration', () => {
     mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
     mockStartDevManifestWatcher.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
     mockExtractCoreAppManifest.mockResolvedValue(undefined)
+    mockGetCliConfigUncached.mockResolvedValue({app: workbenchApp()})
     mockGetAppId.mockReturnValue(undefined)
   })
 
@@ -199,9 +206,13 @@ describe('startFederationRegistration', () => {
     )
   })
 
-  test('wires extractCoreAppManifest into the core-app watcher', async () => {
+  test('wires extractCoreAppManifest into the core-app watcher and re-derives interfaces', async () => {
     const appManifest = {icon: '<svg><path d="M0 0"/></svg>', title: 'My App', version: '1'}
     mockExtractCoreAppManifest.mockResolvedValue(appManifest)
+    // A fresh config read with a panel → the watcher re-derives + forwards it.
+    mockGetCliConfigUncached.mockResolvedValue({
+      app: workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]}),
+    })
 
     await startFederationRegistration({
       cliConfig: workbenchCliConfig(),
@@ -212,13 +223,20 @@ describe('startFederationRegistration', () => {
     })
 
     const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
+    // The manifest stays pure; interfaces ride alongside as a separate field.
     await expect(
       extract({configPath: '/tmp/sanity-project/sanity.cli.ts', workDir: '/tmp/sanity-project'}),
-    ).resolves.toEqual(appManifest)
+    ).resolves.toEqual({
+      interfaces: [{entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'}],
+      manifest: appManifest,
+    })
     expect(mockExtractCoreAppManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
   })
 
-  test('wires extractStudioManifest into the studio watcher', async () => {
+  test('wires extractStudioManifest into the studio watcher (no interfaces)', async () => {
+    const studioManifest = {version: 3, workspaces: []}
+    mockExtractStudioManifest.mockResolvedValue(studioManifest)
+
     await startFederationRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: false,
@@ -228,7 +246,10 @@ describe('startFederationRegistration', () => {
     })
 
     const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
-    expect(extract).toBe(mockExtractStudioManifest)
+    await expect(
+      extract({configPath: '/tmp/sanity-project/sanity.config.ts', workDir: '/tmp/sanity-project'}),
+    ).resolves.toEqual({interfaces: undefined, manifest: studioManifest})
+    expect(mockExtractStudioManifest).toHaveBeenCalled()
   })
 
   test('calls manifest cleanup on close', async () => {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -678,6 +678,55 @@ describe('startWorkbenchDevServer', () => {
       })
     })
 
+    test('full-reloads the page when a running app gains or drops an interface', async () => {
+      // Adding/removing a view or service rebuilds the app remote with new
+      // exposes; module federation has the old remote-entry cached, so the page
+      // must reload to re-fetch it. A soft reconcile would render an empty panel.
+      mockResolveLocalPackage.mockResolvedValue({})
+      const mockServer = createMockServer()
+      mockCreateServer.mockResolvedValue(mockServer)
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+      const watchCallback = mockWatchRegistry.mock.calls[0][0]
+
+      const base = {host: 'localhost', id: 'app-1', pid: 3, port: 3335, type: 'coreApp'}
+      const feed = {entry_point: './src/Feed.tsx', interface_type: 'panel', name: 'feed'}
+      const alerts = {entry_point: './src/Alerts.tsx', interface_type: 'panel', name: 'alerts'}
+
+      // First sighting of the app — reconcile softly, don't reload.
+      watchCallback([{...base, interfaces: [feed]}])
+      expect(mockServer.ws.send).toHaveBeenLastCalledWith(
+        'sanity:workbench:local-applications',
+        expect.anything(),
+      )
+
+      // A second panel is declared — the remote was rebuilt, reload the page.
+      watchCallback([{...base, interfaces: [feed, alerts]}])
+      expect(mockServer.ws.send).toHaveBeenLastCalledWith({type: 'full-reload'})
+    })
+
+    test('does not reload on a new app or a manifest-only change', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      const mockServer = createMockServer()
+      mockCreateServer.mockResolvedValue(mockServer)
+
+      await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
+      const watchCallback = mockWatchRegistry.mock.calls[0][0]
+
+      const feed = {entry_point: './src/Feed.tsx', interface_type: 'panel', name: 'feed'}
+      const base = {host: 'localhost', id: 'app-1', interfaces: [feed], pid: 3, port: 3335}
+
+      watchCallback([{...base, manifest: {title: 'V1', version: '1'}, type: 'coreApp'}])
+      // Same interface set, new title only — stay on the soft reconcile path.
+      watchCallback([{...base, manifest: {title: 'V2', version: '1'}, type: 'coreApp'}])
+
+      expect(mockServer.ws.send).not.toHaveBeenCalledWith({type: 'full-reload'})
+      expect(mockServer.ws.send).toHaveBeenLastCalledWith(
+        'sanity:workbench:local-applications',
+        expect.anything(),
+      )
+    })
+
     test('responds to client request with current applications', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
       const mockServer = createMockServer()

--- a/packages/@sanity/cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/cli/src/actions/dev/deriveInterfaces.ts
@@ -1,0 +1,53 @@
+import {type CliConfig} from '@sanity/cli-core'
+import {isWorkbenchApp} from '@sanity/federation'
+
+import {type DevServerManifest} from './devServerRegistry.js'
+
+/** One forwarded interface record on the dev-server registry entry. */
+export type DevServerInterface = NonNullable<DevServerManifest['interfaces']>[number]
+
+/**
+ * Derive the workbench `interfaces[]` an app forwards to the dev-server
+ * registry from its `unstable_defineApp` config: `views` → `panel`s,
+ * `services` → `worker`s, and (SDK apps) `entry` → the navigable `app` view.
+ * `entry_point` is the declared `src` — the raw value, not a resolved URL.
+ *
+ * Returns `undefined` for a non-branded app (no `unstable_defineApp`). A studio
+ * that declares `entry` reaches the not-yet-implemented studio app-view path and
+ * is rejected (FR-026).
+ *
+ * Shared by the initial registration and the dev config watcher so editing
+ * `views`/`services`/`entry` in `sanity.cli.ts` re-pushes the same shape live,
+ * the way `title`/`icon` already re-sync (FR-024).
+ */
+export function deriveInterfaces(
+  app: CliConfig['app'],
+  options: {isApp: boolean},
+): DevServerInterface[] | undefined {
+  if (!isWorkbenchApp(app)) return undefined
+
+  // US5 — studio app views are not implemented yet. A studio (not an SDK app)
+  // that declares `entry` reaches the app-view path; reject with a clear error
+  // rather than deriving an `app` interface for it.
+  if (!options.isApp && app.entry !== undefined) {
+    throw new Error('App views for studios are not implemented yet')
+  }
+
+  return [
+    ...(app.views?.map((view) => ({
+      entry_point: view.src,
+      interface_type: view.type,
+      name: view.name,
+    })) ?? []),
+    ...(app.services?.map((service) => ({
+      entry_point: service.src,
+      interface_type: service.type,
+      name: service.name,
+    })) ?? []),
+    // US5 — with no `entry` the app has no `app` view and isn't reachable as a
+    // full-page app; with one, forward it so the workbench gates navigability.
+    ...(app.entry === undefined
+      ? []
+      : [{entry_point: app.entry, interface_type: 'app' as const, name: app.name}]),
+  ]
+}

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -1,6 +1,8 @@
 import {styleText} from 'node:util'
 
+import {getCliConfigUncached} from '@sanity/cli-core'
 import {isWorkbenchApp} from '@sanity/federation'
+import {type ViteDevServer} from 'vite'
 
 import {getSharedServerConfig} from '../../util/getSharedServerConfig.js'
 import {startAppDevServer} from './startAppDevServer.js'
@@ -44,13 +46,21 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   }
 
   let closeAppDevServer: () => Promise<void> = noop
-  let server
-  try {
+  let server: ViteDevServer | undefined
+
+  // (Re)start the app/studio dev server, tracking its close handle + server ref.
+  // Takes the config so a rebuild can feed a freshly-loaded one.
+  const startApp = async (config: DevActionOptions['cliConfig']) => {
     const result = options.isApp
-      ? await startAppDevServer(appOptions)
-      : await startStudioDevServer(appOptions)
+      ? await startAppDevServer({...appOptions, cliConfig: config})
+      : await startStudioDevServer({...appOptions, cliConfig: config})
     closeAppDevServer = result.close ?? noop
     server = result.server
+    return result.server
+  }
+
+  try {
+    await startApp(cliConfig)
   } catch (err) {
     await closeWorkbenchServer()
     throw err
@@ -60,12 +70,30 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     return {close: closeWorkbenchServer}
   }
 
+  // Adding/removing a view or service in `sanity.cli.ts` during dev requires
+  // rebuilding the federation remote: its module-federation `exposes` map +
+  // codegen artifacts are computed once at server start, so a newly-declared
+  // interface has no expose until the server is recreated. `server.restart()`
+  // can't do it — it re-uses the inline config — so we tear the app server down
+  // and bring it back up on the same port with a freshly-loaded config. The
+  // workbench page then reloads (driven by the registry watch in the workbench
+  // server) to re-fetch the rebuilt remote. A view/service *source* edit doesn't
+  // change the interface set, so it stays on the HMR path untouched.
+  const onInterfacesChange = options.isApp
+    ? async () => {
+        const freshConfig = await getCliConfigUncached(workDir)
+        await closeAppDevServer()
+        await startApp(freshConfig)
+      }
+    : undefined
+
   // Workbench is opted into solely by calling `unstable_defineApp` — its
   // branded identity is the only signal.
   const closeFederation = isWorkbenchApp(cliConfig?.app)
     ? await startFederationRegistration({
         cliConfig,
         isApp: options.isApp,
+        onInterfacesChange,
         output,
         server,
         workDir,

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -31,11 +31,14 @@ const workbenchLockSchema = z.object({
 const devServerManifestSchema = z.extend(workbenchLockSchema, {
   id: z.optional(z.string()),
   /**
-   * Interfaces the app exposes (e.g. dock panels), mapped from the declared
-   * views. Carried separately from the manifest — interfaces live in the
-   * application service, not the manifest — so the workbench can render local
-   * panels without a deploy. `entry_point` is the declared `src`. Lenient by
-   * design; the workbench is the authority on the interface shape.
+   * Interfaces the app exposes, mapped from the declared `views` (dock panels,
+   * `interface_type: "panel"`) and `services` (background workers,
+   * `interface_type: "worker"`). A service is just an interface, so both live
+   * in this one list. Carried separately from the manifest — interfaces live in
+   * the application service, not the manifest — so the workbench can render
+   * local panels and run local workers without a deploy. `entry_point` is the
+   * declared `src`. Lenient by design; the workbench is the authority on the
+   * interface shape.
    */
   interfaces: z.optional(
     z.array(z.object({entry_point: z.string(), interface_type: z.string(), name: z.string()})),

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -34,11 +34,12 @@ const devServerManifestSchema = z.extend(workbenchLockSchema, {
    * Interfaces the app exposes (e.g. dock panels), mapped from the declared
    * views. Carried separately from the manifest — interfaces live in the
    * application service, not the manifest — so the workbench can render local
-   * panels without a deploy. The workbench derives each interface's
-   * `entry_point` from this entry's host/port. Lenient by design; the workbench
-   * is the authority on the interface shape.
+   * panels without a deploy. `entry_point` is the declared `src`. Lenient by
+   * design; the workbench is the authority on the interface shape.
    */
-  interfaces: z.optional(z.array(z.object({interface_type: z.string(), name: z.string()}))),
+  interfaces: z.optional(
+    z.array(z.object({entry_point: z.string(), interface_type: z.string(), name: z.string()})),
+  ),
   /** Inlined manifest — either a {@link StudioManifest} or {@link CoreAppManifest}. */
   manifest: z.optional(z.union([studioManifestSchema, coreAppManifestSchema])),
   /**

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -40,6 +40,13 @@ const devServerManifestSchema = z.extend(workbenchLockSchema, {
   manifestUpdatedAt: z.optional(z.string()),
   projectId: z.optional(z.string()),
   type: z.enum(['coreApp', 'studio']),
+  /**
+   * Views the app declares (e.g. dock panels). Carried separately from the
+   * manifest — views live in the application service, not the manifest — so the
+   * workbench can render local panels without a deploy. Lenient by design;
+   * `@sanity/federation` is the authority on the view shape.
+   */
+  views: z.optional(z.array(z.object({name: z.string(), src: z.string(), type: z.string()}))),
   workDir: z.string(),
 })
 /**

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -30,6 +30,16 @@ const workbenchLockSchema = z.object({
 
 const devServerManifestSchema = z.extend(workbenchLockSchema, {
   id: z.optional(z.string()),
+  /**
+   * Interfaces the app exposes (e.g. dock panels), mapped from the declared
+   * views with the local dev server as their `entry_point`. Carried separately
+   * from the manifest — interfaces live in the application service, not the
+   * manifest — so the workbench can render local panels without a deploy.
+   * Lenient by design; the workbench is the authority on the interface shape.
+   */
+  interfaces: z.optional(
+    z.array(z.object({entry_point: z.string(), interface_type: z.string(), name: z.string()})),
+  ),
   /** Inlined manifest — either a {@link StudioManifest} or {@link CoreAppManifest}. */
   manifest: z.optional(z.union([studioManifestSchema, coreAppManifestSchema])),
   /**
@@ -40,13 +50,6 @@ const devServerManifestSchema = z.extend(workbenchLockSchema, {
   manifestUpdatedAt: z.optional(z.string()),
   projectId: z.optional(z.string()),
   type: z.enum(['coreApp', 'studio']),
-  /**
-   * Views the app declares (e.g. dock panels). Carried separately from the
-   * manifest — views live in the application service, not the manifest — so the
-   * workbench can render local panels without a deploy. Lenient by design;
-   * `@sanity/federation` is the authority on the view shape.
-   */
-  views: z.optional(z.array(z.object({name: z.string(), src: z.string(), type: z.string()}))),
   workDir: z.string(),
 })
 /**

--- a/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
+++ b/packages/@sanity/cli/src/actions/dev/devServerRegistry.ts
@@ -32,14 +32,13 @@ const devServerManifestSchema = z.extend(workbenchLockSchema, {
   id: z.optional(z.string()),
   /**
    * Interfaces the app exposes (e.g. dock panels), mapped from the declared
-   * views with the local dev server as their `entry_point`. Carried separately
-   * from the manifest — interfaces live in the application service, not the
-   * manifest — so the workbench can render local panels without a deploy.
-   * Lenient by design; the workbench is the authority on the interface shape.
+   * views. Carried separately from the manifest — interfaces live in the
+   * application service, not the manifest — so the workbench can render local
+   * panels without a deploy. The workbench derives each interface's
+   * `entry_point` from this entry's host/port. Lenient by design; the workbench
+   * is the authority on the interface shape.
    */
-  interfaces: z.optional(
-    z.array(z.object({entry_point: z.string(), interface_type: z.string(), name: z.string()})),
-  ),
+  interfaces: z.optional(z.array(z.object({interface_type: z.string(), name: z.string()}))),
   /** Inlined manifest — either a {@link StudioManifest} or {@link CoreAppManifest}. */
   manifest: z.optional(z.union([studioManifestSchema, coreAppManifestSchema])),
   /**

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -49,6 +49,9 @@ export function getDevServerConfig({
 
   return {
     ...baseConfig,
+    // The app's navigable entry. A branded app that omits `entry` has no app
+    // view (US5): the runtime/federation skip the `./App` render path entirely.
+    entry: app?.entry,
     isWorkbench: isWorkbenchApp(app),
     reactCompiler: cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
     reactStrictMode,

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -55,6 +55,7 @@ export function getDevServerConfig({
     isWorkbench: isWorkbenchApp(app),
     reactCompiler: cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
     reactStrictMode,
+    services: isWorkbenchApp(app) ? app.services : undefined,
     staticPath: path.join(workDir, 'static'),
     typegen: cliConfig?.typegen,
     views: isWorkbenchApp(app) ? app.views : undefined,

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -36,6 +36,9 @@ export function getDevServerConfig({
 
   const isApp = cliConfig ? determineIsApp(cliConfig) : false
   const reactStrictMode = resolveReactStrictMode(cliConfig)
+  // `views` is declared via `unstable_defineApp`, so read it off the branded
+  // app result rather than the legacy `app` config type.
+  const app = cliConfig?.app
 
   const envBasePath = getSanityEnvVar('BASEPATH', isApp ?? false)
   if (envBasePath && cliConfig?.project?.basePath) {
@@ -46,11 +49,11 @@ export function getDevServerConfig({
 
   return {
     ...baseConfig,
-    isWorkbench: isWorkbenchApp(cliConfig?.app),
+    isWorkbench: isWorkbenchApp(app),
     reactCompiler: cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
     reactStrictMode,
     staticPath: path.join(workDir, 'static'),
     typegen: cliConfig?.typegen,
-    views: cliConfig?.app?.views,
+    views: isWorkbenchApp(app) ? app.views : undefined,
   }
 }

--- a/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/getDevServerConfig.ts
@@ -51,5 +51,6 @@ export function getDevServerConfig({
     reactStrictMode,
     staticPath: path.join(workDir, 'static'),
     typegen: cliConfig?.typegen,
+    views: cliConfig?.app?.views,
   }
 }

--- a/packages/@sanity/cli/src/actions/dev/interfacesChanged.ts
+++ b/packages/@sanity/cli/src/actions/dev/interfacesChanged.ts
@@ -1,0 +1,31 @@
+import {type DevServerInterface} from './deriveInterfaces.js'
+
+/**
+ * Order-independent string key for a declared interface set. Two sets that
+ * differ only in declaration order produce the same key, so reordering
+ * `views`/`services` in `sanity.cli.ts` does not count as a change. `undefined`
+ * (project types that declare no interfaces, e.g. studios) keys to the empty set.
+ */
+export function serializeInterfaces(interfaces: readonly DevServerInterface[] | undefined): string {
+  if (!interfaces || interfaces.length === 0) return ''
+  return interfaces
+    .map((iface) => [iface.interface_type, iface.name, iface.entry_point].join('::'))
+    .toSorted()
+    .join('|')
+}
+
+/**
+ * Whether the declared interface set changed between two registry snapshots.
+ *
+ * A change here means a view/service was added, removed, renamed, or repointed
+ * in `sanity.cli.ts` — which requires the federation remote to be rebuilt (its
+ * `exposes` map + codegen artifacts are computed once at server start, so a new
+ * interface has no expose until the server is recreated). Editing a view's or
+ * service's *source file* does NOT change this set, so it stays on the HMR path.
+ */
+export function interfacesChanged(
+  a: readonly DevServerInterface[] | undefined,
+  b: readonly DevServerInterface[] | undefined,
+): boolean {
+  return serializeInterfaces(a) !== serializeInterfaces(b)
+}

--- a/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
@@ -4,6 +4,7 @@ import {basename, dirname} from 'node:path'
 import {findProjectRoot, type Output} from '@sanity/cli-core'
 
 import {canonicalizeWatchDir} from './canonicalizeWatchDir.js'
+import {type DevServerInterface} from './deriveInterfaces.js'
 import {devDebug} from './devDebug.js'
 
 /**
@@ -21,17 +22,29 @@ interface DevManifestWatcher {
 interface ManifestPatch<T> {
   manifest: T | undefined
   manifestUpdatedAt: string
+
+  /**
+   * Workbench interfaces (views/services/app view) re-derived from the config
+   * on each change, so editing `views`/`services`/`entry` in `sanity.cli.ts`
+   * re-syncs live like `title`/`icon` (FR-024). `undefined` for project types
+   * that don't declare interfaces (e.g. studios).
+   */
+  interfaces?: DevServerInterface[] | undefined
 }
 
 interface StartDevManifestWatcherOptions<T> {
   /**
-   * Run the project-specific manifest extraction and resolve to the inlined
-   * manifest. Receives the resolved config path (e.g. `sanity.config.ts` for
-   * studios, `sanity.cli.ts` for core-apps) and the working directory.
+   * Run the project-specific extraction and resolve to the inlined manifest
+   * plus the workbench `interfaces[]` (when the project declares them).
+   * Receives the resolved config path (e.g. `sanity.config.ts` for studios,
+   * `sanity.cli.ts` for core-apps) and the working directory.
    */
-  extract: (params: {configPath: string; workDir: string}) => Promise<T | undefined>
+  extract: (params: {
+    configPath: string
+    workDir: string
+  }) => Promise<{interfaces?: DevServerInterface[] | undefined; manifest: T | undefined}>
   output: Output
-  /** Called after every successful extraction with the inlined manifest. */
+  /** Called after every successful extraction with the inlined manifest + interfaces. */
   update: (patch: ManifestPatch<T>) => void
   workDir: string
 }
@@ -72,9 +85,9 @@ export async function startDevManifestWatcher<T>({
     }
     running = true
     try {
-      const manifest = await extract({configPath, workDir})
+      const {interfaces, manifest} = await extract({configPath, workDir})
       if (closed) return
-      update({manifest, manifestUpdatedAt: new Date().toISOString()})
+      update({interfaces, manifest, manifestUpdatedAt: new Date().toISOString()})
     } catch (err) {
       // Extractors print their own spinner failure; log the reason here so
       // the user sees what went wrong alongside the spinner indicator.

--- a/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/startDevManifestWatcher.ts
@@ -44,8 +44,12 @@ interface StartDevManifestWatcherOptions<T> {
     workDir: string
   }) => Promise<{interfaces?: DevServerInterface[] | undefined; manifest: T | undefined}>
   output: Output
-  /** Called after every successful extraction with the inlined manifest + interfaces. */
-  update: (patch: ManifestPatch<T>) => void
+  /**
+   * Called after every successful extraction with the inlined manifest +
+   * interfaces. Awaited, so an interface-set change can rebuild the federation
+   * remote before the registry is patched (which is what reloads the workbench).
+   */
+  update: (patch: ManifestPatch<T>) => Promise<void> | void
   workDir: string
 }
 
@@ -87,7 +91,7 @@ export async function startDevManifestWatcher<T>({
     try {
       const {interfaces, manifest} = await extract({configPath, workDir})
       if (closed) return
-      update({interfaces, manifest, manifestUpdatedAt: new Date().toISOString()})
+      await update({interfaces, manifest, manifestUpdatedAt: new Date().toISOString()})
     } catch (err) {
       // Extractors print their own spinner failure; log the reason here so
       // the user sees what went wrong alongside the spinner indicator.

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -38,18 +38,27 @@ export async function startFederationRegistration(
   const addr = server.httpServer?.address()
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
-  // Views live on the branded `unstable_defineApp` result. Forward them on the
+  // Interfaces live on the branded `unstable_defineApp` result as declared
+  // views. Map them to the local interface shape — the dev server is the
+  // `entry_point` the workbench loads each from — and forward them on the
   // registry entry (alongside, not inside, the manifest) so the workbench can
   // render local panels without a deploy.
-  const views = isWorkbenchApp(cliConfig.app) ? cliConfig.app.views : undefined
+  const entryPoint = `http://${appHost}:${appPort}/mf-manifest.json`
+  const interfaces = isWorkbenchApp(cliConfig.app)
+    ? cliConfig.app.views?.map((view) => ({
+        entry_point: entryPoint,
+        interface_type: view.type,
+        name: view.name,
+      }))
+    : undefined
 
   const registration = registerDevServer({
     host: appHost,
     id: getAppId(cliConfig),
+    interfaces,
     port: appPort,
     projectId: cliConfig?.api?.projectId,
     type: isApp ? 'coreApp' : 'studio',
-    views,
     workDir,
   })
 

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -39,12 +39,12 @@ export async function startFederationRegistration(
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
   // Interfaces live on the branded `unstable_defineApp` result as declared
-  // views. Forward each as `{interface_type, name}` on the registry entry
-  // (alongside, not inside, the manifest) so the workbench can render local
-  // panels without a deploy. The workbench derives each interface's
-  // `entry_point` from this entry's host/port.
+  // views. Forward each on the registry entry (alongside, not inside, the
+  // manifest) so the workbench can render local panels without a deploy. The
+  // `entry_point` is the declared `src` — the raw value, not a resolved URL.
   const interfaces = isWorkbenchApp(cliConfig.app)
     ? cliConfig.app.views?.map((view) => ({
+        entry_point: view.src,
         interface_type: view.type,
         name: view.name,
       }))

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -1,9 +1,9 @@
-import {type CliConfig, type Output} from '@sanity/cli-core'
-import {isWorkbenchApp} from '@sanity/federation'
+import {type CliConfig, getCliConfigUncached, type Output} from '@sanity/cli-core'
 import {type ViteDevServer} from 'vite'
 
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
 import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
+import {deriveInterfaces} from './deriveInterfaces.js'
 import {registerDevServer} from './devServerRegistry.js'
 import {extractStudioManifest} from './extractDevServerManifest.js'
 import {startDevManifestWatcher} from './startDevManifestWatcher.js'
@@ -38,50 +38,13 @@ export async function startFederationRegistration(
   const addr = server.httpServer?.address()
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
-  // Interfaces live on the branded `unstable_defineApp` result as declared
-  // `views` (panels), `services` (workers), and the app's navigable `entry`. A
-  // service is just an interface discriminated by `interface_type`, so map them
-  // into a single `interfaces` list and forward them on the registry entry
-  // (alongside, not inside, the manifest) so the workbench can render local
-  // panels, run local workers, and resolve the app view without a deploy.
-  // `entry_point` is the declared `src` — the raw value, not a resolved URL.
-  const app = isWorkbenchApp(cliConfig.app) ? cliConfig.app : undefined
-
-  // US5 — studio app views are not implemented yet. A studio (not an SDK app)
-  // that declares `entry` reaches the app-view path; reject with a clear error
-  // rather than deriving an `app` interface for it. SDK app views are a later
-  // iteration for studios (FR-026).
-  if (app && !isApp && app.entry !== undefined) {
-    throw new Error('App views for studios are not implemented yet')
-  }
-
-  const interfaces = app
-    ? [
-        ...(app.views?.map((view) => ({
-          entry_point: view.src,
-          interface_type: view.type,
-          name: view.name,
-        })) ?? []),
-        ...(app.services?.map((service) => ({
-          entry_point: service.src,
-          interface_type: service.type,
-          name: service.name,
-        })) ?? []),
-        // US5 — an SDK app's `entry` declares its navigable full-page `app`
-        // view. Forward it as an `app` interface so the workbench knows the app
-        // is navigable; with no `entry` the app has no `app` view and is not
-        // reachable as a full-page app.
-        ...(app.entry === undefined
-          ? []
-          : [
-              {
-                entry_point: app.entry,
-                interface_type: 'app' as const,
-                name: app.name,
-              },
-            ]),
-      ]
-    : undefined
+  // Interfaces (panels/workers/app view) are derived from the branded
+  // `unstable_defineApp` config and forwarded on the registry entry (alongside,
+  // not inside, the manifest) so the workbench renders local panels, runs local
+  // workers, and resolves the app view without a deploy. The watcher below
+  // re-derives them on every `sanity.cli.ts` edit so adding/removing a view or
+  // service re-syncs live (FR-024) — the way `title`/`icon` already do.
+  const interfaces = deriveInterfaces(cliConfig.app, {isApp})
 
   const registration = registerDevServer({
     host: appHost,
@@ -95,8 +58,15 @@ export async function startFederationRegistration(
 
   const watcher = await startDevManifestWatcher({
     extract: isApp
-      ? ({workDir: wd}) => extractCoreAppManifest({workDir: wd})
-      : extractStudioManifest,
+      ? async ({workDir: wd}) => ({
+          // Interfaces are NOT part of the manifest — they're re-derived from the
+          // same config edit and forwarded as a separate registry field, so a
+          // `views`/`services`/`entry` change re-syncs live (FR-024).
+          interfaces: deriveInterfaces((await getCliConfigUncached(wd)).app, {isApp}),
+          manifest: await extractCoreAppManifest({workDir: wd}),
+        })
+      : (params) =>
+          extractStudioManifest(params).then((manifest) => ({interfaces: undefined, manifest})),
     output,
     update: registration.update,
     workDir,

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -1,4 +1,5 @@
 import {type CliConfig, type Output} from '@sanity/cli-core'
+import {isWorkbenchApp} from '@sanity/federation'
 import {type ViteDevServer} from 'vite'
 
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
@@ -37,12 +38,18 @@ export async function startFederationRegistration(
   const addr = server.httpServer?.address()
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
+  // Views live on the branded `unstable_defineApp` result. Forward them on the
+  // registry entry (alongside, not inside, the manifest) so the workbench can
+  // render local panels without a deploy.
+  const views = isWorkbenchApp(cliConfig.app) ? cliConfig.app.views : undefined
+
   const registration = registerDevServer({
     host: appHost,
     id: getAppId(cliConfig),
     port: appPort,
     projectId: cliConfig?.api?.projectId,
     type: isApp ? 'coreApp' : 'studio',
+    views,
     workDir,
   })
 

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -39,9 +39,11 @@ export async function startFederationRegistration(
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
   // Interfaces live on the branded `unstable_defineApp` result as declared
-  // `views` (panels) and the app's navigable `entry`. Forward each on the
-  // registry entry (alongside, not inside, the manifest) so the workbench can
-  // render local panels and resolve the app view without a deploy. The
+  // `views` (panels), `services` (workers), and the app's navigable `entry`. A
+  // service is just an interface discriminated by `interface_type`, so map them
+  // into a single `interfaces` list and forward them on the registry entry
+  // (alongside, not inside, the manifest) so the workbench can render local
+  // panels, run local workers, and resolve the app view without a deploy.
   // `entry_point` is the declared `src` — the raw value, not a resolved URL.
   const app = isWorkbenchApp(cliConfig.app) ? cliConfig.app : undefined
 
@@ -59,6 +61,11 @@ export async function startFederationRegistration(
           entry_point: view.src,
           interface_type: view.type,
           name: view.name,
+        })) ?? []),
+        ...(app.services?.map((service) => ({
+          entry_point: service.src,
+          interface_type: service.type,
+          name: service.name,
         })) ?? []),
         // US5 — an SDK app's `entry` declares its navigable full-page `app`
         // view. Forward it as an `app` interface so the workbench knows the app

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -6,6 +6,7 @@ import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
 import {deriveInterfaces} from './deriveInterfaces.js'
 import {registerDevServer} from './devServerRegistry.js'
 import {extractStudioManifest} from './extractDevServerManifest.js'
+import {serializeInterfaces} from './interfacesChanged.js'
 import {startDevManifestWatcher} from './startDevManifestWatcher.js'
 
 interface FederationRegistrationOptions {
@@ -14,6 +15,16 @@ interface FederationRegistrationOptions {
   output: Output
   server: ViteDevServer
   workDir: string
+
+  /**
+   * Called when the declared interface *set* changes (a view/service added,
+   * removed, renamed, or repointed in `sanity.cli.ts`) — before the registry is
+   * patched. The remote's `exposes` map + codegen artifacts are computed once at
+   * server start, so a newly-declared interface has no expose until the app dev
+   * server is recreated with the fresh config; this hook does that recreation.
+   * Awaited so the rebuilt remote is live before the workbench page reloads.
+   */
+  onInterfacesChange?: () => Promise<void>
 }
 
 interface FederationRegistration {
@@ -28,7 +39,7 @@ interface FederationRegistration {
 export async function startFederationRegistration(
   options: FederationRegistrationOptions,
 ): Promise<FederationRegistration> {
-  const {cliConfig, isApp, output, server, workDir} = options
+  const {cliConfig, isApp, onInterfacesChange, output, server, workDir} = options
 
   checkForDeprecatedAppId({cliConfig, output})
 
@@ -56,6 +67,11 @@ export async function startFederationRegistration(
     workDir,
   })
 
+  // Track the registered set so a watcher pass can tell whether the *set* of
+  // interfaces changed (rebuild needed) vs. only the manifest (title/icon) or a
+  // view/service source file (HMR handles it — the set is unchanged).
+  let lastInterfaces = serializeInterfaces(interfaces)
+
   const watcher = await startDevManifestWatcher({
     extract: isApp
       ? async ({workDir: wd}) => ({
@@ -68,7 +84,18 @@ export async function startFederationRegistration(
       : (params) =>
           extractStudioManifest(params).then((manifest) => ({interfaces: undefined, manifest})),
     output,
-    update: registration.update,
+    update: async (patch) => {
+      const nextInterfaces = serializeInterfaces(patch.interfaces)
+      if (nextInterfaces !== lastInterfaces) {
+        lastInterfaces = nextInterfaces
+        // Rebuild the app remote first (so the new view/service has an expose +
+        // artifact), THEN patch the registry — the registry patch is what reloads
+        // the workbench page, and it must re-fetch a remote that already exposes
+        // the new interface.
+        await onInterfacesChange?.()
+      }
+      registration.update(patch)
+    },
     workDir,
   })
 

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -39,15 +39,41 @@ export async function startFederationRegistration(
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
   // Interfaces live on the branded `unstable_defineApp` result as declared
-  // views. Forward each on the registry entry (alongside, not inside, the
-  // manifest) so the workbench can render local panels without a deploy. The
+  // `views` (panels) and the app's navigable `entry`. Forward each on the
+  // registry entry (alongside, not inside, the manifest) so the workbench can
+  // render local panels and resolve the app view without a deploy. The
   // `entry_point` is the declared `src` — the raw value, not a resolved URL.
-  const interfaces = isWorkbenchApp(cliConfig.app)
-    ? cliConfig.app.views?.map((view) => ({
-        entry_point: view.src,
-        interface_type: view.type,
-        name: view.name,
-      }))
+  const app = isWorkbenchApp(cliConfig.app) ? cliConfig.app : undefined
+
+  // US5 — studio app views are not implemented yet. A studio (not an SDK app)
+  // that declares `entry` reaches the app-view path; reject with a clear error
+  // rather than deriving an `app` interface for it. SDK app views are a later
+  // iteration for studios (FR-026).
+  if (app && !isApp && app.entry !== undefined) {
+    throw new Error('App views for studios are not implemented yet')
+  }
+
+  const interfaces = app
+    ? [
+        ...(app.views?.map((view) => ({
+          entry_point: view.src,
+          interface_type: view.type,
+          name: view.name,
+        })) ?? []),
+        // US5 — an SDK app's `entry` declares its navigable full-page `app`
+        // view. Forward it as an `app` interface so the workbench knows the app
+        // is navigable; with no `entry` the app has no `app` view and is not
+        // reachable as a full-page app.
+        ...(app.entry === undefined
+          ? []
+          : [
+              {
+                entry_point: app.entry,
+                interface_type: 'app' as const,
+                name: app.name,
+              },
+            ]),
+      ]
     : undefined
 
   const registration = registerDevServer({

--- a/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/startFederationRegistration.ts
@@ -39,14 +39,12 @@ export async function startFederationRegistration(
   const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
 
   // Interfaces live on the branded `unstable_defineApp` result as declared
-  // views. Map them to the local interface shape — the dev server is the
-  // `entry_point` the workbench loads each from — and forward them on the
-  // registry entry (alongside, not inside, the manifest) so the workbench can
-  // render local panels without a deploy.
-  const entryPoint = `http://${appHost}:${appPort}/mf-manifest.json`
+  // views. Forward each as `{interface_type, name}` on the registry entry
+  // (alongside, not inside, the manifest) so the workbench can render local
+  // panels without a deploy. The workbench derives each interface's
+  // `entry_point` from this entry's host/port.
   const interfaces = isWorkbenchApp(cliConfig.app)
     ? cliConfig.app.views?.map((view) => ({
-        entry_point: entryPoint,
         interface_type: view.type,
         name: view.name,
       }))

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -21,14 +21,14 @@ import {writeWorkbenchRuntime} from './writeWorkbenchRuntime.js'
 const noop = async () => {}
 
 const toApplicationsPayload = (servers: DevServerManifest[]) => ({
-  applications: servers.map(({host, id, manifest, port, projectId, type, views}) => ({
+  applications: servers.map(({host, id, interfaces, manifest, port, projectId, type}) => ({
     host,
     id,
+    interfaces,
     manifest,
     port,
     projectId,
     type,
-    views,
   })),
 })
 

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -21,13 +21,14 @@ import {writeWorkbenchRuntime} from './writeWorkbenchRuntime.js'
 const noop = async () => {}
 
 const toApplicationsPayload = (servers: DevServerManifest[]) => ({
-  applications: servers.map(({host, id, manifest, port, projectId, type}) => ({
+  applications: servers.map(({host, id, manifest, port, projectId, type, views}) => ({
     host,
     id,
     manifest,
     port,
     projectId,
     type,
+    views,
   })),
 })
 

--- a/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -15,10 +15,14 @@ import {
   readWorkbenchLock,
   watchRegistry,
 } from './devServerRegistry.js'
+import {serializeInterfaces} from './interfacesChanged.js'
 import {type DevActionOptions} from './types.js'
 import {writeWorkbenchRuntime} from './writeWorkbenchRuntime.js'
 
 const noop = async () => {}
+
+/** Stable per-app key for the registry-watch interface diff. */
+const serverKey = (s: DevServerManifest) => `${s.id ?? ''}@${s.host ?? ''}:${s.port}`
 
 const toApplicationsPayload = (servers: DevServerManifest[]) => ({
   applications: servers.map(({host, id, interfaces, manifest, port, projectId, type}) => ({
@@ -213,7 +217,27 @@ async function createWorkbenchViteServer(
     )
   })
 
+  // A running app's declared interface set changing (a view/service added or
+  // removed in `sanity.cli.ts`) means its remote was rebuilt with new exposes.
+  // Module federation has the old remote-entry cached, so an in-place reconcile
+  // would load a stale remote (empty panel / no worker) — the page must reload
+  // to re-fetch it. A new/removed app, or a manifest-only edit (title/icon),
+  // reconciles softly as before. Source-file edits don't change the set, so they
+  // stay on the HMR path and never trip a reload here.
+  let knownInterfaces = new Map<string, string>()
   const registryWatcher = watchRegistry((servers) => {
+    const rebuiltApp = servers.some((s) => {
+      const key = serverKey(s)
+      return (
+        knownInterfaces.has(key) && knownInterfaces.get(key) !== serializeInterfaces(s.interfaces)
+      )
+    })
+    knownInterfaces = new Map(servers.map((s) => [serverKey(s), serializeInterfaces(s.interfaces)]))
+
+    if (rebuiltApp) {
+      server.ws.send({type: 'full-reload'})
+      return
+    }
     server.ws.send('sanity:workbench:local-applications', toApplicationsPayload(servers))
   })
 

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -50,6 +50,26 @@ describe('extractCoreAppManifest', () => {
     expect(mockReadFile).not.toHaveBeenCalled()
   })
 
+  test('merges group and priority into the manifest', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: {group: 'dock.system', organizationId: 'org-1', priority: 20, title: 'My App'},
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result).toEqual({group: 'dock.system', priority: 20, title: 'My App', version: '1'})
+  })
+
+  test('keeps priority 0 (not dropped as a falsy value)', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: {organizationId: 'org-1', priority: 0, title: 'My App'},
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result?.priority).toBe(0)
+  })
+
   test('reads icon from file path and inlines in manifest', async () => {
     const workDir = '/project'
     mockGetCliConfig.mockResolvedValue({

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -78,6 +78,8 @@ export async function extractCoreAppManifest(
       version: '1',
       ...(icon ? {icon} : {}),
       ...(app.title ? {title: app.title} : {}),
+      ...(app.group ? {group: app.group} : {}),
+      ...(app.priority === undefined ? {} : {priority: app.priority}),
     })
 
     spin.succeed(`Extracted manifest`)

--- a/packages/@sanity/cli/src/actions/manifest/types.ts
+++ b/packages/@sanity/cli/src/actions/manifest/types.ts
@@ -25,7 +25,9 @@ export interface CreateManifest {
  * since the CLI produces the payload in full.
  */
 export const coreAppManifestSchema = z.object({
+  group: z.optional(z.string()),
   icon: z.optional(z.string()),
+  priority: z.optional(z.number()),
   title: z.optional(z.string()),
   version: z.string(),
 })

--- a/packages/@sanity/cli/src/exports/index.ts
+++ b/packages/@sanity/cli/src/exports/index.ts
@@ -9,4 +9,8 @@ export type {CliConfig, UserViteConfig} from '@sanity/cli-core'
 // Workbench application extension API. Canonical implementation in
 // `@sanity/federation`; re-exported here so `sanity/cli` can surface it to
 // app authors via `import {unstable_defineApp} from 'sanity/cli'`.
-export {type DefineAppInput, unstable_defineApp} from '@sanity/federation'
+// `unstable_defineView` is the runtime view-authoring helper; its long-term
+// home is the `sanity` runtime package, but it's surfaced here for now so view
+// src files can `import {unstable_defineView} from '@sanity/cli'`. Component
+// props are inferred from the view type, so no prop types are re-exported.
+export {type DefineAppInput, unstable_defineApp, unstable_defineView} from '@sanity/federation'

--- a/packages/@sanity/cli/src/exports/index.ts
+++ b/packages/@sanity/cli/src/exports/index.ts
@@ -6,11 +6,10 @@ export {type CliClientOptions, getCliClient} from '../util/cliClient.js'
 export {loadEnv} from '../util/loadEnv.js'
 export type {CliConfig, UserViteConfig} from '@sanity/cli-core'
 
-// Workbench application extension API. Canonical implementation in
-// `@sanity/federation`; re-exported here so `sanity/cli` can surface it to
+// Workbench application extension API (config-time). Canonical implementation
+// in `@sanity/federation`; re-exported here so `sanity/cli` can surface it to
 // app authors via `import {unstable_defineApp} from 'sanity/cli'`.
-// `unstable_defineView` is the runtime view-authoring helper; its long-term
-// home is the `sanity` runtime package, but it's surfaced here for now so view
-// src files can `import {unstable_defineView} from '@sanity/cli'`. Component
-// props are inferred from the view type, so no prop types are re-exported.
-export {type DefineAppInput, unstable_defineApp, unstable_defineView} from '@sanity/federation'
+// The runtime helper `unstable_defineView` is NOT here — it bundles to the
+// browser, so it lives on the browser-safe `@sanity/cli/runtime` entry to keep
+// `cli-core` out of the frontend bundle.
+export {type DefineAppInput, unstable_defineApp} from '@sanity/federation'

--- a/packages/@sanity/cli/src/exports/runtime.ts
+++ b/packages/@sanity/cli/src/exports/runtime.ts
@@ -8,4 +8,4 @@
 //
 // `unstable_defineApp` is config-time (Node) and stays on the main `@sanity/cli`
 // entry; only the runtime helpers live here.
-export {unstable_defineView} from '@sanity/federation'
+export {unstable_defineService, unstable_defineView} from '@sanity/federation'

--- a/packages/@sanity/cli/src/exports/runtime.ts
+++ b/packages/@sanity/cli/src/exports/runtime.ts
@@ -1,0 +1,11 @@
+// Browser-safe runtime authoring helpers for the workbench extension API.
+//
+// View/service src files bundle to the browser, so this entry re-exports ONLY
+// from `@sanity/federation` (a pure, dependency-light package) — it must never
+// import `@sanity/cli-core` or anything Node-only, or it would drag the CLI
+// into the frontend bundle. The `sanity` runtime package re-exports from here,
+// so the same constraint protects it.
+//
+// `unstable_defineApp` is config-time (Node) and stays on the main `@sanity/cli`
+// entry; only the runtime helpers live here.
+export {unstable_defineView} from '@sanity/federation'

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -4,7 +4,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {CliConfig, getCliTelemetry, type UserViteConfig} from '@sanity/cli-core'
-import {type InterfaceArtifact} from '@sanity/federation/vite'
+import {type InterfaceArtifact, type ServiceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {type FSWatcher} from 'chokidar'
 import {createServer, type InlineConfig, type ViteDevServer} from 'vite'
@@ -35,6 +35,7 @@ export interface DevServerOptions {
   isWorkbench?: boolean
   projectName?: string
   schemaExtraction?: CliConfig['schemaExtraction']
+  services?: readonly ServiceArtifact[]
   typegen?: CliConfig['typegen']
   views?: readonly InterfaceArtifact[]
   vite?: UserViteConfig
@@ -60,6 +61,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactCompiler,
     reactStrictMode,
     schemaExtraction,
+    services,
     typegen,
     views,
     vite: extendViteConfig,
@@ -108,6 +110,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactCompiler,
     schemaExtraction,
     server: {host: httpHost, port: httpPort},
+    services,
     views,
   })
 

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -4,7 +4,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {CliConfig, getCliTelemetry, type UserViteConfig} from '@sanity/cli-core'
-import {type ViewArtifact} from '@sanity/federation/vite'
+import {type InterfaceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {type FSWatcher} from 'chokidar'
 import {createServer, type InlineConfig, type ViteDevServer} from 'vite'
@@ -36,7 +36,7 @@ export interface DevServerOptions {
   projectName?: string
   schemaExtraction?: CliConfig['schemaExtraction']
   typegen?: CliConfig['typegen']
-  views?: readonly ViewArtifact[]
+  views?: readonly InterfaceArtifact[]
   vite?: UserViteConfig
 }
 

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -4,6 +4,7 @@ import {
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {CliConfig, getCliTelemetry, type UserViteConfig} from '@sanity/cli-core'
+import {type ViewArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {type FSWatcher} from 'chokidar'
 import {createServer, type InlineConfig, type ViteDevServer} from 'vite'
@@ -35,6 +36,7 @@ export interface DevServerOptions {
   projectName?: string
   schemaExtraction?: CliConfig['schemaExtraction']
   typegen?: CliConfig['typegen']
+  views?: readonly ViewArtifact[]
   vite?: UserViteConfig
 }
 
@@ -59,6 +61,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactStrictMode,
     schemaExtraction,
     typegen,
+    views,
     vite: extendViteConfig,
   } = options
 
@@ -105,6 +108,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactCompiler,
     schemaExtraction,
     server: {host: httpHost, port: httpPort},
+    views,
   })
 
   // Extend Vite configuration with user-provided config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
 
 importers:
 
@@ -265,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: 0.1.0-alpha.9
-        version: 0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -537,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: 0.1.0-alpha.9
-        version: 0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -826,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: 0.1.0-alpha.9
-        version: 0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -962,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: 0.1.0-alpha.9
-        version: 0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4924,8 +4925,9 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@0.1.0-alpha.9':
-    resolution: {integrity: sha512-mSsRVzqSrniPtg50+hhbO2WE8vzX/PGkI123ysS8xrUECV0m/v/9YH3ha159dcuUxG0JzgjAtj1+gVy+TmqANQ==}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091':
+    resolution: {tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091}
+    version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
       vite: ^7.0.0 || ^8.0.0
@@ -14543,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14556,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@0.1.0-alpha.9(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
-  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
 
 importers:
 
@@ -266,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -538,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -827,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -963,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4925,8 +4925,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091':
-    resolution: {tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d':
+    resolution: {integrity: sha512-YKgES0eH9N7i3b0mLPQHmTd0PhWHMpWL9SxYhRfxV2qTWvIvLINBSpd4PVvm2tv0+4k7cHHatKVD3IWSBjoacw==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d}
     version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
@@ -14545,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14558,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@1a9ececc8238fb63e5a8f7bd21b091c2067c2091(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
-  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48
 
 importers:
 
@@ -266,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -538,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -827,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -963,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4925,8 +4925,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450':
-    resolution: {integrity: sha512-hfsw2aIaLD1psykxFF3tPPTm/oQNWclX8yN76IhBtj559huRjpV+NaQLBwRjlghHa/2RdOvmgcARRrHBDpI7MQ==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48':
+    resolution: {integrity: sha512-65aDKytAsZcCn+F5vKmL2h/6WSfPPWNU8QpTAEt54umEaMQQlkDddCo29xhV8+cTxsF5xTYC1RX0vDeo5zlROA==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48}
     version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
@@ -14545,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14558,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@14f2b48(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
-  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
+  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
 
 importers:
 
@@ -266,8 +266,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -538,8 +538,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -827,8 +827,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -963,8 +963,8 @@ importers:
         specifier: ^7.22.0
         version: 7.22.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450
+        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4925,8 +4925,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d':
-    resolution: {integrity: sha512-YKgES0eH9N7i3b0mLPQHmTd0PhWHMpWL9SxYhRfxV2qTWvIvLINBSpd4PVvm2tv0+4k7cHHatKVD3IWSBjoacw==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d}
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450':
+    resolution: {integrity: sha512-hfsw2aIaLD1psykxFF3tPPTm/oQNWclX8yN76IhBtj559huRjpV+NaQLBwRjlghHa/2RdOvmgcARRrHBDpI7MQ==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450}
     version: 0.1.0-alpha.9
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
@@ -14545,7 +14545,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14558,7 +14558,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@281d26d(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@75dd450(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))


### PR DESCRIPTION
Follow-up to the interface re-sync (#1176). Adding or removing a `views` panel or `services` worker in `sanity.cli.ts` during `sanity dev` updated the registry — so the dock reacted — but left the federation remote untouched. Its module-federation `exposes` map and codegen artifacts are computed once at server start, so the new interface had no expose: the panel rendered empty (or the worker never ran) until a manual restart.

Recreate the app dev server with a freshly-loaded config on an interface-set change (`server.restart()` re-uses the inline config, so it can't pick up the new set), then full-reload the workbench page — driven by the registry watch in the workbench server, so it works cross-process — to re-fetch the rebuilt remote. A view/service *source* edit doesn't change the set, so it stays on the existing HMR path.

Runtime behaviour is being verified by new e2e in the workbench repo (views add/remove + HMR, services add/remove + reload); draft until that's green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dev-server lifecycle (tear down/restart Vite), federation registration ordering, and workbench full-reload behavior; scoped to workbench app dev mode with new unit test coverage.
> 
> **Overview**
> Fixes workbench dev so **adding, removing, or repointing `views`/`services` in `sanity.cli.ts`** rebuilds the app’s module-federation remote instead of only updating the registry (which left new panels empty until a manual restart).
> 
> For **core apps**, `devAction` wires an `onInterfacesChange` hook that **closes and restarts** the app Vite server on the same port with config from `getCliConfigUncached` (restart alone can’t pick up new exposes). The manifest watcher **awaits** that hook **before** patching the registry when `serializeInterfaces` detects a set change; manifest-only edits and interface **source** edits still skip rebuild/HMR as before.
> 
> The **workbench dev server** compares serialized interface sets per registered app and issues a **full page reload** when a running app’s set changes (stale remote-entry cache); new apps and title/icon-only updates still use soft reconcile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 093b71d52ff78f3e28be9148897b1483445f564e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->