### PR TITLE
refactor(dev): make server start contracts and the interface-rebuild lifecycle explicit

### DIFF
--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -6,7 +6,7 @@ import {createBaseDevOptions, createMockOutput, workbenchCliConfig} from './test
 const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
 const mockStartAppDevServer = vi.hoisted(() => vi.fn())
 const mockStartStudioDevServer = vi.hoisted(() => vi.fn())
-const mockStartFederationRegistration = vi.hoisted(() => vi.fn())
+const mockStartDevServerRegistration = vi.hoisted(() => vi.fn())
 const mockGetSharedServerConfig = vi.hoisted(() => vi.fn())
 const mockGetCliConfigUncached = vi.hoisted(() => vi.fn())
 
@@ -25,8 +25,8 @@ vi.mock('../servers/startAppDevServer.js', () => ({
 vi.mock('../servers/startStudioDevServer.js', () => ({
   startStudioDevServer: mockStartStudioDevServer,
 }))
-vi.mock('../registration/startFederationRegistration.js', () => ({
-  startFederationRegistration: mockStartFederationRegistration,
+vi.mock('../registration/startDevServerRegistration.js', () => ({
+  startDevServerRegistration: mockStartDevServerRegistration,
 }))
 vi.mock('../../../util/getSharedServerConfig.js', () => ({
   getSharedServerConfig: mockGetSharedServerConfig,
@@ -38,7 +38,19 @@ function mockServer({host, port = 3334}: {host?: boolean | string; port?: number
   return {
     close: vi.fn().mockResolvedValue(undefined),
     server: {config: {server: {host, port}}},
+    started: true,
   }
+}
+
+function mockRegistrationHandle() {
+  return {
+    close: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+/** Pull the rebuild handler devAction passed into startDevServerRegistration. */
+function passedInterfaceSetChange(): (() => Promise<void>) | undefined {
+  return mockStartDevServerRegistration.mock.calls[0][0].onInterfaceSetChange
 }
 
 describe('devAction', () => {
@@ -51,9 +63,7 @@ describe('devAction', () => {
       workbenchAvailable: false,
       workbenchPort: 3333,
     })
-    mockStartFederationRegistration.mockResolvedValue({
-      close: vi.fn().mockResolvedValue(undefined),
-    })
+    mockStartDevServerRegistration.mockResolvedValue(mockRegistrationHandle())
   })
 
   afterEach(() => {
@@ -139,13 +149,13 @@ describe('devAction', () => {
     expect(mockAppClose).toHaveBeenCalled()
   })
 
-  describe('federation registration', () => {
-    test('starts federation registration when federation is enabled', async () => {
+  describe('dev server registration', () => {
+    test('starts registration when workbench is enabled', async () => {
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
 
-      expect(mockStartFederationRegistration).toHaveBeenCalledWith(
+      expect(mockStartDevServerRegistration).toHaveBeenCalledWith(
         expect.objectContaining({
           isApp: false,
           workDir: '/tmp/sanity-project',
@@ -153,12 +163,12 @@ describe('devAction', () => {
       )
     })
 
-    test('does not start federation registration when federation is disabled', async () => {
+    test('does not start registration when workbench is disabled', async () => {
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
 
       await devAction(createBaseDevOptions())
 
-      expect(mockStartFederationRegistration).not.toHaveBeenCalled()
+      expect(mockStartDevServerRegistration).not.toHaveBeenCalled()
     })
 
     test('passes isApp: true for app mode', async () => {
@@ -166,34 +176,34 @@ describe('devAction', () => {
 
       await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}))
 
-      expect(mockStartFederationRegistration).toHaveBeenCalledWith(
+      expect(mockStartDevServerRegistration).toHaveBeenCalledWith(
         expect.objectContaining({isApp: true}),
       )
     })
 
-    test('passes the vite dev server to federation registration', async () => {
+    test('passes the vite dev server to the registration', async () => {
       const server = mockServer({port: 3334})
       mockStartStudioDevServer.mockResolvedValue(server)
 
       await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
 
-      expect(mockStartFederationRegistration).toHaveBeenCalledWith(
+      expect(mockStartDevServerRegistration).toHaveBeenCalledWith(
         expect.objectContaining({server: server.server}),
       )
     })
 
-    test('calls federation close on close', async () => {
-      const mockFederationClose = vi.fn().mockResolvedValue(undefined)
-      mockStartFederationRegistration.mockResolvedValue({close: mockFederationClose})
+    test('calls registration close on close', async () => {
+      const handle = mockRegistrationHandle()
+      mockStartDevServerRegistration.mockResolvedValue(handle)
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       const result = await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
 
       await result.close()
-      expect(mockFederationClose).toHaveBeenCalled()
+      expect(handle.close).toHaveBeenCalled()
     })
 
-    test('rebuilds the app server with a freshly-loaded config when interfaces change', async () => {
+    test('rebuilds the app server with a freshly-loaded config when the interface set changes', async () => {
       const firstClose = vi.fn().mockResolvedValue(undefined)
       const secondClose = vi.fn().mockResolvedValue(undefined)
       mockStartAppDevServer
@@ -204,10 +214,10 @@ describe('devAction', () => {
 
       await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}))
 
-      const {onInterfacesChange} = mockStartFederationRegistration.mock.calls[0][0]
-      expect(onInterfacesChange).toBeInstanceOf(Function)
+      const onSetChange = passedInterfaceSetChange()
+      expect(onSetChange).toBeInstanceOf(Function)
 
-      await onInterfacesChange()
+      await onSetChange!()
 
       // Old app server torn down, a new one started with the re-read config.
       expect(firstClose).toHaveBeenCalledTimes(1)
@@ -217,13 +227,32 @@ describe('devAction', () => {
       )
     })
 
-    test('wires no rebuild hook for studios (they declare no interfaces)', async () => {
+    test('close stays safe when the rebuilt app server reports an expected early exit', async () => {
+      const firstClose = vi.fn().mockResolvedValue(undefined)
+      mockStartAppDevServer
+        .mockResolvedValueOnce({...mockServer({port: 3334}), close: firstClose})
+        // e.g. the user removed organizationId from sanity.cli.ts before saving
+        .mockResolvedValueOnce({reason: 'missing-organization-id', started: false})
+      mockGetCliConfigUncached.mockResolvedValue(workbenchCliConfig())
+
+      const result = await devAction(
+        createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}),
+      )
+
+      await passedInterfaceSetChange()!()
+
+      // The old server was closed during the rebuild; close() must not call it
+      // again or trip over the missing replacement.
+      await expect(result.close()).resolves.toBeUndefined()
+      expect(firstClose).toHaveBeenCalledTimes(1)
+    })
+
+    test('passes no rebuild hook for studios (they declare no interfaces)', async () => {
       mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
       await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: false}))
 
-      const {onInterfacesChange} = mockStartFederationRegistration.mock.calls[0][0]
-      expect(onInterfacesChange).toBeUndefined()
+      expect(passedInterfaceSetChange()).toBeUndefined()
     })
   })
 
@@ -285,8 +314,8 @@ describe('devAction', () => {
     expect(output.log).toHaveBeenCalledWith(expect.stringContaining('mydev.local:3333'))
   })
 
-  test('returns early with workbench-only close when app server exits without a server', async () => {
-    // startAppDevServer resolves with {} when orgId is missing — no `server`.
+  test('returns early with workbench-only close when the app server does not start', async () => {
+    // startAppDevServer reports an expected early exit when orgId is missing.
     const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
     mockStartWorkbenchDevServer.mockResolvedValue({
       close: mockWorkbenchClose,
@@ -294,7 +323,7 @@ describe('devAction', () => {
       workbenchAvailable: false,
       workbenchPort: 3333,
     })
-    mockStartAppDevServer.mockResolvedValue({})
+    mockStartAppDevServer.mockResolvedValue({reason: 'missing-organization-id', started: false})
 
     const result = await devAction(createBaseDevOptions({isApp: true}))
 
@@ -302,7 +331,7 @@ describe('devAction', () => {
     // The close must still tear down the workbench server
     await result.close()
     expect(mockWorkbenchClose).toHaveBeenCalled()
-    // No registration should have happened because federation wasn't evaluated
-    expect(mockStartFederationRegistration).not.toHaveBeenCalled()
+    // No registration should have happened because the app never started
+    expect(mockStartDevServerRegistration).not.toHaveBeenCalled()
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -1,13 +1,12 @@
 import {styleText} from 'node:util'
 
 import {getCliConfigUncached, isWorkbenchApp} from '@sanity/cli-core'
-import {type ViteDevServer} from 'vite'
 
 import {getSharedServerConfig} from '../../util/getSharedServerConfig.js'
-import {startFederationRegistration} from './registration/startFederationRegistration.js'
+import {startDevServerRegistration} from './registration/startDevServerRegistration.js'
 import {startAppDevServer} from './servers/startAppDevServer.js'
 import {startStudioDevServer} from './servers/startStudioDevServer.js'
-import {type DevActionOptions} from './types.js'
+import {type DevActionOptions, type StartDevServerResult} from './types.js'
 import {startWorkbenchDevServer} from './workbench/startWorkbenchDevServer.js'
 
 const noop = async () => {}
@@ -45,29 +44,30 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   }
 
   let closeAppDevServer: () => Promise<void> = noop
-  let server: ViteDevServer | undefined
 
-  // (Re)start the app/studio dev server, tracking its close handle + server ref.
+  // (Re)start the app/studio dev server, tracking its close handle.
   // Takes the config so a rebuild can feed a freshly-loaded one.
-  const startApp = async (config: DevActionOptions['cliConfig']) => {
+  const startApp = async (config: DevActionOptions['cliConfig']): Promise<StartDevServerResult> => {
     const result = options.isApp
       ? await startAppDevServer({...appOptions, cliConfig: config})
       : await startStudioDevServer({...appOptions, cliConfig: config})
-    closeAppDevServer = result.close ?? noop
-    server = result.server
-    return result.server
+    closeAppDevServer = result.started ? result.close : noop
+    return result
   }
 
+  let initial: StartDevServerResult
   try {
-    await startApp(cliConfig)
+    initial = await startApp(cliConfig)
   } catch (err) {
     await closeWorkbenchServer()
     throw err
   }
 
-  if (!server) {
+  if (!initial.started) {
+    // The server has already reported why (e.g. missing organization ID).
     return {close: closeWorkbenchServer}
   }
+  const {server} = initial
 
   // Adding/removing a view or service in `sanity.cli.ts` during dev requires
   // rebuilding the federation remote: its module-federation `exposes` map +
@@ -78,7 +78,8 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   // workbench page then reloads (driven by the registry watch in the workbench
   // server) to re-fetch the rebuilt remote. A view/service *source* edit doesn't
   // change the interface set, so it stays on the HMR path untouched.
-  const onInterfacesChange = options.isApp
+  // Studios declare no interfaces, so they get no rebuild hook.
+  const onInterfaceSetChange = options.isApp
     ? async () => {
         const freshConfig = await getCliConfigUncached(workDir)
         await closeAppDevServer()
@@ -88,11 +89,11 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
 
   // Workbench is opted into solely by calling `unstable_defineApp` — its
   // branded identity is the only signal.
-  const closeFederation = isWorkbenchApp(cliConfig?.app)
-    ? await startFederationRegistration({
+  const registration = isWorkbenchApp(cliConfig?.app)
+    ? await startDevServerRegistration({
         cliConfig,
         isApp: options.isApp,
-        onInterfacesChange,
+        onInterfaceSetChange,
         output,
         server,
         workDir,
@@ -111,11 +112,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   const close = async () => {
     process.off('SIGINT', onSignal)
     process.off('SIGTERM', onSignal)
-    await Promise.allSettled([
-      closeFederation?.close(),
-      closeWorkbenchServer(),
-      closeAppDevServer(),
-    ])
+    await Promise.allSettled([registration?.close(), closeWorkbenchServer(), closeAppDevServer()])
   }
 
   // Ensure the workbench lock file and registry entries are cleaned up on

--- a/packages/@sanity/cli/src/actions/dev/registration/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/__tests__/startDevServerRegistration.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {createMockOutput, workbenchApp, workbenchCliConfig} from '../../__tests__/testHelpers.js'
-import {startFederationRegistration} from '../startFederationRegistration.js'
+import {startDevServerRegistration} from '../startDevServerRegistration.js'
 
 const mockRegisterDevServer = vi.hoisted(() => vi.fn())
 const mockStartDevManifestWatcher = vi.hoisted(() => vi.fn())
@@ -40,7 +40,7 @@ function mockServer({host, port = 3334}: {host?: boolean | string; port?: number
   }
 }
 
-describe('startFederationRegistration', () => {
+describe('startDevServerRegistration', () => {
   beforeEach(() => {
     mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
     mockStartDevManifestWatcher.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
@@ -54,7 +54,7 @@ describe('startFederationRegistration', () => {
   })
 
   test('registers studio in registry', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: false,
       output: createMockOutput(),
@@ -74,7 +74,7 @@ describe('startFederationRegistration', () => {
   test('passes deployment.appId to registerDevServer', async () => {
     mockGetAppId.mockReturnValue('app-abc')
 
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: {app: workbenchApp(), deployment: {appId: 'app-abc'}},
       isApp: false,
       output: createMockOutput(),
@@ -86,7 +86,7 @@ describe('startFederationRegistration', () => {
   })
 
   test('forwards api.projectId to registerDevServer', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: {api: {projectId: 'x1g7jygt'}, app: workbenchApp()},
       isApp: false,
       output: createMockOutput(),
@@ -100,7 +100,7 @@ describe('startFederationRegistration', () => {
   })
 
   test('omits projectId when api.projectId is not configured', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: false,
       output: createMockOutput(),
@@ -115,7 +115,7 @@ describe('startFederationRegistration', () => {
   test('checks for deprecated app.id', async () => {
     const output = createMockOutput()
 
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: {app: workbenchApp({id: 'legacy-app'})},
       isApp: false,
       output,
@@ -127,7 +127,7 @@ describe('startFederationRegistration', () => {
   })
 
   test('registers without icon/title — they are derived from the inlined manifest', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: false,
       output: createMockOutput(),
@@ -141,7 +141,7 @@ describe('startFederationRegistration', () => {
   })
 
   test('registers app under the host applied by the vite dev server', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: false,
       output: createMockOutput(),
@@ -155,7 +155,7 @@ describe('startFederationRegistration', () => {
   })
 
   test('falls back to localhost when the vite server host is not a string', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: false,
       output: createMockOutput(),
@@ -167,7 +167,7 @@ describe('startFederationRegistration', () => {
   })
 
   test('registers app type when isApp is true', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: true,
       output: createMockOutput(),
@@ -179,7 +179,7 @@ describe('startFederationRegistration', () => {
   })
 
   test('starts the manifest watcher for studios', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: false,
       output: createMockOutput(),
@@ -193,7 +193,7 @@ describe('startFederationRegistration', () => {
   })
 
   test('starts the manifest watcher for core apps', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: true,
       output: createMockOutput(),
@@ -214,7 +214,7 @@ describe('startFederationRegistration', () => {
       app: workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]}),
     })
 
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: true,
       output: createMockOutput(),
@@ -237,7 +237,7 @@ describe('startFederationRegistration', () => {
     const studioManifest = {version: 3, workspaces: []}
     mockExtractStudioManifest.mockResolvedValue(studioManifest)
 
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: false,
       output: createMockOutput(),
@@ -256,7 +256,7 @@ describe('startFederationRegistration', () => {
     const mockCleanup = vi.fn()
     mockRegisterDevServer.mockReturnValue({release: mockCleanup, update: vi.fn()})
 
-    const result = await startFederationRegistration({
+    const result = await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
       isApp: false,
       output: createMockOutput(),
@@ -275,7 +275,7 @@ describe('startFederationRegistration', () => {
     })
 
     await expect(
-      startFederationRegistration({
+      startDevServerRegistration({
         cliConfig: workbenchCliConfig(),
         isApp: false,
         output: createMockOutput(),
@@ -290,7 +290,7 @@ describe('startFederationRegistration', () => {
     mockStartDevManifestWatcher.mockRejectedValue(error)
 
     await expect(
-      startFederationRegistration({
+      startDevServerRegistration({
         cliConfig: workbenchCliConfig(),
         isApp: false,
         output: createMockOutput(),
@@ -307,7 +307,7 @@ describe('startFederationRegistration', () => {
 
     const output = createMockOutput()
 
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: {
         app: workbenchApp({id: 'legacy-app'}),
         deployment: {appId: 'new-app'},
@@ -326,7 +326,7 @@ describe('startFederationRegistration', () => {
 
   // US5 — `entry` declares an SDK app's navigable `app` view.
   test('forwards an `app` interface derived from `entry` for an SDK app', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: {app: workbenchApp({entry: './src/App.tsx'})},
       isApp: true,
       output: createMockOutput(),
@@ -344,7 +344,7 @@ describe('startFederationRegistration', () => {
   })
 
   test('forwards no `app` interface when an SDK app declares no `entry`', async () => {
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: {app: workbenchApp()},
       isApp: true,
       output: createMockOutput(),
@@ -360,7 +360,7 @@ describe('startFederationRegistration', () => {
 
   test('rejects a studio that declares `entry` — app views for studios are not implemented yet', async () => {
     await expect(
-      startFederationRegistration({
+      startDevServerRegistration({
         cliConfig: {app: workbenchApp({entry: './src/App.tsx'})},
         isApp: false,
         output: createMockOutput(),
@@ -375,14 +375,14 @@ describe('startFederationRegistration', () => {
   const feed = {entry_point: './src/Feed.tsx', interface_type: 'panel', name: 'feed'}
 
   test('rebuilds the remote when the interface set changes, then keeps quiet on a repeat', async () => {
-    const onInterfacesChange = vi.fn().mockResolvedValue(undefined)
+    const onInterfaceSetChange = vi.fn().mockResolvedValue(undefined)
     const update = vi.fn()
     mockRegisterDevServer.mockReturnValue({release: vi.fn(), update})
 
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: {app: workbenchApp()}, // no interfaces yet
       isApp: true,
-      onInterfacesChange,
+      onInterfaceSetChange,
       output: createMockOutput(),
       server: mockServer({port: 3334}) as any,
       workDir: '/tmp/sanity-project',
@@ -391,25 +391,25 @@ describe('startFederationRegistration', () => {
 
     // A panel appears → rebuild, then patch the registry.
     await watcherUpdate({interfaces: [feed], manifest: undefined, manifestUpdatedAt: 'a'})
-    expect(onInterfacesChange).toHaveBeenCalledTimes(1)
+    expect(onInterfaceSetChange).toHaveBeenCalledTimes(1)
     expect(update).toHaveBeenCalledTimes(1)
 
     // Same set on the next pass → no rebuild, registry still patched.
     await watcherUpdate({interfaces: [feed], manifest: undefined, manifestUpdatedAt: 'b'})
-    expect(onInterfacesChange).toHaveBeenCalledTimes(1)
+    expect(onInterfaceSetChange).toHaveBeenCalledTimes(1)
     expect(update).toHaveBeenCalledTimes(2)
   })
 
   test('does not rebuild when only the manifest changes (same interface set)', async () => {
-    const onInterfacesChange = vi.fn().mockResolvedValue(undefined)
+    const onInterfaceSetChange = vi.fn().mockResolvedValue(undefined)
     mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
 
-    await startFederationRegistration({
+    await startDevServerRegistration({
       cliConfig: {
         app: workbenchApp({views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}]}),
       },
       isApp: true,
-      onInterfacesChange,
+      onInterfaceSetChange,
       output: createMockOutput(),
       server: mockServer({port: 3334}) as any,
       workDir: '/tmp/sanity-project',
@@ -422,6 +422,25 @@ describe('startFederationRegistration', () => {
       manifest: {title: 'Renamed', version: '1'},
       manifestUpdatedAt: 'a',
     })
-    expect(onInterfacesChange).not.toHaveBeenCalled()
+    expect(onInterfaceSetChange).not.toHaveBeenCalled()
+  })
+
+  test('still patches the registry when no rebuild handler is passed', async () => {
+    const update = vi.fn()
+    mockRegisterDevServer.mockReturnValue({release: vi.fn(), update})
+
+    await startDevServerRegistration({
+      cliConfig: {app: workbenchApp()}, // no interfaces yet
+      isApp: true,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+    const watcherUpdate = mockStartDevManifestWatcher.mock.calls[0][0].update
+
+    // The set changed but no handler was passed (e.g. studios) — no crash, and
+    // the registry patch still goes through.
+    await watcherUpdate({interfaces: [feed], manifest: undefined, manifestUpdatedAt: 'a'})
+    expect(update).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/registration/startDevServerRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/startDevServerRegistration.ts
@@ -9,7 +9,7 @@ import {extractStudioManifest} from './extractDevServerManifest.js'
 import {interfaceSetId} from './interfaceSetId.js'
 import {startDevManifestWatcher} from './startDevManifestWatcher.js'
 
-interface FederationRegistrationOptions {
+interface DevServerRegistrationOptions {
   cliConfig: CliConfig
   isApp: boolean
   output: Output
@@ -18,16 +18,17 @@ interface FederationRegistrationOptions {
 
   /**
    * Called when the declared interface *set* changes (a view/service added,
-   * removed, renamed, or repointed in `sanity.cli.ts`) — before the registry is
-   * patched. The remote's `exposes` map + codegen artifacts are computed once at
-   * server start, so a newly-declared interface has no expose until the app dev
-   * server is recreated with the fresh config; this hook does that recreation.
-   * Awaited so the rebuilt remote is live before the workbench page reloads.
+   * removed, renamed, or repointed in `sanity.cli.ts`), awaited *before* the
+   * registry is patched — the registry patch is what reloads the workbench
+   * page, and it must re-fetch a remote that already exposes the new
+   * interface, so the caller's rebuild has to complete first. A view/service
+   * *source* edit doesn't change the set and never fires this. Studios declare
+   * no interfaces, so they pass nothing.
    */
-  onInterfacesChange?: () => Promise<void>
+  onInterfaceSetChange?: () => Promise<void>
 }
 
-interface FederationRegistration {
+interface DevServerRegistrationHandle {
   close: () => Promise<void>
 }
 
@@ -36,10 +37,10 @@ interface FederationRegistration {
  * is used by the workbench to know where the dev server is running and to display it in the UI. The manifest watcher
  * is used to update the registration with the latest manifest, which the workbench uses to display project metadata.
  */
-export async function startFederationRegistration(
-  options: FederationRegistrationOptions,
-): Promise<FederationRegistration> {
-  const {cliConfig, isApp, onInterfacesChange, output, server, workDir} = options
+export async function startDevServerRegistration(
+  options: DevServerRegistrationOptions,
+): Promise<DevServerRegistrationHandle> {
+  const {cliConfig, isApp, onInterfaceSetChange, output, server, workDir} = options
 
   checkForDeprecatedAppId({cliConfig, output})
 
@@ -92,7 +93,7 @@ export async function startFederationRegistration(
         // artifact), THEN patch the registry — the registry patch is what reloads
         // the workbench page, and it must re-fetch a remote that already exposes
         // the new interface.
-        await onInterfacesChange?.()
+        await onInterfaceSetChange?.()
       }
       registration.update(patch)
     },

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
@@ -62,7 +62,7 @@ describe('startAppDevServer', () => {
       expect.stringContaining('organization ID'),
       expect.objectContaining({exit: 1}),
     )
-    expect(result).toEqual({})
+    expect(result).toEqual({reason: 'missing-organization-id', started: false})
     expect(mockStartDevServer).not.toHaveBeenCalled()
   })
 
@@ -74,7 +74,7 @@ describe('startAppDevServer', () => {
       expect.stringContaining('organization ID'),
       expect.objectContaining({exit: 1}),
     )
-    expect(result).toEqual({})
+    expect(result).toEqual({reason: 'missing-organization-id', started: false})
   })
 
   test('starts dev server with isApp and appTitle from cliConfig', async () => {
@@ -94,6 +94,8 @@ describe('startAppDevServer', () => {
         isApp: true,
       }),
     )
+    expect(result.started).toBe(true)
+    if (!result.started) throw new Error('expected the server to start')
     expect(result.server).toBeDefined()
     expect(result.close).toBeDefined()
   })

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/startStudioDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/startStudioDevServer.test.ts
@@ -115,6 +115,8 @@ describe('startStudioDevServer', () => {
     )
     expect(mockCheckRequiredDependencies).toHaveBeenCalled()
     expect(mockStartDevServer).toHaveBeenCalled()
+    expect(result.started).toBe(true)
+    if (!result.started) throw new Error('expected the server to start')
     expect(result.close).toBeDefined()
     expect(result.server).toBeDefined()
   })

--- a/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
@@ -1,14 +1,10 @@
-import {type ViteDevServer} from 'vite'
-
 import {startDevServer} from '../../../server/devServer.js'
 import {gracefulServerDeath} from '../../../server/gracefulServerDeath.js'
 import {devDebug} from '../devDebug.js'
-import {type DevActionOptions} from '../types.js'
+import {type DevActionOptions, type StartDevServerResult} from '../types.js'
 import {getDevServerConfig} from './getDevServerConfig.js'
 
-export async function startAppDevServer(
-  options: DevActionOptions,
-): Promise<{close?: () => Promise<void>; server?: ViteDevServer}> {
+export async function startAppDevServer(options: DevActionOptions): Promise<StartDevServerResult> {
   const {cliConfig, flags, output, workbenchAvailable, workDir} = options
 
   let organizationId: string | undefined
@@ -20,7 +16,7 @@ export async function startAppDevServer(
     output.error(`Apps require an organization ID (orgId) specified in your sanity.cli.ts file`, {
       exit: 1,
     })
-    return {}
+    return {reason: 'missing-organization-id', started: false}
   }
 
   const config = getDevServerConfig({cliConfig, flags, output, workDir})
@@ -41,7 +37,7 @@ export async function startAppDevServer(
       output.log(`App dev server started on port ${port}`)
     }
 
-    return {close, server}
+    return {close, server, started: true}
   } catch (err) {
     devDebug('Error starting app dev server', err)
     throw gracefulServerDeath('dev', config.httpHost, config.httpPort, err)

--- a/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
@@ -4,7 +4,6 @@ import {checkStudioDependencyVersions} from '@sanity/cli-build/_internal/build'
 import {getLocalPackageVersion, isInteractive} from '@sanity/cli-core'
 import {confirm, logSymbols, spinner} from '@sanity/cli-core/ux'
 import {parse as semverParse} from 'semver'
-import {type ViteDevServer} from 'vite'
 
 import {startDevServer} from '../../../server/devServer.js'
 import {gracefulServerDeath} from '../../../server/gracefulServerDeath.js'
@@ -15,12 +14,12 @@ import {upgradePackages} from '../../../util/packageManager/upgradePackages.js'
 import {checkRequiredDependencies} from '../../build/checkRequiredDependencies.js'
 import {shouldAutoUpdate} from '../../build/shouldAutoUpdate.js'
 import {devDebug} from '../devDebug.js'
-import {type DevActionOptions} from '../types.js'
+import {type DevActionOptions, type StartDevServerResult} from '../types.js'
 import {getDevServerConfig} from './getDevServerConfig.js'
 
 export async function startStudioDevServer(
   options: DevActionOptions,
-): Promise<{close: () => Promise<void>; server: ViteDevServer}> {
+): Promise<StartDevServerResult> {
   const {cliConfig, flags, output, workbenchAvailable, workDir} = options
 
   // Check studio dependency versions
@@ -121,7 +120,7 @@ export async function startStudioDevServer(
         (workbenchAvailable ? '' : ` and running at ${styleText('cyan', url)}`),
     )
 
-    return {close, server}
+    return {close, server, started: true}
   } catch (err) {
     devDebug('Error starting studio dev server', err)
     throw gracefulServerDeath('dev', config.httpHost, config.httpPort, err)

--- a/packages/@sanity/cli/src/actions/dev/types.ts
+++ b/packages/@sanity/cli/src/actions/dev/types.ts
@@ -1,4 +1,5 @@
 import {type CliConfig, type Output} from '@sanity/cli-core'
+import {type ViteDevServer} from 'vite'
 
 import {type DevCommand} from '../../commands/dev.js'
 
@@ -13,3 +14,14 @@ export interface DevActionOptions {
 
   workbenchAvailable?: boolean
 }
+
+/**
+ * Result of starting an app/studio dev server. Discriminated on `started` so
+ * callers handle the didn't-start case explicitly instead of null-checking
+ * optional fields. A server that fails to *boot* still throws — the
+ * not-started arm is reserved for expected early exits the server has
+ * already reported to the user.
+ */
+export type StartDevServerResult =
+  | {close: () => Promise<void>; server: ViteDevServer; started: true}
+  | {reason: 'missing-organization-id'; started: false}


### PR DESCRIPTION
### Description

Third tidy-up of the `dev/` action subsystem (after #1252, #1253). No behaviour change — it makes two fuzzy parts of the dev orchestration say what they mean:

- The app and studio servers now share one return type that states whether they started, so the caller stops inferring it from optional fields.
- The "rebuild the app server when views/services change" restart is owned by `devAction` and passed to the registration as a plain option, instead of being wired through a callback the registration held onto.

Also renames `startFederationRegistration` → `startDevServerRegistration` to match its folder and what it actually does.