### PR TITLE
refactor: extract emptyAuth object to avoid duplication in getStudioWorkspaces

### DIFF
--- a/packages/@sanity/cli-core/src/config/studio/getStudioWorkspaces.ts
+++ b/packages/@sanity/cli-core/src/config/studio/getStudioWorkspaces.ts
@@ -57,9 +57,11 @@ export async function getStudioWorkspaces(configPath: string): Promise<Workspace
     ? config
     : [{...config, basePath: config.basePath || '/', name: config.name || 'default'}]
 
+  const emptyAuth = {state: of(getEmptyAuth())}
+
   const unauthedWorkspaces = rawWorkspaces.map((workspace) => ({
     ...workspace,
-    auth: {state: of(getEmptyAuth())},
+    auth: emptyAuth,
   }))
 
   debug('Unauthed workspaces %o', unauthedWorkspaces)


### PR DESCRIPTION
### Description

Should fix #1239 

### What to review


### Testing
