### PR TITLE
fix: move next js config after the mcp config

### DIFF
--- a/.changeset/pr-1235.md
+++ b/.changeset/pr-1235.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix: move next js config after the mcp config

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -161,34 +161,6 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
     return
   }
 
-  let initNext = flagOrDefault(options.nextjsAddConfigFiles, false)
-  if (isNextJs && shouldPrompt(options.unattended, options.nextjsAddConfigFiles)) {
-    initNext = await promptForConfigFiles()
-  }
-
-  trace.log({
-    detectedFramework: detectedFramework?.name,
-    selectedOption: initNext ? 'yes' : 'no',
-    step: 'useDetectedFramework',
-  })
-
-  const sluggedName = deburr(displayName.toLowerCase())
-    .replaceAll(/\s+/g, '-')
-    .replaceAll(/[^a-z0-9-]/g, '')
-
-  const initFramework = initNext
-
-  const defaults = await getProjectDefaults({isPlugin: false, workDir})
-
-  const outputPath = await getProjectOutputPath({
-    initFramework,
-    outputPath: options.outputPath,
-    sluggedName,
-    unattended: options.unattended,
-    useEnv: Boolean(options.env),
-    workDir,
-  })
-
   // Detect editors once, then share the result with MCP and skills setup so
   // we don't pay the detection cost (filesystem probes + CLI execa calls) twice.
   const detectedEditors =
@@ -241,6 +213,34 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
         : `${alreadyConfiguredEditors.length} editors already configured for Sanity MCP`
     spinner(label).start().succeed()
   }
+
+  let initNext = flagOrDefault(options.nextjsAddConfigFiles, false)
+  if (isNextJs && shouldPrompt(options.unattended, options.nextjsAddConfigFiles)) {
+    initNext = await promptForConfigFiles()
+  }
+
+  trace.log({
+    detectedFramework: detectedFramework?.name,
+    selectedOption: initNext ? 'yes' : 'no',
+    step: 'useDetectedFramework',
+  })
+
+  const sluggedName = deburr(displayName.toLowerCase())
+    .replaceAll(/\s+/g, '-')
+    .replaceAll(/[^a-z0-9-]/g, '')
+
+  const initFramework = initNext
+
+  const defaults = await getProjectDefaults({isPlugin: false, workDir})
+
+  const outputPath = await getProjectOutputPath({
+    initFramework,
+    outputPath: options.outputPath,
+    sluggedName,
+    unattended: options.unattended,
+    useEnv: Boolean(options.env),
+    workDir,
+  })
 
   if (isNextJs) {
     await checkNextJsReactCompatibility({


### PR DESCRIPTION
### Description

Reorders `sanity init` so the MCP setup step (editor detection, `setupMCP`, and the "already configured" spinner) runs **before** the Next.js "Would you like to add configuration files?" prompt.

Previously the interactive flow was:
1. Select project / dataset
2. "Would you like to add configuration files?" (Next.js only)
3. MCP editor setup

Now it is:
1. Select project / dataset
2. MCP editor setup
3. "Would you like to add configuration files?" (Next.js only)

This is a pure control-flow reorder — no logic, flags, or signatures were changed. The MCP setup block has no dependencies on anything computed after dataset selection, so moving it earlier is safe.

### What to review

- Verify the block move in `initAction.ts` — the MCP setup block (editor detection, `setupMCP` call, telemetry logging, `installSkills` definition, and "already configured" spinner) now runs immediately after the `--bare` early return, before the Next.js config prompt and output path resolution.
- No other files are changed.

### Testing

Existing init test suite passes (excluding one pre-existing flaky test in `init.authentication.test.ts` that also fails on `main`). No new tests needed since this is a reorder of independent steps with no changed behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flow-only reorder in init with no change to MCP or Next.js logic; low risk aside from altered prompt order for Next.js projects.
> 
> **Overview**
> Reorders the **`sanity init`** flow in `initAction.ts` so **MCP setup** (shared editor detection, `setupMCP`, and the “already configured” spinner) runs **before** the Next.js-specific steps.
> 
> The Next.js block—`nextjsAddConfigFiles` / `promptForConfigFiles`, telemetry for `useDetectedFramework`, slug/output path resolution, `checkNextJsReactCompatibility`, and `initNextJs`—is unchanged but now comes **after** MCP. Interactive init should prompt for MCP/editor configuration before asking about adding Next.js config files.
> 
> Shipped as a **patch** to `@sanity/cli` via changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ea9707a6618e04e8434beaf7f2e99fab50242d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->