### PR TITLE
feat(deploy): add --dry-run flag for instant deployability feedback

### DIFF
--- a/.changeset/pr-1255.md
+++ b/.changeset/pr-1255.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': minor
+---
+
+feat(deploy): add --dry-run flag for instant deployability feedback

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -21,27 +21,53 @@ import {extractCoreAppManifest, resolveTitleUpdate} from '../manifest/extractCor
 import {type CoreAppManifest} from '../manifest/types.js'
 import {createUserApplicationForApp} from './createUserApplication.js'
 import {
+  checkAppTarget,
   checkAutoUpdates,
   checkBuild,
+  checkOutputDir,
   checkPackageVersion,
+  createAggregatingChecks,
   createFailFastChecks,
   type DeployChecks,
+  type DeployTarget,
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
+import {type DryRunReport, isDeployable} from './dryRunReport.js'
 import {findUserApplicationForApp} from './findUserApplication.js'
-import {type DeployAppOptions} from './types.js'
+import {type DeployFileSummary} from './listDeploymentFiles.js'
+import {type DeployAppOptions, type DeployFlags} from './types.js'
 
 type Workbench = ReturnType<typeof getWorkbench>
 
 /**
- * Builds and deploys a Sanity application.
+ * Builds and deploys a Sanity application. With --dry-run, runs the same
+ * sequence read-only and returns a report instead of shipping.
  *
  * @internal
  */
-export async function deployApp(options: DeployAppOptions): Promise<void> {
-  const {cliConfig, output} = options
+export async function deployApp(options: DeployAppOptions): Promise<DryRunReport | undefined> {
+  const {cliConfig, flags, output} = options
   const workbench = getWorkbench(cliConfig)
+
+  if (flags['dry-run']) {
+    const checks = createAggregatingChecks()
+    if (workbench) {
+      try {
+        workbench.assertDeployable()
+      } catch (err) {
+        checks.add({message: getErrorMessage(err), name: 'app-deployable', status: 'fail'})
+      }
+    }
+    const {files, target} = await createAppDeployment(options, checks, workbench)
+    return {
+      checks: checks.all(),
+      deployable: isDeployable(checks.all()),
+      dryRun: true,
+      files,
+      target,
+    }
+  }
 
   // A federated app with no entry, view or service would ship a remote with
   // nothing to load — fail before any prompts or API calls.
@@ -50,7 +76,7 @@ export async function deployApp(options: DeployAppOptions): Promise<void> {
       workbench.assertDeployable()
     } catch (err) {
       output.error(getErrorMessage(err), {exit: exitCodes.USAGE_ERROR})
-      return
+      return undefined
     }
   }
 
@@ -61,28 +87,32 @@ export async function deployApp(options: DeployAppOptions): Promise<void> {
     // Don't throw a generic error when the user cancels a prompt
     if (error.name === 'ExitPromptError') {
       output.error('Deployment cancelled by user', {exit: 1})
-      return
+      return undefined
     }
     if (error instanceof CLIError) {
       const {message, ...errorOptions} = error
       output.error(message, {...errorOptions, exit: 1})
-      return
+      return undefined
     }
     deployDebug('Error deploying application', error)
     output.error(`Error deploying application: ${error}`, {exit: 1})
   }
+  return undefined
 }
 
 interface AppDeployment {
   application: UserApplication | null
+  files: DeployFileSummary | null
   isAutoUpdating: boolean
   manifest: CoreAppManifest | undefined
+  target: DeployTarget | null
   version: string | null
 }
 
 /**
  * Validates the deploy, syncs the title from the manifest, and ships the build.
- * Steps report through `checks`; a real deploy fails fast on the first problem.
+ * Steps report through `checks` (fail fast for real deploys, aggregated for dry
+ * runs); side-effecting steps and the upload branch on `--dry-run`.
  */
 async function createAppDeployment(
   options: DeployAppOptions,
@@ -92,6 +122,7 @@ async function createAppDeployment(
   const {cliConfig, flags, output, projectRoot, sourceDir} = options
   const workDir = projectRoot.directory
   const organizationId = cliConfig.app?.organizationId
+  const dryRun = !!flags['dry-run']
 
   const isAutoUpdating = checkAutoUpdates(checks, {cliConfig, flags})
 
@@ -108,8 +139,14 @@ async function createAppDeployment(
   )
 
   let application: UserApplication | null = null
+  let target: DeployTarget | null = null
   if (flags.external) {
     checks.add({message: EXTERNAL_APP_NOT_SUPPORTED, name: 'target', status: 'fail'})
+  } else if (dryRun) {
+    ;({existingApp: application, target} = await checkAppTarget(checks, {
+      appId: getAppId(cliConfig),
+      organizationId,
+    }))
   } else {
     application = await resolveAppApplication(options)
   }
@@ -120,7 +157,8 @@ async function createAppDeployment(
         autoUpdatesEnabled: isAutoUpdating,
         calledFromDeploy: true,
         cliConfig,
-        flags,
+        // Dry runs never prompt
+        flags: dryRun ? ({...flags, yes: true} as DeployFlags) : flags,
         outDir: sourceDir,
         output,
         workDir,
@@ -131,10 +169,16 @@ async function createAppDeployment(
     successMessage: 'App built',
   })
 
-  await verifyOutputDir({output, sourceDir, workbench})
+  let files: DeployFileSummary | null = null
+  if (dryRun) {
+    files = await checkOutputDir(checks, {sourceDir, workbench})
+  } else {
+    await verifyOutputDir({output, sourceDir, workbench})
+  }
 
   // Manifests aren't strictly essential, so a failure warns and continues
   let manifest: CoreAppManifest | undefined
+  let manifestFailed = false
   try {
     manifest = await extractCoreAppManifest({workDir})
   } catch (err) {
@@ -144,11 +188,26 @@ async function createAppDeployment(
       name: 'app-manifest',
       status: 'warn',
     })
+    manifestFailed = true
   }
 
   // Sync the application title from the manifest when it has changed
   const titleUpdate = application ? resolveTitleUpdate(manifest, application) : null
-  if (application && titleUpdate) {
+  if (dryRun) {
+    if (!manifestFailed) {
+      checks.add({
+        message: titleUpdate
+          ? titleUpdate.from
+            ? `Would update application title from "${titleUpdate.from}" to "${titleUpdate.to}"`
+            : `Would set application title to "${titleUpdate.to}"`
+          : manifest
+            ? 'App manifest extracted'
+            : 'No app manifest (no icon or title in app configuration)',
+        name: 'app-manifest',
+        status: 'pass',
+      })
+    }
+  } else if (application && titleUpdate) {
     deployDebug('Updating application title from manifest', titleUpdate)
     output.log(
       titleUpdate.from
@@ -171,7 +230,9 @@ async function createAppDeployment(
     }
   }
 
-  if (!application || !version) return {application, isAutoUpdating, manifest, version}
+  if (dryRun || !application || !version) {
+    return {application, files, isAutoUpdating, manifest, target, version}
+  }
 
   const parentDir = dirname(sourceDir)
   const base = basename(sourceDir)
@@ -192,7 +253,7 @@ async function createAppDeployment(
       }
     } catch (err) {
       output.error(`Invalid view declaration: ${getErrorMessage(err)}`, {exit: 1})
-      return {application, isAutoUpdating, manifest, version}
+      return {application, files, isAutoUpdating, manifest, target, version}
     }
   }
 
@@ -234,7 +295,7 @@ ${styleText(
 )}`)
   }
 
-  return {application, isAutoUpdating, manifest, version}
+  return {application, files, isAutoUpdating, manifest, target, version}
 }
 
 /** Resolves the app's target application, creating one when none exists. */

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -10,12 +10,13 @@ import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {getAutoUpdateIssueMessage, resolveAutoUpdates} from '../build/shouldAutoUpdate.js'
 import {checkDir} from './checkDir.js'
 import {deployDebug} from './deployDebug.js'
+import {type DeployFileSummary, listDeploymentFiles} from './listDeploymentFiles.js'
 import {resolveAppDeployTarget, resolveStudioDeployTarget} from './resolveDeployTarget.js'
 import {type DeployFlags} from './types.js'
 
-type DeployCheckStatus = 'fail' | 'pass' | 'skip' | 'warn'
+export type DeployCheckStatus = 'fail' | 'pass' | 'skip' | 'warn'
 
-interface DeployCheck {
+export interface DeployCheck {
   message: string
 
   /** Stable identifier for machine consumers; the message carries the details */
@@ -166,6 +167,39 @@ export async function verifyOutputDir({
     deployDebug('Error checking directory', err)
     output.error(getErrorMessage(err), {exit: 1})
   }
+}
+
+/**
+ * Validates the output directory and lists the files a deploy would upload,
+ * reporting through `checks` instead of a spinner.
+ */
+export async function checkOutputDir(
+  checks: DeployChecks,
+  {
+    skipReason,
+    sourceDir,
+    workbench,
+  }: {
+    skipReason?: string
+    sourceDir: string
+    workbench: {checkBuiltOutput(sourceDir: string): Promise<void>} | null
+  },
+): Promise<DeployFileSummary | null> {
+  if (skipReason) {
+    checks.add({message: skipReason, name: 'output-dir', status: 'skip'})
+    return null
+  }
+
+  return checks.run('output-dir', async () => {
+    await (workbench ? workbench.checkBuiltOutput(sourceDir) : checkDir(sourceDir))
+    checks.add({message: `Output directory: ${sourceDir}`, name: 'output-dir', status: 'pass'})
+    const list = await listDeploymentFiles(sourceDir)
+    return {
+      count: list.length,
+      list,
+      totalBytes: list.reduce((total, file) => total + file.size, 0),
+    }
+  })
 }
 
 export interface DeployTarget {

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -13,49 +13,83 @@ import {pack} from 'tar-fs'
 import {createDeployment, type UserApplication} from '../../services/userApplications.js'
 import {getAppId} from '../../util/appId.js'
 import {NO_PROJECT_ID} from '../../util/errorMessages.js'
+import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {buildStudio} from '../build/buildStudio.js'
 import {createStudioUserApplication} from './createUserApplication.js'
 import {
   checkAutoUpdates,
   checkBuild,
+  checkOutputDir,
   checkPackageVersion,
+  checkStudioTarget,
+  createAggregatingChecks,
   createFailFastChecks,
   type DeployChecks,
+  type DeployTarget,
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
 import {deployStudioSchemasAndManifests} from './deployStudioSchemasAndManifests.js'
+import {type DryRunReport, isDeployable} from './dryRunReport.js'
 import {findUserApplicationForStudio} from './findUserApplication.js'
-import {type DeployAppOptions} from './types.js'
+import {type DeployFileSummary} from './listDeploymentFiles.js'
+import {type DeployAppOptions, type DeployFlags} from './types.js'
 
 /**
- * Builds and deploys the studio.
+ * Builds and deploys the studio. With --dry-run, runs the same sequence
+ * read-only and returns a report instead of shipping.
  */
-export async function deployStudio(options: DeployAppOptions): Promise<void> {
-  const {output} = options
+export async function deployStudio(options: DeployAppOptions): Promise<DryRunReport | undefined> {
+  const {cliConfig, flags, output} = options
+
+  if (flags['dry-run']) {
+    const checks = createAggregatingChecks()
+    const {files, target} = await createStudioDeployment(options, checks)
+
+    if (!getAppId(cliConfig) && target?.appId) {
+      checks.add({
+        message: `Add deployment.appId: '${target.appId}' to sanity.cli.ts to skip hostname lookups and prompts on deploy.`,
+        name: 'app-id-config',
+        status: 'warn',
+      })
+    }
+
+    return {
+      checks: checks.all(),
+      deployable: isDeployable(checks.all()),
+      dryRun: true,
+      files,
+      target,
+    }
+  }
+
   try {
     const checks = createFailFastChecks(output)
     await createStudioDeployment(options, checks)
   } catch (error) {
     if (error instanceof CLIError) {
       output.error(error.message, {exit: error.oclif?.exit ?? exitCodes.RUNTIME_ERROR})
-      return
+      return undefined
     }
     deployDebug('Error deploying studio', error)
     output.error(`Error deploying studio: ${error}`, {exit: 1})
   }
+  return undefined
 }
 
 interface StudioDeployment {
   application: UserApplication | null
+  files: DeployFileSummary | null
   isAutoUpdating: boolean
   studioManifest: StudioManifest | null
+  target: DeployTarget | null
   version: string | null
 }
 
 /**
  * Validates the deploy, extracts and uploads the schema, and ships the build.
- * Steps report through `checks`; a real deploy fails fast on the first problem.
+ * Steps report through `checks` (fail fast for real deploys, aggregated for dry
+ * runs); side-effecting steps and the upload branch on `--dry-run`.
  */
 async function createStudioDeployment(
   options: DeployAppOptions,
@@ -66,6 +100,7 @@ async function createStudioDeployment(
   const isExternal = !!flags.external
   const workbench = getWorkbench(cliConfig)
   const projectId = cliConfig.api?.projectId
+  const dryRun = !!flags['dry-run']
 
   const isAutoUpdating = checkAutoUpdates(checks, {cliConfig, flags})
 
@@ -94,7 +129,19 @@ async function createStudioDeployment(
       : {message: NO_PROJECT_ID, name: 'project-id', status: 'fail'},
   )
 
-  const application = await resolveStudioApplication(options)
+  let application: UserApplication | null = null
+  let target: DeployTarget | null = null
+  if (dryRun) {
+    target = await checkStudioTarget(checks, {
+      appId: getAppId(cliConfig),
+      isExternal,
+      projectId,
+      studioHost: cliConfig.studioHost,
+      urlFlag: flags.url,
+    })
+  } else {
+    application = await resolveStudioApplication(options)
+  }
 
   await checkBuild(checks, {
     build: () =>
@@ -102,7 +149,8 @@ async function createStudioDeployment(
         autoUpdatesEnabled: isAutoUpdating,
         calledFromDeploy: true,
         cliConfig,
-        flags,
+        // Dry runs never prompt
+        flags: dryRun ? ({...flags, yes: true} as DeployFlags) : flags,
         outDir: sourceDir,
         output,
         workDir,
@@ -111,36 +159,24 @@ async function createStudioDeployment(
     successMessage: 'Studio built',
   })
 
-  let studioManifest: StudioManifest | null = null
-  try {
-    studioManifest = await deployStudioSchemasAndManifests({
-      configPath: projectRoot.path,
-      isExternal,
-      outPath: `${sourceDir}/static`,
-      projectId: projectId ?? '',
-      schemaRequired: flags['schema-required'],
-      verbose: flags.verbose,
-      workDir,
-    })
-  } catch (error) {
-    deployDebug('Error deploying studio schemas and manifests', error)
-    if (error instanceof SchemaExtractionError) {
-      output.error(formatSchemaValidation(error.validation || []), {exit: 1})
-    }
-    output.error(`Error deploying studio schemas and manifests: ${error}`, {exit: 1})
-  }
+  const studioManifest = await deployStudioSchema(options, checks)
 
-  if (!studioManifest) {
-    output.error('Failed to generate studio manifest. Please check your schemas and manifests.', {
-      exit: 1,
+  let files: DeployFileSummary | null = null
+  if (dryRun) {
+    files = await checkOutputDir(checks, {
+      skipReason: isExternal
+        ? 'Output directory check skipped for externally hosted studios'
+        : undefined,
+      sourceDir,
+      workbench,
     })
-  }
-
-  if (!isExternal) {
+  } else if (!isExternal) {
     await verifyOutputDir({output, sourceDir, workbench})
   }
 
-  if (!application || !version) return {application, isAutoUpdating, studioManifest, version}
+  if (dryRun || !application || !version) {
+    return {application, files, isAutoUpdating, studioManifest, target, version}
+  }
 
   let tarball: Gzip | undefined
   if (!isExternal) {
@@ -188,7 +224,7 @@ export default defineCliConfig({
     output.log(`\n${example}`)
   }
 
-  return {application, isAutoUpdating, studioManifest, version}
+  return {application, files, isAutoUpdating, studioManifest, target, version}
 }
 
 /** Resolves the studio's target application, registering a new host if none exists. */
@@ -228,6 +264,67 @@ async function resolveStudioApplication(
 
   deployDebug('Found user application', application)
   return application
+}
+
+/**
+ * Extracts and validates the schema. A real deploy uploads it and returns the
+ * studio manifest; a dry run validates only and reports a workspace summary.
+ */
+async function deployStudioSchema(
+  options: DeployAppOptions,
+  checks: DeployChecks,
+): Promise<StudioManifest | null> {
+  const {cliConfig, flags, output, projectRoot, sourceDir} = options
+  const dryRun = !!flags['dry-run']
+  const schemaOptions = {
+    configPath: projectRoot.path,
+    isExternal: !!flags.external,
+    outPath: `${sourceDir}/static`,
+    projectId: cliConfig.api?.projectId ?? '',
+    schemaRequired: flags['schema-required'],
+    verbose: flags.verbose,
+    workDir: projectRoot.directory,
+  }
+
+  if (dryRun) {
+    await checks.run(
+      'schema',
+      async () => {
+        const {workspaces} = await deployStudioSchemasAndManifests({...schemaOptions, dryRun})
+        const typeCount = workspaces.reduce((count, workspace) => count + workspace.schemaTypes, 0)
+        checks.add({
+          message: `Schema valid (${workspaces.length} ${workspaces.length === 1 ? 'workspace' : 'workspaces'}, ${typeCount} ${typeCount === 1 ? 'type' : 'types'})`,
+          name: 'schema',
+          status: 'pass',
+        })
+      },
+      (err) =>
+        err instanceof SchemaExtractionError && err.validation
+          ? `Schema validation failed:\n${formatSchemaValidation(err.validation)}`
+          : `Schema validation failed: ${getErrorMessage(err)}`,
+    )
+    return null
+  }
+
+  let studioManifest: StudioManifest | null = null
+  try {
+    const result = await deployStudioSchemasAndManifests(schemaOptions)
+    studioManifest = result.studioManifest
+  } catch (error) {
+    deployDebug('Error deploying studio schemas and manifests', error)
+    if (error instanceof SchemaExtractionError) {
+      output.error(formatSchemaValidation(error.validation || []), {exit: 1})
+    }
+    output.error(`Error deploying studio schemas and manifests: ${error}`, {exit: 1})
+  }
+
+  if (!studioManifest) {
+    output.error('Failed to generate studio manifest. Please check your schemas and manifests.', {
+      exit: 1,
+    })
+  }
+
+  return studioManifest
 }
 
 function studioBuildSkipReason({build, isExternal}: {build: boolean; isExternal: boolean}) {

--- a/packages/@sanity/cli/src/actions/deploy/deployStudioSchemasAndManifests.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudioSchemasAndManifests.ts
@@ -6,7 +6,10 @@ import {getCliTelemetry, studioWorkerTask, subdebug} from '@sanity/cli-core'
 import {type SchemaValidationProblemGroup} from '@sanity/types'
 import {type StudioManifest} from 'sanity'
 
-import {type DeployStudioSchemasAndManifestsWorkerData} from './types.js'
+import {
+  type DeployStudioSchemasAndManifestsWorkerData,
+  type WorkspaceSchemaSummary,
+} from './types.js'
 
 type DeployStudioSchemasAndManifestsWorkerMessage =
   | {
@@ -17,7 +20,13 @@ type DeployStudioSchemasAndManifestsWorkerMessage =
   | {
       studioManifest: StudioManifest | null
       type: 'success'
+      workspaces: WorkspaceSchemaSummary[]
     }
+
+export interface DeployStudioSchemasAndManifestsResult {
+  studioManifest: StudioManifest | null
+  workspaces: WorkspaceSchemaSummary[]
+}
 
 const debug = subdebug('deployStudioSchemasAndManifests')
 
@@ -25,21 +34,35 @@ const debug = subdebug('deployStudioSchemasAndManifests')
  * 1. Extracts the create manifest in dist/static (automatically deployed with studio)
  * 2. Deploys the schemas to /schemas endpoint
  * 3. Creates a studio manifest, uploads it to user application and lexicon
+ *
+ * With `dryRun`, stops after extraction and validation — nothing is uploaded
+ * and no schema-deploy telemetry is recorded.
  */
 export async function deployStudioSchemasAndManifests(
   options: DeployStudioSchemasAndManifestsWorkerData,
-): Promise<StudioManifest | null> {
-  const {configPath, isExternal, outPath, projectId, schemaRequired, verbose, workDir} = options
-
-  const trace = getCliTelemetry().trace(SchemaDeploy, {
-    // If the studio is externally hosted, we don't need to extract the manifest
-    extractManifest: !isExternal,
-    manifestDir: outPath,
+): Promise<DeployStudioSchemasAndManifestsResult> {
+  const {
+    configPath,
+    dryRun = false,
+    isExternal,
+    outPath,
+    projectId,
     schemaRequired,
-  })
+    verbose,
+    workDir,
+  } = options
+
+  const trace = dryRun
+    ? null
+    : getCliTelemetry().trace(SchemaDeploy, {
+        // If the studio is externally hosted, we don't need to extract the manifest
+        extractManifest: !isExternal,
+        manifestDir: outPath,
+        schemaRequired,
+      })
 
   try {
-    trace.start()
+    trace?.start()
     const result = await studioWorkerTask<DeployStudioSchemasAndManifestsWorkerMessage>(
       new URL('deployStudioSchemasAndManifests.worker.js', import.meta.url),
       {
@@ -52,6 +75,7 @@ export async function deployStudioSchemasAndManifests(
         studioRootPath: workDir,
         workerData: {
           configPath,
+          dryRun,
           isExternal,
           outPath,
           projectId,
@@ -69,13 +93,15 @@ export async function deployStudioSchemasAndManifests(
       throw new SchemaExtractionError(result.error, result.validation)
     }
 
-    trace.complete()
-    ux.stdout(
-      `${styleText('gray', '↳ List deployed schemas with:')} ${styleText('cyan', 'sanity schema list')}`,
-    )
-    return result.studioManifest
+    trace?.complete()
+    if (!dryRun) {
+      ux.stdout(
+        `${styleText('gray', '↳ List deployed schemas with:')} ${styleText('cyan', 'sanity schema list')}`,
+      )
+    }
+    return {studioManifest: result.studioManifest, workspaces: result.workspaces}
   } catch (err) {
-    trace.error(err)
+    trace?.error(err)
     throw err
   }
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployStudioSchemasAndManifests.worker.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudioSchemasAndManifests.worker.ts
@@ -21,7 +21,7 @@ async function main() {
     throw new Error('Should only be run in a worker!')
   }
 
-  const {configPath, isExternal, outPath, projectId, schemaRequired, verbose, workDir} =
+  const {configPath, dryRun, isExternal, outPath, projectId, schemaRequired, verbose, workDir} =
     deployStudioSchemasAndManifestsWorkerData.parse(workerData)
 
   try {
@@ -44,6 +44,28 @@ async function main() {
       projectId: manifest.projectId,
       title: manifest.title,
     }))
+
+    const workspaceSummaries = workspaceManifests.map((manifest) => ({
+      dataset: manifest.dataset,
+      name: manifest.name,
+      projectId: manifest.projectId,
+      schemaTypes: manifest.schema.length,
+    }))
+
+    // Extraction above is the validation work — a dry run stops short of uploading.
+    // The create-manifest is still written for internal deploys so the dry-run file
+    // summary matches what a real deploy would include in the tarball.
+    if (dryRun) {
+      if (!isExternal) {
+        await writeManifestFile({outPath, workDir, workspaceManifests})
+      }
+      parentPort.postMessage({
+        studioManifest: null,
+        type: 'success',
+        workspaces: workspaceSummaries,
+      })
+      return
+    }
 
     debug('Handling deployment for %s', isExternal ? 'external' : 'internal')
 
@@ -73,6 +95,7 @@ async function main() {
     parentPort.postMessage({
       studioManifest,
       type: 'success',
+      workspaces: workspaceSummaries,
     })
   } catch (error) {
     debug('Error deploying studio schemas and manifests', error)

--- a/packages/@sanity/cli/src/actions/deploy/dryRunReport.ts
+++ b/packages/@sanity/cli/src/actions/deploy/dryRunReport.ts
@@ -1,0 +1,77 @@
+import {styleText} from 'node:util'
+
+import {type Output} from '@sanity/cli-core'
+
+import {type DeployCheck, type DeployCheckStatus, type DeployTarget} from './deployChecks.js'
+import {type DeployFileSummary} from './listDeploymentFiles.js'
+
+export interface DryRunReport {
+  checks: DeployCheck[]
+  deployable: boolean
+  dryRun: true
+  files: DeployFileSummary | null
+  target: DeployTarget | null
+}
+
+export function isDeployable(checks: DeployCheck[]): boolean {
+  return checks.every((check) => check.status !== 'fail')
+}
+
+const checkIcon: Record<DeployCheckStatus, string> = {
+  fail: styleText('red', '✗'),
+  pass: styleText('green', '✓'),
+  skip: styleText('gray', '○'),
+  warn: styleText('yellow', '⚠'),
+}
+
+const MAX_FILES_LISTED = 20
+
+export function renderDryRunReport(report: DryRunReport, output: Output): void {
+  output.log('')
+  for (const check of report.checks) {
+    // Indent multi-line messages (e.g. schema validation output) under the icon
+    output.log(`${checkIcon[check.status]} ${check.message.replaceAll('\n', '\n  ')}`)
+  }
+
+  if (report.files) {
+    const {count, list, totalBytes} = report.files
+    output.log('')
+    output.log(
+      `Would upload ${count} ${count === 1 ? 'file' : 'files'} (${formatBytes(totalBytes)}):`,
+    )
+    for (const file of list.slice(0, MAX_FILES_LISTED)) {
+      output.log(`  ${file.path} ${styleText('gray', formatBytes(file.size))}`)
+    }
+    if (count > MAX_FILES_LISTED) {
+      output.log(styleText('gray', `  … and ${count - MAX_FILES_LISTED} more`))
+    }
+  }
+
+  output.log('')
+  if (report.deployable) {
+    output.log(
+      `${styleText('green', 'Ready to deploy.')} ${styleText('gray', 'Dry run — nothing was deployed.')}`,
+    )
+  } else {
+    const failed = report.checks.filter((check) => check.status === 'fail').length
+    output.log(
+      `${styleText('red', `Not deployable — ${failed} ${failed === 1 ? 'check' : 'checks'} failed.`)} ${styleText('gray', 'Dry run — nothing was deployed.')}`,
+    )
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1000) {
+    return `${bytes} B`
+  }
+
+  let value = bytes
+  let unit = 'B'
+  for (const next of ['kB', 'MB', 'GB']) {
+    if (value < 1000) break
+    value /= 1000
+    unit = next
+  }
+
+  return `${value >= 100 ? Math.round(value) : value.toFixed(1)} ${unit}`
+}

--- a/packages/@sanity/cli/src/actions/deploy/listDeploymentFiles.ts
+++ b/packages/@sanity/cli/src/actions/deploy/listDeploymentFiles.ts
@@ -1,0 +1,40 @@
+import {readdir, stat} from 'node:fs/promises'
+import {join, relative, sep} from 'node:path'
+
+interface DeployFile {
+  /** Path relative to the source directory, always with forward slashes */
+  path: string
+  size: number
+}
+
+export interface DeployFileSummary {
+  count: number
+  list: DeployFile[]
+  totalBytes: number
+}
+
+/**
+ * Lists the files that would be included in the deployment tarball,
+ * with paths relative to the source directory.
+ *
+ * @internal
+ */
+export async function listDeploymentFiles(sourceDir: string): Promise<DeployFile[]> {
+  const files: DeployFile[] = []
+  await walk(sourceDir, sourceDir, files)
+  return files.toSorted((a, b) => a.path.localeCompare(b.path))
+}
+
+async function walk(dir: string, baseDir: string, files: DeployFile[]): Promise<void> {
+  const entries = await readdir(dir, {withFileTypes: true})
+
+  for (const entry of entries) {
+    const absolutePath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      await walk(absolutePath, baseDir, files)
+    } else if (entry.isFile()) {
+      const {size} = await stat(absolutePath)
+      files.push({path: relative(baseDir, absolutePath).split(sep).join('/'), size})
+    }
+  }
+}

--- a/packages/@sanity/cli/src/actions/deploy/types.ts
+++ b/packages/@sanity/cli/src/actions/deploy/types.ts
@@ -15,6 +15,8 @@ export interface DeployAppOptions {
 
 export const deployStudioSchemasAndManifestsWorkerData = z.object({
   configPath: z.string(),
+  // Validate and extract only — skip schema and manifest uploads
+  dryRun: z.optional(z.boolean()),
   isExternal: z.boolean(),
   outPath: z.string(),
   projectId: z.string(),
@@ -26,3 +28,14 @@ export const deployStudioSchemasAndManifestsWorkerData = z.object({
 export type DeployStudioSchemasAndManifestsWorkerData = z.infer<
   typeof deployStudioSchemasAndManifestsWorkerData
 >
+
+/**
+ * Per-workspace summary reported back from the schema worker,
+ * used by dry runs to describe what passed validation.
+ */
+export interface WorkspaceSchemaSummary {
+  dataset: string
+  name: string
+  projectId: string
+  schemaTypes: number
+}

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -1,12 +1,13 @@
 import path from 'node:path'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 
 import {deployApp} from '../actions/deploy/deployApp.js'
 import {deployDebug} from '../actions/deploy/deployDebug.js'
 import {deployStudio} from '../actions/deploy/deployStudio.js'
+import {type DryRunReport, renderDryRunReport} from '../actions/deploy/dryRunReport.js'
 import {determineIsApp} from '../util/determineIsApp.js'
 import {dirIsEmptyOrNonExistent} from '../util/dirIsEmptyOrNonExistent.js'
 
@@ -19,6 +20,8 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
 
   static override description = 'Builds and deploys Sanity Studio or application to Sanity hosting'
 
+  static override enableJsonFlag = true
+
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
@@ -27,6 +30,10 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
     {
       command: '<%= config.bin %> <%= command.id %> --no-minify --source-maps',
       description: 'Deploys non-minified build with source maps',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --dry-run --json',
+      description: 'Validate the deployment without deploying, as machine-readable output',
     },
     {
       command: '<%= config.bin %> <%= command.id %> --schema-required',
@@ -50,6 +57,11 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
       default: true,
       description:
         'Build the studio before deploying (use --no-build to deploy existing `dist/` output)',
+    }),
+    'dry-run': Flags.boolean({
+      default: false,
+      description:
+        'Run all deploy checks and list the files that would be uploaded, without deploying. Exits non-zero when not deployable.',
     }),
     external: Flags.boolean({
       default: false,
@@ -85,7 +97,7 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
     }),
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<DryRunReport | undefined> {
     const {flags} = await this.parse(DeployCommand)
 
     const cliConfig = await this.getCliConfig()
@@ -96,8 +108,14 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
     const defaultOutputDir = path.resolve(path.join(projectRoot.directory, 'dist'))
     const sourceDir = path.resolve(process.cwd(), this.args.sourceDir || defaultOutputDir)
 
-    // Skip the directory check if the studio is externally hosted
-    if (this.args.sourceDir && this.args.sourceDir !== 'dist' && !flags.external) {
+    // Skip the directory check for externally hosted studios, and for dry runs
+    // (which never prompt and never overwrite remote state)
+    if (
+      this.args.sourceDir &&
+      this.args.sourceDir !== 'dist' &&
+      !flags.external &&
+      !flags['dry-run']
+    ) {
       let relativeOutput = path.relative(process.cwd(), sourceDir)
       if (relativeOutput[0] !== '.') {
         relativeOutput = `./${relativeOutput}`
@@ -119,24 +137,20 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
       this.output.log(`Building to ${relativeOutput}\n`)
     }
 
-    if (isApp) {
-      deployDebug('Deploying app')
-      await deployApp({
-        cliConfig,
-        flags,
-        output: this.output,
-        projectRoot,
-        sourceDir,
-      })
-    } else {
-      deployDebug('Deploying studio')
-      await deployStudio({
-        cliConfig,
-        flags,
-        output: this.output,
-        projectRoot,
-        sourceDir,
-      })
+    const deployOptions = {cliConfig, flags, output: this.output, projectRoot, sourceDir}
+
+    deployDebug(isApp ? 'Deploying app' : 'Deploying studio')
+    const report = isApp ? await deployApp(deployOptions) : await deployStudio(deployOptions)
+
+    // A report is only returned for dry runs
+    if (report) {
+      renderDryRunReport(report, this.output)
+      if (!report.deployable) {
+        // Set the exit code without throwing so --json still emits the full report
+        process.exitCode = exitCodes.USAGE_ERROR
+      }
     }
+
+    return report
   }
 }

--- a/packages/@sanity/cli/test/integration/commands/deploy.dry-run.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.dry-run.test.ts
@@ -1,0 +1,337 @@
+import {studioWorkerTask} from '@sanity/cli-core'
+import {testCommand, testFixture} from '@sanity/cli-test'
+import {cleanAll, pendingMocks} from 'nock'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {buildApp} from '../../../src/actions/build/buildApp.js'
+import {buildStudio} from '../../../src/actions/build/buildStudio.js'
+import {checkDir} from '../../../src/actions/deploy/checkDir.js'
+import {type DryRunReport} from '../../../src/actions/deploy/dryRunReport.js'
+import {extractCoreAppManifest} from '../../../src/actions/manifest/extractCoreAppManifest.js'
+import {DeployCommand} from '../../../src/commands/deploy.js'
+import {
+  coreApplication,
+  createDistFiles,
+  mockGetCoreApp,
+  mockGetStudioAppByHost,
+  mockListCoreApps,
+  studioApplication,
+} from './deployTestHelpers.js'
+
+const mockGetLocalPackageVersion = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/cli-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/cli-core')>()
+  return {
+    ...actual,
+    getLocalPackageVersion: mockGetLocalPackageVersion,
+    studioWorkerTask: vi.fn(),
+  }
+})
+
+vi.mock('../../../src/actions/build/buildStudio.js', () => ({
+  buildStudio: vi.fn(),
+}))
+
+vi.mock('../../../src/actions/build/buildApp.js', () => ({
+  buildApp: vi.fn(),
+}))
+
+vi.mock('../../../src/actions/deploy/checkDir.js', () => ({
+  checkDir: vi.fn(),
+}))
+
+vi.mock('../../../src/actions/manifest/extractCoreAppManifest.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../src/actions/manifest/extractCoreAppManifest.js')>()
+  return {
+    ...actual,
+    extractCoreAppManifest: vi.fn(),
+  }
+})
+
+const mockStudioWorkerTask = vi.mocked(studioWorkerTask)
+const mockCheckDir = vi.mocked(checkDir)
+const mockBuildStudio = vi.mocked(buildStudio)
+const mockBuildApp = vi.mocked(buildApp)
+const mockExtractAppManifest = vi.mocked(extractCoreAppManifest)
+
+const projectId = 'test-project-id'
+const studioHost = 'existing-studio'
+const studioAppId = 'studio-app-id'
+
+function getCheck(report: DryRunReport | undefined, name: string) {
+  return report?.checks.find((check) => check.name === name)
+}
+
+describe('#deploy dry run', () => {
+  beforeEach(() => {
+    mockGetLocalPackageVersion.mockImplementation(async (moduleName) => {
+      if (moduleName === 'sanity') return '3.0.0'
+      if (moduleName === '@sanity/sdk-react') return '1.0.0'
+      return null
+    })
+    mockCheckDir.mockResolvedValue()
+    mockExtractAppManifest.mockResolvedValue(undefined)
+    mockStudioWorkerTask.mockResolvedValue({
+      studioManifest: null,
+      type: 'success',
+      workspaces: [{dataset: 'production', name: 'default', projectId, schemaTypes: 12}],
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = 0
+    const pending = pendingMocks()
+    cleanAll()
+    expect(pending, 'pending mocks').toEqual([])
+  })
+
+  describe('studio', () => {
+    test('reports deployable and lists files for an existing studio', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+      await createDistFiles(cwd)
+
+      mockGetStudioAppByHost({appHost: studioHost, projectId}).reply(
+        200,
+        studioApplication({
+          appHost: studioHost,
+          id: studioAppId,
+          projectId,
+          title: 'Existing Studio',
+        }),
+      )
+
+      const {error, result, stdout} = await testCommand(DeployCommand, ['--dry-run'], {
+        config: {root: cwd},
+        mocks: {cliConfig: {api: {projectId}, studioHost}},
+      })
+
+      if (error) throw error
+      const report = result as DryRunReport
+
+      expect(report.deployable).toBe(true)
+      expect(report.dryRun).toBe(true)
+      expect(getCheck(report, 'sanity-version')?.status).toBe('pass')
+      expect(getCheck(report, 'project-id')?.status).toBe('pass')
+      expect(getCheck(report, 'target')).toMatchObject({
+        message: `Deploys to existing studio https://${studioHost}.sanity.studio`,
+        status: 'pass',
+      })
+      expect(getCheck(report, 'build')?.status).toBe('pass')
+      expect(getCheck(report, 'schema')).toMatchObject({
+        message: 'Schema valid (1 workspace, 12 types)',
+        status: 'pass',
+      })
+      expect(getCheck(report, 'output-dir')?.status).toBe('pass')
+
+      expect(report.target).toEqual({
+        appId: studioAppId,
+        exists: true,
+        host: studioHost,
+        type: 'studio',
+      })
+      expect(report.files).toEqual({
+        count: 2,
+        list: [
+          {path: 'index.html', size: 13},
+          {path: 'static/app.js', size: 14},
+        ],
+        totalBytes: 27,
+      })
+
+      // No deployment.appId configured, so the report should nudge towards it
+      expect(getCheck(report, 'app-id-config')).toMatchObject({status: 'warn'})
+
+      // The build runs, but nothing is uploaded (any POST would fail the pending-mocks check)
+      expect(mockBuildStudio).toHaveBeenCalledTimes(1)
+      expect(mockBuildStudio).toHaveBeenCalledWith(
+        expect.objectContaining({flags: expect.objectContaining({yes: true})}),
+      )
+      expect(mockStudioWorkerTask).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({workerData: expect.objectContaining({dryRun: true})}),
+      )
+
+      expect(stdout).toContain('Ready to deploy')
+      expect(process.exitCode ?? 0).toBe(0)
+    })
+
+    test('reports the hostname that would be created when it does not exist yet', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+      await createDistFiles(cwd)
+
+      mockGetStudioAppByHost({appHost: 'new-studio', projectId}).reply(404, {message: 'Not found'})
+
+      const {error, result} = await testCommand(DeployCommand, ['--dry-run'], {
+        config: {root: cwd},
+        mocks: {cliConfig: {api: {projectId}, studioHost: 'new-studio'}},
+      })
+
+      if (error) throw error
+      const report = result as DryRunReport
+
+      expect(report.deployable).toBe(true)
+      expect(getCheck(report, 'target')?.status).toBe('pass')
+      expect(getCheck(report, 'target')?.message).toContain(
+        'Would create studio hostname https://new-studio.sanity.studio',
+      )
+      expect(report.target).toEqual({
+        appId: null,
+        exists: false,
+        host: 'new-studio',
+        type: 'studio',
+      })
+    })
+
+    test('aggregates all failures and exits non-zero', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      mockStudioWorkerTask.mockResolvedValue({
+        error: 'Schema extraction failed',
+        type: 'error',
+        validation: [],
+      })
+      mockCheckDir.mockRejectedValue(new Error('Directory "dist" does not exist'))
+
+      const {error, result, stdout} = await testCommand(DeployCommand, ['--dry-run'], {
+        config: {root: cwd},
+        // No projectId and no studioHost: target cannot resolve, deploy would prompt
+        mocks: {cliConfig: {}},
+      })
+
+      if (error) throw error
+      const report = result as DryRunReport
+
+      expect(report.deployable).toBe(false)
+      expect(getCheck(report, 'project-id')?.status).toBe('fail')
+      expect(getCheck(report, 'target')?.status).toBe('fail')
+      expect(getCheck(report, 'schema')?.status).toBe('fail')
+      expect(getCheck(report, 'output-dir')?.status).toBe('fail')
+      expect(report.files).toBeNull()
+
+      expect(stdout).toContain('Not deployable')
+      expect(process.exitCode).toBe(2)
+    })
+
+    test('emits a machine-readable report with --json', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+      await createDistFiles(cwd)
+
+      mockGetStudioAppByHost({appHost: studioHost, projectId}).reply(
+        200,
+        studioApplication({
+          appHost: studioHost,
+          id: studioAppId,
+          projectId,
+          title: 'Existing Studio',
+        }),
+      )
+
+      const {error, stdout} = await testCommand(DeployCommand, ['--dry-run', '--json'], {
+        config: {root: cwd},
+        mocks: {cliConfig: {api: {projectId}, studioHost}},
+      })
+
+      if (error) throw error
+      const parsed = JSON.parse(stdout)
+
+      expect(parsed.deployable).toBe(true)
+      expect(parsed.dryRun).toBe(true)
+      expect(Array.isArray(parsed.checks)).toBe(true)
+      expect(parsed.files.count).toBe(2)
+      expect(parsed.target.appId).toBe(studioAppId)
+    })
+  })
+
+  describe('app', () => {
+    const appId = 'app-id'
+    const organizationId = 'org-id'
+
+    test('reports deployable for an existing application', async () => {
+      const cwd = await testFixture('basic-app')
+      process.cwd = () => cwd
+      await createDistFiles(cwd)
+
+      mockExtractAppManifest.mockResolvedValue({title: 'New Title', version: '1'})
+
+      mockGetCoreApp({appId}).reply(
+        200,
+        coreApplication({
+          appHost: 'existing-host',
+          id: appId,
+          organizationId,
+          projectId: null,
+          title: 'Existing App',
+        }),
+      )
+
+      const {error, result} = await testCommand(DeployCommand, ['--dry-run'], {
+        config: {root: cwd},
+        mocks: {cliConfig: {app: {organizationId}, deployment: {appId}}},
+      })
+
+      if (error) throw error
+      const report = result as DryRunReport
+
+      expect(report.deployable).toBe(true)
+      expect(getCheck(report, 'sdk-version')?.status).toBe('pass')
+      expect(getCheck(report, 'organization-id')?.status).toBe('pass')
+      expect(getCheck(report, 'target')).toMatchObject({
+        message: 'Deploys to existing application "Existing App"',
+        status: 'pass',
+      })
+      // Title differs from the manifest: a real deploy would sync it
+      expect(getCheck(report, 'app-manifest')).toMatchObject({
+        message: 'Would update application title from "Existing App" to "New Title"',
+        status: 'pass',
+      })
+      expect(report.target).toEqual({
+        appId,
+        exists: true,
+        host: 'existing-host',
+        type: 'coreApp',
+      })
+      expect(report.files?.count).toBe(2)
+
+      // The build runs, but nothing is uploaded or updated
+      // (any POST or PATCH would fail the pending-mocks check)
+      expect(mockBuildApp).toHaveBeenCalledTimes(1)
+    })
+
+    test('fails the target check when no appId is configured and applications exist', async () => {
+      const cwd = await testFixture('basic-app')
+      process.cwd = () => cwd
+      await createDistFiles(cwd)
+
+      mockListCoreApps({organizationId}).reply(200, [
+        coreApplication({
+          appHost: 'existing-host',
+          id: 'other-app-id',
+          organizationId,
+          projectId: null,
+          title: 'Existing App',
+        }),
+      ])
+
+      const {error, result} = await testCommand(DeployCommand, ['--dry-run'], {
+        config: {root: cwd},
+        mocks: {cliConfig: {app: {organizationId}}},
+      })
+
+      if (error) throw error
+      const report = result as DryRunReport
+
+      expect(report.deployable).toBe(false)
+      expect(getCheck(report, 'target')).toMatchObject({status: 'fail'})
+      expect(getCheck(report, 'target')?.message).toContain('deploy would prompt')
+      expect(report.target).toBeNull()
+      expect(process.exitCode).toBe(2)
+    })
+  })
+})

--- a/packages/@sanity/cli/test/integration/commands/deployTestHelpers.ts
+++ b/packages/@sanity/cli/test/integration/commands/deployTestHelpers.ts
@@ -1,0 +1,153 @@
+/**
+ * Shared fixtures for the deploy command tests: user-application API
+ * responses with sensible defaults, and the user-applications endpoints the
+ * deploy flows call. Each mock helper returns the interceptor so tests chain
+ * their own `.reply(...)`.
+ */
+
+import {mkdir, writeFile} from 'node:fs/promises'
+import {join} from 'node:path'
+
+import {mockApi} from '@sanity/cli-test'
+
+import {
+  USER_APPLICATIONS_API_VERSION,
+  type UserApplication,
+} from '../../../src/services/userApplications.js'
+
+export function studioApplication(overrides: Partial<UserApplication> = {}): UserApplication {
+  return {
+    appHost: 'test-studio',
+    createdAt: '2024-01-01T00:00:00Z',
+    id: 'studio-app-id',
+    organizationId: null,
+    projectId: 'test-project-id',
+    title: null,
+    type: 'studio',
+    updatedAt: '2024-01-01T00:00:00Z',
+    urlType: 'internal',
+    ...overrides,
+  }
+}
+
+export function coreApplication(overrides: Partial<UserApplication> = {}): UserApplication {
+  return {
+    appHost: 'app-host',
+    createdAt: '2024-01-01T00:00:00Z',
+    id: 'app-id',
+    organizationId: 'org-id',
+    projectId: null,
+    title: null,
+    type: 'coreApp',
+    updatedAt: '2024-01-01T00:00:00Z',
+    urlType: 'internal',
+    ...overrides,
+  }
+}
+
+/** GET a studio application by host */
+export function mockGetStudioAppByHost({appHost, projectId}: {appHost: string; projectId: string}) {
+  return mockApi({
+    apiVersion: USER_APPLICATIONS_API_VERSION,
+    query: {appHost, appType: 'studio'},
+    uri: `/projects/${projectId}/user-applications`,
+  })
+}
+
+/** GET a studio application by id */
+export function mockGetStudioAppById({appId, projectId}: {appId: string; projectId: string}) {
+  return mockApi({
+    apiVersion: USER_APPLICATIONS_API_VERSION,
+    uri: `/projects/${projectId}/user-applications/${appId}`,
+  })
+}
+
+/** GET all studio applications of a project */
+export function mockListStudioApps({projectId}: {projectId: string}) {
+  return mockApi({
+    apiVersion: USER_APPLICATIONS_API_VERSION,
+    query: {appType: 'studio'},
+    uri: `/projects/${projectId}/user-applications`,
+  })
+}
+
+/** POST a new studio application */
+export function mockCreateStudioApp({projectId}: {projectId: string}) {
+  return mockApi({
+    apiVersion: USER_APPLICATIONS_API_VERSION,
+    method: 'post',
+    query: {appType: 'studio'},
+    uri: `/projects/${projectId}/user-applications`,
+  })
+}
+
+/** POST a studio deployment */
+export function mockCreateStudioDeployment({
+  applicationId,
+  projectId,
+}: {
+  applicationId: string
+  projectId: string
+}) {
+  return mockApi({
+    apiVersion: USER_APPLICATIONS_API_VERSION,
+    method: 'post',
+    query: {appType: 'studio'},
+    uri: `/projects/${projectId}/user-applications/${applicationId}/deployments`,
+  })
+}
+
+/** GET an app (coreApp) by id */
+export function mockGetCoreApp({appId}: {appId: string}) {
+  return mockApi({
+    apiVersion: USER_APPLICATIONS_API_VERSION,
+    query: {appType: 'coreApp'},
+    uri: `/user-applications/${appId}`,
+  })
+}
+
+/** GET all apps (coreApp) of an organization */
+export function mockListCoreApps({organizationId}: {organizationId: string}) {
+  return mockApi({
+    apiVersion: USER_APPLICATIONS_API_VERSION,
+    query: {appType: 'coreApp', organizationId},
+    uri: `/user-applications`,
+  })
+}
+
+/** POST a new app (coreApp) */
+export function mockCreateCoreApp({organizationId}: {organizationId: string}) {
+  return mockApi({
+    apiVersion: USER_APPLICATIONS_API_VERSION,
+    method: 'post',
+    query: {appType: 'coreApp', organizationId},
+    uri: `/user-applications`,
+  })
+}
+
+/** PATCH an app (coreApp), e.g. the title sync */
+export function mockUpdateCoreApp({appId}: {appId: string}) {
+  return mockApi({
+    apiVersion: USER_APPLICATIONS_API_VERSION,
+    method: 'patch',
+    query: {appType: 'coreApp'},
+    uri: `/user-applications/${appId}`,
+  })
+}
+
+/** POST an app (coreApp) deployment */
+export function mockCreateCoreAppDeployment({applicationId}: {applicationId: string}) {
+  return mockApi({
+    apiVersion: USER_APPLICATIONS_API_VERSION,
+    method: 'post',
+    query: {appType: 'coreApp'},
+    uri: `/user-applications/${applicationId}/deployments`,
+  })
+}
+
+/** A minimal built output directory for file-listing assertions */
+export async function createDistFiles(cwd: string): Promise<void> {
+  await mkdir(join(cwd, 'dist', 'static'), {recursive: true})
+  await writeFile(join(cwd, 'dist', 'index.html'), '<html></html>')
+  await writeFile(join(cwd, 'dist', 'static', 'app.js'), 'console.log(1)')
+}


### PR DESCRIPTION
### Description

`sanity deploy --dry-run` answers "can this deploy" without deploying — a fast feedback loop for agents and CI. Stacked on #1254; it runs the same `createStudioDeployment`/`createAppDeployment` sequence read-only:

- Target resolution returns a verdict instead of prompting or creating an application.
- The schema worker validates and extracts without uploading, and still writes the create-manifest locally so the file list matches a real deploy.
- The output directory is listed (with sizes) instead of packed.

Failures aggregate instead of bailing on the first, so one run reports every problem. It never prompts — would-prompt situations become failed checks with the fix in the message — and exits 2 when not deployable.

`--json` emits the `{deployable, checks, target, files}` report via oclif's `enableJsonFlag`. The exit code is set without throwing, so the full report still reaches stdout on failure.

The only new seam implementation is the aggregating checks collector; real deploys keep failing fast through the same steps, so a real deploy fails with the same message its dry run reports.

### What to review

- The `dryRun` branches in `createStudioDeployment`/`createAppDeployment` — target verdict, schema validate-only, output listing, title as a check.
- The aggregating vs fail-fast adapters in `deployChecks`.
- Check names and report shape — a machine contract for `--json` consumers.

### Testing

`deploy.dry-run.test.ts` covers both deploy types: all-checks-pass with file listing, would-create hostname, aggregated failures with exit 2, `--json` output, and the would-prompt failure when no appId is configured.
