### PR TITLE
refactor(dev): drop the inert react plugin from the workbench dev server

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -96,7 +96,6 @@
     "@sanity/types": "catalog:",
     "@sanity/worker-channels": "^2.0.0",
     "@vercel/frameworks": "3.21.1",
-    "@vitejs/plugin-react": "catalog:",
     "chokidar": "^5.0.0",
     "console-table-printer": "^2.15.0",
     "date-fns": "^4.4.0",

--- a/packages/@sanity/cli/src/actions/dev/workbench/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/workbench/__tests__/startWorkbenchDevServer.test.ts
@@ -26,7 +26,6 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
   }
 })
 vi.mock('vite', () => ({createServer: mockCreateServer}))
-vi.mock('@vitejs/plugin-react', () => ({default: vi.fn(() => [])}))
 vi.mock('../writeWorkbenchRuntime.js', () => ({
   writeWorkbenchRuntime: mockWriteWorkbenchRuntime,
 }))

--- a/packages/@sanity/cli/src/actions/dev/workbench/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/workbench/startWorkbenchDevServer.ts
@@ -1,6 +1,5 @@
 import {SANITY_CACHE_DIR} from '@sanity/cli-build/_internal/build'
 import {isWorkbenchApp, resolveLocalPackage} from '@sanity/cli-core'
-import viteReact from '@vitejs/plugin-react'
 import {createServer, type InlineConfig, type Plugin} from 'vite'
 import {z} from 'zod/mini'
 
@@ -171,7 +170,7 @@ async function createWorkbenchViteServer(
       // discovery to silently not fire.
       exclude: ['sanity', '@sanity/workbench'],
     },
-    plugins: [viteReact(), ...(remoteUrl ? [remoteManifestPreloadHeaderPlugin(remoteUrl)] : [])],
+    plugins: remoteUrl ? [remoteManifestPreloadHeaderPlugin(remoteUrl)] : [],
     resolve: {dedupe: ['react', 'react-dom']},
     root,
     server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,9 +578,6 @@ importers:
       '@vercel/frameworks':
         specifier: 3.21.1
         version: 3.21.1
-      '@vitejs/plugin-react':
-        specifier: 'catalog:'
-        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.0)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0


### PR DESCRIPTION
### Description

`@vitejs/plugin-react` was re-added to `@sanity/cli` for the workbench dev server, but it does nothing there. The served module graph is the generated plain-JS `workbench.js`, sanity's compiled `lib/workbench.js`, and `@sanity/workbench` — TypeScript source that vite's own esbuild transforms. The plugin excludes `node_modules` from fast refresh, and every React component in this graph lives under `node_modules`, so it never transformed a single module; its only output was a refresh preamble in `index.html` that nothing consumed.

Verified against the `federated-studio` fixture with `sanity@5.31.0-workbench.20260610121446`: with the plugin removed, the full module chain serves identically, the shell boots in a real browser exactly like the baseline (same console profile, same login redirect), and the local-app discovery HMR events still work — they ride on `/@vite/client`, which vite core injects regardless.

Removing it also drops `@vitejs/plugin-react` from `@sanity/cli`'s dependencies, keeping vite plugins contained to `@sanity/cli-build` (whose own use in `getViteConfig` is real and untouched) — back in line with the #1130 package split.

### What to review

Three deletions: the import + plugin call in `startWorkbenchDevServer.ts`, the mock in its test, and the dependency entry. If the workbench team ever wants fast refresh while developing `@sanity/workbench` from linked source, the plugin wouldn't have delivered it anyway without `include` overrides for `node_modules` paths.

> [!NOTE]
> The bundle-stats job fails on its **baseline** build: the action checks out `feat/workbench` (which still imports the plugin) without re-running `pnpm install`, so the PR'''s node_modules lack the package. Any dependency-removal PR trips this; the job is `continue-on-error` and doesn'''t gate the merge.

### Testing

Existing workbench dev-server tests pass; types/lint/deps/build are green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow dev-server config and dependency cleanup; studio build paths in `@sanity/cli-build` are unchanged.
> 
> **Overview**
> Removes **`@vitejs/plugin-react`** from the workbench Vite dev server in `startWorkbenchDevServer.ts`: the import and `viteReact()` in the `plugins` array are gone, so only the optional remote-manifest preload plugin remains when `SANITY_INTERNAL_WORKBENCH_REMOTE_URL` is set.
> 
> The dependency is dropped from **`@sanity/cli`** `package.json`, the corresponding Vitest mock is removed, and **`pnpm-lock.yaml`** is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2afc81326ade263cce9264764664534205639e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

