### PR TITLE
chore(workbench): remove temporary scaffolding

### DIFF
--- a/.changeset/bump-federation-alpha-10.md
+++ b/.changeset/bump-federation-alpha-10.md
@@ -1,6 +1,0 @@
----
-"@sanity/cli": patch
-"@sanity/cli-build": patch
----
-
-bump @sanity/federation to 0.1.0-alpha.10

--- a/.changeset/bump-federation-alpha-6.md
+++ b/.changeset/bump-federation-alpha-6.md
@@ -1,5 +1,0 @@
----
-"@sanity/cli": patch
----
-
-bump @sanity/federation to 0.1.0-alpha.6

--- a/.changeset/clear-dragons-search.md
+++ b/.changeset/clear-dragons-search.md
@@ -1,5 +1,0 @@
----
-'@sanity/cli-core': minor
----
-
-Add federation to CLI config

--- a/.changeset/cli-build-schema-extraction-error.md
+++ b/.changeset/cli-build-schema-extraction-error.md
@@ -1,5 +1,0 @@
----
-"@sanity/cli-build": minor
----
-
-Export `SchemaExtractionError` and related schema-extraction utilities from `_internal`. Without this, `@sanity/cli` fails at runtime on `sanity dev` because the published `cli-build` does not yet have the symbols that #1120 moved into it.

--- a/.changeset/cli-core-drop-federation.md
+++ b/.changeset/cli-core-drop-federation.md
@@ -1,5 +1,0 @@
----
-'@sanity/cli-core': patch
----
-
-Drop `@sanity/federation` from `@sanity/cli-core`'s runtime dependencies by inlining the one-line workbench brand check. cli-core loads on every CLI command, so commands that never touch workbench (e.g. `sanity documents query`) no longer pay that package's import cost.

--- a/.changeset/fancy-cycles-strive.md
+++ b/.changeset/fancy-cycles-strive.md
@@ -1,5 +1,0 @@
----
-"@sanity/cli": patch
----
-
-externalize sanity and @sanity/workbench

--- a/.changeset/pr-1000.md
+++ b/.changeset/pr-1000.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-do not resolve dist tags

--- a/.changeset/pr-1005.md
+++ b/.changeset/pr-1005.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-apply user vite config to federation builds [SDK-1281]

--- a/.changeset/pr-1022.md
+++ b/.changeset/pr-1022.md
@@ -1,7 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli-core': patch
-'@sanity/cli': patch
----
-
-watch for changes of the cli config file

--- a/.changeset/pr-1027.md
+++ b/.changeset/pr-1027.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-forward CLI project id for local applications

--- a/.changeset/pr-1042.md
+++ b/.changeset/pr-1042.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-perf(workbench): preload workbench and warmup dev-server files

--- a/.changeset/pr-1047.md
+++ b/.changeset/pr-1047.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(workbench): remove warmup for dependencies

--- a/.changeset/pr-1057.md
+++ b/.changeset/pr-1057.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(workbench): prune stale lock files

--- a/.changeset/pr-1066.md
+++ b/.changeset/pr-1066.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(workbench): throw error on invalid `SANITY_INTERNAL_WORKBENCH_REMOTE_URL`

--- a/.changeset/pr-1067.md
+++ b/.changeset/pr-1067.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(workbench): detect PID reuse on Windows via PowerShell

--- a/.changeset/pr-1143.md
+++ b/.changeset/pr-1143.md
@@ -1,8 +1,0 @@
----
-'@sanity/cli-core': minor
-'@sanity/cli': minor
----
-
-Add `unstable_defineApp`, exported from `sanity/cli`, as the opt-in for workbench apps. Calling it in `sanity.cli.ts` enables workbench for a studio or SDK app — the previous experimental `federation: { enabled }` config flag is removed.
-
-Icons passed to `unstable_defineApp` are sanitized through the shared manifest allowlist (the same DOMPurify config the studio manifest uses) before they're inlined into the core-app manifest.

--- a/.changeset/pr-1146.md
+++ b/.changeset/pr-1146.md
@@ -1,7 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli-core': minor
-'@sanity/cli': minor
----
-
-feat(workbench): merge app group + priority into the core-app manifest

--- a/.changeset/pr-1149.md
+++ b/.changeset/pr-1149.md
@@ -1,7 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli-build': minor
-'@sanity/cli': minor
----
-
-feat(workbench): build + register app view artifacts, re-synced live in dev (US3 + US5)

--- a/.changeset/pr-1156.md
+++ b/.changeset/pr-1156.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(dev): canonicalize watch dirs to long path on Windows

--- a/.changeset/pr-1176.md
+++ b/.changeset/pr-1176.md
@@ -1,7 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli-build': minor
-'@sanity/cli': minor
----
-
-feat(workbench): thread workbench services through, re-run live in dev (US4)

--- a/.changeset/pr-1236.md
+++ b/.changeset/pr-1236.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-feat(workbench): add --unstable--workbench flag scaffolding unstable_defineApp

--- a/.changeset/pr-1241.md
+++ b/.changeset/pr-1241.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-feat(workbench): reject --external deploy for federated applications

--- a/.changeset/pr-1243.md
+++ b/.changeset/pr-1243.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-feat(workbench): deploy federated builds

--- a/.changeset/pr-1257.md
+++ b/.changeset/pr-1257.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(dev): restore main's dev output and --load-in-dashboard for non-workbench projects

--- a/.changeset/pr-1259.md
+++ b/.changeset/pr-1259.md
@@ -1,7 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli-build': patch
-'@sanity/cli': patch
----
-
-fix(workbench): restore main's port and signal behavior for non-workbench projects

--- a/.changeset/pr-1264.md
+++ b/.changeset/pr-1264.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli-build': patch
----
-
-fix(build): apply caller-provided vite plugins to workbench dev servers

--- a/.changeset/pr-1266.md
+++ b/.changeset/pr-1266.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(dev): release the workbench lock when server creation throws

--- a/.changeset/pr-1267.md
+++ b/.changeset/pr-1267.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(dev): display localhost for non-routable workbench bind addresses

--- a/.changeset/pr-1279.md
+++ b/.changeset/pr-1279.md
@@ -1,7 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli-build': major
-'@sanity/cli': major
----
-
-feat(cli-build)!: require organizationId in unstable_defineApp

--- a/.changeset/pr-770.md
+++ b/.changeset/pr-770.md
@@ -1,5 +1,0 @@
----
-'@sanity/cli': minor
----
-
-Enforce single workbench instance with dev-server registry, fix PID-reuse detection and signal cleanup

--- a/.changeset/pr-905.md
+++ b/.changeset/pr-905.md
@@ -1,5 +1,0 @@
----
-'@sanity/cli': minor
----
-
-Support passing organization ID to the workbench dev server

--- a/.changeset/pr-930.md
+++ b/.changeset/pr-930.md
@@ -1,5 +1,0 @@
----
-'@sanity/cli': patch
----
-
-Prevent dev server from failing to start when the default port is already in use

--- a/.changeset/pr-964.md
+++ b/.changeset/pr-964.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-propagate staging env to workbench dev server

--- a/.changeset/pr-972.md
+++ b/.changeset/pr-972.md
@@ -1,5 +1,0 @@
----
-'@sanity/cli': patch
----
-
-use the same clock for workbench locks

--- a/.changeset/pr-988.md
+++ b/.changeset/pr-988.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-add promt for federation

--- a/.changeset/pr-989.md
+++ b/.changeset/pr-989.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-types for federation promt

--- a/.changeset/pr-992.md
+++ b/.changeset/pr-992.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-use `workbench` dist-tag for `sanity` package

--- a/.changeset/pr-997.md
+++ b/.changeset/pr-997.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-extract manifests for local applications

--- a/.changeset/workbench-pass-appid.md
+++ b/.changeset/workbench-pass-appid.md
@@ -1,5 +1,0 @@
----
-'@sanity/cli': minor
----
-
-Workbench now displays each local application's title and icon and can match local applications to their remote counterparts by ID.

--- a/.changeset/workbench.md
+++ b/.changeset/workbench.md
@@ -1,0 +1,7 @@
+---
+'@sanity/cli': minor
+'@sanity/cli-core': minor
+'@sanity/cli-build': minor
+---
+
+Workbench support for local development of Sanity applications

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,17 +1,12 @@
 name: Snapshot Release
 
 on:
-  push:
-    branches:
-      # Note: this needs to be removed before the feature branch gets merged to main
-      - feat/workbench
   workflow_dispatch:
     inputs:
       tag:
         description: 'npm dist-tag for the snapshot release'
         required: false
-        # TODO: revert to "snapshot" before the feature branch gets merged to main
-        default: 'workbench'
+        default: 'snapshot'
         type: string
       forceBump:
         description: 'Force a version bump for all packages'
@@ -63,8 +58,42 @@ jobs:
 
       - name: Configure npm registry
         run: echo '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' > .npmrc
+
+      - name: Generate changeset for all packages
+        if: ${{ inputs.forceBump != 'false' }}
+        run: |
+          PACKAGES=$(pnpm ls -r --json --depth -1 | jq -r '.[] | select(.private != true) | .name')
+          {
+            echo '---'
+            for pkg in $PACKAGES; do
+              echo "'${pkg}': ${{ inputs.forceBump }}"
+            done
+            echo '---'
+            echo ''
+            echo 'Force snapshot release'
+          } > .changeset/force-snapshot.md
+
       - name: Create snapshot versions
+        if: ${{ inputs.forceBump == 'false' }}
         run: pnpm changeset version --snapshot
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Create release versions
+        if: ${{ inputs.forceBump != 'false' }}
+        run: pnpm changeset version
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Commit and push version changes
+        if: ${{ inputs.forceBump != 'false' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git add -A
+          git commit -m "chore: version packages"
+          git push origin HEAD:${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
@@ -72,8 +101,40 @@ jobs:
         run: pnpm run build:cli
 
       - name: Publish snapshot packages
-        run: pnpm changeset publish --tag "workbench" 2>&1 | tee publish-output.txt
+        if: ${{ inputs.forceBump == 'false' }}
+        run: pnpm changeset publish --tag "$DIST_TAG" 2>&1 | tee publish-output.txt
         env:
           DIST_TAG: ${{ inputs.tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Publish release packages
+        if: ${{ inputs.forceBump != 'false' }}
+        run: pnpm changeset publish 2>&1 | tee publish-output.txt
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Push tags and create GitHub releases
+        if: ${{ inputs.forceBump != 'false' }}
+        run: |
+          git push origin --tags
+          for tag in $(git tag --points-at HEAD); do
+            gh release create "$tag" --generate-notes
+          done
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Summary
+        run: |
+          echo "## Snapshot Release" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**dist-tag:** \`${{ inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Published packages" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep 'New tag:' publish-output.txt >> $GITHUB_STEP_SUMMARY || echo "No packages published" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Description

A sweep of `feat/workbench` for changes that must not reach main as-is:

- **snapshot-release.yml**: reverted to main, byte-for-byte. The branch had gutted the `forceBump` full-release path and hardcoded the `workbench` dist-tag — merging would have silently removed the manual release capability. Branch snapshots are now published by dispatching the workflow manually with `workbench` as the tag input; pushes to `feat/workbench` no longer auto-publish.
- **Changesets**: squashed the 40 accumulated files (auto-generated per-PR entries, a superseded alpha bump, snapshot-publish-ordering notes) into a single entry. `changeset status` produces the identical bump plan before and after (majors across the board, driven by main's Node 20 drop), so branch snapshots version the same.

Still on the branch, tracked for stabilization rather than changed here: the `sanity: 'workbench'` dist-tag pin in `bootstrapLocalTemplate` (required until a stable `sanity` ships `unstable_defineApp`) and the `@sanity/federation` alpha pin (needs a stable federation release). The `knip.config.ts` change was checked and left alone — knip itself flags the old `@types/debug` ignore as removable on this branch, so the removal was required, not a drive-by.

> [!IMPORTANT]
> This PR and https://github.com/sanity-io/sanity/pull/13058 both need to be merged before the final round of review of the feature branch.

### What to review

`git diff origin/main -- .github/workflows/snapshot-release.yml` on this branch is empty — that's the point. For the changesets, check nothing changelog-worthy got lost in the squash; the single remaining entry is `workbench.md`.

### Testing

No runtime changes — CI workflow and changeset markdown only. Verified `changeset status` yields the same bump plan as before the squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and changeset markdown only; restores main’s release workflow behavior and consolidates changelog entries without application code changes.
> 
> **Overview**
> Removes **temporary workbench-branch scaffolding** so `feat/workbench` is safe to merge toward main: **no runtime or product code** changes.
> 
> **Changesets:** Deletes ~40 accumulated per-PR and alpha-bump changeset files and replaces them with a **single** entry (`workbench.md`) covering `@sanity/cli`, `@sanity/cli-core`, and `@sanity/cli-build` (minor: workbench local dev). Intent is the same release bump plan as before the squash.
> 
> **Snapshot release workflow:** Stops **auto-publishing on push** to `feat/workbench` and drops the hardcoded **`workbench` dist-tag** default (back to **`snapshot`**). Restores the full **manual `workflow_dispatch`** flow, including **`forceBump`** (generate changeset, version, commit/push, publish without snapshot tag, push tags, GitHub releases) and snapshot publish using the **user-supplied tag** input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a51170b2caad5f514b602a78d980bd5a7ce3c2df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->