### PR TITLE
feat(workbench): add --unstable--workbench flag scaffolding unstable_defineApp

### DIFF
--- a/.changeset/pr-1236.md
+++ b/.changeset/pr-1236.md
@@ -1,5 +1,7 @@
 <!-- auto-generated -->
 ---
+'@sanity/cli-build': minor
+'@sanity/cli-core': minor
 '@sanity/cli': minor
 ---
 

--- a/.changeset/pr-1236.md
+++ b/.changeset/pr-1236.md
@@ -1,7 +1,5 @@
 <!-- auto-generated -->
 ---
-'@sanity/cli-build': minor
-'@sanity/cli-core': minor
 '@sanity/cli': minor
 ---
 

--- a/.changeset/pr-1236.md
+++ b/.changeset/pr-1236.md
@@ -3,4 +3,4 @@
 '@sanity/cli': minor
 ---
 
-feat(init): add --unstable-extension-api flag scaffolding unstable_defineApp
+feat(workbench): add --unstable-extension-api flag scaffolding unstable_defineApp

--- a/.changeset/pr-1236.md
+++ b/.changeset/pr-1236.md
@@ -3,4 +3,4 @@
 '@sanity/cli': minor
 ---
 
-feat(init): add --unstable--workbench flag scaffolding unstable_defineApp
+feat(workbench): add --unstable--workbench flag scaffolding unstable_defineApp

--- a/.changeset/pr-1236.md
+++ b/.changeset/pr-1236.md
@@ -3,4 +3,4 @@
 '@sanity/cli': minor
 ---
 
-feat(workbench): add --unstable-extension-api flag scaffolding unstable_defineApp
+feat(init): add --unstable--workbench flag scaffolding unstable_defineApp

--- a/.changeset/pr-1236.md
+++ b/.changeset/pr-1236.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(init): add --unstable-extension-api flag scaffolding unstable_defineApp

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import {type Output} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
+import {resolveLatestVersions} from '../../../util/resolveLatestVersions.js'
 import {bootstrapLocalTemplate} from '../bootstrapLocalTemplate.js'
 
 vi.mock('../../../util/resolveLatestVersions.js', () => ({
@@ -52,6 +53,7 @@ describe('bootstrapLocalTemplate (app templates)', () => {
       variables: {
         autoUpdates: false,
         dataset: 'production',
+        extensionApi: false,
         organizationId: 'org1',
         projectId: 'abc123',
         projectName: 'my-app',
@@ -75,6 +77,7 @@ describe('bootstrapLocalTemplate (app templates)', () => {
       variables: {
         autoUpdates: false,
         dataset: '',
+        extensionApi: false,
         organizationId: 'org1',
         projectId: '',
         projectName: 'my-app',
@@ -86,5 +89,160 @@ describe('bootstrapLocalTemplate (app templates)', () => {
     expect(appTsx).toContain(`dataset: ''`)
     expect(appTsx).not.toContain('%projectId%')
     expect(appTsx).not.toContain('%dataset%')
+  })
+})
+
+describe('bootstrapLocalTemplate (extension API)', () => {
+  let tmp: string
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'cli-bootstrap-'))
+  })
+  afterEach(async () => {
+    await rm(tmp, {force: true, recursive: true})
+    vi.clearAllMocks()
+  })
+
+  test('overrides the `sanity` dependency with the `workbench` dist-tag when the extension API is enabled', async () => {
+    await bootstrapLocalTemplate({
+      output: makeOutput(),
+      outputPath: tmp,
+      packageName: 'my-studio',
+      templateName: 'clean',
+      useTypeScript: true,
+      variables: {
+        autoUpdates: false,
+        dataset: 'production',
+        extensionApi: true,
+        organizationId: 'org1',
+        projectId: 'abc123',
+        projectName: 'My Studio',
+      },
+    })
+
+    expect(resolveLatestVersions).toHaveBeenCalledOnce()
+    const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
+    expect(resolvedDeps.sanity).toBe('workbench')
+
+    const pkgJson = JSON.parse(await readFile(path.join(tmp, 'package.json'), 'utf8'))
+    expect(pkgJson.dependencies.sanity).toBe('1.0.0')
+  })
+
+  test('keeps the `sanity` dependency on the `latest` dist-tag when the extension API is disabled', async () => {
+    await bootstrapLocalTemplate({
+      output: makeOutput(),
+      outputPath: tmp,
+      packageName: 'my-studio',
+      templateName: 'clean',
+      useTypeScript: true,
+      variables: {
+        autoUpdates: false,
+        dataset: 'production',
+        extensionApi: false,
+        organizationId: 'org1',
+        projectId: 'abc123',
+        projectName: 'My Studio',
+      },
+    })
+
+    expect(resolveLatestVersions).toHaveBeenCalledOnce()
+    const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
+    expect(resolvedDeps.sanity).toBe('latest')
+  })
+
+  test('overrides the `sanity` devDependency for app templates when the extension API is enabled', async () => {
+    await bootstrapLocalTemplate({
+      output: makeOutput(),
+      outputPath: tmp,
+      packageName: 'my-app',
+      templateName: 'app-quickstart',
+      useTypeScript: true,
+      variables: {
+        autoUpdates: false,
+        dataset: 'production',
+        extensionApi: true,
+        organizationId: 'org1',
+        projectId: 'abc123',
+        projectName: 'my-app',
+      },
+    })
+
+    expect(resolveLatestVersions).toHaveBeenCalledOnce()
+    const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
+    expect(resolvedDeps.sanity).toBe('workbench')
+  })
+
+  test('scaffolds a studio sanity.cli.ts branded with unstable_defineApp', async () => {
+    await bootstrapLocalTemplate({
+      output: makeOutput(),
+      outputPath: tmp,
+      packageName: 'my-studio',
+      templateName: 'clean',
+      useTypeScript: true,
+      variables: {
+        autoUpdates: false,
+        dataset: 'production',
+        extensionApi: true,
+        organizationId: 'org1',
+        projectId: 'abc123',
+        projectName: 'My Studio',
+      },
+    })
+
+    const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
+    expect(cliConfig).toContain(`import {defineCliConfig, unstable_defineApp} from 'sanity/cli'`)
+    expect(cliConfig).toContain(`name: 'my-studio'`)
+    expect(cliConfig).toContain(`title: 'My Studio'`)
+    expect(cliConfig).toContain(`projectId: 'abc123'`)
+    // Studios brand without an entry — studio app views aren't implemented yet
+    expect(cliConfig).not.toContain('entry:')
+  })
+
+  test('scaffolds an app sanity.cli.ts branded with unstable_defineApp, keeping the entry', async () => {
+    await bootstrapLocalTemplate({
+      output: makeOutput(),
+      outputPath: tmp,
+      packageName: 'my-app',
+      templateName: 'app-quickstart',
+      useTypeScript: true,
+      variables: {
+        autoUpdates: false,
+        dataset: 'production',
+        extensionApi: true,
+        organizationId: 'org1',
+        projectId: 'abc123',
+        projectName: 'My App',
+      },
+    })
+
+    const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
+    expect(cliConfig).toContain(`import {defineCliConfig, unstable_defineApp} from 'sanity/cli'`)
+    // App init derives `name` from the output directory, same as package.json
+    const pkgJson = JSON.parse(await readFile(path.join(tmp, 'package.json'), 'utf8'))
+    expect(cliConfig).toContain(`name: '${pkgJson.name}'`)
+    expect(cliConfig).toContain(`title: 'My App'`)
+    expect(cliConfig).toContain(`organizationId: 'org1'`)
+    expect(cliConfig).toContain(`entry: './src/App.tsx'`)
+  })
+
+  test('scaffolds the plain sanity.cli.ts when the extension API is disabled', async () => {
+    await bootstrapLocalTemplate({
+      output: makeOutput(),
+      outputPath: tmp,
+      packageName: 'my-studio',
+      templateName: 'clean',
+      useTypeScript: true,
+      variables: {
+        autoUpdates: false,
+        dataset: 'production',
+        extensionApi: false,
+        organizationId: 'org1',
+        projectId: 'abc123',
+        projectName: 'My Studio',
+      },
+    })
+
+    const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
+    expect(cliConfig).not.toContain('unstable_defineApp')
+    expect(cliConfig).toContain(`projectId: 'abc123'`)
   })
 })

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapLocalTemplate.test.ts
@@ -53,10 +53,10 @@ describe('bootstrapLocalTemplate (app templates)', () => {
       variables: {
         autoUpdates: false,
         dataset: 'production',
-        extensionApi: false,
         organizationId: 'org1',
         projectId: 'abc123',
         projectName: 'my-app',
+        workbench: false,
       },
     })
 
@@ -77,10 +77,10 @@ describe('bootstrapLocalTemplate (app templates)', () => {
       variables: {
         autoUpdates: false,
         dataset: '',
-        extensionApi: false,
         organizationId: 'org1',
         projectId: '',
         projectName: 'my-app',
+        workbench: false,
       },
     })
 
@@ -92,7 +92,7 @@ describe('bootstrapLocalTemplate (app templates)', () => {
   })
 })
 
-describe('bootstrapLocalTemplate (extension API)', () => {
+describe('bootstrapLocalTemplate (workbench)', () => {
   let tmp: string
   beforeEach(async () => {
     tmp = await mkdtemp(path.join(tmpdir(), 'cli-bootstrap-'))
@@ -102,7 +102,7 @@ describe('bootstrapLocalTemplate (extension API)', () => {
     vi.clearAllMocks()
   })
 
-  test('overrides the `sanity` dependency with the `workbench` dist-tag when the extension API is enabled', async () => {
+  test('overrides the `sanity` dependency with the `workbench` dist-tag when workbench is enabled', async () => {
     await bootstrapLocalTemplate({
       output: makeOutput(),
       outputPath: tmp,
@@ -112,10 +112,10 @@ describe('bootstrapLocalTemplate (extension API)', () => {
       variables: {
         autoUpdates: false,
         dataset: 'production',
-        extensionApi: true,
         organizationId: 'org1',
         projectId: 'abc123',
         projectName: 'My Studio',
+        workbench: true,
       },
     })
 
@@ -127,7 +127,7 @@ describe('bootstrapLocalTemplate (extension API)', () => {
     expect(pkgJson.dependencies.sanity).toBe('1.0.0')
   })
 
-  test('keeps the `sanity` dependency on the `latest` dist-tag when the extension API is disabled', async () => {
+  test('keeps the `sanity` dependency on the `latest` dist-tag when workbench is disabled', async () => {
     await bootstrapLocalTemplate({
       output: makeOutput(),
       outputPath: tmp,
@@ -137,10 +137,10 @@ describe('bootstrapLocalTemplate (extension API)', () => {
       variables: {
         autoUpdates: false,
         dataset: 'production',
-        extensionApi: false,
         organizationId: 'org1',
         projectId: 'abc123',
         projectName: 'My Studio',
+        workbench: false,
       },
     })
 
@@ -149,7 +149,7 @@ describe('bootstrapLocalTemplate (extension API)', () => {
     expect(resolvedDeps.sanity).toBe('latest')
   })
 
-  test('overrides the `sanity` devDependency for app templates when the extension API is enabled', async () => {
+  test('overrides the `sanity` devDependency for app templates when workbench is enabled', async () => {
     await bootstrapLocalTemplate({
       output: makeOutput(),
       outputPath: tmp,
@@ -159,10 +159,10 @@ describe('bootstrapLocalTemplate (extension API)', () => {
       variables: {
         autoUpdates: false,
         dataset: 'production',
-        extensionApi: true,
         organizationId: 'org1',
         projectId: 'abc123',
         projectName: 'my-app',
+        workbench: true,
       },
     })
 
@@ -181,10 +181,10 @@ describe('bootstrapLocalTemplate (extension API)', () => {
       variables: {
         autoUpdates: false,
         dataset: 'production',
-        extensionApi: true,
         organizationId: 'org1',
         projectId: 'abc123',
         projectName: 'My Studio',
+        workbench: true,
       },
     })
 
@@ -207,10 +207,10 @@ describe('bootstrapLocalTemplate (extension API)', () => {
       variables: {
         autoUpdates: false,
         dataset: 'production',
-        extensionApi: true,
         organizationId: 'org1',
         projectId: 'abc123',
         projectName: 'My App',
+        workbench: true,
       },
     })
 
@@ -224,7 +224,7 @@ describe('bootstrapLocalTemplate (extension API)', () => {
     expect(cliConfig).toContain(`entry: './src/App.tsx'`)
   })
 
-  test('scaffolds the plain sanity.cli.ts when the extension API is disabled', async () => {
+  test('scaffolds the plain sanity.cli.ts when workbench is disabled', async () => {
     await bootstrapLocalTemplate({
       output: makeOutput(),
       outputPath: tmp,
@@ -234,10 +234,10 @@ describe('bootstrapLocalTemplate (extension API)', () => {
       variables: {
         autoUpdates: false,
         dataset: 'production',
-        extensionApi: false,
         organizationId: 'org1',
         projectId: 'abc123',
         projectName: 'My Studio',
+        workbench: false,
       },
     })
 

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapRemoteTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapRemoteTemplate.test.ts
@@ -76,6 +76,7 @@ const baseOpts = {
   variables: {
     autoUpdates: false,
     dataset: 'production',
+    extensionApi: false,
     projectId: 'test-project-id',
   },
 }

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapRemoteTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapRemoteTemplate.test.ts
@@ -76,8 +76,8 @@ const baseOpts = {
   variables: {
     autoUpdates: false,
     dataset: 'production',
-    extensionApi: false,
     projectId: 'test-project-id',
+    workbench: false,
   },
 }
 

--- a/packages/@sanity/cli/src/actions/init/__tests__/flagsToInitOptions.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/flagsToInitOptions.test.ts
@@ -39,6 +39,7 @@ describe('flagsToInitOptions', () => {
         'project-plan': 'enterprise',
         template: 'blog',
         'template-token': 'ghp_abc',
+        'unstable-extension-api': true,
         visibility: 'private',
       }),
       false,
@@ -53,6 +54,7 @@ describe('flagsToInitOptions', () => {
     expect(result.projectPlan).toBe('enterprise')
     expect(result.template).toBe('blog')
     expect(result.templateToken).toBe('ghp_abc')
+    expect(result.unstableExtensionApi).toBe(true)
     expect(result.visibility).toBe('private')
   })
 

--- a/packages/@sanity/cli/src/actions/init/__tests__/flagsToInitOptions.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/flagsToInitOptions.test.ts
@@ -39,7 +39,7 @@ describe('flagsToInitOptions', () => {
         'project-plan': 'enterprise',
         template: 'blog',
         'template-token': 'ghp_abc',
-        'unstable-extension-api': true,
+        'unstable--workbench': true,
         visibility: 'private',
       }),
       false,
@@ -54,7 +54,7 @@ describe('flagsToInitOptions', () => {
     expect(result.projectPlan).toBe('enterprise')
     expect(result.template).toBe('blog')
     expect(result.templateToken).toBe('ghp_abc')
-    expect(result.unstableExtensionApi).toBe(true)
+    expect(result.unstableWorkbench).toBe(true)
     expect(result.visibility).toBe('private')
   })
 

--- a/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
@@ -91,7 +91,7 @@ export async function bootstrapLocalTemplate(
     ...template.devDependencies,
     // `unstable_defineApp` (re-exported via `sanity/cli`) only exists on the
     // workbench dist-tag of `sanity`.
-    ...(variables.extensionApi && {sanity: 'workbench'}),
+    ...(variables.workbench && {sanity: 'workbench'}),
   })
   spin.succeed()
 
@@ -144,18 +144,18 @@ export async function bootstrapLocalTemplate(
   const cliConfig = isAppTemplate
     ? createAppCliConfig({
         entry: template.entry!,
-        extensionApi: variables.extensionApi,
         name: packageJsonName,
         organizationId: variables.organizationId,
         title: variables.projectName || packageJsonName,
+        workbench: variables.workbench,
       })
     : createCliConfig({
         autoUpdates: variables.autoUpdates,
         dataset: variables.dataset,
-        extensionApi: variables.extensionApi,
         name: packageJsonName,
         projectId: variables.projectId,
         title: variables.projectName || packageJsonName,
+        workbench: variables.workbench,
       })
 
   // Write non-template files to disc

--- a/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
@@ -89,6 +89,9 @@ export async function bootstrapLocalTemplate(
     ...(isAppTemplate ? sdkAppDependencies.devDependencies : studioDependencies.devDependencies),
     ...template.dependencies,
     ...template.devDependencies,
+    // `unstable_defineApp` (re-exported via `sanity/cli`) only exists on the
+    // workbench dist-tag of `sanity`.
+    ...(variables.extensionApi && {sanity: 'workbench'}),
   })
   spin.succeed()
 
@@ -141,12 +144,18 @@ export async function bootstrapLocalTemplate(
   const cliConfig = isAppTemplate
     ? createAppCliConfig({
         entry: template.entry!,
+        extensionApi: variables.extensionApi,
+        name: packageJsonName,
         organizationId: variables.organizationId,
+        title: variables.projectName || packageJsonName,
       })
     : createCliConfig({
         autoUpdates: variables.autoUpdates,
         dataset: variables.dataset,
+        extensionApi: variables.extensionApi,
+        name: packageJsonName,
         projectId: variables.projectId,
+        title: variables.projectName || packageJsonName,
       })
 
   // Write non-template files to disc

--- a/packages/@sanity/cli/src/actions/init/bootstrapTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapTemplate.ts
@@ -9,6 +9,7 @@ interface BootstrapTemplateOptions {
   autoUpdates: boolean
   bearerToken: string | undefined
   dataset: string
+  extensionApi: boolean
   organizationId: string | undefined
   output: Output
   outputPath: string
@@ -27,6 +28,7 @@ export async function bootstrapTemplate({
   autoUpdates,
   bearerToken,
   dataset,
+  extensionApi,
   organizationId,
   output,
   outputPath,
@@ -41,6 +43,7 @@ export async function bootstrapTemplate({
   const bootstrapVariables: GenerateConfigOptions['variables'] = {
     autoUpdates,
     dataset,
+    extensionApi,
     organizationId,
     projectId,
     projectName,

--- a/packages/@sanity/cli/src/actions/init/bootstrapTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapTemplate.ts
@@ -9,7 +9,6 @@ interface BootstrapTemplateOptions {
   autoUpdates: boolean
   bearerToken: string | undefined
   dataset: string
-  extensionApi: boolean
   organizationId: string | undefined
   output: Output
   outputPath: string
@@ -20,6 +19,7 @@ interface BootstrapTemplateOptions {
   templateName: string
 
   useTypeScript: boolean
+  workbench: boolean
 
   overwriteFiles?: boolean
 }
@@ -28,7 +28,6 @@ export async function bootstrapTemplate({
   autoUpdates,
   bearerToken,
   dataset,
-  extensionApi,
   organizationId,
   output,
   outputPath,
@@ -39,14 +38,15 @@ export async function bootstrapTemplate({
   remoteTemplateInfo,
   templateName,
   useTypeScript,
+  workbench,
 }: BootstrapTemplateOptions) {
   const bootstrapVariables: GenerateConfigOptions['variables'] = {
     autoUpdates,
     dataset,
-    extensionApi,
     organizationId,
     projectId,
     projectName,
+    workbench,
   }
 
   if (remoteTemplateInfo) {

--- a/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
@@ -11,16 +11,35 @@ export default defineCliConfig({
 })
 `
 
+// The branded `unstable_defineApp` result is the sole workbench (module
+// federation) opt-in — `entry` auto-declares the navigable app view.
+const workbenchAppTemplate = `
+import {defineCliConfig, unstable_defineApp} from 'sanity/cli'
+
+export default defineCliConfig({
+  app: unstable_defineApp({
+    name: '%name%',
+    title: '%title%',
+    organizationId: '%organizationId%',
+    entry: '%entry%',
+  }),
+})
+`
+
 interface GenerateCliConfigOptions {
   entry: string
+  extensionApi: boolean
+  name: string
+  title: string
 
   organizationId?: string
 }
 
 export function createAppCliConfig(options: GenerateCliConfigOptions): string {
+  const {extensionApi, ...variables} = options
   return processTemplate({
     includeBooleanTransform: true,
-    template: defaultAppTemplate,
-    variables: options,
+    template: extensionApi ? workbenchAppTemplate : defaultAppTemplate,
+    variables,
   })
 }

--- a/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
@@ -28,18 +28,18 @@ export default defineCliConfig({
 
 interface GenerateCliConfigOptions {
   entry: string
-  extensionApi: boolean
   name: string
   title: string
+  workbench: boolean
 
   organizationId?: string
 }
 
 export function createAppCliConfig(options: GenerateCliConfigOptions): string {
-  const {extensionApi, ...variables} = options
+  const {workbench, ...variables} = options
   return processTemplate({
     includeBooleanTransform: true,
-    template: extensionApi ? workbenchAppTemplate : defaultAppTemplate,
+    template: workbench ? workbenchAppTemplate : defaultAppTemplate,
     variables,
   })
 }

--- a/packages/@sanity/cli/src/actions/init/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createCliConfig.ts
@@ -18,16 +18,45 @@ export default defineCliConfig({
 })
 `
 
+// The branded `unstable_defineApp` result is the sole workbench (module
+// federation) opt-in. Studios brand with name/title only — no `entry`
+// (studio app views aren't implemented yet).
+const workbenchTemplate = `
+import {defineCliConfig, unstable_defineApp} from 'sanity/cli'
+
+export default defineCliConfig({
+  api: {
+    projectId: '%projectId%',
+    dataset: '%dataset%'
+  },
+  app: unstable_defineApp({
+    name: '%name%',
+    title: '%title%',
+  }),
+  deployment: {
+    /**
+     * Enable auto-updates for studios.
+     * Learn more at https://www.sanity.io/docs/studio/latest-version-of-sanity#k47faf43faf56
+     */
+    autoUpdates: __BOOL__autoUpdates__,
+  },
+})
+`
+
 interface GenerateCliConfigOptions {
   autoUpdates: boolean
   dataset: string
+  extensionApi: boolean
+  name: string
   projectId: string
+  title: string
 }
 
 export function createCliConfig(options: GenerateCliConfigOptions): string {
+  const {extensionApi, ...variables} = options
   return processTemplate({
     includeBooleanTransform: true,
-    template: defaultTemplate,
-    variables: options,
+    template: extensionApi ? workbenchTemplate : defaultTemplate,
+    variables,
   })
 }

--- a/packages/@sanity/cli/src/actions/init/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createCliConfig.ts
@@ -46,17 +46,17 @@ export default defineCliConfig({
 interface GenerateCliConfigOptions {
   autoUpdates: boolean
   dataset: string
-  extensionApi: boolean
   name: string
   projectId: string
   title: string
+  workbench: boolean
 }
 
 export function createCliConfig(options: GenerateCliConfigOptions): string {
-  const {extensionApi, ...variables} = options
+  const {workbench, ...variables} = options
   return processTemplate({
     includeBooleanTransform: true,
-    template: extensionApi ? workbenchTemplate : defaultTemplate,
+    template: workbench ? workbenchTemplate : defaultTemplate,
     variables,
   })
 }

--- a/packages/@sanity/cli/src/actions/init/createStudioConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createStudioConfig.ts
@@ -31,6 +31,7 @@ export interface GenerateConfigOptions {
   variables: {
     autoUpdates: boolean
     dataset: string
+    extensionApi: boolean
     organizationId?: string
     projectId: string
     projectName?: string

--- a/packages/@sanity/cli/src/actions/init/createStudioConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createStudioConfig.ts
@@ -31,12 +31,12 @@ export interface GenerateConfigOptions {
   variables: {
     autoUpdates: boolean
     dataset: string
-    extensionApi: boolean
     organizationId?: string
     projectId: string
     projectName?: string
     sourceName?: string
     sourceTitle?: string
+    workbench: boolean
   }
 
   template?: ((variables: GenerateConfigOptions['variables']) => string) | string

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -285,14 +285,13 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
     return
   }
 
-  // The extension API is opt-in (no prompt): the flag swaps the scaffolded
+  // Workbench is opt-in (no prompt): the flag swaps the scaffolded
   // `sanity.cli.*` over to `unstable_defineApp` — the branded app is the sole
   // workbench opt-in.
-  const extensionApi = flagOrDefault(options.unstableExtensionApi, false)
+  const workbench = flagOrDefault(options.unstableWorkbench, false)
 
   const sharedParams = {
     defaults,
-    extensionApi,
     mcpConfigured,
     options,
     organizationId,
@@ -301,6 +300,7 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
     remoteTemplateInfo,
     sluggedName,
     trace,
+    workbench,
     workDir,
   }
 

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -285,8 +285,14 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
     return
   }
 
+  // The extension API is opt-in (no prompt): the flag swaps the scaffolded
+  // `sanity.cli.*` over to `unstable_defineApp` — the branded app is the sole
+  // workbench opt-in.
+  const extensionApi = flagOrDefault(options.unstableExtensionApi, false)
+
   const sharedParams = {
     defaults,
+    extensionApi,
     mcpConfigured,
     options,
     organizationId,

--- a/packages/@sanity/cli/src/actions/init/initApp.ts
+++ b/packages/@sanity/cli/src/actions/init/initApp.ts
@@ -15,7 +15,6 @@ import {type InitOptions} from './types.js'
 export async function initApp({
   datasetName,
   defaults,
-  extensionApi,
   mcpConfigured,
   options,
   organizationId,
@@ -25,11 +24,11 @@ export async function initApp({
   remoteTemplateInfo,
   sluggedName,
   trace,
+  workbench,
   workDir,
 }: {
   datasetName: string
   defaults: {projectName: string}
-  extensionApi: boolean
   mcpConfigured: EditorName[]
   options: InitOptions
   organizationId: string | undefined
@@ -39,6 +38,7 @@ export async function initApp({
   remoteTemplateInfo: RepoInfo | undefined
   sluggedName: string
   trace: TelemetryTrace<TelemetryUserProperties, InitStepResult>
+  workbench: boolean
   workDir: string
 }): Promise<void> {
   const {
@@ -59,7 +59,6 @@ export async function initApp({
     datasetName,
     defaults,
     displayName: '',
-    extensionApi,
     options,
     organizationId,
     output,
@@ -70,6 +69,7 @@ export async function initApp({
     templateName,
     trace,
     useTypeScript,
+    workbench,
     workDir,
   })
 

--- a/packages/@sanity/cli/src/actions/init/initApp.ts
+++ b/packages/@sanity/cli/src/actions/init/initApp.ts
@@ -15,6 +15,7 @@ import {type InitOptions} from './types.js'
 export async function initApp({
   datasetName,
   defaults,
+  extensionApi,
   mcpConfigured,
   options,
   organizationId,
@@ -28,6 +29,7 @@ export async function initApp({
 }: {
   datasetName: string
   defaults: {projectName: string}
+  extensionApi: boolean
   mcpConfigured: EditorName[]
   options: InitOptions
   organizationId: string | undefined
@@ -57,6 +59,7 @@ export async function initApp({
     datasetName,
     defaults,
     displayName: '',
+    extensionApi,
     options,
     organizationId,
     output,

--- a/packages/@sanity/cli/src/actions/init/initStudio.ts
+++ b/packages/@sanity/cli/src/actions/init/initStudio.ts
@@ -27,7 +27,6 @@ export async function initStudio({
   datasetName,
   defaults,
   displayName,
-  extensionApi,
   isFirstProject,
   mcpConfigured,
   options,
@@ -38,12 +37,12 @@ export async function initStudio({
   remoteTemplateInfo,
   sluggedName,
   trace,
+  workbench,
   workDir,
 }: {
   datasetName: string
   defaults: {projectName: string}
   displayName: string
-  extensionApi: boolean
   isFirstProject: boolean
   mcpConfigured: EditorName[]
   options: InitOptions
@@ -54,6 +53,7 @@ export async function initStudio({
   remoteTemplateInfo: RepoInfo | undefined
   sluggedName: string
   trace: TelemetryTrace<TelemetryUserProperties, InitStepResult>
+  workbench: boolean
   workDir: string
 }): Promise<void> {
   const {importDataset, unattended} = options
@@ -93,7 +93,6 @@ export async function initStudio({
     datasetName,
     defaults,
     displayName,
-    extensionApi,
     options,
     organizationId,
     output,
@@ -104,6 +103,7 @@ export async function initStudio({
     templateName,
     trace,
     useTypeScript,
+    workbench,
     workDir,
   })
 

--- a/packages/@sanity/cli/src/actions/init/initStudio.ts
+++ b/packages/@sanity/cli/src/actions/init/initStudio.ts
@@ -27,6 +27,7 @@ export async function initStudio({
   datasetName,
   defaults,
   displayName,
+  extensionApi,
   isFirstProject,
   mcpConfigured,
   options,
@@ -42,6 +43,7 @@ export async function initStudio({
   datasetName: string
   defaults: {projectName: string}
   displayName: string
+  extensionApi: boolean
   isFirstProject: boolean
   mcpConfigured: EditorName[]
   options: InitOptions
@@ -91,6 +93,7 @@ export async function initStudio({
     datasetName,
     defaults,
     displayName,
+    extensionApi,
     options,
     organizationId,
     output,

--- a/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
@@ -98,7 +98,6 @@ export async function scaffoldAndInstall({
   datasetName,
   defaults,
   displayName,
-  extensionApi,
   options,
   organizationId,
   output,
@@ -109,12 +108,12 @@ export async function scaffoldAndInstall({
   templateName,
   trace,
   useTypeScript,
+  workbench,
   workDir,
 }: {
   datasetName: string
   defaults: {projectName: string}
   displayName: string
-  extensionApi: boolean
   options: InitOptions
   organizationId: string | undefined
   output: Output
@@ -125,6 +124,7 @@ export async function scaffoldAndInstall({
   templateName: string
   trace: TelemetryTrace<TelemetryUserProperties, InitStepResult>
   useTypeScript: boolean
+  workbench: boolean
   workDir: string
 }): Promise<{pkgManager: PackageManager}> {
   const {autoUpdates, git, overwriteFiles, packageManager, templateToken, unattended} = options
@@ -134,7 +134,6 @@ export async function scaffoldAndInstall({
     autoUpdates,
     bearerToken: templateToken,
     dataset: datasetName,
-    extensionApi,
     organizationId,
     output,
     outputPath,
@@ -145,6 +144,7 @@ export async function scaffoldAndInstall({
     remoteTemplateInfo,
     templateName,
     useTypeScript,
+    workbench,
   })
 
   const pkgManager = await resolvePackageManager({

--- a/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
@@ -98,6 +98,7 @@ export async function scaffoldAndInstall({
   datasetName,
   defaults,
   displayName,
+  extensionApi,
   options,
   organizationId,
   output,
@@ -113,6 +114,7 @@ export async function scaffoldAndInstall({
   datasetName: string
   defaults: {projectName: string}
   displayName: string
+  extensionApi: boolean
   options: InitOptions
   organizationId: string | undefined
   output: Output
@@ -132,6 +134,7 @@ export async function scaffoldAndInstall({
     autoUpdates,
     bearerToken: templateToken,
     dataset: datasetName,
+    extensionApi,
     organizationId,
     output,
     outputPath,

--- a/packages/@sanity/cli/src/actions/init/types.ts
+++ b/packages/@sanity/cli/src/actions/init/types.ts
@@ -49,7 +49,7 @@ export interface InitOptions {
   template?: string
   templateToken?: string
   typescript?: boolean
-  unstableExtensionApi?: boolean
+  unstableWorkbench?: boolean
   visibility?: 'private' | 'public'
 }
 
@@ -89,7 +89,7 @@ interface InitCommandFlags {
   template?: string
   'template-token'?: string
   typescript?: boolean
-  'unstable-extension-api'?: boolean
+  'unstable--workbench'?: boolean
   visibility?: string
 }
 
@@ -147,7 +147,7 @@ export function flagsToInitOptions(
     templateToken: flags['template-token'],
     typescript: flags.typescript,
     unattended: isUnattended,
-    unstableExtensionApi: flags['unstable-extension-api'],
+    unstableWorkbench: flags['unstable--workbench'],
     visibility: narrowVisibility(flags.visibility),
   }
 }

--- a/packages/@sanity/cli/src/actions/init/types.ts
+++ b/packages/@sanity/cli/src/actions/init/types.ts
@@ -49,6 +49,7 @@ export interface InitOptions {
   template?: string
   templateToken?: string
   typescript?: boolean
+  unstableExtensionApi?: boolean
   visibility?: 'private' | 'public'
 }
 
@@ -88,6 +89,7 @@ interface InitCommandFlags {
   template?: string
   'template-token'?: string
   typescript?: boolean
+  'unstable-extension-api'?: boolean
   visibility?: string
 }
 
@@ -145,6 +147,7 @@ export function flagsToInitOptions(
     templateToken: flags['template-token'],
     typescript: flags.typescript,
     unattended: isUnattended,
+    unstableExtensionApi: flags['unstable-extension-api'],
     visibility: narrowVisibility(flags.visibility),
   }
 }

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -195,6 +195,7 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: 'test',
+      extensionApi: false,
       organizationId: undefined,
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),
@@ -227,6 +228,54 @@ describe('#init: bootstrap-app-initialization', () => {
     const bootstrapOrder = mocks.bootstrapTemplate.mock.invocationCallOrder[0]
     const skillsOrder = mocks.setupSkills.mock.invocationCallOrder[0]
     expect(skillsOrder).toBeGreaterThan(bootstrapOrder)
+  })
+
+  test('passes the extension API opt-in through to bootstrapTemplate', async () => {
+    setupInitSuccessMocks()
+
+    mocks.select.mockResolvedValueOnce('blog') // template
+
+    mockApi({
+      apiVersion: PROJECTS_API_VERSION,
+      method: 'get',
+      uri: '/projects/test',
+    }).reply(200, {
+      id: 'test',
+      metadata: {
+        cliInitializedAt: '',
+      },
+    })
+
+    mockApi({
+      apiVersion: MCP_JOURNEY_API_VERSION,
+      method: 'get',
+      uri: '/journey/mcp/post-init-prompt',
+    }).reply(200, {
+      message: 'Setup your Cursor IDE',
+    })
+
+    const {error} = await testCommand(
+      InitCommand,
+      [
+        '--output-path=/test/output',
+        '--project=test',
+        '--dataset=test',
+        '--package-manager=npm',
+        '--typescript',
+        '--unstable-extension-api',
+      ],
+      {
+        mocks: {
+          ...defaultMocks,
+          isInteractive: true,
+        },
+      },
+    )
+    if (error) throw error
+
+    expect(mocks.bootstrapTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({extensionApi: true}),
+    )
   })
 
   test('initializes app with env file', async () => {
@@ -289,6 +338,7 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: '',
+      extensionApi: false,
       organizationId: 'org-1',
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),
@@ -351,6 +401,7 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: '',
+      extensionApi: false,
       organizationId: 'org-1',
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),
@@ -421,6 +472,7 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: '',
+      extensionApi: false,
       organizationId: 'org-1',
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -195,7 +195,6 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: 'test',
-      extensionApi: false,
       organizationId: undefined,
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),
@@ -207,6 +206,7 @@ describe('#init: bootstrap-app-initialization', () => {
       schemaUrl: undefined,
       templateName: 'blog',
       useTypeScript: true,
+      workbench: false,
     })
     expect(stdout).toContain('Success! Your Studio has been created')
     expect(stdout).toContain(
@@ -230,7 +230,7 @@ describe('#init: bootstrap-app-initialization', () => {
     expect(skillsOrder).toBeGreaterThan(bootstrapOrder)
   })
 
-  test('passes the extension API opt-in through to bootstrapTemplate', async () => {
+  test('passes the workbench opt-in through to bootstrapTemplate', async () => {
     setupInitSuccessMocks()
 
     mocks.select.mockResolvedValueOnce('blog') // template
@@ -262,7 +262,7 @@ describe('#init: bootstrap-app-initialization', () => {
         '--dataset=test',
         '--package-manager=npm',
         '--typescript',
-        '--unstable-extension-api',
+        '--unstable--workbench',
       ],
       {
         mocks: {
@@ -273,9 +273,7 @@ describe('#init: bootstrap-app-initialization', () => {
     )
     if (error) throw error
 
-    expect(mocks.bootstrapTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({extensionApi: true}),
-    )
+    expect(mocks.bootstrapTemplate).toHaveBeenCalledWith(expect.objectContaining({workbench: true}))
   })
 
   test('initializes app with env file', async () => {
@@ -338,7 +336,6 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: '',
-      extensionApi: false,
       organizationId: 'org-1',
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),
@@ -349,6 +346,7 @@ describe('#init: bootstrap-app-initialization', () => {
       remoteTemplateInfo: undefined,
       templateName: 'app-quickstart',
       useTypeScript: true,
+      workbench: false,
     })
 
     // App-specific success message (not Studio message)
@@ -401,7 +399,6 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: '',
-      extensionApi: false,
       organizationId: 'org-1',
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),
@@ -412,6 +409,7 @@ describe('#init: bootstrap-app-initialization', () => {
       remoteTemplateInfo: undefined,
       templateName: 'app-quickstart',
       useTypeScript: true,
+      workbench: false,
     })
 
     // No prompts should have been called
@@ -472,7 +470,6 @@ describe('#init: bootstrap-app-initialization', () => {
       autoUpdates: true,
       bearerToken: undefined,
       dataset: '',
-      extensionApi: false,
       organizationId: 'org-1',
       output: expect.any(Object),
       outputPath: convertToSystemPath('/test/output'),
@@ -483,6 +480,7 @@ describe('#init: bootstrap-app-initialization', () => {
       remoteTemplateInfo: undefined,
       templateName: 'app-quickstart',
       useTypeScript: true,
+      workbench: false,
     })
 
     // No prompts should have been called — CI detection makes init unattended

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -201,12 +201,11 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       description: 'Enable TypeScript support',
       exclusive: ['bare'],
     }),
-    'unstable-extension-api': Flags.boolean({
+    'unstable--workbench': Flags.boolean({
       allowNo: true,
       default: undefined,
-      description:
-        'Opt into the unstable extension API: scaffolds the CLI config with unstable_defineApp',
-      // Internal-only while the extension API is unstable — keep it out of help/docs
+      description: 'Opt into workbench: scaffolds the CLI config with unstable_defineApp',
+      // Internal-only while workbench is unstable — keep it out of help/docs
       hidden: true,
     }),
     visibility: Flags.string({

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -206,6 +206,8 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       default: undefined,
       description:
         'Opt into the unstable extension API: scaffolds the CLI config with unstable_defineApp',
+      // Internal-only while the extension API is unstable — keep it out of help/docs
+      hidden: true,
     }),
     visibility: Flags.string({
       description: 'Visibility mode for dataset',

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -201,6 +201,12 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
       description: 'Enable TypeScript support',
       exclusive: ['bare'],
     }),
+    'unstable-extension-api': Flags.boolean({
+      allowNo: true,
+      default: undefined,
+      description:
+        'Opt into the unstable extension API: scaffolds the CLI config with unstable_defineApp',
+    }),
     visibility: Flags.string({
       description: 'Visibility mode for dataset',
       helpValue: '<mode>',


### PR DESCRIPTION
### Description

Follow-up to #1143, which removed the `--federation` flag (and its prompt) from `sanity init` along with the `federation: { enabled }` config it scaffolded.

This brings back an init-time opt-in: `--unstable--workbench` (hidden from help/docs — internal-only while the API is unstable). Since the branded `unstable_defineApp` result is now the sole workbench opt-in, the flag scaffolds the `sanity.cli.*` with it instead of a config flag:

- **SDK apps** get `app: unstable_defineApp({ name, title, organizationId, entry })` — `entry` auto-declares the navigable app view (US5).
- **Studios** get `app: unstable_defineApp({ name, title })` alongside the usual `api`/`deployment` blocks — branding only, no `entry` (studio app views aren't implemented yet, FR-026).
- The `sanity` dependency is pinned to the `workbench` dist-tag, since that's where the `sanity/cli` re-export of `unstable_defineApp` lives.

Differences from the old flag: no prompt and default off — workbench stays opt-in, matching #1143's direction. `name` reuses the package name (slugged project name for studios, output-dir basename for apps), `title` the project display name.

Spec: [002-workbench-extension-api](https://github.com/sanity-io/workbench/tree/main/specs/002-workbench-extension-api)

### What to review

- The generated config templates in `createCliConfig.ts` / `createAppCliConfig.ts` — sane `unstable_defineApp` shapes for studio vs app?
- Flag naming and plumbing (`unstable--workbench` → `unstableWorkbench` → `workbench` through the bootstrap chain).
- Restored the `workbench` dist-tag tests from before #1143 in `bootstrapLocalTemplate.test.ts`, plus new assertions on the generated `sanity.cli.ts`.

### Testing

Unit tests cover the flag mapping, the bootstrapTemplate pass-through, the dist-tag override, and the generated config content for both template kinds (enabled and disabled). Full `@sanity/cli` suite passes (2540 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in hidden flag with default-off behavior; changes only affect new projects that explicitly pass the flag, not existing init flows.
> 
> **Overview**
> Adds a hidden, opt-in **`--unstable--workbench`** flag to `sanity init` (default off, no prompt). When set, init threads **`workbench: true`** through bootstrap and changes what gets scaffolded.
> 
> **Scaffolding:** Generated `sanity.cli.*` switches from plain `defineCliConfig` to **`app: unstable_defineApp({...})`** — SDK apps include `name`, `title`, `organizationId`, and `entry`; studios add branding (`name`/`title`) alongside existing `api`/`deployment` but **omit `entry`**. **`sanity`** is resolved from the **`workbench`** npm dist-tag instead of `latest` so `unstable_defineApp` from `sanity/cli` is available.
> 
> **Plumbing:** Flag maps `unstable--workbench` → `unstableWorkbench` in init options; `initAction` derives `workbench` and passes it through `scaffoldTemplate` / `bootstrapTemplate`. Unit tests cover flag mapping, init pass-through, dist-tag override, and generated CLI config for studio and app templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266418c1a018fb3c2837b81572857c0b59166357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->