### PR TITLE
fix(cli-core): release worker handles so studio commands exit cleanly

### DIFF
--- a/.changeset/pr-1244.md
+++ b/.changeset/pr-1244.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': patch
+---
+
+fix(cli-core): release worker handles so studio commands exit cleanly

--- a/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLoader.worker.ts
+++ b/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLoader.worker.ts
@@ -180,4 +180,10 @@ const runner = new ViteNodeRunner({
 // point why this is, so we should investigate whether it's necessary or not.
 await runner.executeId('/@vite/env')
 
-await runner.executeId(workerScriptPath)
+try {
+  await runner.executeId(workerScriptPath)
+} finally {
+  // Close the Vite server to release handles. Especially important with Vite 8+
+  // where Rolldown's native bindings can keep the worker thread's event loop alive.
+  await server.close()
+}

--- a/packages/@sanity/cli-core/src/util/__tests__/promisifyWorker.test.ts
+++ b/packages/@sanity/cli-core/src/util/__tests__/promisifyWorker.test.ts
@@ -18,6 +18,7 @@ function createMockWorker() {
       for (const key of Object.keys(listeners)) delete listeners[key]
     }),
     terminate: vi.fn(),
+    unref: vi.fn(),
   }
 }
 
@@ -103,15 +104,13 @@ describe('promisifyWorker', () => {
     await expect(promise).rejects.toThrow('Worker exited without sending a message')
   })
 
-  test('terminates the worker after receiving a message', async () => {
+  test('unrefs the worker after receiving a message', async () => {
     const promise = promisifyWorker(TEST_WORKER_URL, {name: 'test'})
 
     lastCreatedWorker.emit('message', 'data')
     await promise
 
-    // terminate is called via setImmediate, so flush it
-    await new Promise((resolve) => setImmediate(resolve))
-    expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
   })
 
   test('removes all listeners after receiving a message', async () => {
@@ -123,25 +122,23 @@ describe('promisifyWorker', () => {
     expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
   })
 
-  test('terminates the worker after an error', async () => {
+  test('unrefs the worker after an error', async () => {
     const promise = promisifyWorker(TEST_WORKER_URL, {name: 'test'})
 
     lastCreatedWorker.emit('error', new Error('fail'))
     await promise.catch(() => {})
 
-    await new Promise((resolve) => setImmediate(resolve))
-    expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
     expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
   })
 
-  test('terminates the worker after a messageerror', async () => {
+  test('unrefs the worker after a messageerror', async () => {
     const promise = promisifyWorker(TEST_WORKER_URL, {name: 'test'})
 
     lastCreatedWorker.emit('messageerror', new Error('bad message'))
     await promise.catch(() => {})
 
-    await new Promise((resolve) => setImmediate(resolve))
-    expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
     expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
   })
 
@@ -170,7 +167,7 @@ describe('promisifyWorker', () => {
     await promise.catch(() => {})
 
     expect(lastCreatedWorker.removeAllListeners).not.toHaveBeenCalled()
-    expect(lastCreatedWorker.terminate).not.toHaveBeenCalled()
+    expect(lastCreatedWorker.unref).not.toHaveBeenCalled()
   })
 
   test('rejects with error when error is followed by non-zero exit', async () => {
@@ -213,10 +210,15 @@ describe('promisifyWorker', () => {
     lastCreatedWorker.emit('error', new Error('fail'))
     await promise.catch(() => {})
 
-    vi.advanceTimersByTime(1000)
+    // Advance past both the user timeout (1s) and deferred terminate (5s)
+    vi.advanceTimersByTime(6000)
 
-    expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
+    // Only one unref + removeAllListeners from the error handler cleanup,
+    // the timeout handler should NOT fire again
+    expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
     expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
+    // Deferred terminate fires after 5s
+    expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
   })
 
   test('cleans up timer after a messageerror', async () => {
@@ -227,10 +229,11 @@ describe('promisifyWorker', () => {
     lastCreatedWorker.emit('messageerror', new Error('bad message'))
     await promise.catch(() => {})
 
-    vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(6000)
 
-    expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
     expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
   })
 
   test('cleans up timer after receiving a message', async () => {
@@ -241,9 +244,10 @@ describe('promisifyWorker', () => {
     lastCreatedWorker.emit('message', 'result')
     await promise
 
-    vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(6000)
 
-    expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
     expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
   })
 })

--- a/packages/@sanity/cli-core/src/util/promisifyWorker.ts
+++ b/packages/@sanity/cli-core/src/util/promisifyWorker.ts
@@ -78,8 +78,21 @@ export function promisifyWorker<T = unknown>(
     })
 
     function cleanup() {
-      setImmediate(() => worker.terminate())
+      // Unref first so the parent process can exit immediately without
+      // waiting for the worker thread to finish shutting down.
+      worker.unref()
       worker.removeAllListeners()
+
+      // Schedule a deferred terminate() as a safety net to force-kill
+      // workers that don't exit on their own (e.g. native addons holding
+      // handles). The timer is unref'd so it won't keep the process alive
+      // — it only fires if the process is still running for other reasons.
+      //
+      // We avoid calling terminate() synchronously because it creates an
+      // internal ref'd MessagePort that would keep the parent process alive
+      // if the worker is slow to respond (e.g. Rolldown in Vite 8).
+      const terminateTimer = setTimeout(() => void worker.terminate(), 5000)
+      terminateTimer.unref()
     }
   })
 }


### PR DESCRIPTION
### Description

Worker threads spawned via `promisifyWorker` were terminated with a synchronous `setImmediate(() => worker.terminate())`. `terminate()` creates an internal ref'd `MessagePort` that keeps the parent process alive until the worker has fully shut down. With Vite 8+, Rolldown's native bindings can keep the worker thread's event loop alive indefinitely, so the CLI would hang after a command finished instead of exiting.

This changes the cleanup to:

- `unref()` the worker immediately so the parent process can exit without waiting for the worker to shut down.
- Schedule a deferred, `unref()`'d `terminate()` (5s) as a safety net to force-kill workers that never exit on their own (e.g. native addons holding handles), without keeping the process alive itself.
- Close the Vite server in `studioWorkerLoader.worker.ts`'s `finally` block to release handles — especially important under Vite 8+ where Rolldown's native bindings hold the event loop open.

### What to review

- `promisifyWorker.ts`: the new `cleanup()` logic — confirm the unref-first + deferred-terminate approach is sound and the timer is correctly unref'd.
- `studioWorkerLoader.worker.ts`: the `try/finally` around `executeId` and `server.close()`.

### Testing

Updated `promisifyWorker.test.ts` to assert the new behavior: `unref()` is called (instead of synchronous `terminate()`) after a message/error/messageerror, listeners are removed, and the deferred `terminate()` fires after 5s without double-firing alongside the timeout handler.