### PR TITLE
fix(workbench): restore main's port and signal behavior for non-workbench projects

### DIFF
--- a/.changeset/pr-1259.md
+++ b/.changeset/pr-1259.md
@@ -4,4 +4,4 @@
 '@sanity/cli': patch
 ---
 
-fix: restore main's port and signal behavior for non-workbench projects
+fix(workbench): restore main's port and signal behavior for non-workbench projects

--- a/.changeset/pr-1259.md
+++ b/.changeset/pr-1259.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': patch
+'@sanity/cli': patch
+---
+
+fix: restore main's port and signal behavior for non-workbench projects

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
@@ -135,7 +135,7 @@ describe('#getViteConfig', () => {
       server: {
         host: undefined,
         port: 3333,
-        strictPort: false,
+        strictPort: true,
       },
     })
 
@@ -173,6 +173,7 @@ describe('#getViteConfig', () => {
     const config = await getViteConfig(options)
 
     expect(config.envPrefix).toBe('SANITY_APP_')
+    expect(config.server?.strictPort).toBe(false)
     expect(config.define).toMatchObject({
       'process.env.APP_VAR': '"app-value"',
     })
@@ -268,7 +269,7 @@ describe('#getViteConfig', () => {
     expect(config.server).toMatchObject({
       host: '0.0.0.0',
       port: 8080,
-      strictPort: false,
+      strictPort: true,
     })
   })
 
@@ -506,6 +507,9 @@ describe('#getViteConfig', () => {
       workDir: mockTestCwd,
     })
     expect(federationPlugin).toBeDefined()
+    // Workbench stacks the app server next to the workbench port, so it must
+    // be able to drift even when the project is a studio.
+    expect(config.server?.strictPort).toBe(false)
   })
 
   test('should not include federation plugin when disabled', async () => {

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -249,7 +249,10 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     server: {
       host: server?.host,
       port: server?.port || 3333,
-      strictPort: false,
+      // Apps drift to a free port (the reported URL embeds whichever port was
+      // claimed), and workbench runs stack servers on adjacent ports — both
+      // need the fallback. Studios fail fast on a busy port.
+      strictPort: !isApp && !isWorkbenchApp,
 
       /**
        * Significantly speed up startup time,

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -1,7 +1,12 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {devAction} from '../devAction.js'
-import {createBaseDevOptions, createMockOutput, workbenchCliConfig} from './testHelpers.js'
+import {
+  createBaseDevOptions,
+  createMockOutput,
+  DEV_FLAGS,
+  workbenchCliConfig,
+} from './testHelpers.js'
 
 const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
 const mockStartAppDevServer = vi.hoisted(() => vi.fn())
@@ -70,14 +75,15 @@ describe('devAction', () => {
     vi.clearAllMocks()
   })
 
-  test('studio mode without workbench uses original port', async () => {
+  test('studio mode without workbench passes flags through untouched', async () => {
     mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
+    // No port flag: resolution must stay downstream in getDevServerConfig
+    // (flags → env → cli config → default), as it does on main.
+    const flags = {...DEV_FLAGS, port: undefined}
 
-    await devAction(createBaseDevOptions())
+    await devAction(createBaseDevOptions({flags}))
 
-    expect(mockStartStudioDevServer).toHaveBeenCalledWith(
-      expect.objectContaining({flags: expect.objectContaining({port: '3333'})}),
-    )
+    expect(mockStartStudioDevServer).toHaveBeenCalledWith(expect.objectContaining({flags}))
   })
 
   test('studio mode with workbench bumps port and logs workbench URL', async () => {

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -256,28 +256,14 @@ describe('devAction', () => {
     })
   })
 
-  test('registers signal handlers that trigger close on SIGINT', async () => {
-    const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
-    const mockAppClose = vi.fn().mockResolvedValue(undefined)
+  test('registers signal handlers when the workbench is running', async () => {
     mockStartWorkbenchDevServer.mockResolvedValue({
-      close: mockWorkbenchClose,
+      close: vi.fn().mockResolvedValue(undefined),
       httpHost: 'localhost',
-      workbenchAvailable: false,
+      workbenchAvailable: true,
       workbenchPort: 3333,
     })
-    mockStartStudioDevServer.mockResolvedValue({
-      ...mockServer({port: 3333}),
-      close: mockAppClose,
-    })
-
-    await devAction(createBaseDevOptions())
-
-    expect(process.listenerCount('SIGINT')).toBeGreaterThanOrEqual(1)
-    expect(process.listenerCount('SIGTERM')).toBeGreaterThanOrEqual(1)
-  })
-
-  test('close removes signal handlers', async () => {
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
+    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
 
     const sigintBefore = process.listenerCount('SIGINT')
     const sigtermBefore = process.listenerCount('SIGTERM')
@@ -288,6 +274,53 @@ describe('devAction', () => {
     expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + 1)
 
     await result.close()
+  })
+
+  test('registers signal handlers for workbench apps even when the workbench is unavailable', async () => {
+    // The registry entry still needs cleanup on abrupt shutdown.
+    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
+
+    const sigintBefore = process.listenerCount('SIGINT')
+
+    const result = await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
+
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
+
+    await result.close()
+  })
+
+  test('close removes signal handlers', async () => {
+    mockStartWorkbenchDevServer.mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      httpHost: 'localhost',
+      workbenchAvailable: true,
+      workbenchPort: 3333,
+    })
+    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+
+    const sigintBefore = process.listenerCount('SIGINT')
+    const sigtermBefore = process.listenerCount('SIGTERM')
+
+    const result = await devAction(createBaseDevOptions())
+
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + 1)
+
+    await result.close()
+
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)
+  })
+
+  test('registers no signal handlers for plain projects', async () => {
+    // Plain runs have no workbench lock or registry entry to clean up, so they
+    // keep the default Ctrl-C behavior (and exit code) from main.
+    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
+
+    const sigintBefore = process.listenerCount('SIGINT')
+    const sigtermBefore = process.listenerCount('SIGTERM')
+
+    await devAction(createBaseDevOptions())
 
     expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
     expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -34,14 +34,13 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     workbenchPort,
   } = await startWorkbenchDevServer({...options, httpHost, httpPort})
 
-  // Use workbenchPort + 1 when workbench claims the configured port
-  const desiredAppPort = workbenchAvailable ? workbenchPort + 1 : workbenchPort
-
-  const appOptions: DevActionOptions = {
-    ...options,
-    flags: {...options.flags, port: String(desiredAppPort)},
-    workbenchAvailable,
-  }
+  // A running workbench claims the configured port, so the app server is
+  // pushed to the next one. Without a workbench the flags pass through
+  // untouched — port resolution stays downstream in getDevServerConfig,
+  // exactly as it did before workbench existed.
+  const appOptions: DevActionOptions = workbenchAvailable
+    ? {...options, flags: {...options.flags, port: String(workbenchPort + 1)}, workbenchAvailable}
+    : {...options, workbenchAvailable}
 
   let closeAppDevServer: () => Promise<void> = noop
 

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -118,9 +118,13 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   // Ensure the workbench lock file and registry entries are cleaned up on
   // abrupt shutdown. The registry is self-healing (stale PIDs are pruned on
   // next read), but eager cleanup avoids the detect-prune-retry cycle.
+  // Plain projects have no lock or registry entry, so they keep the default
+  // signal handling (and exit codes) they had before workbench existed.
   const onSignal = () => void close()
-  process.once('SIGINT', onSignal)
-  process.once('SIGTERM', onSignal)
+  if (workbenchAvailable || registration) {
+    process.once('SIGINT', onSignal)
+    process.once('SIGTERM', onSignal)
+  }
 
   return {close}
 }

--- a/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/dev.test.ts
@@ -596,24 +596,25 @@ describe('#dev', {timeout: (platform() === 'win32' ? 60 : 30) * 1000}, () => {
     })
   })
 
-  test('should start on next available port when requested port is in use', async () => {
+  test('should throw an error if port is already in use', async () => {
     const cwd = await testFixture('basic-studio')
     process.cwd = () => cwd
 
-    // Studios use strictPort: false, so Vite auto-selects the next available port
+    // Studios use strictPort: true, so a busy port is an error — same as main
     const server1 = createServer()
     await new Promise<void>((resolve) => server1.listen(5337, 'localhost', resolve))
 
     try {
-      const {error, result, stdout} = await testCommand(DevCommand, ['--port', '5337'], {
+      const {error, result} = await testCommand(DevCommand, ['--port', '5337'], {
         config: {root: cwd},
         mocks: {isInteractive: true},
       })
 
-      if (error) throw error
-      expect(stdout).toMatch(/running at http:\/\/localhost:\d{4}/)
-      expect(stdout).not.toContain('running at http://localhost:5337')
       await tryCloseServer(result)
+
+      expect(error).toBeDefined()
+      expect(error?.message).toContain('Port 5337 is already in use')
+      expect(error?.oclif?.exit).toBe(1)
     } finally {
       await closeServer(server1)
     }


### PR DESCRIPTION
### Description

An audit of `feat/workbench` vs `main` for plain projects (no `unstable_defineApp`) turned up three behavior changes that leaked outside the workbench opt-in. #1257 restored the dev output and `--load-in-dashboard`; this picks up the rest, one commit per item:

- **Studios lost strict-port.** `getViteConfig` hardcoded `strictPort: false`, so a plain studio on a busy port silently drifted to the next free one instead of failing like on main. Now strict again for plain studios — apps and workbench runs keep the fallback (workbench deliberately stacks servers on adjacent ports).
- **Ctrl-C changed for everyone.** `devAction` installed SIGINT/SIGTERM handlers for every project, changing exit semantics for plain runs that have no workbench lock or registry entry to clean up. Handlers now only register when workbench state exists.
- **Port resolution moved up-front.** `devAction` pre-resolved the port and injected it into `flags.port` for every project. The override only exists so the app server can move off the port the workbench claimed — without a workbench the flags now pass through untouched and resolution stays downstream in `getDevServerConfig`, same as main.

### What to review

Each commit stands alone. The strict-port commit also swaps the branch's "starts on next available port" studio command test back to main's "throws an error if port is already in use" — that test codified the regression. `getDevServerConfig` resolves through the same `getSharedServerConfig` chain `devAction` used, so dropping the injection can't change the resolved port.

### Testing

Unit tests cover both sides of each gate: strict for plain studios / fallback for apps and workbench, no signal handlers for plain runs / registered for workbench (including the package-unavailable case), and flags passing through untouched without a workbench.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted CLI/dev-server behavior fixes with broad test coverage; no auth, data, or security surface changes.
> 
> **Overview**
> Restores **pre-workbench dev behavior** for plain Sanity Studio projects while keeping workbench-specific port stacking and cleanup.
> 
> **Vite (`getViteConfig`)**: `strictPort` is **true** for plain studios (busy port fails fast). Apps and workbench runs keep **`strictPort: false`** so ports can drift when stacking servers or embedding the chosen port in URLs.
> 
> **`devAction`**: Port override (`flags.port = workbenchPort + 1`) only runs when the workbench is actually available; otherwise flags pass through and port resolution stays in `getDevServerConfig` as on main. **SIGINT/SIGTERM** handlers register only when workbench is running or dev-server registration exists—not for plain studio runs (default Ctrl-C exit behavior).
> 
> **Tests**: Studio integration test expects **error on port in use** again; unit tests cover strictPort matrix, flag passthrough, and conditional signal handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 624244d41b103fa92f355cb2366bbb2f1d02058b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->