### PR TITLE
fix(dev): release the workbench lock when server creation throws

### DIFF
--- a/.changeset/pr-1266.md
+++ b/.changeset/pr-1266.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(dev): release the workbench lock when server creation throws

--- a/packages/@sanity/cli/src/actions/dev/workbench/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/workbench/__tests__/startWorkbenchDevServer.test.ts
@@ -400,6 +400,32 @@ describe('startWorkbenchDevServer', () => {
       ).rejects.toThrow(/Invalid SANITY_INTERNAL_WORKBENCH_REMOTE_URL/)
     })
 
+    test('releases the lock when server creation throws', async () => {
+      vi.stubEnv('SANITY_INTERNAL_WORKBENCH_REMOTE_URL', 'javascript:alert(1)')
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+      const release = vi.fn()
+      mockAcquireWorkbenchLock.mockReturnValue({release, updatePort: vi.fn()})
+
+      await expect(
+        startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig})),
+      ).rejects.toThrow()
+      expect(release).toHaveBeenCalled()
+    })
+
+    test('releases the lock when writing runtime files throws', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+      mockWriteWorkbenchRuntime.mockRejectedValue(new Error('EACCES: permission denied'))
+      const release = vi.fn()
+      mockAcquireWorkbenchLock.mockReturnValue({release, updatePort: vi.fn()})
+
+      await expect(
+        startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig})),
+      ).rejects.toThrow(/EACCES/)
+      expect(release).toHaveBeenCalled()
+    })
+
     test('accepts an http:// remote URL', async () => {
       vi.stubEnv(
         'SANITY_INTERNAL_WORKBENCH_REMOTE_URL',

--- a/packages/@sanity/cli/src/actions/dev/workbench/startWorkbenchDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/workbench/startWorkbenchDevServer.ts
@@ -95,13 +95,22 @@ export async function startWorkbenchDevServer(
     }
   }
 
-  const result = await createWorkbenchViteServer({
-    cliConfig,
-    httpHost,
-    output,
-    workbenchPort,
-    workDir,
-  })
+  // The lock is already held; an exception here (runtime-file write failure,
+  // invalid remote URL) would otherwise leak it until the next acquire prunes
+  // the stale PID.
+  let result: Awaited<ReturnType<typeof createWorkbenchViteServer>>
+  try {
+    result = await createWorkbenchViteServer({
+      cliConfig,
+      httpHost,
+      output,
+      workbenchPort,
+      workDir,
+    })
+  } catch (err) {
+    workbenchLock.release()
+    throw err
+  }
 
   if (!result) {
     workbenchLock.release()


### PR DESCRIPTION
### Description

Split out of finding 2 in the [#907 review](https://github.com/sanity-io/cli/pull/907#issuecomment-4215256669). The workbench lock is acquired before `createWorkbenchViteServer` runs, but only the `undefined`-result fallback released it — an exception (runtime-file write failure, invalid `SANITY_INTERNAL_WORKBENCH_REMOTE_URL`) propagated out with the lock still on disk. The PID staleness check heals it on the next acquire, but eager release keeps failed runs from leaving state behind, consistent with the cleanup philosophy in `devAction`.

Companion to #1265, which handles the org-id resolution path specifically.

### What to review

The throw is re-raised unchanged — only the lock release is added on that path.

### Testing

Two new tests: the invalid-remote-URL throw and a runtime-file write failure both assert the lock's `release()` was called.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized dev-server cleanup with no change to successful startup; errors are still propagated unchanged.
> 
> **Overview**
> **Fixes workbench dev lock leaks** when `createWorkbenchViteServer` throws after the exclusive lock is already acquired.
> 
> `startWorkbenchDevServer` now wraps that call in **try/catch**, calls **`workbenchLock.release()`** on failure, and re-raises the original error—matching the existing release path when server creation returns `undefined`.
> 
> Two tests assert **`release()`** runs on invalid `SANITY_INTERNAL_WORKBENCH_REMOTE_URL` and on `writeWorkbenchRuntime` errors (e.g. `EACCES`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e75b7c75848112bb002ed16ef10a9aec5836d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->