### PR TITLE
fix(dev): require the workbench organization ID from unstable_defineApp

### DIFF
--- a/.changeset/sdk-1277-workbench-resolve-org-id.md
+++ b/.changeset/sdk-1277-workbench-resolve-org-id.md
@@ -1,5 +1,0 @@
----
-'@sanity/cli': minor
----
-
-Resolve the workbench organization ID from the configured project when `app.organizationId` is not set in the CLI config

--- a/packages/@sanity/cli/src/actions/dev/workbench/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/workbench/__tests__/startWorkbenchDevServer.test.ts
@@ -3,7 +3,6 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 import {
   createDevOptions,
   createMockOutput,
-  studioWorkbenchApp,
   workbenchApp,
   workbenchCliConfig,
 } from '../../__tests__/testHelpers.js'
@@ -16,7 +15,6 @@ const mockAcquireWorkbenchLock = vi.hoisted(() => vi.fn())
 const mockGetRegisteredServers = vi.hoisted(() => vi.fn())
 const mockReadWorkbenchLock = vi.hoisted(() => vi.fn())
 const mockWatchRegistry = vi.hoisted(() => vi.fn())
-const mockGetProjectById = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
@@ -34,9 +32,6 @@ vi.mock('../../registry/index.js', () => ({
   getRegisteredServers: mockGetRegisteredServers,
   readWorkbenchLock: mockReadWorkbenchLock,
   watchRegistry: mockWatchRegistry,
-}))
-vi.mock('../../../../services/projects.js', () => ({
-  getProjectById: mockGetProjectById,
 }))
 
 function createMockServer(port = 3333) {
@@ -190,46 +185,7 @@ describe('startWorkbenchDevServer', () => {
       )
     })
 
-    test('resolves organizationId from project when only api.projectId is set', async () => {
-      mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
-      mockGetProjectById.mockResolvedValue({organizationId: 'org-from-project'})
-
-      await startWorkbenchDevServer(
-        createDevOptions({
-          cliConfig: {
-            api: {projectId: 'proj-123'},
-            app: studioWorkbenchApp({organizationId: undefined}),
-          },
-        }),
-      )
-
-      expect(mockGetProjectById).toHaveBeenCalledWith('proj-123')
-      expect(mockWriteWorkbenchRuntime).toHaveBeenCalledWith(
-        expect.objectContaining({organizationId: 'org-from-project'}),
-      )
-    })
-
-    test('prefers cliConfig.app.organizationId over project lookup', async () => {
-      mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
-
-      await startWorkbenchDevServer(
-        createDevOptions({
-          cliConfig: {
-            api: {projectId: 'proj-123'},
-            app: workbenchApp({organizationId: 'org-explicit'}),
-          },
-        }),
-      )
-
-      expect(mockGetProjectById).not.toHaveBeenCalled()
-      expect(mockWriteWorkbenchRuntime).toHaveBeenCalledWith(
-        expect.objectContaining({organizationId: 'org-explicit'}),
-      )
-    })
-
-    test('throws when neither app.organizationId nor api.projectId is configured', async () => {
+    test('throws a readable error when neither app.organizationId nor api.projectId is configured', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
       mockCreateServer.mockResolvedValue(createMockServer())
 
@@ -237,24 +193,7 @@ describe('startWorkbenchDevServer', () => {
         startWorkbenchDevServer(
           createDevOptions({cliConfig: {app: workbenchApp({organizationId: undefined})}}),
         ),
-      ).rejects.toThrow(/Unable to determine organization ID/)
-    })
-
-    test('throws when project lookup returns no organizationId', async () => {
-      mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
-      mockGetProjectById.mockResolvedValue({organizationId: undefined})
-
-      await expect(
-        startWorkbenchDevServer(
-          createDevOptions({
-            cliConfig: {
-              api: {projectId: 'proj-123'},
-              app: studioWorkbenchApp({organizationId: undefined}),
-            },
-          }),
-        ),
-      ).rejects.toThrow(/Unable to determine organization ID/)
+      ).rejects.toThrow(/Pass "organizationId" to unstable_defineApp/)
     })
 
     test('configures warmup for the workbench entry file', async () => {

--- a/packages/@sanity/cli/src/actions/dev/workbench/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/workbench/startWorkbenchDevServer.ts
@@ -3,7 +3,6 @@ import {isWorkbenchApp, resolveLocalPackage} from '@sanity/cli-core'
 import {createServer, type InlineConfig, type Plugin} from 'vite'
 import {z} from 'zod/mini'
 
-import {getProjectById} from '../../../services/projects.js'
 import {resolveReactStrictMode} from '../../../util/resolveReactStrictMode.js'
 import {devDebug} from '../devDebug.js'
 import {interfaceSetId} from '../registration/interfaceSetId.js'
@@ -151,7 +150,8 @@ async function createWorkbenchViteServer(
 
   const remoteUrl = parseRemoteUrl(process.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL)
   const reactStrictMode = resolveReactStrictMode(cliConfig)
-  const organizationId = await resolveOrganizationId(cliConfig)
+
+  const organizationId = resolveOrganizationId(cliConfig)
 
   devDebug('Writing workbench runtime files')
   const root = await writeWorkbenchRuntime({
@@ -255,21 +255,17 @@ async function createWorkbenchViteServer(
   }
 }
 
-const resolveOrganizationId = async (cliConfig: DevActionOptions['cliConfig']): Promise<string> => {
+// Workbench is opted into via `unstable_defineApp`, which carries the
+// organization ID. Deliberately no fallback (e.g. resolving it from the
+// configured project): the lookup would need an authenticated user and an
+// API round-trip on every startup for something the opt-in already declares.
+const resolveOrganizationId = (cliConfig: DevActionOptions['cliConfig']): string => {
   if (cliConfig.app?.organizationId) {
     return cliConfig.app.organizationId
   }
 
-  if (cliConfig.api?.projectId) {
-    const project = await getProjectById(cliConfig.api.projectId)
-
-    if (project.organizationId) {
-      return project.organizationId
-    }
-  }
-
   throw new Error(
-    'Unable to determine organization ID for workbench runtime. Please ensure that your sanity.json has either "app.organizationId" or "api.projectId" configured.',
+    'Workbench requires an organization ID. Pass "organizationId" to unstable_defineApp() in sanity.cli.ts.',
   )
 }
 


### PR DESCRIPTION
### Description

Reworked from the finding in the [#907 review](https://github.com/sanity-io/cli/pull/907#issuecomment-4215256669). `unstable_defineApp` is the workbench opt-in and carries the organization ID, so the fallback that resolved it from the configured project (SDK-1277) is removed: it required an authenticated user — a logged-out `sanity dev` died on a raw auth error — and added an API round-trip to every workbench startup for something the opt-in already declares. No fallback applies to workbench.

A missing ID is now a readable error:

```
Workbench requires an organization ID. Pass "organizationId" to unstable_defineApp() in sanity.cli.ts.
```

The SDK-1277 changeset is deleted with the behavior, and the `federated-studio` fixture now passes `organizationId`.

### What to review

One known consequence: the `--unstable--workbench` init template for **studios** brands with `name`/`title` only — projects scaffolded from it will hit the new error until the template passes `organizationId` too. The studio init flow doesn't currently know the org ID, so that's a follow-up rather than part of this PR.

`organizationId` is made required in `DefineAppInput`'s type by https://github.com/sanity-io/workbench/pull/250, moving the error to type-check time once the CLI picks up that federation version; this dev-time error covers configs built against older types.

### Testing

Project-lookup tests are gone with the behavior; the missing-ID case asserts the new message. Full affected-test run passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workbench startup requirements for any config that relied on project-based org resolution; logged-out or unauthenticated `sanity dev` no longer gets an implicit org ID but may fail earlier with the new error.
> 
> **Overview**
> **Workbench dev** no longer resolves `organizationId` from `api.projectId` via `getProjectById`. The ID must come from `unstable_defineApp` (`cliConfig.app.organizationId`); `resolveOrganizationId` is synchronous and drops the authenticated API lookup on every startup.
> 
> Missing configuration now fails with a directed message to pass `organizationId` to `unstable_defineApp()` in `sanity.cli.ts`. The SDK-1277 changeset is removed with that behavior.
> 
> Tests drop project-lookup mocks and cases; the missing-ID test asserts the new error text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c08b1315d0d67ca66b59e19a9cef64a5c6a2cdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->