### PR TITLE
fix: use next-sanity@13 for Next.js init

### DIFF
--- a/.changeset/pr-1234.md
+++ b/.changeset/pr-1234.md
@@ -1,0 +1,7 @@
+---
+'@sanity/cli': patch
+---
+
+fix(init): use `next-sanity@13` when adding Sanity to a Next.js project
+
+Next.js projects scaffolded with `sanity init` now install `next-sanity@13` instead of `next-sanity@12`, keeping new projects on the latest major (with Next.js 16 and React 19 support).

--- a/packages/@sanity/cli/src/actions/init/initNextJs.ts
+++ b/packages/@sanity/cli/src/actions/init/initNextJs.ts
@@ -314,17 +314,17 @@ export async function initNextJs({
 
   switch (chosen) {
     case 'npm': {
-      await execa('npm', ['install', 'next-sanity@12'], execOptions)
+      await execa('npm', ['install', 'next-sanity@13'], execOptions)
       break
     }
     case 'pnpm': {
-      await execa('pnpm', ['install', 'next-sanity@12'], execOptions)
+      await execa('pnpm', ['install', 'next-sanity@13'], execOptions)
       break
     }
     case 'yarn': {
-      const peerDeps = await getPeerDependencies('next-sanity@12', workDir)
+      const peerDeps = await getPeerDependencies('next-sanity@13', workDir)
       await installNewPackages(
-        {packageManager: 'yarn', packages: ['next-sanity@12', ...peerDeps]},
+        {packageManager: 'yarn', packages: ['next-sanity@13', ...peerDeps]},
         {output, workDir},
       )
       break

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/getPeerDependencies.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/getPeerDependencies.test.ts
@@ -26,20 +26,20 @@ describe('getPeerDependencies', () => {
     mockGetPartialEnvWithNpmPath.mockReturnValue({PATH: '/mock/path'})
     mockExeca.mockResolvedValueOnce({
       stdout: JSON.stringify({
-        next: '^15.0.0',
+        next: '^16.0.0',
         react: '^19.0.0',
         'react-dom': '^19.0.0',
       }),
     } as unknown as Result)
 
-    const result = await getPeerDependencies('next-sanity@12', cwd)
+    const result = await getPeerDependencies('next-sanity@13', cwd)
 
     expect(mockExeca).toHaveBeenCalledWith(
       'npm',
-      ['view', 'next-sanity@12', 'peerDependencies', '--json'],
+      ['view', 'next-sanity@13', 'peerDependencies', '--json'],
       {cwd, encoding: 'utf8', env: {PATH: '/mock/path'}},
     )
-    expect(result).toEqual(['next@^15.0.0', 'react@^19.0.0', 'react-dom@^19.0.0'])
+    expect(result).toEqual(['next@^16.0.0', 'react@^19.0.0', 'react-dom@^19.0.0'])
   })
 
   test('returns empty array when package has no peer dependencies', async () => {

--- a/packages/@sanity/cli/src/util/packageManager/getPeerDependencies.ts
+++ b/packages/@sanity/cli/src/util/packageManager/getPeerDependencies.ts
@@ -5,9 +5,9 @@ import {getPartialEnvWithNpmPath} from './packageManagerChoice.js'
 /**
  * Resolves the peer dependencies of a package by querying the npm registry.
  *
- * @param packageName - Package name with version (e.g. "next-sanity\@11")
+ * @param packageName - Package name with version (e.g. "next-sanity\@13")
  * @param cwd - Working directory (used to resolve local npm paths)
- * @returns Array of peer dependency strings (e.g. ["next\@^15.0.0", "react\@^19.0.0"])
+ * @returns Array of peer dependency strings (e.g. ["next\@^16.0.0", "react\@^19.0.0"])
  */
 export async function getPeerDependencies(packageName: string, cwd: string): Promise<string[]> {
   let stdout: string


### PR DESCRIPTION
### Description

`sanity init` now installs `next-sanity@13` instead of `next-sanity@12` when adding Sanity to a Next.js project.

`next-sanity@12` is a major version behind. v13 is the current major and targets the latest framework versions (peer deps: `next@^16`, `react@^19.2`, `react-dom@^19.2`, `sanity@^5.26`). Scaffolding new projects on the latest major keeps generated apps current and avoids shipping immediately-outdated dependencies.

The bump is applied to all three managed install paths (npm, pnpm, and yarn). The yarn path resolves peer dependencies up front via `getPeerDependencies`, so its test and the `getPeerDependencies` JSDoc examples were updated to reflect v13 (e.g. `next@^16`).

No linked issue.

### What to review

- `packages/@sanity/cli/src/actions/init/initNextJs.ts` — `next-sanity@12` → `next-sanity@13` in the npm, pnpm, and yarn branches.
- `packages/@sanity/cli/src/util/packageManager/getPeerDependencies.ts` — JSDoc examples updated to `next-sanity@13` / `next@^16`; no behavior change.
- `packages/@sanity/cli/src/util/packageManager/__tests__/getPeerDependencies.test.ts` — mock and assertions updated to `next-sanity@13` / `next@^16`.
- Confirm `patch` is the correct bump (CLI behavior fix, no public API change).

### Testing

- `getPeerDependencies.test.ts` was updated to assert the yarn path queries `next-sanity@13` and resolves its peers (`next@^16`, `react@^19`, `react-dom@^19`). Verified locally with `pnpm test packages/@sanity/cli/src/util/packageManager/__tests__/getPeerDependencies.test.ts` (6 passing).
- Existing `init.nextjs.test.ts` continues to exercise the init flow with the package-install paths mocked.
- Manual check: running `sanity init` against a Next.js project installs `next-sanity@13`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped dependency version bump in CLI init only; no public API or runtime behavior changes beyond what gets installed for new projects.
> 
> **Overview**
> **`sanity init`** for Next.js now installs **`next-sanity@13`** instead of **`next-sanity@12`** on the npm, pnpm, and yarn install paths in `initNextJs.ts`, so newly scaffolded apps get the current major (Next.js 16 / React 19 peer expectations).
> 
> The yarn path still resolves peers via **`getPeerDependencies`**; tests and JSDoc examples were updated to **`next-sanity@13`** and **`next@^16`** with no logic changes. A **`@sanity/cli` patch** changeset documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f20dd9804203cec17763f4962d0e32f094191cbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->