### PR TITLE
fix(build): apply caller-provided vite plugins to workbench dev servers

### DIFF
--- a/.changeset/pr-1264.md
+++ b/.changeset/pr-1264.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': patch
+---
+
+fix(build): apply caller-provided vite plugins to workbench dev servers

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
@@ -484,6 +484,30 @@ describe('#getViteConfig', () => {
     expect(typegenPlugin).toBeDefined()
   })
 
+  test('should include additional plugins for workbench apps', async () => {
+    const options = {
+      additionalPlugins: [
+        {
+          name: 'sanity/typegen',
+        },
+      ],
+      cwd: mockTestCwd,
+      entries: {relativeConfigLocation: '../../sanity.config.ts', relativeEntry: '../../src/App'},
+      getEnvironmentVariables,
+      isWorkbenchApp: true,
+      mode: 'development' as const,
+      reactCompiler: undefined,
+    }
+
+    const config = await getViteConfig(options)
+
+    const typegenPlugin = config.plugins?.find(
+      (p) => p && typeof p === 'object' && 'name' in p && p.name === 'sanity/typegen',
+    )
+
+    expect(typegenPlugin).toBeDefined()
+  })
+
   test('should include federation plugin when enabled', async () => {
     const options = {
       cwd: mockTestCwd,

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -235,8 +235,10 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
             }),
             sanityRuntimeRewritePlugin(),
             sanityBuildEntries({autoUpdates, basePath, cwd, isApp}),
-            ...(additionalPlugins || []),
           ]),
+      // Caller-provided plugins (e.g. typegen in dev) aren't client-specific,
+      // so they apply to federation builds too.
+      ...(additionalPlugins || []),
     ],
     resolve: {
       dedupe: ['react', 'react-dom', 'sanity', 'styled-components'],


### PR DESCRIPTION
### Description

Follow-up to the typegen finding in the [#907 review](https://github.com/sanity-io/cli/pull/907#issuecomment-4215256669). The original duplicate registration was fixed by #1113 (typegen moved out of `getViteConfig` into `additionalPlugins`), but the remnant went the other way: `additionalPlugins` is only spread into the non-workbench plugin branch, so `typegen.enabled: true` is silently ignored when a workbench app runs `sanity dev`.

Hoists `...(additionalPlugins || [])` out of the workbench/client ternary — these plugins are caller-provided dev tooling, not client-specific.

### What to review

That nothing else relies on workbench builds dropping `additionalPlugins`: the only caller passing them is `devServer.ts` (typegen), and production federation builds don't pass any.

### Testing

New test asserts additional plugins survive the workbench branch; the existing non-workbench test still covers the other side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted plugin-array change in dev config; only `devServer` passes `additionalPlugins` and production federation builds do not.
> 
> **Overview**
> Fixes a bug where **caller-provided Vite plugins** (notably **typegen** from `sanity dev`) were only merged into the **non-workbench** plugin list in `getViteConfig`, so workbench/federation dev servers silently skipped them.
> 
> The spread `...(additionalPlugins || [])` is **hoisted** after the workbench vs studio ternary so dev tooling applies to both paths. A test asserts `additionalPlugins` survive when `isWorkbenchApp: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d5ded4e2c7a0bdf3da240b7dd0b82c63dea938b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->