### PR TITLE
fix(dev): display localhost for non-routable workbench bind addresses

### DIFF
--- a/.changeset/pr-1267.md
+++ b/.changeset/pr-1267.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(dev): display localhost for non-routable workbench bind addresses

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -353,6 +353,21 @@ describe('devAction', () => {
     expect(output.log).toHaveBeenCalledWith(expect.stringContaining('mydev.local:3333'))
   })
 
+  test('displays localhost when the workbench binds a non-routable address', async () => {
+    mockStartWorkbenchDevServer.mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      httpHost: '0.0.0.0',
+      workbenchAvailable: true,
+      workbenchPort: 3333,
+    })
+    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+    const output = createMockOutput()
+
+    await devAction(createBaseDevOptions({output}))
+
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('http://localhost:3333'))
+  })
+
   test('returns early with workbench-only close when the app server does not start', async () => {
     // startAppDevServer reports an expected early exit when orgId is missing.
     const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -11,6 +11,17 @@ import {startWorkbenchDevServer} from './workbench/startWorkbenchDevServer.js'
 
 const noop = async () => {}
 
+// Bind-only addresses ('0.0.0.0', '::') aren't routable URLs in every
+// browser (notably on Windows), so the displayed URL falls back to
+// localhost. The bind address itself is untouched — listening and the
+// lock file keep whatever the user configured.
+function toDisplayHost(host: string | undefined): string {
+  if (!host || host === '0.0.0.0' || host === '::' || host === '[::]') {
+    return 'localhost'
+  }
+  return host
+}
+
 /**
  * Orchestrates the dev servers required by the process. It will attempt to run a workbench
  * dev-server and, if successful, will run the app/studio dev server on the next available port.
@@ -100,7 +111,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     : undefined
 
   if (workbenchAvailable) {
-    const workbenchUrl = `http://${workbenchHost || 'localhost'}:${workbenchPort}`
+    const workbenchUrl = `http://${toDisplayHost(workbenchHost)}:${workbenchPort}`
     const addr = server.httpServer?.address()
     const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
     output.log(


### PR DESCRIPTION
### Description

Finding 4 from the [#907 review](https://github.com/sanity-io/cli/pull/907#issuecomment-4215256669). `sanity dev --host 0.0.0.0` printed `http://0.0.0.0:3333` as the workbench URL — both in the binding process and in any second process that reuses the lock (the lock stores the bind host verbatim, and the tests codify that). `0.0.0.0`/`::` don't open in every browser, notably on Windows.

The displayed URL now falls back to `localhost` for bind-only addresses. Listening behavior and the lock contents are deliberately untouched — the bind address still needs to be the real one for LAN access and for the next process's port checks.

### What to review

Normalization happens at the single display point in `devAction`, so both the fresh-start and lock-reuse paths get it. Real hostnames (e.g. `mydev.local` from another process's lock) still display as-is — the existing test covers that.

### Testing

New devAction test asserts `--host 0.0.0.0` displays `http://localhost:<port>`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change at a single log site in devAction; no changes to networking, locks, or server startup.
> 
> **Overview**
> Fixes the **workbench dev URL** printed by `sanity dev` when the server binds to all interfaces (`0.0.0.0`, `::`, etc.). Those bind addresses are no longer shown literally; `devAction` now maps them to **`localhost`** in the log line only via a new `toDisplayHost()` helper.
> 
> **Listening, `--host`, and lock-file host values are unchanged**—only the displayed URL is normalized. Real hostnames (e.g. from an existing lock) still appear as-is.
> 
> A **devAction** test asserts that when the workbench reports `httpHost: '0.0.0.0'`, the output contains `http://localhost:3333`. Includes a patch **changeset** for `@sanity/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d9360622d461c5265f665f254cd7dfd0e50b98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->