### PR TITLE
fix: don't treat ignored build scripts as failure during dep install

### DIFF
--- a/.changeset/pr-1237.md
+++ b/.changeset/pr-1237.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix: don't treat ignored build scripts as failure during dep install

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/installPackages.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/installPackages.test.ts
@@ -67,6 +67,7 @@ describe('installDeclaredPackages', () => {
       cwd: workDir,
       encoding: 'utf8',
       env: {PATH: '/mock/path'},
+      reject: false,
       stdio: 'pipe',
     })
     expect(mockSpinnerInstance.start).toHaveBeenCalled()
@@ -88,6 +89,7 @@ describe('installDeclaredPackages', () => {
       cwd: workDir,
       encoding: 'utf8',
       env: {PATH: '/mock/path'},
+      reject: false,
       stdio: 'pipe',
     })
     expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
@@ -107,6 +109,7 @@ describe('installDeclaredPackages', () => {
       cwd: workDir,
       encoding: 'utf8',
       env: {PATH: '/mock/path'},
+      reject: false,
       stdio: 'pipe',
     })
     expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
@@ -126,6 +129,7 @@ describe('installDeclaredPackages', () => {
       cwd: workDir,
       encoding: 'utf8',
       env: {PATH: '/mock/path'},
+      reject: false,
       stdio: 'pipe',
     })
     expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
@@ -190,6 +194,7 @@ describe('installNewPackages', () => {
       cwd: workDir,
       encoding: 'utf8',
       env: {PATH: '/mock/path'},
+      reject: false,
       stdio: 'pipe',
     })
     expect(mockSpinnerInstance.start).toHaveBeenCalled()
@@ -214,6 +219,7 @@ describe('installNewPackages', () => {
       cwd: workDir,
       encoding: 'utf8',
       env: {PATH: '/mock/path'},
+      reject: false,
       stdio: 'pipe',
     })
     expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
@@ -234,6 +240,7 @@ describe('installNewPackages', () => {
       cwd: workDir,
       encoding: 'utf8',
       env: {PATH: '/mock/path'},
+      reject: false,
       stdio: 'pipe',
     })
     expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
@@ -254,6 +261,7 @@ describe('installNewPackages', () => {
       cwd: workDir,
       encoding: 'utf8',
       env: {PATH: '/mock/path'},
+      reject: false,
       stdio: 'pipe',
     })
     expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
@@ -317,9 +325,190 @@ describe('installNewPackages', () => {
       cwd: workDir,
       encoding: 'utf8',
       env: {PATH: '/mock/path'},
+      reject: false,
       stdio: 'pipe',
     })
     expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
+  })
+})
+
+describe('pnpm ignored build scripts', () => {
+  const workDir = '/test/project'
+  const context = {output: mockOutput, workDir}
+
+  const approveBuildsNotice =
+    'pnpm skipped build scripts for some dependencies. Run "pnpm approve-builds" in the project directory to pick which dependencies should be allowed to run scripts.'
+
+  test('treats ignored esbuild build script as success without notice', async () => {
+    const mockResult: Partial<Result> = {
+      exitCode: 1,
+      failed: true,
+      stderr: [
+        ' ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.28.0',
+        '',
+        'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.',
+      ].join('\n'),
+      stdout: 'Packages: +123',
+    }
+    mockExeca.mockResolvedValueOnce(mockResult as Result)
+
+    await installDeclaredPackages(workDir, 'pnpm', context)
+
+    expect(mockExeca).toHaveBeenCalledTimes(1)
+    expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
+    expect(mockSpinnerInstance.fail).not.toHaveBeenCalled()
+    expect(mockOutput.warn).not.toHaveBeenCalled()
+    expect(mockOutput.error).not.toHaveBeenCalled()
+  })
+
+  test('treats ignored builds as success but prints notice for non-esbuild packages', async () => {
+    const mockResult: Partial<Result> = {
+      exitCode: 1,
+      failed: true,
+      stderr: [
+        ' ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.28.0, sharp@0.34.1.',
+        '',
+        'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.',
+      ].join('\n'),
+      stdout: 'Packages: +123',
+    }
+    mockExeca.mockResolvedValueOnce(mockResult as Result)
+
+    await installDeclaredPackages(workDir, 'pnpm', context)
+
+    expect(mockExeca).toHaveBeenCalledTimes(1)
+    expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
+    expect(mockSpinnerInstance.fail).not.toHaveBeenCalled()
+    expect(mockOutput.warn).toHaveBeenCalledWith(approveBuildsNotice)
+    expect(mockOutput.error).not.toHaveBeenCalled()
+  })
+
+  test('prints notice for scoped packages with ignored build scripts', async () => {
+    const mockResult: Partial<Result> = {
+      exitCode: 1,
+      failed: true,
+      stdout: ' ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: @tailwindcss/oxide@4.0.0',
+    }
+    mockExeca.mockResolvedValueOnce(mockResult as Result)
+
+    await installDeclaredPackages(workDir, 'pnpm', context)
+
+    expect(mockExeca).toHaveBeenCalledTimes(1)
+    expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
+    expect(mockOutput.warn).toHaveBeenCalledWith(approveBuildsNotice)
+    expect(mockOutput.error).not.toHaveBeenCalled()
+  })
+
+  test('handles line-wrapped error output', async () => {
+    const mockResult: Partial<Result> = {
+      exitCode: 1,
+      failed: true,
+      stderr: [
+        ' ERR_PNPM_IGNORED_BUILDS  Ignored build',
+        'scripts: esbuild@0.28.0,',
+        'sharp@0.34.1.',
+        '',
+        'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.',
+      ].join('\n'),
+    }
+    mockExeca.mockResolvedValueOnce(mockResult as Result)
+
+    await installDeclaredPackages(workDir, 'pnpm', context)
+
+    expect(mockExeca).toHaveBeenCalledTimes(1)
+    expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
+    expect(mockSpinnerInstance.fail).not.toHaveBeenCalled()
+    expect(mockOutput.warn).toHaveBeenCalledWith(approveBuildsNotice)
+    expect(mockOutput.error).not.toHaveBeenCalled()
+  })
+
+  test('does not print notice when wrapped output only skips esbuild', async () => {
+    const mockResult: Partial<Result> = {
+      exitCode: 1,
+      failed: true,
+      stderr: [
+        ' ERR_PNPM_IGNORED_BUILDS  Ignored build',
+        'scripts: esbuild@0.28.0',
+        '',
+        'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.',
+      ].join('\n'),
+    }
+    mockExeca.mockResolvedValueOnce(mockResult as Result)
+
+    await installDeclaredPackages(workDir, 'pnpm', context)
+
+    expect(mockExeca).toHaveBeenCalledTimes(1)
+    expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
+    expect(mockOutput.warn).not.toHaveBeenCalled()
+    expect(mockOutput.error).not.toHaveBeenCalled()
+  })
+
+  test('applies to installNewPackages as well', async () => {
+    const mockResult: Partial<Result> = {
+      exitCode: 1,
+      failed: true,
+      stderr: ' ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.28.0',
+    }
+    mockExeca.mockResolvedValueOnce(mockResult as Result)
+
+    await installNewPackages({packageManager: 'pnpm', packages: ['lodash']}, context)
+
+    expect(mockExeca).toHaveBeenCalledTimes(1)
+    expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
+    expect(mockOutput.warn).not.toHaveBeenCalled()
+    expect(mockOutput.error).not.toHaveBeenCalled()
+  })
+
+  test('does not apply ignored builds handling for other package managers', async () => {
+    const mockResult: Partial<Result> = {
+      exitCode: 1,
+      failed: true,
+      stdout: ' ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.28.0',
+    }
+    mockExeca.mockResolvedValueOnce(mockResult as Result)
+
+    await installDeclaredPackages(workDir, 'npm', context)
+
+    expect(mockExeca).toHaveBeenCalledTimes(1)
+    expect(mockSpinnerInstance.fail).toHaveBeenCalled()
+    expect(mockOutput.error).toHaveBeenCalledWith('Dependency installation failed', {exit: 1})
+  })
+
+  test('prints notice for whitespace-separated package list', async () => {
+    const mockResult: Partial<Result> = {
+      exitCode: 1,
+      failed: true,
+      stdout: ' ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.28.0 sharp@0.34.1',
+    }
+    mockExeca.mockResolvedValueOnce(mockResult as Result)
+
+    await installDeclaredPackages(workDir, 'pnpm', context)
+
+    expect(mockExeca).toHaveBeenCalledTimes(1)
+    expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
+    expect(mockOutput.warn).toHaveBeenCalledWith(approveBuildsNotice)
+    expect(mockOutput.error).not.toHaveBeenCalled()
+  })
+
+  test('still fails pnpm installs without the ignored builds marker', async () => {
+    const mockResult: Partial<Result> = {
+      exitCode: 1,
+      failed: true,
+      stderr: ' ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/nope: Not Found - 404',
+      stdout: 'Packages: +0',
+    }
+    mockExeca.mockResolvedValueOnce(mockResult as Result)
+
+    await installDeclaredPackages(workDir, 'pnpm', context)
+
+    expect(mockExeca).toHaveBeenCalledTimes(1)
+    expect(mockSpinnerInstance.fail).toHaveBeenCalled()
+    expect(mockOutput.warn).not.toHaveBeenCalled()
+    // The actionable error lives on stderr, so it must be surfaced to the user.
+    expect(mockOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining('ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/nope'),
+    )
+    expect(mockOutput.error).toHaveBeenCalledWith('Dependency installation failed', {exit: 1})
   })
 })
 

--- a/packages/@sanity/cli/src/util/packageManager/installPackages.ts
+++ b/packages/@sanity/cli/src/util/packageManager/installPackages.ts
@@ -34,6 +34,36 @@ const PACKAGE_MANAGER_COMMANDS: PackageManagerCommands = {
   },
 }
 
+const IGNORED_BUILDS_NOTICE =
+  'pnpm skipped build scripts for some dependencies. Run "pnpm approve-builds" in the project directory to pick which dependencies should be allowed to run scripts.'
+
+// Matches pnpm's `ERR_PNPM_IGNORED_BUILDS` error against whitespace-normalized
+// output (pnpm may wrap the message), capturing the list of skipped packages,
+// eg `esbuild@0.25.0, sharp@0.34.0.` - the `<pkg>@<version>` token sequence
+// ends the capture where the trailing `Run "pnpm approve-builds"…` hint starts
+const IGNORED_BUILDS_PATTERN =
+  /ERR_PNPM_IGNORED_BUILDS.*?Ignored build scripts: ?((?:[^\s,]+@[^\s,]+[, ]*)+)/
+
+function getIgnoredBuildScripts(commandOutput: string): string[] | undefined {
+  const match = commandOutput.replaceAll(/\s+/g, ' ').match(IGNORED_BUILDS_PATTERN)
+  if (!match) {
+    return undefined
+  }
+
+  // The capture allows both comma and whitespace separators (pnpm may print
+  // either, and wrapping can drop the comma), so split on both.
+  return match[1]
+    .split(/[\s,]+/)
+    .map((entry) => entry.replace(/\.$/, ''))
+    .filter(Boolean)
+}
+
+function isEsbuild(ignoredEntry: string): boolean {
+  // Entries are on the form `<pkg-name>@<version>` - strip the version,
+  // keeping in mind that scoped package names also start with `@`
+  return ignoredEntry.replace(/@[^@]+$/, '') === 'esbuild'
+}
+
 async function executePackageManagerCommand(
   packageManager: PackageManagerLibs,
   args: string[],
@@ -46,8 +76,28 @@ async function executePackageManagerCommand(
   const result = await execa(packageManager, args, execOptions)
 
   if (result?.exitCode || result?.failed) {
+    // pnpm exits non-zero if dependency build scripts were skipped, even though
+    // the install itself succeeded. Treat it as a success, but point to
+    // `pnpm approve-builds` if anything other than esbuild was skipped
+    // (esbuild works without its build script through a JS fallback).
+    const commandOutput = [result.stdout, result.stderr]
+      .filter((chunk): chunk is string => typeof chunk === 'string')
+      .join('\n')
+    const ignoredBuilds =
+      packageManager === 'pnpm' ? getIgnoredBuildScripts(commandOutput) : undefined
+
+    if (ignoredBuilds) {
+      progress.succeed()
+      if (ignoredBuilds.some((entry) => !isEsbuild(entry))) {
+        output.warn(IGNORED_BUILDS_NOTICE)
+      }
+      return
+    }
+
     progress.fail()
-    output.log(String(result.stdout))
+    // Log both streams - package managers often print the actionable error
+    // details to stderr, so logging stdout alone can hide the failure reason.
+    output.log(commandOutput)
     output.error(errorMessage, {exit: 1})
   } else {
     progress.succeed()
@@ -64,6 +114,7 @@ export async function installDeclaredPackages(
     cwd,
     encoding: 'utf8',
     env: getPartialEnvWithNpmPath(cwd),
+    reject: false,
     stdio: 'pipe',
   }
 
@@ -92,6 +143,7 @@ export async function installNewPackages(
     cwd: workDir,
     encoding: 'utf8',
     env: getPartialEnvWithNpmPath(workDir),
+    reject: false,
     stdio: 'pipe',
   }
 


### PR DESCRIPTION
### Description

SDK-1654

When running `npm create sanity`/`sanity init`, if selecting pnpm to use for installing dependencies you can get into this situation where pnpm installs dependencies, but exits with a non-zero exit code, and a message like:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.28.0

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

We need to allow this to happen - treating it as if this was a success (which it kind of is), instead of failing the onboarding process. Since esbuild works fine for the vast majority of cases without running the postinstall script, I decided to not show the "Run 'pnpm approve-builds'" text if that is the only dependency that needs it - but open to changing/removing that, just figured it would be less noise.

> [!NOTE]
> `pnpm create sanity` has a similar problem, but during the `pnpx` stage. This is harder to fix, but might be solved if/when https://github.com/sanity-io/cli/pull/1011 lands

### What to review

Does the change seem sensible?

### Testing

New tests added.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CLI package install error handling for pnpm; real install failures still exit with an error, with broader test coverage.
> 
> **Overview**
> Fixes **pnpm** dependency installs during Sanity CLI onboarding (`sanity init` / `npm create sanity`) when pnpm exits non-zero after **`ERR_PNPM_IGNORED_BUILDS`** even though packages were installed.
> 
> **`installPackages`** now runs package-manager commands with **`reject: false`**, detects ignored-build-script output (including wrapped/whitespace-separated lists), and treats that case as **success**. If only **esbuild** was skipped, no extra message is shown; for other packages (e.g. **sharp**, scoped names), it **warns** to run **`pnpm approve-builds`**. Real failures still fail the spinner but now log **stdout and stderr** so errors on stderr are visible. Behavior is unchanged for npm/yarn/bun.
> 
> Tests cover the new pnpm paths plus updated **`execa`** expectations; changeset is a **patch** for **`@sanity/cli`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3452a2f9763c48aa752a3f16770ed0d0afc7ee68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->