### PR TITLE
feat(workbench): reject --external deploy for federated applications

### DIFF
--- a/.changeset/pr-1241.md
+++ b/.changeset/pr-1241.md
@@ -3,4 +3,4 @@
 '@sanity/cli': minor
 ---
 
-feat(workbench): reject --external deploy for unstable_defineApp applications
+feat(workbench): reject --external deploy for federated applications

--- a/.changeset/pr-1241.md
+++ b/.changeset/pr-1241.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(workbench): reject --external deploy for unstable_defineApp applications

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -4,7 +4,7 @@ import {createGzip, type Gzip} from 'node:zlib'
 
 import {CLIError} from '@oclif/core/errors'
 import {formatSchemaValidation, SchemaExtractionError} from '@sanity/cli-build/_internal/extract'
-import {exitCodes, getLocalPackageVersion, type Output} from '@sanity/cli-core'
+import {exitCodes, getLocalPackageVersion, isWorkbenchApp, type Output} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {type StudioManifest} from 'sanity'
 import {pack} from 'tar-fs'
@@ -35,6 +35,18 @@ export async function deployStudio(options: DeployAppOptions) {
 
   const isExternal = !!flags.external
   const urlType: 'external' | 'internal' = isExternal ? 'external' : 'internal'
+
+  // `unstable_defineApp` applications integrate through Sanity's build and
+  // hosting pipeline, which `--external` skips. Fail before any prompts or
+  // API calls.
+  if (isExternal && isWorkbenchApp(cliConfig.app)) {
+    output.error(
+      'Deploying an `unstable_defineApp` application to an external host is not supported. ' +
+        'Deploy without `--external`.',
+      {exit: exitCodes.USAGE_ERROR},
+    )
+    return
+  }
 
   // Resolve the app host from --url flag (takes precedence) or studioHost config
   const appHost = resolveAppHost({flags, isExternal, output, studioHost: cliConfig.studioHost})

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -36,13 +36,13 @@ export async function deployStudio(options: DeployAppOptions) {
   const isExternal = !!flags.external
   const urlType: 'external' | 'internal' = isExternal ? 'external' : 'internal'
 
-  // `unstable_defineApp` applications integrate through Sanity's build and
-  // hosting pipeline, which `--external` skips. Fail before any prompts or
-  // API calls.
+  // Federated (`unstable_defineApp`) applications integrate through Sanity's
+  // build and hosting pipeline, which `--external` skips. Fail before any
+  // prompts or API calls.
   if (isExternal && isWorkbenchApp(cliConfig.app)) {
     output.error(
-      'Deploying an `unstable_defineApp` application to an external host is not supported. ' +
-        'Deploy without `--external`.',
+      'Deploying a federated application to an external host is not yet supported. ' +
+        'Remove the `--external` flag to deploy to Sanity hosting.',
       {exit: exitCodes.USAGE_ERROR},
     )
     return

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
@@ -1,6 +1,7 @@
-import {exitCodes, studioWorkerTask} from '@sanity/cli-core'
+import {type CliConfig, exitCodes, studioWorkerTask} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
+import {unstable_defineApp} from '@sanity/federation'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -835,6 +836,38 @@ describe('#deploy studio (external)', () => {
       )
       expect(mockBuildStudio).not.toHaveBeenCalled()
       expect(mockCheckDir).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unstable_defineApp', () => {
+    test('should reject --external for an unstable_defineApp studio', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      // Brand the config as a studio so the deploy command routes it through
+      // deployStudio (the only path that accepts --external).
+      const app = unstable_defineApp({
+        name: 'test-studio',
+        title: 'Test Studio',
+      }) as unknown as NonNullable<CliConfig['app']> & {applicationType?: string}
+      app.applicationType = 'studio'
+
+      const {error} = await testCommand(DeployCommand, ['--external'], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId: 'test-project-id'},
+            app,
+            studioHost: 'https://studio.example.com',
+          } as CliConfig,
+        },
+      })
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain(
+        'Deploying an `unstable_defineApp` application to an external host is not supported',
+      )
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
   })
 })

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
@@ -865,7 +865,7 @@ describe('#deploy studio (external)', () => {
 
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain(
-        'Deploying an `unstable_defineApp` application to an external host is not supported',
+        'Deploying a federated application to an external host is not yet supported',
       )
       expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })


### PR DESCRIPTION
### Description

`sanity deploy --external` registers an externally hosted studio and skips the build pipeline entirely. `unstable_defineApp` applications integrate through Sanity's build and hosting, so registering one against an external host would advertise an application nothing serves.

The deploy now fails fast with a usage error when the config's `app` is a branded `unstable_defineApp(...)` result and `--external` is passed — before any prompts or API calls. Legacy `app` configs are unaffected; the guard keys off the brand symbol only `unstable_defineApp` stamps.

### What to review

The guard lives in `deployStudio` because that's the only path `--external` can reach — `deployApp` already rejects the flag for all SDK apps. The remaining gap was a workbench-branded config with `applicationType: 'studio'`.

### Testing

Added a test that builds a real `unstable_defineApp` config (typed as a studio so it routes through `deployStudio`) and asserts the error message and `USAGE_ERROR` exit code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deploy preflight and CLI error paths for studio/app uploads; incorrect federation validation could block valid workbench deploys, but scope is limited to deploy commands.
> 
> **Overview**
> **Blocks `sanity deploy --external` for federated (`unstable_defineApp`) configs** in `deployStudio`, exiting with a usage error before prompts or API calls so workbench apps cannot be registered as externally hosted.
> 
> **Workbench deploy validation:** `checkDir` can validate a **module federation** build (`mf-manifest.json`, remote entry, and manifest-referenced assets) instead of `index.html` when `isWorkbenchApp` is set; app and studio internal deploys pass that flag from `isWorkbenchApp(cliConfig.app)`.
> 
> **Deploy UX:** Pre-upload **`logUploadSummary`** logs the deployment POST target, metadata, and tarball size/file listing (skipped for external studios with no tarball). **`getDeploymentEndpoint`** is shared with `createDeployment`. Directory check failures now print the **underlying error message** instead of a generic label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c83ec607f2d5aaa08c68389773adee1a2a5efe78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->