### PR TITLE
feat(cli-build): derive vendor import-map entry points from package.json exports

### DIFF
--- a/.changeset/pr-1222.md
+++ b/.changeset/pr-1222.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+---
+
+feat(cli-build): derive vendor import-map entry points from package.json exports

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/resolveCjsNamedExportsSource.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/resolveCjsNamedExportsSource.test.ts
@@ -1,0 +1,30 @@
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+import {describe, expect, test} from 'vitest'
+
+import {getCjsNamedExports} from '../getCjsNamedExports.js'
+import {resolveCjsNamedExportsSource} from '../resolveCjsNamedExportsSource.js'
+
+const packageRoot = fileURLToPath(new URL('../../../../', import.meta.url))
+
+describe('resolveCjsNamedExportsSource', () => {
+  test('follows production CJS re-export wrappers', async () => {
+    const reactDir = path.join(packageRoot, 'node_modules/react')
+    const source = await resolveCjsNamedExportsSource(reactDir, path.join(reactDir, 'index.js'))
+
+    expect(source).toContain('exports.createElement')
+    expect(source).not.toMatch(/module\.exports\s*=\s*require/)
+  })
+
+  test('returns wrapper source when it declares named exports directly', async () => {
+    const reactDomDir = path.join(packageRoot, 'node_modules/react-dom')
+    const entryPath = path.join(reactDomDir, 'server.browser.js')
+    const source = await resolveCjsNamedExportsSource(reactDomDir, entryPath)
+
+    expect(source).toContain('exports.renderToString')
+    expect(await getCjsNamedExports(source, 'react-dom/server')).toEqual(
+      expect.arrayContaining(['renderToString', 'renderToStaticMarkup']),
+    )
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/resolveVendorEntryPoints.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/resolveVendorEntryPoints.test.ts
@@ -1,0 +1,142 @@
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+import {readPackageJson} from '@sanity/cli-core'
+import {describe, expect, test} from 'vitest'
+
+import {
+  listExportSubpaths,
+  resolveBrowserFieldEntryPoints,
+  resolveExportsEntryPoints,
+  resolveExportTarget,
+  resolveVendorEntryPoints,
+} from '../resolveVendorEntryPoints.js'
+
+const packageRoot = fileURLToPath(new URL('../../../../', import.meta.url))
+
+describe('resolveExportTarget', () => {
+  test('returns string targets as-is', () => {
+    expect(resolveExportTarget('./index.js')).toBe('./index.js')
+  })
+
+  test('prefers browser over import and default', () => {
+    expect(
+      resolveExportTarget({
+        browser: './browser.js',
+        default: './default.js',
+        import: './import.mjs',
+      }),
+    ).toBe('./browser.js')
+  })
+
+  test('falls back to import then default', () => {
+    expect(resolveExportTarget({default: './default.js', import: './import.mjs'})).toBe(
+      './import.mjs',
+    )
+    expect(resolveExportTarget({default: './default.js'})).toBe('./default.js')
+  })
+
+  test('resolves nested conditions', () => {
+    expect(
+      resolveExportTarget({
+        default: {browser: './browser.js', default: './node.js'},
+        'react-server': './server.js',
+      }),
+    ).toBe('./browser.js')
+  })
+})
+
+describe('listExportSubpaths', () => {
+  test('omits pattern exports', () => {
+    expect(
+      listExportSubpaths({
+        '.': './index.js',
+        './features/*': './features/*.js',
+        './package.json': './package.json',
+      }),
+    ).toEqual(['.', './package.json'])
+  })
+})
+
+describe('resolveExportsEntryPoints', () => {
+  test('derives react entry points from installed package.json exports', async () => {
+    const manifest = await readPackageJson(
+      path.join(packageRoot, 'node_modules/react/package.json'),
+      {
+        skipSchemaValidation: true,
+      },
+    )
+
+    const entryPoints = resolveExportsEntryPoints(manifest.exports!)
+
+    expect(entryPoints).toEqual({
+      '.': './index.js',
+      './compiler-runtime': './compiler-runtime.js',
+      './jsx-dev-runtime': './jsx-dev-runtime.js',
+      './jsx-runtime': './jsx-runtime.js',
+      './package.json': './package.json',
+    })
+  })
+
+  test('derives react-dom entry points with browser conditions', async () => {
+    const manifest = await readPackageJson(
+      path.join(packageRoot, 'node_modules/react-dom/package.json'),
+      {skipSchemaValidation: true},
+    )
+
+    const entryPoints = resolveExportsEntryPoints(manifest.exports!)
+
+    expect(entryPoints['./server']).toBe('./server.browser.js')
+    expect(entryPoints['./static']).toBe('./static.browser.js')
+    expect(entryPoints['./client']).toBe('./client.js')
+    expect(entryPoints['./server.node']).toBe('./server.node.js')
+  })
+})
+
+describe('resolveBrowserFieldEntryPoints', () => {
+  test('derives styled-components browser ESM entry from module + browser field', async () => {
+    const manifest = await readPackageJson(
+      path.join(packageRoot, 'node_modules/styled-components/package.json'),
+      {skipSchemaValidation: true},
+    )
+
+    expect(resolveBrowserFieldEntryPoints(manifest)).toEqual({
+      '.': './dist/styled-components.browser.esm.js',
+      './package.json': './package.json',
+    })
+  })
+})
+
+describe('resolveVendorEntryPoints', () => {
+  test('uses exports when present', async () => {
+    const manifest = await readPackageJson(
+      path.join(packageRoot, 'node_modules/react/package.json'),
+      {
+        skipSchemaValidation: true,
+      },
+    )
+
+    const entryPoints = resolveVendorEntryPoints({
+      fallback: 'exports',
+      manifest,
+      packageDir: path.join(packageRoot, 'node_modules/react'),
+    })
+
+    expect(entryPoints['./jsx-runtime']).toBe('./jsx-runtime.js')
+  })
+
+  test('falls back to browser-field strategy when exports are absent', async () => {
+    const manifest = await readPackageJson(
+      path.join(packageRoot, 'node_modules/styled-components/package.json'),
+      {skipSchemaValidation: true},
+    )
+
+    const entryPoints = resolveVendorEntryPoints({
+      fallback: 'browser-field',
+      manifest,
+      packageDir: path.join(packageRoot, 'node_modules/styled-components'),
+    })
+
+    expect(entryPoints['.']).toBe('./dist/styled-components.browser.esm.js')
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/buildVendorDependencies.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildVendorDependencies.ts
@@ -1,100 +1,51 @@
-import {readFile} from 'node:fs/promises'
 import path from 'node:path'
 
-import {getLocalPackageDir, getLocalPackageVersion} from '@sanity/cli-core'
+import {getLocalPackageDir, getLocalPackageVersion, readPackageJson} from '@sanity/cli-core'
 import {gt, minVersion, rcompare, satisfies} from 'semver'
 import {build, esmExternalRequirePlugin} from 'vite'
 
 import {SANITY_CACHE_DIR} from '../../constants.js'
 import {createExternalFromImportMap} from './createExternalFromImportMap.js'
 import {getCjsNamedExports} from './getCjsNamedExports.js'
+import {resolveCjsNamedExportsSource} from './resolveCjsNamedExportsSource.js'
+import {
+  resolveEntryPointPath,
+  resolveVendorEntryPoints,
+  type VendorEntryPoints,
+  type VendorEntryPointStrategy,
+} from './resolveVendorEntryPoints.js'
 import {createVendorNamedExportsPlugin} from './vite/plugin-sanity-vendor-named-exports.js'
 
 // Directory where vendor packages will be stored
 const VENDOR_DIR = 'vendor'
 
 /**
- * A type representing the imports of vendor packages, defining specific entry
- * points for various versions and subpaths of the packages.
- *
- * The `VendorImports` object is used to build ESM browser-compatible versions
- * of the specified packages. This approach ensures that the appropriate version
- * and entry points are used for each package, enabling compatibility and proper
- * functionality in the browser environment.
- *
- * ## Rationale
- *
- * The rationale for this structure is to handle different versions of the
- * packages carefully, especially major versions. Major version bumps often
- * introduce breaking changes, so the module scheme for the package needs to be
- * checked when there is a major version update. However, minor and patch
- * versions are generally backward compatible, so they are handled more
- * leniently. By assuming that new minor versions are compatible, we avoid
- * unnecessary warnings and streamline the update process.
- *
- * If a new minor version introduces an additional subpath export within the
- * package of this version range, the corresponding package can add a more
- * specific version range that includes the new subpath. This design allows for
- * flexibility and ease of maintenance, ensuring that the latest features and
- * fixes are incorporated without extensive manual intervention.
- *
- * An additional subpath export within the package of this version range that
- * could cause the build to break if that new export is used, can be treated as
- * a bug fix. It might make more sense to our users that this new subpath isn't
- * supported yet until we address it as a bug fix. This approach helps maintain
- * stability and prevents unexpected issues during the build process.
- *
- * ## Structure
- * The `VendorImports` type is a nested object where:
- * - The keys at the first level represent the package names.
- * - The keys at the second level represent the version ranges (e.g., `^19.0.0`).
- * - The keys at the third level represent the subpaths within the package (e.g., `.` for the main entry point).
- * - The values at the third level are the relative paths to the corresponding entry points within the package.
- *
- * This structure allows for precise specification of the entry points for
- * different versions and subpaths, ensuring that the correct files are used
- * during the build process.
+ * Supported version ranges for vendor packages whose entry points are resolved
+ * from each package's `package.json` at build time.
  */
-type VendorImports = {
+type VendorPackageRanges = {
   [packageName: string]: {
-    [versionRange: string]: {
-      [subpath: string]: string
-    }
+    [versionRange: string]: VendorEntryPointStrategy
   }
 }
 
-// Define the vendor packages and their corresponding versions and entry points
-const VENDOR_IMPORTS: VendorImports = {
+const VENDOR_PACKAGES: VendorPackageRanges = {
   react: {
-    '^19.2.0': {
-      '.': './cjs/react.production.js',
-      './compiler-runtime': './cjs/react-compiler-runtime.production.js',
-      './jsx-dev-runtime': './cjs/react-jsx-dev-runtime.production.js',
-      './jsx-runtime': './cjs/react-jsx-runtime.production.js',
-      './package.json': './package.json',
-    },
+    '^19.2.0': 'exports',
   },
   'react-dom': {
-    '^19.2.0': {
-      '.': './cjs/react-dom.production.js',
-      './client': './cjs/react-dom-client.production.js',
-      './package.json': './package.json',
-      './server': './cjs/react-dom-server-legacy.browser.production.js',
-      './server.browser': './cjs/react-dom-server-legacy.browser.production.js',
-      './static': './cjs/react-dom-server.browser.production.js',
-      './static.browser': './cjs/react-dom-server.browser.production.js',
-    },
+    '^19.2.0': 'exports',
   },
 }
 
-const STYLED_COMPONENTS_IMPORTS = {
+const STYLED_COMPONENTS_PACKAGES: VendorPackageRanges = {
   'styled-components': {
-    '^6.1.0': {
-      '.': './dist/styled-components.browser.esm.js',
-      './package.json': './package.json',
-    },
+    '^6.1.0': 'browser-field',
   },
 }
+
+/** Packages whose entries are CommonJS and need the named-exports plugin. */
+const CJS_VENDOR_PACKAGES = new Set(Object.keys(VENDOR_PACKAGES))
 
 interface VendorBuildOptions {
   basePath: string
@@ -103,9 +54,56 @@ interface VendorBuildOptions {
   outputDir: string
 }
 
+async function resolveSupportedEntryPoints(
+  packageName: string,
+  ranges: VendorPackageRanges[string],
+  cwd: string,
+): Promise<VendorEntryPoints> {
+  const version = await getLocalPackageVersion(packageName, cwd)
+  if (!version) {
+    throw new Error(`Could not get version for '${packageName}'`)
+  }
+
+  const sortedRanges = Object.keys(ranges).toSorted((range1, range2) => {
+    const min1 = minVersion(range1)
+    const min2 = minVersion(range2)
+
+    if (!min1) throw new Error(`Could not parse range '${range1}'`)
+    if (!min2) throw new Error(`Could not parse range '${range2}'`)
+
+    return rcompare(min1.version, min2.version)
+  })
+
+  const matchedRange = sortedRanges.find((range) => satisfies(version, range))
+
+  if (!matchedRange) {
+    const min = minVersion(sortedRanges.at(-1)!)
+    if (!min) {
+      throw new Error(`Could not find a minimum version for package '${packageName}'`)
+    }
+
+    if (gt(min.version, version)) {
+      throw new Error(`Package '${packageName}' requires at least ${min.version}.`)
+    }
+
+    throw new Error(`Version '${version}' of package '${packageName}' is not supported yet.`)
+  }
+
+  const packageDir = getLocalPackageDir(packageName, cwd)
+  const manifest = await readPackageJson(path.join(packageDir, 'package.json'), {
+    skipSchemaValidation: true,
+  })
+
+  return resolveVendorEntryPoints({
+    fallback: ranges[matchedRange],
+    manifest,
+    packageDir,
+  })
+}
+
 /**
  * Builds the ESM browser compatible versions of the vendor packages
- * specified in VENDOR_IMPORTS. Returns the `imports` object of an import map.
+ * specified in VENDOR_PACKAGES. Returns the `imports` object of an import map.
  */
 export async function buildVendorDependencies({
   basePath,
@@ -119,51 +117,14 @@ export async function buildVendorDependencies({
   // Named exports each CommonJS entry must re-expose as ESM, keyed by chunk name.
   const namesByChunkName: Record<string, readonly string[]> = {}
 
-  // If we're building an app, we don't need to build the styled-components package
-  const vendorImports = isApp ? VENDOR_IMPORTS : {...VENDOR_IMPORTS, ...STYLED_COMPONENTS_IMPORTS}
+  const vendorPackages = isApp
+    ? VENDOR_PACKAGES
+    : {...VENDOR_PACKAGES, ...STYLED_COMPONENTS_PACKAGES}
 
-  // Iterate over each package and its version ranges in VENDOR_IMPORTS
-  for (const [packageName, ranges] of Object.entries(vendorImports)) {
-    const version = await getLocalPackageVersion(packageName, cwd)
-    if (!version) {
-      throw new Error(`Could not get version for '${packageName}'`)
-    }
-
-    // Sort version ranges in descending order
-    const sortedRanges = Object.keys(ranges).toSorted((range1, range2) => {
-      const min1 = minVersion(range1)
-      const min2 = minVersion(range2)
-
-      if (!min1) throw new Error(`Could not parse range '${range1}'`)
-      if (!min2) throw new Error(`Could not parse range '${range2}'`)
-
-      // sort them in reverse so we can rely on array `.find` below
-      return rcompare(min1.version, min2.version)
-    })
-
-    // Find the first version range that satisfies the package version
-    const matchedRange = sortedRanges.find((range) => satisfies(version, range))
-
-    if (!matchedRange) {
-      const min = minVersion(sortedRanges.at(-1)!)
-      if (!min) {
-        throw new Error(`Could not find a minimum version for package '${packageName}'`)
-      }
-
-      if (gt(min.version, version)) {
-        throw new Error(`Package '${packageName}' requires at least ${min.version}.`)
-      }
-
-      throw new Error(`Version '${version}' of package '${packageName}' is not supported yet.`)
-    }
-
-    const subpaths = ranges[matchedRange]
-
-    // Resolve the actual package directory using Node module resolution,
-    // so that hoisted packages in monorepos/workspaces are found correctly
+  for (const [packageName, ranges] of Object.entries(vendorPackages)) {
+    const subpaths = await resolveSupportedEntryPoints(packageName, ranges, cwd)
     const packageDir = getLocalPackageDir(packageName, cwd)
 
-    // Iterate over each subpath and its corresponding entry point
     for (const [subpath, relativeEntryPoint] of Object.entries(subpaths)) {
       const specifier = path.posix.join(packageName, subpath)
       const chunkName = path.posix.join(
@@ -171,7 +132,7 @@ export async function buildVendorDependencies({
         path.relative(packageName, specifier) || 'index',
       )
 
-      const entryPath = path.join(packageDir, relativeEntryPoint)
+      const entryPath = resolveEntryPointPath(packageDir, relativeEntryPoint)
       entry[chunkName] = entryPath
       imports[specifier] = path.posix.join('/', basePath, VENDOR_DIR, `${chunkName}.mjs`)
 
@@ -180,8 +141,8 @@ export async function buildVendorDependencies({
       // must additionally re-expose (see `createVendorNamedExportsPlugin`).
       // `styled-components` is native ESM and `package.json` is JSON, so both are
       // skipped here.
-      if (packageName in VENDOR_IMPORTS && subpath !== './package.json') {
-        const source = await readFile(entryPath, 'utf8')
+      if (CJS_VENDOR_PACKAGES.has(packageName) && subpath !== './package.json') {
+        const source = await resolveCjsNamedExportsSource(packageDir, entryPath)
         namesByChunkName[chunkName] = await getCjsNamedExports(source, chunkName)
       }
     }

--- a/packages/@sanity/cli-build/src/actions/build/resolveCjsNamedExportsSource.ts
+++ b/packages/@sanity/cli-build/src/actions/build/resolveCjsNamedExportsSource.ts
@@ -1,0 +1,31 @@
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+
+// Matches React's production wrapper:
+// `if (process.env.NODE_ENV === 'production') { module.exports = require('./cjs/...'); }`
+const PRODUCTION_CJS_REEXPORT =
+  /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{[^}]*module\.exports\s*=\s*require\(\s*['"]([^'"]+)['"]\s*\)/
+
+/**
+ * Resolves the CommonJS source file whose named exports should be extracted for
+ * a vendor entry point.
+ *
+ * Many packages (e.g. `react`, `react-dom`) ship thin wrappers that re-export a
+ * production CJS bundle via `module.exports = require(...)`. The vendor build
+ * entry uses those wrappers (per `package.json` `exports`), but named-export
+ * extraction must read the underlying CJS module instead.
+ */
+export async function resolveCjsNamedExportsSource(
+  packageDir: string,
+  entryPath: string,
+): Promise<string> {
+  const source = await readFile(entryPath, 'utf8')
+  const [, relativeTarget] = PRODUCTION_CJS_REEXPORT.exec(source) ?? []
+
+  if (!relativeTarget) {
+    return source
+  }
+
+  const targetPath = path.resolve(path.dirname(entryPath), relativeTarget)
+  return readFile(targetPath, 'utf8')
+}

--- a/packages/@sanity/cli-build/src/actions/build/resolveVendorEntryPoints.ts
+++ b/packages/@sanity/cli-build/src/actions/build/resolveVendorEntryPoints.ts
@@ -1,0 +1,135 @@
+import path from 'node:path'
+
+import {type PackageJson} from '@sanity/cli-core'
+
+/** Conditions a browser bundler would apply when resolving package exports. */
+const BROWSER_BUNDLER_CONDITIONS = ['browser', 'import', 'default'] as const
+
+type ExportValue = string | {[condition: string]: ExportValue} | null
+
+export type VendorEntryPoints = Record<string, string>
+
+/**
+ * Resolves a conditional `exports` value for a browser bundler.
+ *
+ * Walks `browser` → `import` → `default`, matching the order bundlers use for
+ * browser-targeted builds.
+ */
+export function resolveExportTarget(
+  value: ExportValue,
+  conditions: readonly string[] = BROWSER_BUNDLER_CONDITIONS,
+): string {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (!value || typeof value !== 'object') {
+    throw new Error('Invalid package export target')
+  }
+
+  for (const condition of conditions) {
+    if (condition in value) {
+      return resolveExportTarget(value[condition]!, conditions)
+    }
+  }
+
+  throw new Error(
+    `Could not resolve package export target (missing conditions: ${conditions.join(', ')})`,
+  )
+}
+
+/**
+ * Lists export subpaths declared in a package's `exports` field.
+ *
+ * Pattern exports (keys containing `*`) are omitted because their concrete
+ * entry points cannot be enumerated ahead of time.
+ */
+export function listExportSubpaths(exportsField: NonNullable<PackageJson['exports']>): string[] {
+  return Object.keys(exportsField).filter((subpath) => !subpath.includes('*'))
+}
+
+/**
+ * Resolves browser-targeted entry points from a package's `exports` field.
+ */
+export function resolveExportsEntryPoints(
+  exportsField: NonNullable<PackageJson['exports']>,
+): VendorEntryPoints {
+  const entryPoints: VendorEntryPoints = {}
+
+  for (const subpath of listExportSubpaths(exportsField)) {
+    entryPoints[subpath] = resolveExportTarget(exportsField[subpath] as ExportValue)
+  }
+
+  return entryPoints
+}
+
+/**
+ * Resolves entry points for packages that use the webpack-style top-level
+ * `browser` field instead of `exports` (e.g. `styled-components`).
+ *
+ * Picks the ESM `module` entry when present, then applies any `browser` remap.
+ */
+interface BrowserFieldManifest extends PackageJson {
+  browser?: Record<string, string> | string
+  module?: string
+}
+
+export function resolveBrowserFieldEntryPoints(manifest: PackageJson): VendorEntryPoints {
+  const {browser, main, module: moduleField} = manifest as BrowserFieldManifest
+  const entryField = moduleField ?? main
+  if (!entryField) {
+    throw new Error(`Package '${manifest.name}' is missing 'module' and 'main' entry points`)
+  }
+
+  let entryPath = entryField
+
+  if (browser && typeof browser === 'object') {
+    const lookupKey = entryPath.startsWith('./') ? entryPath : `./${entryPath}`
+    const remapped = browser[lookupKey]
+    if (remapped) {
+      entryPath = remapped
+    }
+  }
+
+  return {
+    '.': entryPath,
+    './package.json': './package.json',
+  }
+}
+
+export type VendorEntryPointStrategy = 'browser-field' | 'exports'
+
+export interface ResolveVendorEntryPointsOptions {
+  manifest: PackageJson
+  packageDir: string
+
+  /** How to resolve entry points when a package does not use `exports`. */
+  fallback?: VendorEntryPointStrategy
+}
+
+/**
+ * Resolves the vendor entry-point map for a package from its `package.json`.
+ */
+export function resolveVendorEntryPoints({
+  fallback = 'exports',
+  manifest,
+}: ResolveVendorEntryPointsOptions): VendorEntryPoints {
+  if (manifest.exports) {
+    return resolveExportsEntryPoints(manifest.exports)
+  }
+
+  if (fallback === 'browser-field') {
+    return resolveBrowserFieldEntryPoints(manifest)
+  }
+
+  throw new Error(
+    `Package '${manifest.name}' does not declare an 'exports' field and no fallback strategy applies`,
+  )
+}
+
+/**
+ * Resolves the on-disk path for a package entry point.
+ */
+export function resolveEntryPointPath(packageDir: string, relativeEntryPoint: string): string {
+  return path.join(packageDir, relativeEntryPoint)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Vendor import-map entry points for `react`, `react-dom`, and `styled-components` were hardcoded per package/version/subpath in `buildVendorDependencies.ts`. When upstream packages add new `exports` subpaths, studios cannot use them until we manually update the table and cut a CLI release.

This PR resolves vendor entry points automatically from each package's `package.json`:

- **`react` / `react-dom`**: enumerate subpaths from `exports`, resolving targets with browser bundler conditions (`browser` → `import` → `default`).
- **`styled-components`**: special-case fallback using the webpack-style top-level `browser` field (picks `module`, then applies the browser remap), since it does not yet use `exports`.
- **CJS named exports**: wrapper entries (e.g. `react/index.js` → `cjs/react.production.js`) are followed when extracting named exports for the vendor build plugin.

Version range checks remain in place; only the subpath table is derived dynamically.

Fixes https://github.com/sanity-io/cli/issues/1209

### What to review

- `resolveVendorEntryPoints.ts` — export resolution logic and styled-components browser-field fallback
- `resolveCjsNamedExportsSource.ts` — production CJS wrapper following for named-export extraction
- `buildVendorDependencies.ts` — wiring: version validation + dynamic entry-point resolution
- New unit tests against the installed `react`/`react-dom`/`styled-components` package.json files
- Existing `buildVendorDependencies.test.ts` integration tests (named exports, external require rewrite, styled-components)

### Testing

- `resolveVendorEntryPoints.test.ts` — export condition resolution, react/react-dom/styled-components entry-point derivation
- `resolveCjsNamedExportsSource.test.ts` — CJS wrapper following for named-export extraction
- `buildVendorDependencies.test.ts` — end-to-end vendor build (react, react-dom, styled-components named exports + no runtime `require` shims)
- `pnpm check:types --filter=@sanity/cli-build`
- `pnpm lint` in `@sanity/cli-build`
- `pnpm knip --workspace @sanity/cli-build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-603ac3d3-a573-40b7-b804-ac2a5c3b5804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-603ac3d3-a573-40b7-b804-ac2a5c3b5804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

