### PR TITLE
fix: remove spread operator from viteReact plugin

### DIFF
--- a/.changeset/pr-1230.md
+++ b/.changeset/pr-1230.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': patch
+---
+
+fix: remove spread operator from viteReact plugin

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -153,7 +153,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     logLevel: mode === 'production' ? 'silent' : 'info',
     mode,
     plugins: [
-      ...viteReact(),
+      viteReact(),
       ...(reactCompiler ? [babel({presets: [reactCompilerPreset(reactCompiler)]})] : []),
       sanityFaviconsPlugin({customFaviconsPath, defaultFaviconsPath, staticUrlPath: staticPath}),
       sanityRuntimeRewritePlugin(),


### PR DESCRIPTION
### Description

Official docs do not spread: https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md#react-compiler
By spreading we risk running into trouble if the plugin one day decides to not return an array.

### What to review

All good?

### Testing

If CI pass we good

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Vite plugin wiring change in build config with no auth, data, or runtime behavior changes beyond correct plugin registration.
> 
> **Overview**
> Aligns Studio/app Vite config with **@vitejs/plugin-react** usage by registering the React plugin as a single entry instead of spreading its return value.
> 
> In `getViteConfig.ts`, the `plugins` array now uses `viteReact()` directly (replacing `...viteReact()`). That avoids incorrectly flattening the plugin if its API ever returns a non-array. A patch changeset is added for `@sanity/cli-build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc70fea7781b17eb26bfe9816e423781b6f850f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->