### PR TITLE
fix(dev): restore main's dev output and --load-in-dashboard for non-workbench projects

### DIFF
--- a/.changeset/pr-1257.md
+++ b/.changeset/pr-1257.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-fix(dev): restore dashboard URL output for non-workbench apps
+fix(dev): restore main's dev output and --load-in-dashboard for non-workbench projects

--- a/.changeset/pr-1257.md
+++ b/.changeset/pr-1257.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(dev): restore dashboard URL output for non-workbench apps

--- a/packages/@sanity/cli/src/actions/dev/__tests__/testHelpers.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/testHelpers.ts
@@ -1,7 +1,7 @@
 import {type CliConfig, type Output} from '@sanity/cli-core'
 import {unstable_defineApp} from '@sanity/federation'
 // eslint-disable-next-line import-x/no-extraneous-dependencies
-import {vi} from 'vitest'
+import {afterEach, beforeEach, type Mock, vi} from 'vitest'
 
 import {type DevActionOptions} from '../types.js'
 import {type StartWorkbenchOptions} from '../workbench/startWorkbenchDevServer.js'
@@ -42,10 +42,11 @@ export function createMockOutput(): Output {
 
 /** Minimal flags object accepted by the dev command — values aren't asserted
  * by the code under test but are required to type-check as `DevFlags`. */
-const DEV_FLAGS = {
+export const DEV_FLAGS = {
   'auto-updates': false,
   host: 'localhost',
   json: false,
+  'load-in-dashboard': false,
   port: '3333',
 } as const
 
@@ -73,4 +74,49 @@ export function createBaseDevOptions(overrides: Partial<DevActionOptions> = {}):
     workDir: '/tmp/sanity-project',
     ...overrides,
   }
+}
+
+/** Return value the `getDevServerConfig` mock should resolve with. */
+export const DEV_SERVER_CONFIG = {
+  basePath: '/',
+  cwd: '/tmp/sanity-project',
+  httpHost: 'localhost',
+  httpPort: 3333,
+  reactStrictMode: false,
+  staticPath: '/tmp/sanity-project/static',
+} as const
+
+/** Minimal `startDevServer` result — a closeable vite server on the given port. */
+export function createMockDevServer({port = 3333}: {port?: number} = {}) {
+  return {
+    close: vi.fn().mockResolvedValue(),
+    server: {
+      config: {
+        logger: {info: vi.fn()},
+        server: {port},
+      },
+    },
+  }
+}
+
+/**
+ * Registers hooks that stub global `fetch` with fake timers for the duration
+ * of the suite. Call at `describe` (or file) top level; use the returned mock
+ * to script responses per test.
+ */
+export function setupFetchStub(): Mock {
+  const mockFetch = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  return mockFetch
 }

--- a/packages/@sanity/cli/src/actions/dev/__tests__/testHelpers.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/testHelpers.ts
@@ -89,7 +89,7 @@ export const DEV_SERVER_CONFIG = {
 /** Minimal `startDevServer` result — a closeable vite server on the given port. */
 export function createMockDevServer({port = 3333}: {port?: number} = {}) {
   return {
-    close: vi.fn().mockResolvedValue(),
+    close: vi.fn(() => Promise.resolve()),
     server: {
       config: {
         logger: {info: vi.fn()},

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/getDashboardAppUrl.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/getDashboardAppUrl.test.ts
@@ -1,0 +1,91 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {getDashboardAppURL} from '../getDashboardAppUrl.js'
+
+const mockFetch = vi.fn()
+
+describe('#getDashboardAppUrl', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  test('should send default dashboard app url if fetch timesout', async () => {
+    mockFetch.mockImplementation(
+      (_url, {signal}) =>
+        new Promise((resolve, reject) => {
+          const timeout = setTimeout(
+            () => resolve({json: () => ({url: 'https://custom.url'}), ok: true}),
+            6000,
+          )
+          signal.addEventListener('abort', () => {
+            clearTimeout(timeout)
+            reject(new DOMException('Aborted', 'AbortError'))
+          })
+        }),
+    )
+
+    const promise = getDashboardAppURL({
+      httpHost: 'localhost',
+      httpPort: 3333,
+      organizationId: 'org-123',
+    })
+
+    await vi.advanceTimersByTimeAsync(5000)
+
+    const result = await promise
+
+    expect(result).toBe('https://www.sanity.io/@org-123?dev=http%3A%2F%2Flocalhost%3A3333')
+  })
+
+  test('should send default dashboard app url if fetch fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      statusText: 'Internal Server Error',
+    })
+
+    const result = await getDashboardAppURL({
+      httpHost: 'localhost',
+      httpPort: 3333,
+      organizationId: 'org-456',
+    })
+
+    expect(result).toBe('https://www.sanity.io/@org-456?dev=http%3A%2F%2Flocalhost%3A3333')
+  })
+
+  test('should send default url if body does not return url', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({}),
+      ok: true,
+    })
+
+    const result = await getDashboardAppURL({
+      httpHost: 'localhost',
+      httpPort: 3333,
+      organizationId: 'org-789',
+    })
+
+    expect(result).toBe('https://www.sanity.io/@org-789?dev=http%3A%2F%2Flocalhost%3A3333')
+  })
+
+  test('sends back dashboard app url when successful', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({url: 'https://custom-dashboard.sanity.io/@org-789?dev=test'}),
+      ok: true,
+    })
+
+    const result = await getDashboardAppURL({
+      httpHost: 'localhost',
+      httpPort: 3333,
+      organizationId: 'org-789',
+    })
+
+    expect(result).toBe('https://custom-dashboard.sanity.io/@org-789?dev=test')
+  })
+})

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/getDashboardAppUrl.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/getDashboardAppUrl.test.ts
@@ -1,20 +1,10 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import {describe, expect, test, vi} from 'vitest'
 
+import {setupFetchStub} from '../../__tests__/testHelpers.js'
 import {getDashboardAppURL} from '../getDashboardAppUrl.js'
 
-const mockFetch = vi.fn()
-
 describe('#getDashboardAppUrl', () => {
-  beforeEach(() => {
-    vi.stubGlobal('fetch', mockFetch)
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.clearAllMocks()
-    vi.unstubAllGlobals()
-    vi.useRealTimers()
-  })
+  const mockFetch = setupFetchStub()
 
   test('should send default dashboard app url if fetch timesout', async () => {
     mockFetch.mockImplementation(

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/getDevServerConfig.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/getDevServerConfig.test.ts
@@ -1,6 +1,7 @@
-import {type CliConfig, type Output} from '@sanity/cli-core'
+import {type CliConfig} from '@sanity/cli-core'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
+import {createMockOutput, DEV_FLAGS as FLAGS} from '../../__tests__/testHelpers.js'
 import {getDevServerConfig} from '../getDevServerConfig.js'
 
 vi.mock('@sanity/cli-core/ux', () => ({
@@ -9,22 +10,6 @@ vi.mock('@sanity/cli-core/ux', () => ({
     succeed: vi.fn(),
   })),
 }))
-
-function createMockOutput(): Output {
-  return {
-    error: vi.fn(),
-    log: vi.fn(),
-    warn: vi.fn(),
-  } as unknown as Output
-}
-
-/** These are not relevant for what we are testing, but still needed to pass type checker */
-const FLAGS = {
-  'auto-updates': false,
-  host: 'localhost',
-  json: false,
-  port: '3333',
-} as const
 
 describe('getDevServerConfig', () => {
   afterEach(() => {

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
@@ -3,7 +3,10 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {
   createDevOptions,
+  createMockDevServer,
   createMockOutput,
+  DEV_FLAGS,
+  DEV_SERVER_CONFIG,
   workbenchCliConfig,
 } from '../../__tests__/testHelpers.js'
 import {type DevActionOptions} from '../../types.js'
@@ -27,13 +30,6 @@ vi.mock('../getDashboardAppUrl.js', () => ({
   getDashboardAppURL: mockGetDashboardAppURL,
 }))
 
-function mockServer({port = 3333}: {port?: number} = {}) {
-  return {
-    close: vi.fn().mockResolvedValue(undefined),
-    server: {config: {server: {port}}},
-  }
-}
-
 function createOptions(overrides: Partial<DevActionOptions> = {}): DevActionOptions {
   return createDevOptions({
     cliConfig: {app: {organizationId: 'org-1'}} as unknown as CliConfig,
@@ -44,15 +40,8 @@ function createOptions(overrides: Partial<DevActionOptions> = {}): DevActionOpti
 
 describe('startAppDevServer', () => {
   beforeEach(() => {
-    mockGetDevServerConfig.mockReturnValue({
-      basePath: '/',
-      cwd: '/tmp/sanity-project',
-      httpHost: 'localhost',
-      httpPort: 3333,
-      reactStrictMode: false,
-      staticPath: '/tmp/sanity-project/static',
-    })
-    mockStartDevServer.mockResolvedValue(mockServer())
+    mockGetDevServerConfig.mockReturnValue(DEV_SERVER_CONFIG)
+    mockStartDevServer.mockResolvedValue(createMockDevServer())
     mockGracefulServerDeath.mockImplementation((_cmd, _host, _port, err) => err)
     mockGetDashboardAppURL.mockResolvedValue('https://sanity.io/@org-1?dev=http://localhost:3334')
   })
@@ -87,7 +76,7 @@ describe('startAppDevServer', () => {
   })
 
   test('starts dev server with isApp and appTitle from cliConfig', async () => {
-    mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
+    mockStartDevServer.mockResolvedValue(createMockDevServer({port: 3334}))
 
     const result = await startAppDevServer(
       createOptions({
@@ -109,11 +98,41 @@ describe('startAppDevServer', () => {
     expect(result.close).toBeDefined()
   })
 
-  test('logs port and dashboard URL for non-workbench apps', async () => {
-    mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
+  test('warns when load-in-dashboard is disabled for non-workbench apps', async () => {
     const output = createMockOutput()
 
-    await startAppDevServer(createOptions({output}))
+    await startAppDevServer(
+      createOptions({flags: {...DEV_FLAGS, 'load-in-dashboard': false}, output}),
+    )
+
+    expect(output.warn).toHaveBeenCalledWith('Apps cannot run without the Sanity dashboard')
+    expect(output.warn).toHaveBeenCalledWith(
+      'Starting dev server with the --load-in-dashboard flag set to true',
+    )
+  })
+
+  test('does not warn about the dashboard for workbench apps', async () => {
+    const output = createMockOutput()
+
+    await startAppDevServer(
+      createOptions({
+        cliConfig: workbenchCliConfig(),
+        flags: {...DEV_FLAGS, 'load-in-dashboard': false},
+        output,
+        workbenchAvailable: true,
+      }),
+    )
+
+    expect(output.warn).not.toHaveBeenCalled()
+  })
+
+  test('logs port and dashboard URL for non-workbench apps', async () => {
+    mockStartDevServer.mockResolvedValue(createMockDevServer({port: 3334}))
+    const output = createMockOutput()
+
+    await startAppDevServer(
+      createOptions({flags: {...DEV_FLAGS, 'load-in-dashboard': true}, output}),
+    )
 
     expect(mockGetDashboardAppURL).toHaveBeenCalledWith({
       httpHost: 'localhost',
@@ -128,7 +147,7 @@ describe('startAppDevServer', () => {
   })
 
   test('logs "App dev server started" for workbench apps when workbench is not available', async () => {
-    mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
+    mockStartDevServer.mockResolvedValue(createMockDevServer({port: 3334}))
     const output = createMockOutput()
 
     await startAppDevServer(
@@ -140,7 +159,7 @@ describe('startAppDevServer', () => {
   })
 
   test('skips the port log line for workbench apps when workbench is available', async () => {
-    mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
+    mockStartDevServer.mockResolvedValue(createMockDevServer({port: 3334}))
     const output = createMockOutput()
 
     await startAppDevServer(

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
@@ -1,13 +1,18 @@
 import {type CliConfig} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {createDevOptions, createMockOutput} from '../../__tests__/testHelpers.js'
+import {
+  createDevOptions,
+  createMockOutput,
+  workbenchCliConfig,
+} from '../../__tests__/testHelpers.js'
 import {type DevActionOptions} from '../../types.js'
 import {startAppDevServer} from '../startAppDevServer.js'
 
 const mockStartDevServer = vi.hoisted(() => vi.fn())
 const mockGracefulServerDeath = vi.hoisted(() => vi.fn())
 const mockGetDevServerConfig = vi.hoisted(() => vi.fn())
+const mockGetDashboardAppURL = vi.hoisted(() => vi.fn())
 
 vi.mock('../../../../server/devServer.js', () => ({
   startDevServer: mockStartDevServer,
@@ -17,6 +22,9 @@ vi.mock('../../../../server/gracefulServerDeath.js', () => ({
 }))
 vi.mock('../getDevServerConfig.js', () => ({
   getDevServerConfig: mockGetDevServerConfig,
+}))
+vi.mock('../getDashboardAppUrl.js', () => ({
+  getDashboardAppURL: mockGetDashboardAppURL,
 }))
 
 function mockServer({port = 3333}: {port?: number} = {}) {
@@ -46,6 +54,7 @@ describe('startAppDevServer', () => {
     })
     mockStartDevServer.mockResolvedValue(mockServer())
     mockGracefulServerDeath.mockImplementation((_cmd, _host, _port, err) => err)
+    mockGetDashboardAppURL.mockResolvedValue('https://sanity.io/@org-1?dev=http://localhost:3334')
   })
 
   afterEach(() => {
@@ -100,24 +109,48 @@ describe('startAppDevServer', () => {
     expect(result.close).toBeDefined()
   })
 
-  test('logs "App dev server started" when workbench is not available', async () => {
+  test('logs port and dashboard URL for non-workbench apps', async () => {
     mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
     const output = createMockOutput()
 
-    await startAppDevServer(createOptions({output, workbenchAvailable: false}))
+    await startAppDevServer(createOptions({output}))
 
-    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('3334'))
+    expect(mockGetDashboardAppURL).toHaveBeenCalledWith({
+      httpHost: 'localhost',
+      httpPort: 3334,
+      organizationId: 'org-1',
+    })
+    expect(output.log).toHaveBeenCalledWith('Dev server started on port 3334')
+    expect(output.log).toHaveBeenCalledWith('View your app in the Sanity dashboard here:')
+    expect(output.log).toHaveBeenCalledWith(
+      expect.stringContaining('https://sanity.io/@org-1?dev=http://localhost:3334'),
+    )
   })
 
-  test('skips the port log line when workbench is available', async () => {
+  test('logs "App dev server started" for workbench apps when workbench is not available', async () => {
     mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
     const output = createMockOutput()
 
-    await startAppDevServer(createOptions({output, workbenchAvailable: true}))
+    await startAppDevServer(
+      createOptions({cliConfig: workbenchCliConfig(), output, workbenchAvailable: false}),
+    )
+
+    expect(output.log).toHaveBeenCalledWith('App dev server started on port 3334')
+    expect(mockGetDashboardAppURL).not.toHaveBeenCalled()
+  })
+
+  test('skips the port log line for workbench apps when workbench is available', async () => {
+    mockStartDevServer.mockResolvedValue(mockServer({port: 3334}))
+    const output = createMockOutput()
+
+    await startAppDevServer(
+      createOptions({cliConfig: workbenchCliConfig(), output, workbenchAvailable: true}),
+    )
 
     // 'Starting dev server' is still logged, but the port announcement is not
     const logCalls = (output.log as ReturnType<typeof vi.fn>).mock.calls.flat()
     expect(logCalls.some((c) => String(c).includes('App dev server started'))).toBe(false)
+    expect(mockGetDashboardAppURL).not.toHaveBeenCalled()
   })
 
   test('wraps startup failures via gracefulServerDeath', async () => {

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/startStudioDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/startStudioDevServer.test.ts
@@ -1,12 +1,21 @@
 import {type CliConfig} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {createDevOptions, createMockOutput} from '../../__tests__/testHelpers.js'
+import {
+  createDevOptions,
+  createMockDevServer,
+  createMockOutput,
+  DEV_FLAGS,
+  DEV_SERVER_CONFIG,
+  studioWorkbenchApp,
+} from '../../__tests__/testHelpers.js'
 import {startStudioDevServer} from '../startStudioDevServer.js'
 
 const mockStartDevServer = vi.hoisted(() => vi.fn())
 const mockGracefulServerDeath = vi.hoisted(() => vi.fn())
 const mockGetDevServerConfig = vi.hoisted(() => vi.fn())
+const mockGetProjectCliClient = vi.hoisted(() => vi.fn())
+const mockGetDashboardAppURL = vi.hoisted(() => vi.fn())
 const mockCheckStudioDependencyVersions = vi.hoisted(() => vi.fn())
 const mockCheckRequiredDependencies = vi.hoisted(() => vi.fn())
 const mockShouldAutoUpdate = vi.hoisted(() => vi.fn())
@@ -26,6 +35,9 @@ vi.mock('../../../../server/gracefulServerDeath.js', () => ({
 }))
 vi.mock('../getDevServerConfig.js', () => ({
   getDevServerConfig: mockGetDevServerConfig,
+}))
+vi.mock('../getDashboardAppUrl.js', () => ({
+  getDashboardAppURL: mockGetDashboardAppURL,
 }))
 vi.mock('@sanity/cli-build/_internal/build', () => ({
   checkStudioDependencyVersions: mockCheckStudioDependencyVersions,
@@ -53,6 +65,7 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
   return {
     ...actual,
     getLocalPackageVersion: mockGetLocalPackageVersion,
+    getProjectCliClient: mockGetProjectCliClient,
     isInteractive: mockIsInteractive,
   }
 })
@@ -70,36 +83,18 @@ vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
   }
 })
 
-function mockServer({port = 3333}: {port?: number} = {}) {
-  return {
-    close: vi.fn().mockResolvedValue(undefined),
-    server: {
-      config: {
-        logger: {info: vi.fn()},
-        server: {port},
-      },
-    },
-  }
-}
-
 describe('startStudioDevServer', () => {
   beforeEach(() => {
     mockCheckStudioDependencyVersions.mockResolvedValue(undefined)
     mockCheckRequiredDependencies.mockResolvedValue({installedSanityVersion: '3.50.0'})
     mockShouldAutoUpdate.mockReturnValue(false)
-    mockGetDevServerConfig.mockReturnValue({
-      basePath: '/',
-      cwd: '/tmp/sanity-project',
-      httpHost: 'localhost',
-      httpPort: 3333,
-      reactStrictMode: false,
-      staticPath: '/tmp/sanity-project/static',
-    })
-    mockStartDevServer.mockResolvedValue(mockServer())
+    mockGetDevServerConfig.mockReturnValue(DEV_SERVER_CONFIG)
+    mockStartDevServer.mockResolvedValue(createMockDevServer())
     mockGetLocalPackageVersion.mockResolvedValue('5.0.0')
     mockGracefulServerDeath.mockImplementation((_cmd, _host, _port, err) => err)
     mockGetAppId.mockReturnValue('app-id')
     mockIsInteractive.mockReturnValue(false)
+    mockGetDashboardAppURL.mockResolvedValue('https://sanity.io/@org-x?dev=http://localhost:3333')
   })
 
   afterEach(() => {
@@ -149,6 +144,65 @@ describe('startStudioDevServer', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error).toBe(wrappedErr)
     expect(mockGracefulServerDeath).toHaveBeenCalledWith('dev', 'localhost', 3333, originalErr)
+  })
+
+  describe('load-in-dashboard', () => {
+    test('resolves the org and logs the dashboard URL for non-workbench studios', async () => {
+      mockGetProjectCliClient.mockResolvedValue({
+        projects: {
+          getById: vi.fn().mockResolvedValue({organizationId: 'org-x'}),
+        },
+      })
+      const output = createMockOutput()
+
+      await startStudioDevServer(
+        createDevOptions({
+          cliConfig: {api: {projectId: 'proj-1'}} as CliConfig,
+          flags: {...DEV_FLAGS, 'load-in-dashboard': true},
+          output,
+        }),
+      )
+
+      expect(mockGetDashboardAppURL).toHaveBeenCalledWith({
+        httpHost: 'localhost',
+        httpPort: 3333,
+        organizationId: 'org-x',
+      })
+      expect(output.log).toHaveBeenCalledWith('Dev server started on port 3333')
+      expect(output.log).toHaveBeenCalledWith('View your studio in the Sanity dashboard here:')
+      expect(output.log).toHaveBeenCalledWith(
+        expect.stringContaining('https://sanity.io/@org-x?dev=http://localhost:3333'),
+      )
+    })
+
+    test('errors when projectId is missing', async () => {
+      const output = createMockOutput()
+
+      await startStudioDevServer(
+        createDevOptions({flags: {...DEV_FLAGS, 'load-in-dashboard': true}, output}),
+      )
+
+      expect(output.error).toHaveBeenCalledWith('Project Id is required to load in dashboard', {
+        exit: 1,
+      })
+    })
+
+    test('ignores the flag for workbench studios', async () => {
+      const output = createMockOutput()
+
+      await startStudioDevServer(
+        createDevOptions({
+          cliConfig: {api: {projectId: 'proj-1'}, app: studioWorkbenchApp()} as CliConfig,
+          flags: {...DEV_FLAGS, 'load-in-dashboard': true},
+          output,
+        }),
+      )
+
+      expect(mockGetProjectCliClient).not.toHaveBeenCalled()
+      expect(mockGetDashboardAppURL).not.toHaveBeenCalled()
+      const logCalls = (output.log as ReturnType<typeof vi.fn>).mock.calls.flat()
+      expect(logCalls.some((c) => String(c).includes('dashboard'))).toBe(false)
+    })
   })
 
   describe('auto-updates', () => {

--- a/packages/@sanity/cli/src/actions/dev/servers/getDashboardAppUrl.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/getDashboardAppUrl.ts
@@ -1,0 +1,65 @@
+import {getSanityUrl, subdebug} from '@sanity/cli-core'
+
+const debug = subdebug('dev:getDashboardAppURL')
+
+const DEFAULT_TIMEOUT = 5000
+
+const getDefaultDashboardURL = ({
+  organizationId,
+  url,
+}: {
+  organizationId: string
+  url: string
+}): string => {
+  return getSanityUrl(
+    `/@${organizationId}?${new URLSearchParams({
+      dev: url,
+    }).toString()}`,
+  )
+}
+
+/**
+ * Gets the dashboard URL from API or uses the default dashboard URL
+ */
+export const getDashboardAppURL = async ({
+  httpHost = 'localhost',
+  httpPort = 3333,
+  organizationId,
+}: {
+  httpHost?: string
+  httpPort?: number
+  organizationId: string
+}): Promise<string> => {
+  const url = `http://${httpHost}:${httpPort}`
+
+  const abortController = new AbortController()
+  // Wait for 5 seconds before aborting the request
+  const timer = setTimeout(() => abortController.abort(), DEFAULT_TIMEOUT)
+  try {
+    const queryParams = new URLSearchParams({
+      organizationId,
+      url,
+    })
+
+    const res = await globalThis.fetch(
+      getSanityUrl(`/api/dashboard/mode/development/resolve-url?${queryParams.toString()}`),
+      {
+        signal: abortController.signal,
+      },
+    )
+
+    if (!res.ok) {
+      debug(`Failed to fetch dashboard URL: ${res.statusText}`)
+      return getDefaultDashboardURL({organizationId, url})
+    }
+
+    const body = await res.json()
+    // <dashboard-app-url>/<orgniazationId>?dev=<dev-server-url>
+    return body?.url ?? getDefaultDashboardURL({organizationId, url})
+  } catch (err) {
+    debug(`Failed to fetch dashboard URL: ${err instanceof Error ? err.message : String(err)}`)
+    return getDefaultDashboardURL({organizationId, url})
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
@@ -12,6 +12,13 @@ import {getDevServerConfig} from './getDevServerConfig.js'
 export async function startAppDevServer(options: DevActionOptions): Promise<StartDevServerResult> {
   const {cliConfig, flags, output, workbenchAvailable, workDir} = options
 
+  // Workbench apps don't load through the dashboard, so the flag has no
+  // meaning for them and is ignored.
+  if (!isWorkbenchApp(cliConfig?.app) && !flags['load-in-dashboard']) {
+    output.warn(`Apps cannot run without the Sanity dashboard`)
+    output.warn(`Starting dev server with the --load-in-dashboard flag set to true`)
+  }
+
   let organizationId: string | undefined
   if (cliConfig && 'app' in cliConfig && cliConfig.app?.organizationId) {
     organizationId = cliConfig.app.organizationId

--- a/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
@@ -1,7 +1,12 @@
+import {styleText} from 'node:util'
+
+import {isWorkbenchApp} from '@sanity/cli-core'
+
 import {startDevServer} from '../../../server/devServer.js'
 import {gracefulServerDeath} from '../../../server/gracefulServerDeath.js'
 import {devDebug} from '../devDebug.js'
 import {type DevActionOptions, type StartDevServerResult} from '../types.js'
+import {getDashboardAppURL} from './getDashboardAppUrl.js'
 import {getDevServerConfig} from './getDevServerConfig.js'
 
 export async function startAppDevServer(options: DevActionOptions): Promise<StartDevServerResult> {
@@ -33,8 +38,24 @@ export async function startAppDevServer(options: DevActionOptions): Promise<Star
 
     const {port} = server.config.server
 
-    if (!workbenchAvailable) {
-      output.log(`App dev server started on port ${port}`)
+    if (isWorkbenchApp(cliConfig?.app)) {
+      // Federated apps surface through the workbench, so the dashboard URL is
+      // meaningless for them. When the workbench runs, devAction announces its
+      // URL instead — only the package-unavailable fallback logs from here.
+      if (!workbenchAvailable) {
+        output.log(`App dev server started on port ${port}`)
+      }
+    } else {
+      const httpHost = config.httpHost || 'localhost'
+
+      const dashboardAppUrl = await getDashboardAppURL({
+        httpHost,
+        httpPort: port,
+        organizationId,
+      })
+      output.log(`Dev server started on port ${port}`)
+      output.log(`View your app in the Sanity dashboard here:`)
+      output.log(styleText(['blue', 'underline'], dashboardAppUrl))
     }
 
     return {close, server, started: true}

--- a/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
@@ -1,12 +1,13 @@
 import {styleText} from 'node:util'
 
 import {checkStudioDependencyVersions} from '@sanity/cli-build/_internal/build'
-import {getLocalPackageVersion, isInteractive} from '@sanity/cli-core'
+import {getLocalPackageVersion, isInteractive, isWorkbenchApp} from '@sanity/cli-core'
 import {confirm, logSymbols, spinner} from '@sanity/cli-core/ux'
 import {parse as semverParse} from 'semver'
 
 import {startDevServer} from '../../../server/devServer.js'
 import {gracefulServerDeath} from '../../../server/gracefulServerDeath.js'
+import {getProjectById} from '../../../services/projects.js'
 import {getAppId} from '../../../util/appId.js'
 import {compareDependencyVersions} from '../../../util/compareDependencyVersions.js'
 import {getPackageManagerChoice} from '../../../util/packageManager/packageManagerChoice.js'
@@ -15,12 +16,19 @@ import {checkRequiredDependencies} from '../../build/checkRequiredDependencies.j
 import {shouldAutoUpdate} from '../../build/shouldAutoUpdate.js'
 import {devDebug} from '../devDebug.js'
 import {type DevActionOptions, type StartDevServerResult} from '../types.js'
+import {getDashboardAppURL} from './getDashboardAppUrl.js'
 import {getDevServerConfig} from './getDevServerConfig.js'
 
 export async function startStudioDevServer(
   options: DevActionOptions,
 ): Promise<StartDevServerResult> {
   const {cliConfig, flags, output, workbenchAvailable, workDir} = options
+  const projectId = cliConfig?.api?.projectId
+  let organizationId: string | undefined
+
+  // Workbench apps don't load through the dashboard, so the flag has no
+  // meaning for them and is ignored.
+  const loadInDashboard = flags['load-in-dashboard'] && !isWorkbenchApp(cliConfig?.app)
 
   // Check studio dependency versions
   await checkStudioDependencyVersions(workDir, output)
@@ -97,6 +105,20 @@ export async function startStudioDevServer(
 
   const config = getDevServerConfig({cliConfig, flags, output, workDir})
 
+  if (loadInDashboard) {
+    if (!projectId) {
+      output.error('Project Id is required to load in dashboard', {exit: 1})
+    }
+
+    try {
+      const project = await getProjectById(projectId!)
+      organizationId = project.organizationId!
+    } catch (error) {
+      devDebug('Error getting organization id from project id', error)
+      output.error('Failed to get organization id from project id', {exit: 1})
+    }
+  }
+
   try {
     const startTime = Date.now()
     const spin = spinner('Starting dev server').start()
@@ -106,19 +128,36 @@ export async function startStudioDevServer(
     const {port} = server.config.server
     const httpHost = config.httpHost || 'localhost'
 
-    const startupDuration = Date.now() - startTime
-    const url = `http://${httpHost || 'localhost'}:${port}${config.basePath}`
-    const appType = 'Sanity Studio'
+    if (loadInDashboard) {
+      spin.succeed()
 
-    const viteVersion = await getLocalPackageVersion('vite', import.meta.url)
-    spin.succeed()
+      output.log(`Dev server started on port ${port}`)
+      output.log(`View your studio in the Sanity dashboard here:`)
+      output.log(
+        styleText(
+          ['blue', 'underline'],
+          await getDashboardAppURL({
+            httpHost,
+            httpPort: port,
+            organizationId: organizationId!,
+          }),
+        ),
+      )
+    } else {
+      const startupDuration = Date.now() - startTime
+      const url = `http://${httpHost || 'localhost'}:${port}${config.basePath}`
+      const appType = 'Sanity Studio'
 
-    loggerInfo(
-      `${appType} ` +
-        `using ${styleText('cyan', `vite@${viteVersion}`)} ` +
-        `ready in ${styleText('cyan', `${Math.ceil(startupDuration)}ms`)}` +
-        (workbenchAvailable ? '' : ` and running at ${styleText('cyan', url)}`),
-    )
+      const viteVersion = await getLocalPackageVersion('vite', import.meta.url)
+      spin.succeed()
+
+      loggerInfo(
+        `${appType} ` +
+          `using ${styleText('cyan', `vite@${viteVersion}`)} ` +
+          `ready in ${styleText('cyan', `${Math.ceil(startupDuration)}ms`)}` +
+          (workbenchAvailable ? '' : ` and running at ${styleText('cyan', url)}`),
+      )
+    }
 
     return {close, server, started: true}
   } catch (err) {

--- a/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
@@ -16,6 +16,14 @@ import {DevCommand} from '../dev.js'
 
 const mockTypegenPlugin = vi.hoisted(() => vi.fn())
 
+const mockGetDashboardAppURL = vi.hoisted(() =>
+  vi.fn().mockResolvedValue('https://www.sanity.io/@test-org?dev=http%3A%2F%2Flocalhost%3A5340'),
+)
+
+vi.mock('../../actions/dev/servers/getDashboardAppUrl.js', () => ({
+  getDashboardAppURL: mockGetDashboardAppURL,
+}))
+
 vi.mock('../../actions/build/checkRequiredDependencies.js', () => ({
   checkRequiredDependencies: vi.fn().mockResolvedValue({
     installedSanityVersion: '3.0.0',
@@ -100,7 +108,8 @@ describe('#dev', {timeout: (platform() === 'win32' ? 60 : 30) * 1000}, () => {
       })
 
       if (error) throw error
-      expect(stdout).toContain('App dev server started on port 5333')
+      expect(stdout).toContain('Dev server started on port 5333')
+      expect(stdout).toContain('View your app in the Sanity dashboard here:')
       expect(stderr).toContain('Checking configuration files')
       await tryCloseServer(result)
 
@@ -131,7 +140,8 @@ describe('#dev', {timeout: (platform() === 'win32' ? 60 : 30) * 1000}, () => {
       })
 
       if (error) throw error
-      expect(stdout).toContain('App dev server started on port 5333')
+      expect(stdout).toContain('Dev server started on port 5333')
+      expect(stdout).toContain('View your app in the Sanity dashboard here:')
       expect(stderr).toContain('Checking configuration files')
       await tryCloseServer(result)
 
@@ -163,8 +173,9 @@ describe('#dev', {timeout: (platform() === 'win32' ? 60 : 30) * 1000}, () => {
         })
 
         if (error) throw error
-        expect(stdout).toMatch(/App dev server started on port \d{4}/)
-        expect(stdout).not.toContain('App dev server started on port 5338')
+        expect(stdout).toMatch(/Dev server started on port \d{4}/)
+        expect(stdout).not.toContain('Dev server started on port 5338')
+        expect(stdout).toContain('View your app in the Sanity dashboard here:')
         await tryCloseServer(result)
       } finally {
         await closeServer(server)
@@ -204,7 +215,7 @@ describe('#dev', {timeout: (platform() === 'win32' ? 60 : 30) * 1000}, () => {
       })
 
       if (error) throw error
-      expect(stdout).toContain('App dev server started on port 5350')
+      expect(stdout).toContain('Dev server started on port 5350')
       await tryCloseServer(result)
     })
 

--- a/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
@@ -3,12 +3,14 @@ import {createServer} from 'node:http'
 import {platform} from 'node:os'
 import {join} from 'node:path'
 
+import {type CliConfig, getProjectCliClient} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 import {testCommand, testFixture} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {closeServer, tryCloseServer} from '../../../test/testUtils.js'
 import {checkRequiredDependencies} from '../../actions/build/checkRequiredDependencies.js'
+import {workbenchApp} from '../../actions/dev/__tests__/testHelpers.js'
 import {compareDependencyVersions} from '../../util/compareDependencyVersions.js'
 import {getPackageManagerChoice} from '../../util/packageManager/packageManagerChoice.js'
 import {upgradePackages} from '../../util/packageManager/upgradePackages.js'
@@ -73,6 +75,7 @@ vi.mock('@sanity/cli-core', async () => {
   const actual = await vi.importActual<typeof import('@sanity/cli-core')>('@sanity/cli-core')
   return {
     ...actual,
+    getProjectCliClient: vi.fn(),
     isInteractive: vi.fn(() => true),
   }
 })
@@ -82,6 +85,7 @@ const mockCompareDependencyVersions = vi.mocked(compareDependencyVersions)
 const mockConfirm = vi.mocked(confirm)
 const mockUpgradePackages = vi.mocked(upgradePackages)
 const mockGetPackageManagerChoice = vi.mocked(getPackageManagerChoice)
+const mockGetProjectCliClient = vi.mocked(getProjectCliClient)
 
 describe('#dev', {timeout: (platform() === 'win32' ? 60 : 30) * 1000}, () => {
   afterEach(() => {
@@ -154,6 +158,26 @@ describe('#dev', {timeout: (platform() === 'win32' ? 60 : 30) * 1000}, () => {
         telemetryLogger: expect.anything(),
         workDir: cwd,
       })
+    })
+
+    test('should warn when --no-load-in-dashboard is used with app', async () => {
+      const cwd = await testFixture('basic-app')
+      process.cwd = () => cwd
+
+      const {error, result, stderr, stdout} = await testCommand(
+        DevCommand,
+        ['--no-load-in-dashboard', '--port', '5334'],
+        {
+          config: {root: cwd},
+          mocks: {isInteractive: true},
+        },
+      )
+
+      if (error) throw error
+      expect(stderr).toContain('Apps cannot run without the Sanity dashboard')
+      expect(stderr).toContain('Starting dev server with the --load-in-dashboard flag set to true')
+      expect(stdout).toContain('Dev server started on port 5334')
+      await tryCloseServer(result)
     })
 
     test('should start on next available port when requested port is in use', async () => {
@@ -242,6 +266,50 @@ describe('#dev', {timeout: (platform() === 'win32' ? 60 : 30) * 1000}, () => {
     })
   })
 
+  describe('workbench-app', () => {
+    test('warns that --load-in-dashboard is ignored for workbench apps', async () => {
+      const cwd = await testFixture('basic-app')
+      process.cwd = () => cwd
+
+      // No organizationId: the command exits before booting a server, after
+      // the flag warning has been emitted.
+      const {error, stderr} = await testCommand(
+        DevCommand,
+        ['--load-in-dashboard', '--port', '5346'],
+        {
+          config: {root: cwd},
+          mocks: {
+            cliConfig: {app: workbenchApp({organizationId: undefined})} as CliConfig,
+            isInteractive: true,
+          },
+        },
+      )
+
+      // oclif line-wraps long warnings, so assert the unwrapped prefix only
+      expect(stderr).toContain('Ignoring --load-in-dashboard')
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.message).toContain('Apps require an organization ID (orgId)')
+      expect(error?.oclif?.exit).toBe(1)
+    })
+
+    test('does not warn when the flag is not passed', async () => {
+      const cwd = await testFixture('basic-app')
+      process.cwd = () => cwd
+
+      const {error, stderr} = await testCommand(DevCommand, ['--port', '5347'], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {app: workbenchApp({organizationId: undefined})} as CliConfig,
+          isInteractive: true,
+        },
+      })
+
+      expect(stderr).not.toContain('Ignoring --load-in-dashboard')
+      expect(error).toBeInstanceOf(Error)
+      expect(error?.oclif?.exit).toBe(1)
+    })
+  })
+
   describe('basic-studio', () => {
     test('should start the dev server for studio', async () => {
       const cwd = await testFixture('basic-studio')
@@ -279,6 +347,91 @@ describe('#dev', {timeout: (platform() === 'win32' ? 60 : 30) * 1000}, () => {
       if (error) throw error
       expect(stdout).toContain('http://127.0.0.1:5359')
       await tryCloseServer(result)
+    })
+
+    test('should start with load-in-dashboard', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project'
+
+      // Need to modify the sanity config to include projectId for this test
+      const configPath = join(cwd, 'sanity.cli.ts')
+      const existingConfig = await readFile(configPath, 'utf8')
+
+      // Add projectId to the config
+      const modifiedConfig = existingConfig.replace(/projectId:.*,/, `projectId: '${projectId}',`)
+
+      await writeFile(configPath, modifiedConfig)
+
+      mockGetProjectCliClient.mockResolvedValue({
+        projects: {
+          getById: vi.fn().mockResolvedValue({organizationId: 'test-org'}),
+        },
+      } as never)
+
+      const {error, result, stderr, stdout} = await testCommand(
+        DevCommand,
+        ['--load-in-dashboard', '--port', '5340'],
+        {
+          config: {root: cwd},
+          mocks: {isInteractive: true},
+        },
+      )
+
+      if (error) throw error
+      expect(stdout).toContain('Dev server started on port 5340')
+      expect(stdout).toContain('View your studio in the Sanity dashboard here:')
+      expect(stdout).toContain('https://www.sanity.io/@test-org?dev=http%3A%2F%2Flocalhost%3A5340')
+      expect(stderr).toContain('Checking configuration files')
+
+      await tryCloseServer(result)
+    })
+
+    test('should error when projectId is missing with --load-in-dashboard', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      // Modify config to remove projectId
+      const configPath = join(cwd, 'sanity.cli.ts')
+      const existingConfig = await readFile(configPath, 'utf8')
+      const modifiedConfig = existingConfig.replace(/projectId:.*,/, '')
+      await writeFile(configPath, modifiedConfig)
+
+      const {error} = await testCommand(DevCommand, ['--load-in-dashboard', '--port', '5343'], {
+        config: {root: cwd},
+        mocks: {isInteractive: true},
+      })
+
+      expect(error).toBeDefined()
+      expect(error?.message).toContain('Project Id is required to load in dashboard')
+      expect(error?.oclif?.exit).toBe(1)
+    })
+
+    test('should error when API fails to fetch organizationId', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project'
+      const configPath = join(cwd, 'sanity.cli.ts')
+      const existingConfig = await readFile(configPath, 'utf8')
+      const modifiedConfig = existingConfig.replace(/projectId:.*,/, `projectId: '${projectId}',`)
+      await writeFile(configPath, modifiedConfig)
+
+      mockGetProjectCliClient.mockResolvedValue({
+        projects: {
+          getById: vi.fn().mockRejectedValue(new Error('Project not found')),
+        },
+      } as never)
+
+      const {error} = await testCommand(DevCommand, ['--load-in-dashboard', '--port', '5344'], {
+        config: {root: cwd},
+        mocks: {isInteractive: true},
+      })
+
+      expect(error).toBeDefined()
+      expect(error?.message).toContain('Failed to get organization id from project id')
+      expect(error?.oclif?.exit).toBe(1)
     })
 
     test('should start dev server successfully when user declines auto-updates', async () => {

--- a/packages/@sanity/cli/src/commands/dev.ts
+++ b/packages/@sanity/cli/src/commands/dev.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {isWorkbenchApp, SanityCommand} from '@sanity/cli-core'
 
 import {devAction} from '../actions/dev/devAction.js'
 import {devDebug} from '../actions/dev/devDebug.js'
@@ -13,6 +13,7 @@ export class DevCommand extends SanityCommand<typeof DevCommand> {
   static override examples = [
     '<%= config.bin %> <%= command.id %> --host=0.0.0.0',
     '<%= config.bin %> <%= command.id %> --port=1942',
+    '<%= config.bin %> <%= command.id %> --load-in-dashboard',
   ]
 
   static override flags = {
@@ -22,6 +23,10 @@ export class DevCommand extends SanityCommand<typeof DevCommand> {
     }),
     host: Flags.string({
       description: 'Local network interface to listen on (default: localhost)',
+    }),
+    'load-in-dashboard': Flags.boolean({
+      allowNo: true,
+      description: 'Load the app/studio in the Sanity dashboard',
     }),
     port: Flags.string({
       description: 'TCP port to start server on (default: 3333)',
@@ -34,6 +39,21 @@ export class DevCommand extends SanityCommand<typeof DevCommand> {
     const workDir = (await this.getProjectRoot()).directory
     const cliConfig = await this.getCliConfig()
     const isApp = determineIsApp(cliConfig)
+
+    // The flag is defaulted below, so undefined still means "not passed".
+    if (isWorkbenchApp(cliConfig?.app) && flags['load-in-dashboard'] !== undefined) {
+      this.output.warn(
+        'Ignoring --load-in-dashboard: workbench apps do not load in the Sanity dashboard',
+      )
+    }
+
+    // load-in-dashboard is defaulted to true for apps.
+    if (isApp && flags['load-in-dashboard'] === undefined) {
+      flags['load-in-dashboard'] = true
+    } else if (flags['load-in-dashboard'] === undefined) {
+      // For non-apps, load-in-dashboard is defaulted to false.
+      flags['load-in-dashboard'] = false
+    }
 
     try {
       const result = await devAction({


### PR DESCRIPTION
### Description

Running `sanity dev` for a non-federated app on `feat/workbench` only prints the port — the dashboard URL is gone. The workbench dev server work (#770) deleted `getDashboardAppUrl` and collapsed the app output to a bare port log, and a later commit dropped the `--load-in-dashboard` flag entirely. Non-federated projects still load through the dashboard, so there was nothing left to open.

This restores main's behavior for everything that isn't a workbench app:

- Plain apps print the dashboard URL again:
  ```
  Dev server started on port 3333
  View your app in the Sanity dashboard here:
  https://www.sanity.io/@<orgId>?dev=...
  ```
- `--load-in-dashboard` is back with main's defaulting (true for apps, false for studios), including the `--no-load-in-dashboard` warnings for apps and the studio dashboard flow (projectId → organizationId → URL).

Workbench apps (branded via `unstable_defineApp`) keep the new behavior — the dashboard URL is meaningless for them, and `devAction` announces the workbench URL instead. The flag is ignored for them; passing it explicitly warns:

```
Ignoring --load-in-dashboard: workbench apps do not load in the Sanity dashboard
```

### What to review

`startAppDevServer` and `startStudioDevServer` branch on `isWorkbenchApp`: non-workbench projects get main's exact flows back, workbench apps keep the port-only/suppressed output. `getDashboardAppUrl.ts` and its test are restored from main unchanged, relocated into `servers/`. The explicit-flag warning lives in `dev.ts`, before the flag defaulting (so only a passed flag triggers it).

The dev suites' duplicated test setup (output mock, flags, dev-server config, vite-result factory, fetch stub) moved into the shared `testHelpers`.

### Testing

Unit tests cover both branches per server (dashboard flows for plain projects, ignored flag for workbench), and the `basic-app`/`basic-studio` command tests assert main's exact output again, plus the new workbench warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `sanity dev` startup paths, CLI flag defaulting, and a network call to resolve dashboard URLs; behavior is largely a restore of main with workbench branching and is heavily covered by tests.
> 
> **Overview**
> Restores **`sanity dev`** behavior for projects that are **not** workbench apps (`isWorkbenchApp`): plain apps and studios again get the Sanity **dashboard deep link** and the **`--load-in-dashboard`** flag (default **on** for apps, **off** for studios).
> 
> **`DevCommand`** reintroduces the boolean flag (with `allowNo`), defaults it before `devAction`, and warns when workbench apps pass the flag explicitly. **`getDashboardAppURL`** is added back under `servers/` (API resolve with timeout, fallback to `sanity.io/@org?dev=...`).
> 
> **`startAppDevServer`** and **`startStudioDevServer`** split output on workbench vs non-workbench: non-workbench apps always resolve and print the dashboard URL (with warnings if `--no-load-in-dashboard`); studios use the flag to either print the dashboard URL (after `projectId` → organization lookup) or keep the Vite “ready at …” line. Workbench apps keep suppressed/port-only logging and skip dashboard resolution.
> 
> Tests and shared **`testHelpers`** are expanded to cover both branches and command-level output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a97d368d44b4d95bf425bfe52d96f86f686580d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->