### PR TITLE
feat: install sanity-migration skill alongside sanity-best-practices

### DIFF
--- a/.changeset/pr-1242.md
+++ b/.changeset/pr-1242.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat: install sanity-migration skill alongside sanity-best-practices

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/promptForMCPSetup.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/promptForMCPSetup.test.ts
@@ -33,13 +33,13 @@ describe('promptForMCPSetup', () => {
 
     await promptForMCPSetup({
       choices: [choice(makeEditor({name: 'Cursor'}), 'mcp-and-skill')],
-      message: 'Configure Sanity MCP and agent skill for these editors?',
+      message: 'Configure Sanity MCP and agent skills for these editors?',
     })
 
     expect(mockCheckbox).toHaveBeenCalledWith(
       expect.objectContaining({
         choices: [{checked: true, name: 'Cursor', value: 'Cursor'}],
-        message: 'Configure Sanity MCP and agent skill for these editors?',
+        message: 'Configure Sanity MCP and agent skills for these editors?',
       }),
     )
   })
@@ -91,7 +91,7 @@ describe('promptForMCPSetup', () => {
         choices: [
           {
             checked: true,
-            name: 'Cursor (skill only — MCP already configured)',
+            name: 'Cursor (skills only — MCP already configured)',
             value: 'Cursor',
           },
         ],

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts
@@ -132,7 +132,9 @@ describe('setupMCP', () => {
 
     const result = await setupMCP({mode: 'auto', skillsMode: 'auto'})
 
-    expect(mockReadSkillState).toHaveBeenCalledWith({skillName: 'sanity-best-practices'})
+    expect(mockReadSkillState).toHaveBeenCalledWith({
+      skillNames: ['sanity-best-practices', 'sanity-migration'],
+    })
     expect(result.configuredEditors).toEqual(['Cursor'])
     expect(result.skillsToInstall).toEqual(['cursor'])
   })
@@ -259,7 +261,7 @@ describe('setupMCP', () => {
 
     expect(mockPromptForMCPSetup).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: 'Configure Sanity MCP and agent skill for these editors?',
+        message: 'Configure Sanity MCP and agent skills for these editors?',
       }),
     )
   })

--- a/packages/@sanity/cli/src/actions/mcp/promptForMCPSetup.ts
+++ b/packages/@sanity/cli/src/actions/mcp/promptForMCPSetup.ts
@@ -13,7 +13,7 @@ export interface EditorChoice {
 function getEditorLabel(choice: EditorChoice): string {
   const {action, editor} = choice
   if (action === 'skill-only') {
-    return `${editor.name} (skill only — MCP already configured)`
+    return `${editor.name} (skills only — MCP already configured)`
   }
   if (editor.configured && editor.authStatus === 'unauthorized') {
     return `${editor.name} (auth expired)`

--- a/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
+++ b/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
@@ -4,7 +4,7 @@ import {logSymbols} from '@sanity/cli-core/ux'
 
 import {createMCPToken, MCP_SERVER_URL} from '../../services/mcp.js'
 import {readSkillState} from '../skills/readSkillState.js'
-import {SANITY_SKILL_NAME} from '../skills/setupSkills.js'
+import {SANITY_SKILL_NAMES} from '../skills/setupSkills.js'
 import {detectAvailableEditors} from './detectAvailableEditors.js'
 import {
   EDITOR_CONFIGS,
@@ -75,7 +75,7 @@ interface ClassifiedEditor {
 
 /**
  * Classify each editor into one of four actions based on MCP status and
- * whether a Sanity skill is already installed for its skills-CLI agent.
+ * whether the Sanity skills are already installed for its skills-CLI agent.
  */
 function classifyEditors(editors: Editor[]): ClassifiedEditor[] {
   return editors.map((editor) => {
@@ -142,13 +142,13 @@ function applyMasking(
 function getPromptMessage(mcpMode: Mode, skillsMode: Mode): string {
   if (mcpMode === 'skip') return 'Install Sanity agent skills for these editors?'
   if (skillsMode === 'skip') return 'Configure Sanity MCP server?'
-  return 'Configure Sanity MCP and agent skill for these editors?'
+  return 'Configure Sanity MCP and agent skills for these editors?'
 }
 
 /**
  * Main MCP setup orchestration.
  *
- * When `skillsMode !== 'skip'`, the prompt combines MCP and skill offers,
+ * When `skillsMode !== 'skip'`, the prompt combines MCP and skills offers,
  * and the result includes `skillsToInstall` — agent IDs the caller should
  * install via `setupSkills`. `setupMCP` itself never installs skills.
  */
@@ -191,7 +191,7 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
 
   // 4. Read skill state when skills are in scope so classification can dedup
   if (skillsMode !== 'skip') {
-    const {installedAgentDisplayNames} = await readSkillState({skillName: SANITY_SKILL_NAME})
+    const {installedAgentDisplayNames} = await readSkillState({skillNames: SANITY_SKILL_NAMES})
     for (const editor of editors) {
       const displayName = getSkillsCliAgentDisplayName(editor.name)
       editor.skillInstalled = displayName ? installedAgentDisplayNames.has(displayName) : false

--- a/packages/@sanity/cli/src/actions/mcp/types.ts
+++ b/packages/@sanity/cli/src/actions/mcp/types.ts
@@ -17,7 +17,7 @@ export interface Editor {
   /** The existing auth token found in the editor config, if any */
   existingToken?: string
   /**
-   * Whether the Sanity agent skill is already installed globally for this
+   * Whether the Sanity agent skills are already installed globally for this
    * editor's skills-CLI agent. Populated during setup classification when
    * skill state has been probed; absent when skill installation isn't being
    * considered (e.g. `mcp configure`).

--- a/packages/@sanity/cli/src/actions/skills/__tests__/readSkillState.test.ts
+++ b/packages/@sanity/cli/src/actions/skills/__tests__/readSkillState.test.ts
@@ -10,6 +10,7 @@ vi.mock('execa', () => ({
 }))
 
 const SKILL = 'sanity-best-practices'
+const MIGRATION_SKILL = 'sanity-migration'
 
 describe('readSkillState', () => {
   afterEach(() => {
@@ -28,7 +29,7 @@ describe('readSkillState', () => {
       ]),
     })
 
-    const result = await readSkillState({skillName: SKILL})
+    const result = await readSkillState({skillNames: [SKILL]})
 
     expect(mockExeca).toHaveBeenCalledWith(
       process.execPath,
@@ -38,12 +39,35 @@ describe('readSkillState', () => {
     expect([...result.installedAgentDisplayNames]).toEqual(['Cursor', 'Claude Code'])
   })
 
+  test('only returns agents that have every requested skill installed', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([
+        {agents: ['Cursor', 'Claude Code'], name: SKILL},
+        {agents: ['Claude Code'], name: MIGRATION_SKILL},
+      ]),
+    })
+
+    const result = await readSkillState({skillNames: [SKILL, MIGRATION_SKILL]})
+
+    expect([...result.installedAgentDisplayNames]).toEqual(['Claude Code'])
+  })
+
+  test('returns an empty Set when one of the requested skills is missing entirely', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([{agents: ['Cursor', 'Claude Code'], name: SKILL}]),
+    })
+
+    const result = await readSkillState({skillNames: [SKILL, MIGRATION_SKILL]})
+
+    expect(result.installedAgentDisplayNames.size).toBe(0)
+  })
+
   test('returns an empty Set when the named skill is not present', async () => {
     mockExeca.mockResolvedValue({
       stdout: JSON.stringify([{agents: ['Cursor'], name: 'something-else'}]),
     })
 
-    const result = await readSkillState({skillName: SKILL})
+    const result = await readSkillState({skillNames: [SKILL]})
 
     expect(result.installedAgentDisplayNames.size).toBe(0)
   })
@@ -51,7 +75,7 @@ describe('readSkillState', () => {
   test('returns an empty Set when the skill entry has no agents array', async () => {
     mockExeca.mockResolvedValue({stdout: JSON.stringify([{name: SKILL}])})
 
-    const result = await readSkillState({skillName: SKILL})
+    const result = await readSkillState({skillNames: [SKILL]})
 
     expect(result.installedAgentDisplayNames.size).toBe(0)
   })
@@ -59,7 +83,7 @@ describe('readSkillState', () => {
   test('returns an empty Set when the list is empty', async () => {
     mockExeca.mockResolvedValue({stdout: '[]'})
 
-    const result = await readSkillState({skillName: SKILL})
+    const result = await readSkillState({skillNames: [SKILL]})
 
     expect(result.installedAgentDisplayNames.size).toBe(0)
   })
@@ -67,7 +91,7 @@ describe('readSkillState', () => {
   test('returns an empty Set when JSON is malformed', async () => {
     mockExeca.mockResolvedValue({stdout: '{not json'})
 
-    const result = await readSkillState({skillName: SKILL})
+    const result = await readSkillState({skillNames: [SKILL]})
 
     expect(result.installedAgentDisplayNames.size).toBe(0)
   })
@@ -75,7 +99,7 @@ describe('readSkillState', () => {
   test('returns an empty Set when the JSON root is not an array', async () => {
     mockExeca.mockResolvedValue({stdout: JSON.stringify({wrong: 'shape'})})
 
-    const result = await readSkillState({skillName: SKILL})
+    const result = await readSkillState({skillNames: [SKILL]})
 
     expect(result.installedAgentDisplayNames.size).toBe(0)
   })
@@ -83,7 +107,7 @@ describe('readSkillState', () => {
   test('returns an empty Set when the subprocess fails', async () => {
     mockExeca.mockRejectedValue(new Error('boom'))
 
-    const result = await readSkillState({skillName: SKILL})
+    const result = await readSkillState({skillNames: [SKILL]})
 
     expect(result.installedAgentDisplayNames.size).toBe(0)
   })

--- a/packages/@sanity/cli/src/actions/skills/__tests__/setupSkills.test.ts
+++ b/packages/@sanity/cli/src/actions/skills/__tests__/setupSkills.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {
-  SANITY_SKILL_NAME,
+  SANITY_SKILL_NAMES,
   SANITY_SKILLS_REPO,
   setupSkills,
   SKILLS_BIN_PATH,
@@ -37,7 +37,7 @@ describe('setupSkills', () => {
         'add',
         SANITY_SKILLS_REPO,
         '--skill',
-        SANITY_SKILL_NAME,
+        ...SANITY_SKILL_NAMES,
         '-g',
         '-a',
         'cursor',
@@ -61,7 +61,7 @@ describe('setupSkills', () => {
         'add',
         SANITY_SKILLS_REPO,
         '--skill',
-        SANITY_SKILL_NAME,
+        ...SANITY_SKILL_NAMES,
         '-g',
         '-a',
         'cline',
@@ -85,7 +85,7 @@ describe('setupSkills', () => {
         'add',
         SANITY_SKILLS_REPO,
         '--skill',
-        SANITY_SKILL_NAME,
+        ...SANITY_SKILL_NAMES,
         '-g',
         '-a',
         'cursor',
@@ -109,6 +109,10 @@ describe('setupSkills', () => {
     expect(result.installedAgents).toEqual([])
     expect(result.error).toBeInstanceOf(Error)
     expect(result.error?.message).toBe('skills exited 1')
+  })
+
+  test('installs both the best-practices and migration skills', () => {
+    expect(SANITY_SKILL_NAMES).toEqual(['sanity-best-practices', 'sanity-migration'])
   })
 
   test('resolves SKILLS_BIN_PATH to a path that points at the bundled cli', () => {

--- a/packages/@sanity/cli/src/actions/skills/readSkillState.ts
+++ b/packages/@sanity/cli/src/actions/skills/readSkillState.ts
@@ -6,12 +6,12 @@ import {SKILLS_BIN_PATH} from './setupSkills.js'
 const debug = subdebug('skills:state')
 
 interface ReadSkillStateOptions {
-  /** Name of the skill to look up (matches the `name` field in `skills list --json`). */
-  skillName: string
+  /** Names of the skills to look up (match the `name` field in `skills list --json`). */
+  skillNames: string[]
 }
 
 interface SkillState {
-  /** Display names of agents that have this skill installed globally. */
+  /** Display names of agents that have all of these skills installed globally. */
   installedAgentDisplayNames: Set<string>
 }
 
@@ -22,7 +22,9 @@ interface SkillListEntry {
 
 /**
  * Runs the bundled `skills list -g --json` and returns the set of agent
- * display names that have `skillName` installed globally.
+ * display names that have every skill in `skillNames` installed globally.
+ * Agents missing any of the skills are excluded, so they get a (idempotent)
+ * re-install that fills the gap.
  *
  * Any failure (spawn, parse, timeout, non-zero exit) is debug-logged and
  * resolved with an empty set. Callers should treat that as "treat all agents
@@ -57,11 +59,16 @@ export async function readSkillState(opts: ReadSkillStateOptions): Promise<Skill
     return empty
   }
 
-  const match = (parsed as SkillListEntry[]).find((entry) => entry?.name === opts.skillName)
-  if (!match || !Array.isArray(match.agents)) {
-    return empty
-  }
+  const agentSets = opts.skillNames.map((skillName) => {
+    const match = (parsed as SkillListEntry[]).find((entry) => entry?.name === skillName)
+    if (!match || !Array.isArray(match.agents)) {
+      return new Set<string>()
+    }
+    return new Set(match.agents.filter((a): a is string => typeof a === 'string'))
+  })
 
-  const displayNames = match.agents.filter((a): a is string => typeof a === 'string')
-  return {installedAgentDisplayNames: new Set(displayNames)}
+  const installedEverywhere = [...(agentSets[0] ?? [])].filter((agent) =>
+    agentSets.every((set) => set.has(agent)),
+  )
+  return {installedAgentDisplayNames: new Set(installedEverywhere)}
 }

--- a/packages/@sanity/cli/src/actions/skills/setupSkills.ts
+++ b/packages/@sanity/cli/src/actions/skills/setupSkills.ts
@@ -12,8 +12,8 @@ const skillsDebug = subdebug('skills:setup')
 /** Source repo for the bundled `skills` CLI. See https://www.sanity.io/docs/ai/skills. */
 export const SANITY_SKILLS_REPO = 'sanity-io/agent-toolkit'
 
-/** Name of the skill we install — must match the entry in the source repo. */
-export const SANITY_SKILL_NAME = 'sanity-best-practices'
+/** Names of the skills we install — must match the entries in the source repo. */
+export const SANITY_SKILL_NAMES = ['sanity-best-practices', 'sanity-migration']
 
 /**
  * Absolute path to the bundled `skills` CLI bin. Resolved once at module load
@@ -55,7 +55,7 @@ export async function setupSkills(options: SetupSkillsOptions): Promise<SetupSki
     'add',
     SANITY_SKILLS_REPO,
     '--skill',
-    SANITY_SKILL_NAME,
+    ...SANITY_SKILL_NAMES,
     '-g',
     ...uniqueAgents.flatMap((agent) => ['-a', agent]),
     '-y',


### PR DESCRIPTION
### Description

`sanity init` currently installs a single agent skill (`sanity-best-practices`) for detected AI editors. This adds [`sanity-migration`](https://github.com/sanity-io/agent-toolkit/tree/main/skills/sanity-migration) to the install so agents helping people move content into Sanity get migration guidance out of the box.

`SANITY_SKILL_NAME` becomes `SANITY_SKILL_NAMES` and both names are passed to the bundled `skills add` via its variadic `--skill` flag. `readSkillState` now takes a list of skill names and only counts an agent as installed when it has every one of them, so anyone who already has `sanity-best-practices` gets an idempotent re-install that fills in `sanity-migration`.

Also pluralised the user-facing wording: "Configure Sanity MCP and agent skills for these editors?" and "(skills only — MCP already configured)".

Linear: [AIGRO-5082](https://linear.app/sanity/issue/AIGRO-5082/cli-init-also-install-sanity-migration-skill-alongside-sanity-best)

### What to review

The intersection logic in `readSkillState.ts` is the only behavioural change worth a close look. The rest is renames and wording.

### Testing

Updated the existing unit tests and added coverage for the multi-skill cases: agents with only one of the two skills installed, and a skill missing entirely. Verified the variadic `--skill` form against the real `skills` CLI in a temp dir, it installs both skills in one run. 155 tests pass across the skills, MCP and init suites. Lint and knip are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI init/skills install behavior only; changes are additive with idempotent reinstall and existing failure-safe empty-set probing.
> 
> **Overview**
> **`sanity init` / MCP setup now installs two agent skills** — `sanity-best-practices` and **`sanity-migration`** — in one `skills add` run via variadic `--skill` flags. `SANITY_SKILL_NAME` is replaced by **`SANITY_SKILL_NAMES`**.
> 
> **`readSkillState`** takes **`skillNames`** and treats an editor as fully installed only when **every** listed skill is present globally (intersection across `skills list` entries). Agents missing `sanity-migration` still get an idempotent re-install that adds the gap without skipping setup.
> 
> MCP prompts and labels are pluralized (**"agent skills"**, **"skills only"**). Tests cover multi-skill intersection and the dual-skill install args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 310d7b157fe05bd1f6311f4be5d1975becc1b9e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->