### PR TITLE
fix(workbench): defer reactStrictMode to the studio default when unset

### DIFF
--- a/.changeset/pr-1221.md
+++ b/.changeset/pr-1221.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): defer reactStrictMode to the studio default when unset

--- a/packages/@sanity/cli/src/actions/dev/__tests__/getDevServerConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/getDevServerConfig.test.ts
@@ -163,7 +163,7 @@ describe('getDevServerConfig', () => {
     expect(config.reactStrictMode).toBe(true)
   })
 
-  test('should resolve reactStrictMode to false when env var is absent and cliConfig is unset', () => {
+  test('should leave reactStrictMode undefined when env var is absent and cliConfig is unset, deferring to the studio default', () => {
     const output = createMockOutput()
 
     const config = getDevServerConfig({
@@ -173,6 +173,6 @@ describe('getDevServerConfig', () => {
       workDir: '/tmp',
     })
 
-    expect(config.reactStrictMode).toBe(false)
+    expect(config.reactStrictMode).toBeUndefined()
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -472,6 +472,24 @@ describe('startWorkbenchDevServer', () => {
         expect.objectContaining({reactStrictMode: true}),
       )
     })
+
+    test('leaves reactStrictMode undefined when neither env var nor cliConfig set it', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+
+      await startWorkbenchDevServer(
+        createDevOptions({
+          cliConfig: {
+            app: {organizationId: 'org-test'},
+            federation: {enabled: true},
+          },
+        }),
+      )
+
+      expect(mockWriteWorkbenchRuntime).toHaveBeenCalledWith(
+        expect.objectContaining({reactStrictMode: undefined}),
+      )
+    })
   })
 
   describe('server startup failure', () => {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/writeWorkbenchRuntime.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/writeWorkbenchRuntime.test.ts
@@ -81,6 +81,18 @@ describe('writeWorkbenchRuntime', () => {
       expect(content).not.toContain('%SANITY_WORKBENCH_REACT_STRICT_MODE%')
     })
 
+    test('substitutes reactStrictMode: undefined into workbench.js when unset', async () => {
+      await writeWorkbenchRuntime({cwd: tmpDir, reactStrictMode: undefined})
+
+      const content = await fs.readFile(
+        join(tmpDir, '.sanity', 'workbench', 'workbench.js'),
+        'utf8',
+      )
+      // Left undefined so the studio's own default applies.
+      expect(content).toContain('{reactStrictMode: undefined}')
+      expect(content).not.toContain('%SANITY_WORKBENCH_REACT_STRICT_MODE%')
+    })
+
     test('passes the workbench element id to renderWorkbench', async () => {
       await writeWorkbenchRuntime({cwd: tmpDir, reactStrictMode: false})
 

--- a/packages/@sanity/cli/src/actions/dev/writeWorkbenchRuntime.ts
+++ b/packages/@sanity/cli/src/actions/dev/writeWorkbenchRuntime.ts
@@ -42,7 +42,7 @@ const indexHtmlTemplate = `\
 export async function writeWorkbenchRuntime(options: {
   cwd: string
   organizationId?: string
-  reactStrictMode: boolean
+  reactStrictMode: boolean | undefined
   remoteUrl?: string
 }): Promise<string> {
   const {cwd, organizationId, reactStrictMode, remoteUrl} = options
@@ -53,7 +53,10 @@ export async function writeWorkbenchRuntime(options: {
       /%SANITY_WORKBENCH_ORGANIZATION_ID%/,
       organizationId === undefined ? 'undefined' : JSON.stringify(organizationId),
     )
-    .replace(/%SANITY_WORKBENCH_REACT_STRICT_MODE%/, JSON.stringify(reactStrictMode))
+    .replace(
+      /%SANITY_WORKBENCH_REACT_STRICT_MODE%/,
+      reactStrictMode === undefined ? 'undefined' : JSON.stringify(reactStrictMode),
+    )
 
   const prefetchHints = buildPrefetchHints(remoteUrl)
 

--- a/packages/@sanity/cli/src/util/resolveReactStrictMode.ts
+++ b/packages/@sanity/cli/src/util/resolveReactStrictMode.ts
@@ -1,8 +1,9 @@
 import {type CliConfig} from '@sanity/cli-core'
 
-export function resolveReactStrictMode(cliConfig?: CliConfig): boolean {
+export function resolveReactStrictMode(cliConfig?: CliConfig): boolean | undefined {
   if (process.env.SANITY_STUDIO_REACT_STRICT_MODE) {
     return process.env.SANITY_STUDIO_REACT_STRICT_MODE === 'true'
   }
-  return Boolean(cliConfig?.reactStrictMode)
+  // Leave unset so the studio's own default applies, rather than forcing it off.
+  return cliConfig?.reactStrictMode
 }


### PR DESCRIPTION
### Description

Aligns the workbench's `reactStrictMode` handling with the studio's pass-through behavior from #1147.

`resolveReactStrictMode` coerced an unset value to `false` (`Boolean(cliConfig?.reactStrictMode)`), which forces React strict mode **off** for federated dev servers instead of letting the studio's own default apply. This leaves it `undefined` when neither `SANITY_STUDIO_REACT_STRICT_MODE` nor `cliConfig.reactStrictMode` is set, matching how the regular dev/build path threads the value through to the studio entry.

The optional value is threaded through `writeWorkbenchRuntime`, which now emits `{reactStrictMode: undefined}` when unset (same pattern already used for `organizationId`).

Based on `chore/workbench-rebase-2026-06-08` (#1220) so the diff is just this alignment.

### What to review

- `resolveReactStrictMode.ts` — pass-through instead of `Boolean(...)` coercion.
- `writeWorkbenchRuntime.ts` — accepts `boolean | undefined`, writes the `undefined` literal when unset.
- Restored the #1147 "deferring to the studio default" expectation and added unset-case coverage.

### Testing

Typecheck plus the `getDevServerConfig`, `writeWorkbenchRuntime` and `startWorkbenchDevServer` suites pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local dev/workbench configuration only; explicit env and CLI overrides behave the same as before.
> 
> **Overview**
> Stops the CLI from **forcing React strict mode off** in the federated workbench when neither `SANITY_STUDIO_REACT_STRICT_MODE` nor `cliConfig.reactStrictMode` is set.
> 
> `resolveReactStrictMode` now returns `undefined` in that case instead of coercing with `Boolean(...)`, matching the regular dev path (#1147). `writeWorkbenchRuntime` threads `boolean | undefined` and writes `{reactStrictMode: undefined}` into generated `workbench.js` so the studio default applies. Tests were updated for the unset case across dev server config, workbench startup, and runtime file generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d8fa45e47c385fcbdf8979b1e0734dcb13a1ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->