### PR TITLE
chore(workbench): bump @sanity/federation to 0.1.0-alpha.10

### DIFF
--- a/.changeset/bump-federation-alpha-10.md
+++ b/.changeset/bump-federation-alpha-10.md
@@ -1,0 +1,6 @@
+---
+"@sanity/cli": patch
+"@sanity/cli-build": patch
+---
+
+bump @sanity/federation to 0.1.0-alpha.10

--- a/fixtures/federated-studio/package.json
+++ b/fixtures/federated-studio/package.json
@@ -12,7 +12,7 @@
     "build:fixture": "sanity build"
   },
   "dependencies": {
-    "@sanity/federation": "0.1.0-alpha.9",
+    "@sanity/federation": "0.1.0-alpha.10",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "sanity": "catalog:",

--- a/package.json
+++ b/package.json
@@ -81,8 +81,7 @@
       "node-pty"
     ],
     "overrides": {
-      "@sanity/cli": "workspace:*",
-      "@sanity/federation": "https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634"
+      "@sanity/cli": "workspace:*"
     }
   }
 }

--- a/packages/@sanity/cli-build/package.json
+++ b/packages/@sanity/cli-build/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@oclif/core": "catalog:",
     "@sanity/cli-core": "workspace:^",
-    "@sanity/federation": "0.1.0-alpha.9",
+    "@sanity/federation": "0.1.0-alpha.10",
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/schema": "catalog:",
     "@sanity/telemetry": "catalog:",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -84,7 +84,7 @@
     "@sanity/codegen": "catalog:",
     "@sanity/descriptors": "^1.3.0",
     "@sanity/export": "^6.2.0",
-    "@sanity/federation": "0.1.0-alpha.9",
+    "@sanity/federation": "0.1.0-alpha.10",
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/id-utils": "^1.0.0",
     "@sanity/import": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,6 @@ catalogs:
 overrides:
   '@sanity/client': ^7.22.0
   '@sanity/cli': workspace:*
-  '@sanity/federation': https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634
 
 importers:
 
@@ -266,8 +265,8 @@ importers:
   fixtures/federated-studio:
     dependencies:
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: 0.1.0-alpha.10
+        version: 0.1.0-alpha.10(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -538,8 +537,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: 0.1.0-alpha.10
+        version: 0.1.0-alpha.10(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -827,8 +826,8 @@ importers:
         specifier: workspace:^
         version: link:../cli-core
       '@sanity/federation':
-        specifier: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634
-        version: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: 0.1.0-alpha.10
+        version: 0.1.0-alpha.10(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -4910,9 +4909,8 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634':
-    resolution: {integrity: sha512-+X83XpGjRHdlWPDdSJ+6EbrOheGQ7FC0l0vJlWSQd6LpvJmY2FfEcRbeIu/MhVNESUveppI43YfgXX84Q6biGQ==, tarball: https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634}
-    version: 0.1.0-alpha.9
+  '@sanity/federation@0.1.0-alpha.10':
+    resolution: {integrity: sha512-4bs2OKoIAitDM0kyDsCJL+prdUrhTFYaZIvQ+CgoVGCsHTOEVTNymC9EdpYdL5jjvsui91A8pptGTNaNhQZtYw==}
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
       vite: ^7.0.0 || ^8.0.0
@@ -14505,7 +14503,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@0.1.0-alpha.10(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -14518,7 +14516,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@sanity/federation@https://pkg.pr.new/sanity-io/workbench/@sanity/federation@50fd634(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sanity/federation@0.1.0-alpha.10(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@module-federation/runtime': 2.5.0
       '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.0.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,5 +94,3 @@ minimumReleaseAgeExclude:
   - 'jiti@2.7.0'
   # Renovate security update: turbo@2.9.14
   - turbo@2.9.14
-  # Required by @sanity/federation@0.1.0-alpha.8
-  - '@module-federation/vite@1.16.0'


### PR DESCRIPTION
Moves `@sanity/cli` and `@sanity/cli-build` onto the published `@sanity/federation@0.1.0-alpha.10` — the same work that was riding the pkg.pr.new preview pin (`@50fd634`), now shipped from npm.

- Both packages (plus the `federated-studio` fixture) declare `0.1.0-alpha.10` directly.
- Dropped the `pnpm.overrides` entry for `@sanity/federation` entirely. It existed to force the preview build globally; the only consumers are these workspace packages, and nothing transitive pulls federation, so the direct declarations are enough.
- Dropped the `@module-federation/vite@1.16.0` `minimumReleaseAgeExclude` entry — it was there for an earlier alpha and isn't needed anymore (resolution stays on 1.16.0).