### PR TITLE
refactor(cli-build): own the module-federation extension API; @sanity/cli re-exports

### DIFF
--- a/packages/@sanity/cli-build/package.json
+++ b/packages/@sanity/cli-build/package.json
@@ -36,6 +36,10 @@
       "source": "./src/_exports/_internal/extract.ts",
       "default": "./dist/_exports/_internal/extract.js"
     },
+    "./_internal/federation": {
+      "source": "./src/_exports/_internal/federation.ts",
+      "default": "./dist/_exports/_internal/federation.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/@sanity/cli-build/src/_exports/_internal/federation.ts
+++ b/packages/@sanity/cli-build/src/_exports/_internal/federation.ts
@@ -1,0 +1,28 @@
+// Browser-safe module-federation extension API — the canonical source for the
+// `unstable_define*` authoring helpers and their contract. Lives in
+// `@sanity/cli-build` (alongside the vite plugin that consumes the same
+// contract) so there is a single source of truth; `@sanity/cli` re-exports it on
+// its public `.` and `/runtime` entries (→ `sanity/cli` and `sanity`).
+//
+// This entry's module graph is zod-only — no `node:*`, no `@sanity/cli-core`, no
+// vite — so `@sanity/cli/runtime` re-exporting it stays browser-safe under
+// per-entry resolution, exactly as the Node-only `./vite` and `./_internal/*`
+// entries don't leak into it.
+export type {InterfaceType, ServiceType} from '../../workbench/contract.js'
+export {unstable_defineApp} from '../../workbench/defineApp.js'
+export type {DefineAppInput, DefineAppResult, DockGroup} from '../../workbench/defineApp.js'
+export {unstable_defineService} from '../../workbench/defineService.js'
+export type {
+  DefinedService,
+  ServiceCallback,
+  ServiceContext,
+  ServiceInfo,
+} from '../../workbench/defineService.js'
+export {unstable_defineView} from '../../workbench/defineView.js'
+export type {
+  DefinedView,
+  PanelComponent,
+  PanelViewComponents,
+  PanelViewProps,
+  ViewComponentsByType,
+} from '../../workbench/defineView.js'

--- a/packages/@sanity/cli-build/src/workbench/__tests__/defineApp.test.ts
+++ b/packages/@sanity/cli-build/src/workbench/__tests__/defineApp.test.ts
@@ -1,0 +1,189 @@
+import {type CliConfig, isWorkbenchApp} from '@sanity/cli-core'
+import {describe, expect, expectTypeOf, test} from 'vitest'
+
+import {
+  DefineAppInputSchema,
+  type DefineAppResult,
+  type DockGroup,
+  unstable_defineApp,
+} from '../defineApp.js'
+
+// The brand is a global-registry symbol; re-derive it the way the CLI loader
+// (`@sanity/cli-core`) does, rather than reaching for a module-private const.
+const WORKBENCH_APP = Symbol.for('sanity.workbench.defineApp')
+
+describe('unstable_defineApp', () => {
+  test('is identity at runtime — returns the same object reference', () => {
+    const input = {name: 'drop-desk', title: 'Drop Desk'}
+    expect(unstable_defineApp(input)).toBe(input)
+  })
+
+  test('brands the result so the CLI can discriminate it', () => {
+    const app = unstable_defineApp({name: 'drop-desk', title: 'Drop Desk'})
+    expect(Object.getOwnPropertyDescriptor(app, WORKBENCH_APP)?.value).toBe(true)
+  })
+
+  test('leaves the brand non-enumerable so it does not leak into config spreads', () => {
+    const app = unstable_defineApp({name: 'drop-desk', title: 'Drop Desk'})
+    expect(Object.keys(app)).toEqual(['name', 'title'])
+    expect(Object.getOwnPropertySymbols({...app})).not.toContain(WORKBENCH_APP)
+  })
+
+  test('preserves declared fields', () => {
+    const app = unstable_defineApp({
+      icon: './icon.svg',
+      name: 'athlete-desk',
+      title: 'Athlete Desk',
+    })
+    expect(app.name).toBe('athlete-desk')
+    expect(app.title).toBe('Athlete Desk')
+    expect(app.icon).toBe('./icon.svg')
+  })
+
+  test('is recognised by `@sanity/cli-core`s `isWorkbenchApp` (shared Symbol.for contract)', () => {
+    const app = unstable_defineApp({name: 'drop-desk', title: 'Drop Desk'})
+    // The whole point of branding via `Symbol.for`: cli-core re-derives the same
+    // global symbol and discriminates on it without importing this module.
+    expect(isWorkbenchApp(app as CliConfig['app'])).toBe(true)
+  })
+})
+
+describe('DefineAppInputSchema (build-time validation)', () => {
+  test('accepts a valid name', () => {
+    const parsed = DefineAppInputSchema.parse({name: 'drop_desk-1', title: 'Drop'})
+    expect(parsed.name).toBe('drop_desk-1')
+  })
+
+  test('rejects a name with illegal characters', () => {
+    const result = DefineAppInputSchema.safeParse({name: 'drop desk!', title: 'Drop'})
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toMatch(/must match/)
+  })
+
+  test('requires a title', () => {
+    expect(DefineAppInputSchema.safeParse({name: 'drop-desk'}).success).toBe(false)
+  })
+
+  test('validates the internal applicationType when present', () => {
+    const parsed = DefineAppInputSchema.parse({
+      applicationType: 'system',
+      name: 'media',
+      title: 'Media',
+    })
+    expect(parsed.applicationType).toBe('system')
+    expect(
+      DefineAppInputSchema.safeParse({applicationType: 'not-a-type', name: 'media', title: 'Media'})
+        .success,
+    ).toBe(false)
+  })
+
+  test('accepts group and priority, rejecting an unknown group', () => {
+    const parsed = DefineAppInputSchema.parse({
+      group: 'dock.system',
+      name: 'drop-desk',
+      priority: 20,
+      title: 'Drop',
+    })
+    expect(parsed.group).toBe('dock.system')
+    expect(parsed.priority).toBe(20)
+    expect(
+      DefineAppInputSchema.safeParse({group: 'dock.nope', name: 'drop-desk', title: 'Drop'})
+        .success,
+    ).toBe(false)
+  })
+
+  test('accepts a panel view declaration', () => {
+    const parsed = DefineAppInputSchema.parse({
+      name: 'drop-desk',
+      title: 'Drop',
+      views: [{name: 'feed', src: './src/panel.tsx', type: 'panel'}],
+    })
+    expect(parsed.views?.[0]).toEqual({name: 'feed', src: './src/panel.tsx', type: 'panel'})
+  })
+
+  test('rejects an unknown view type', () => {
+    expect(
+      DefineAppInputSchema.safeParse({
+        name: 'drop-desk',
+        title: 'Drop',
+        views: [{name: 'feed', src: './src/panel.tsx', type: 'sidebar'}],
+      }).success,
+    ).toBe(false)
+  })
+
+  test('rejects duplicate view names within an app', () => {
+    const result = DefineAppInputSchema.safeParse({
+      name: 'drop-desk',
+      title: 'Drop',
+      views: [
+        {name: 'feed', src: './src/a.tsx', type: 'panel'},
+        {name: 'feed', src: './src/b.tsx', type: 'panel'},
+      ],
+    })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toMatch(/unique/)
+  })
+
+  test('accepts a worker service declaration, rejecting duplicate service names', () => {
+    expect(
+      DefineAppInputSchema.safeParse({
+        name: 'drop-desk',
+        services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+        title: 'Drop',
+      }).success,
+    ).toBe(true)
+    const dupes = DefineAppInputSchema.safeParse({
+      name: 'drop-desk',
+      services: [
+        {name: 'unread', src: './src/a.ts', type: 'worker'},
+        {name: 'unread', src: './src/b.ts', type: 'worker'},
+      ],
+      title: 'Drop',
+    })
+    expect(dupes.success).toBe(false)
+    expect(dupes.error?.issues[0]?.message).toMatch(/unique/)
+  })
+
+  test('rejects `entry` on a studio with a not-yet-implemented error', () => {
+    const result = DefineAppInputSchema.safeParse({
+      applicationType: 'studio',
+      entry: './src/App.tsx',
+      name: 'fernway',
+      title: 'Fernway',
+    })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toMatch(/not implemented yet/)
+    expect(result.error?.issues[0]?.path).toEqual(['entry'])
+  })
+
+  test('accepts `entry` for an SDK app (no applicationType / coreApp)', () => {
+    expect(
+      DefineAppInputSchema.safeParse({entry: './src/App.tsx', name: 'drop-desk', title: 'Drop'})
+        .success,
+    ).toBe(true)
+    expect(
+      DefineAppInputSchema.safeParse({
+        applicationType: 'coreApp',
+        entry: './src/App.tsx',
+        name: 'drop-desk',
+        title: 'Drop',
+      }).success,
+    ).toBe(true)
+  })
+})
+
+describe('type surface', () => {
+  test('exposes title/icon/entry/organizationId/group/priority', () => {
+    expectTypeOf<DefineAppResult['name']>().toEqualTypeOf<string>()
+    expectTypeOf<DefineAppResult['title']>().toEqualTypeOf<string>()
+    expectTypeOf<DefineAppResult['icon']>().toEqualTypeOf<string | undefined>()
+    expectTypeOf<DefineAppResult['entry']>().toEqualTypeOf<string | undefined>()
+    expectTypeOf<DefineAppResult['organizationId']>().toEqualTypeOf<string | undefined>()
+    expectTypeOf<DefineAppResult['group']>().toEqualTypeOf<DockGroup | undefined>()
+    expectTypeOf<DefineAppResult['priority']>().toEqualTypeOf<number | undefined>()
+  })
+
+  test('does not expose the internal applicationType', () => {
+    expectTypeOf<DefineAppResult>().not.toHaveProperty('applicationType')
+  })
+})

--- a/packages/@sanity/cli-build/src/workbench/__tests__/defineService.test.ts
+++ b/packages/@sanity/cli-build/src/workbench/__tests__/defineService.test.ts
@@ -1,0 +1,41 @@
+import {describe, expect, test} from 'vitest'
+
+import {SERVICE_CONTRACT_VERSION, ServiceDeclarationSchema} from '../contract.js'
+import {unstable_defineService} from '../defineService.js'
+
+const run = () => {}
+
+describe('unstable_defineService', () => {
+  test('tags the callback with its type and the contract version', () => {
+    const service = unstable_defineService('worker', run)
+    expect(service.type).toBe('worker')
+    expect(service.version).toBe(SERVICE_CONTRACT_VERSION)
+    // The callback passes through by reference — the helper is pure identity.
+    expect(service.run).toBe(run)
+  })
+})
+
+describe('ServiceDeclarationSchema', () => {
+  test('accepts a worker declaration', () => {
+    const parsed = ServiceDeclarationSchema.parse({
+      name: 'unread',
+      src: './src/service.ts',
+      type: 'worker',
+    })
+    expect(parsed.type).toBe('worker')
+  })
+
+  test('rejects a name with illegal characters', () => {
+    expect(
+      ServiceDeclarationSchema.safeParse({name: 'un read', src: './src/service.ts', type: 'worker'})
+        .success,
+    ).toBe(false)
+  })
+
+  test('rejects an unknown service type', () => {
+    expect(
+      ServiceDeclarationSchema.safeParse({name: 'unread', src: './src/service.ts', type: 'cron'})
+        .success,
+    ).toBe(false)
+  })
+})

--- a/packages/@sanity/cli-build/src/workbench/__tests__/defineView.test.ts
+++ b/packages/@sanity/cli-build/src/workbench/__tests__/defineView.test.ts
@@ -1,0 +1,52 @@
+import {describe, expect, expectTypeOf, test} from 'vitest'
+
+import {VIEW_CONTRACT_VERSION} from '../contract.js'
+import {type DefinedView, type PanelViewProps, unstable_defineView} from '../defineView.js'
+
+const title = ({view}: PanelViewProps) => view.name
+const panel = ({view}: PanelViewProps) => view.name
+
+describe('unstable_defineView', () => {
+  test('returns the view type, contract version, and the author components', () => {
+    const view = unstable_defineView('panel', {panel, title})
+
+    expect(view.type).toBe('panel')
+    expect(view.version).toBe(VIEW_CONTRACT_VERSION)
+    // Components pass through by reference — the helper is pure identity.
+    expect(view.components.title).toBe(title)
+    expect(view.components.panel).toBe(panel)
+  })
+})
+
+describe('type surface', () => {
+  test('narrows the component record from the view type argument', () => {
+    const view = unstable_defineView('panel', {panel: () => null, title: () => null})
+
+    expectTypeOf(view).toEqualTypeOf<DefinedView<'panel'>>()
+    expectTypeOf(view.components).toHaveProperty('title')
+    expectTypeOf(view.components).toHaveProperty('panel')
+  })
+
+  test('passes each panel component the local panel record as props', () => {
+    unstable_defineView('panel', {
+      panel: (props) => {
+        expectTypeOf(props).toEqualTypeOf<PanelViewProps>()
+        return null
+      },
+      title: (props) => {
+        expectTypeOf(props).toEqualTypeOf<PanelViewProps>()
+        expectTypeOf(props.view).toEqualTypeOf<{
+          entry_point: string
+          interface_type: 'panel'
+          name: string
+        }>()
+        return null
+      },
+    })
+  })
+
+  test('rejects an unknown view type', () => {
+    // @ts-expect-error — "sidebar" is not a known view type.
+    unstable_defineView('sidebar', {panel: () => null, title: () => null})
+  })
+})

--- a/packages/@sanity/cli-build/src/workbench/contract.ts
+++ b/packages/@sanity/cli-build/src/workbench/contract.ts
@@ -1,0 +1,96 @@
+import {z} from 'zod/mini'
+
+// The shared kernel of the module-federation extension contract: the supported
+// view/service types, the contract versions the helpers stamp, and the
+// declaration schemas an app author writes in `unstable_defineApp({views, services})`.
+//
+// Lives in `@sanity/cli-build` (alongside the vite plugin that consumes the same
+// contract) so there is a single source of truth. `zod/mini` is used throughout
+// cli-build to keep bundles small.
+
+/**
+ * Contract version stamped on every defined view — lets the host and the
+ * generated artifact evolve the contract without breaking deployed views.
+ * @internal
+ */
+export const VIEW_CONTRACT_VERSION = 1
+
+/**
+ * Contract version stamped on every defined service. Lets the workbench host
+ * and the generated worker artifact evolve the service contract without
+ * breaking already-deployed services; bumped only on a breaking change.
+ * @internal
+ */
+export const SERVICE_CONTRACT_VERSION = 1
+
+/**
+ * A view component. The return is opaque so the runtime helpers carry no React
+ * dependency — the generated artifact renders it with the app's own React.
+ * @public
+ */
+export type ViewComponent<TProps> = (props: TProps) => unknown
+
+/**
+ * Props every view component receives, whatever its type. Per-type props
+ * compose from this, so a prop added here reaches every view.
+ * @public
+ */
+export interface ViewComponentBaseProps<TView> {
+  view: TView
+}
+
+/**
+ * Every supported interface type — the first argument to `unstable_defineView`.
+ * The build's component registry (`VIEW_COMPONENTS`, which expands a view into
+ * one render artifact per component) ships with the vite plugin.
+ * @public
+ */
+export type InterfaceType = 'panel'
+
+/**
+ * Every supported service type — the first argument to `unstable_defineService`.
+ * Add a service type by adding its declaration schema below and registering it
+ * here.
+ * @public
+ */
+export type ServiceType = 'worker'
+
+/**
+ * Fields every extension declaration shares — a view or a service. The shape is
+ * identical (`name` + `src`); `kind` only tailors the validation message. Each
+ * declaration adds its `type` discriminator on top.
+ */
+function extensionDeclarationFields(kind: 'Service' | 'View') {
+  const pattern = /^[a-zA-Z0-9_-]+$/
+  return {
+    name: z.string().check(z.regex(pattern, `${kind} \`name\` must match ${pattern}`)),
+    src: z.string(),
+  }
+}
+
+/** What an author writes for a `panel` in `unstable_defineApp({views})`. */
+const PanelViewSchema = z.object({
+  type: z.literal('panel'),
+  ...extensionDeclarationFields('View'),
+})
+
+/**
+ * The `{type, name, src}` an app declares for a view, discriminated by `type`.
+ * Persisted to the application service on deploy; never part of the app manifest.
+ * @internal
+ */
+export const InterfaceDeclarationSchema = z.discriminatedUnion('type', [PanelViewSchema])
+
+/** Declaration schema for a `worker` service — what a developer writes in `unstable_defineApp({services})`. */
+const WorkerServiceSchema = z.object({
+  type: z.literal('worker'),
+  ...extensionDeclarationFields('Service'),
+})
+
+/**
+ * A service declared on an app, discriminated by `type`. Metadata only; built
+ * into a worker artifact and persisted to the application service on deploy,
+ * never part of the app manifest.
+ * @internal
+ */
+export const ServiceDeclarationSchema = z.discriminatedUnion('type', [WorkerServiceSchema])

--- a/packages/@sanity/cli-build/src/workbench/defineApp.ts
+++ b/packages/@sanity/cli-build/src/workbench/defineApp.ts
@@ -1,0 +1,145 @@
+import {z} from 'zod/mini'
+
+import {InterfaceDeclarationSchema, ServiceDeclarationSchema} from './contract.js'
+
+/** Allowed characters for an app `name`. */
+const APP_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/
+
+/**
+ * Internal application discriminator. Sanity-owned singleton apps only;
+ * validated by the schema but excluded from the public `DefineAppInput` type.
+ */
+const ApplicationType = z.enum([
+  'coreApp',
+  'studio',
+  'canvas',
+  'dashboard',
+  'media-library',
+  'system',
+])
+
+/** Dock groups an app can place itself into. */
+const DockGroupSchema = z.enum(['dock.system', 'dock.applications', 'dock.user'])
+
+/**
+ * Dock group identifier. The API does not block a user app from declaring a
+ * reserved group (e.g. `dock.system`); priority conventions keep Sanity-owned
+ * apps ahead.
+ * @public
+ */
+export type DockGroup = z.output<typeof DockGroupSchema>
+
+/**
+ * Runtime-validation schema for `unstable_defineApp`. Validates the full shape
+ * including the internal `applicationType`; the user-facing `DefineAppInput`
+ * type below omits that field.
+ * @internal
+ */
+export const DefineAppInputSchema = z
+  .object({
+    /**
+     * Internal — Sanity-owned singleton apps only. Validated here but excluded
+     * from the public `DefineAppInput` type.
+     * @internal
+     */
+    applicationType: z.optional(ApplicationType),
+    /**
+     * App entrypoint module. Defaults to `./src/App.tsx` when omitted. The build
+     * derives the app's navigable `app` view from it. SDK apps only — setting it
+     * on a studio is rejected (studio app views are not yet implemented).
+     */
+    entry: z.optional(z.string()),
+    /** Dock group to render in. Defaults to `dock.applications` when omitted. */
+    group: z.optional(DockGroupSchema),
+    /** Optional icon override (path to an SVG). Wins over manifest/studio icon. */
+    icon: z.optional(z.string()),
+    /** Unique app identifier — matches `/^[a-zA-Z0-9_-]+$/`. */
+    name: z.string().check(z.regex(APP_NAME_PATTERN, 'App `name` must match /^[a-zA-Z0-9_-]+$/')),
+    /** Organization that owns the app — required to run and deploy an SDK app. */
+    organizationId: z.optional(z.string()),
+    /** Sort position within the group, ascending. Defaults to `100` when omitted. */
+    priority: z.optional(z.number()),
+    /**
+     * Background services the app runs (e.g. a `worker` emitting dock badges).
+     * Metadata only — built into worker artifacts and persisted to the
+     * application service on deploy, not into the app manifest. Service `name`s
+     * must be unique within the app.
+     */
+    services: z.optional(
+      z
+        .array(ServiceDeclarationSchema)
+        .check(
+          z.refine(
+            (services) => new Set(services.map((service) => service.name)).size === services.length,
+            'Service `name` must be unique within an app',
+          ),
+        ),
+    ),
+    /** User-facing app title. Wins over studio.config.ts title on merge. */
+    title: z.string(),
+    /**
+     * Views the app exposes (e.g. dock panels). Metadata only — built into
+     * render artifacts and persisted to the application service on deploy, not
+     * into the app manifest. View `name`s must be unique within the app.
+     */
+    views: z.optional(
+      z
+        .array(InterfaceDeclarationSchema)
+        .check(
+          z.refine(
+            (views) => new Set(views.map((view) => view.name)).size === views.length,
+            'View `name` must be unique within an app',
+          ),
+        ),
+    ),
+  })
+  .check(
+    // Studio app views are not implemented yet. A studio that declares `entry`
+    // (the SDK app-view entrypoint) is rejected here rather than silently
+    // generating one; studios keep navigating via their existing render path.
+    z.refine((input) => !(input.applicationType === 'studio' && input.entry !== undefined), {
+      error: 'App views for studios are not implemented yet',
+      path: ['entry'],
+    }),
+  )
+
+/**
+ * User-facing input for `unstable_defineApp`. Excludes the internal
+ * `applicationType` — that field is validated by the schema but is not part of
+ * the public surface (Sanity-owned apps set it via `@ts-expect-error`).
+ * @public
+ */
+export type DefineAppInput = Omit<z.output<typeof DefineAppInputSchema>, 'applicationType'>
+
+/**
+ * Nominal brand the CLI discriminates on to enable the workbench build/deploy
+ * codepath. Registered via `Symbol.for` so the marker survives module-realm
+ * boundaries — `@sanity/cli-core` re-derives the same global symbol with
+ * `Symbol.for` rather than importing it, so it stays internal to this module.
+ */
+const WORKBENCH_APP: unique symbol = Symbol.for('sanity.workbench.defineApp')
+
+/**
+ * The branded result of `unstable_defineApp`. Carries the same fields as the
+ * input plus the internal brand — users only ever see `DefineAppInput`.
+ * @public
+ */
+export interface DefineAppResult extends DefineAppInput {
+  readonly [WORKBENCH_APP]: true
+}
+
+/**
+ * Declare a Sanity Workbench application. Identity at runtime — returns the same
+ * object reference, tagged with the workbench brand. Field validation (the
+ * `name` pattern etc.) runs at build time in the CLI via `DefineAppInputSchema`;
+ * this helper stays a thin, pure identity wrapper.
+ * @public
+ */
+export function unstable_defineApp(input: DefineAppInput): DefineAppResult {
+  return Object.defineProperty(input, WORKBENCH_APP, {
+    configurable: false,
+    enumerable: false,
+    value: true,
+    writable: false,
+  }) as DefineAppResult
+}

--- a/packages/@sanity/cli-build/src/workbench/defineService.ts
+++ b/packages/@sanity/cli-build/src/workbench/defineService.ts
@@ -1,0 +1,60 @@
+import {SERVICE_CONTRACT_VERSION, type ServiceType} from './contract.js'
+
+/**
+ * The service's own declaration, surfaced to the callback.
+ * @public
+ */
+export interface ServiceInfo {
+  readonly name: string
+  readonly type: string
+}
+
+/**
+ * Context every service callback receives when its worker starts. Mirrors how a
+ * view component receives its `view` — the service receives its own `service`.
+ * @public
+ */
+export interface ServiceContext {
+  readonly service: ServiceInfo
+}
+
+/**
+ * A service callback. Runs once inside the worker on start; returns an optional
+ * disposer the host calls before terminating the worker.
+ * @public
+ */
+export type ServiceCallback = (context: ServiceContext) => (() => void) | void
+
+/** The callback shape each service type defines, keyed by type. */
+interface ServiceCallbacksByType {
+  worker: ServiceCallback
+}
+
+/**
+ * The result of `unstable_defineService`: the author's callback, the service
+ * type, and the internal contract version the worker artifact targets.
+ * @public
+ */
+export interface DefinedService<TType extends ServiceType = ServiceType> {
+  readonly run: ServiceCallbacksByType[TType]
+  readonly type: TType
+  /** @internal */
+  readonly version: typeof SERVICE_CONTRACT_VERSION
+}
+
+/**
+ * Define a Sanity Workbench background service. The first argument narrows the
+ * callback shape — `"worker"` runs the callback inside a Web Worker, where it
+ * can emit dock-badge updates and return a disposer.
+ *
+ * Identity at runtime: returns the callback tagged with its type and the contract
+ * version, for the CLI build to generate a worker artifact from. Used as the
+ * default export of a service's `src` file.
+ * @public
+ */
+export function unstable_defineService<TType extends ServiceType>(
+  type: TType,
+  run: ServiceCallbacksByType[TType],
+): DefinedService<TType> {
+  return {run, type, version: SERVICE_CONTRACT_VERSION}
+}

--- a/packages/@sanity/cli-build/src/workbench/defineView.ts
+++ b/packages/@sanity/cli-build/src/workbench/defineView.ts
@@ -1,0 +1,72 @@
+import {
+  type InterfaceType,
+  VIEW_CONTRACT_VERSION,
+  type ViewComponent,
+  type ViewComponentBaseProps,
+} from './contract.js'
+
+/**
+ * Props a panel component receives: its interface record, minus the
+ * service-assigned `id`/`deployment_id` a local dev server can't provide. Mirrors
+ * the `panel` record the workbench host renders from (the wire format owned by
+ * `@sanity/workbench`); drift is guarded by the stamped contract version.
+ * @public
+ */
+export type PanelViewProps = ViewComponentBaseProps<{
+  entry_point: string
+  interface_type: 'panel'
+  name: string
+}>
+
+/**
+ * The component slots a `panel` view exposes — each its own module-federation
+ * island, typed with the panel props.
+ * @public
+ */
+export interface PanelViewComponents {
+  panel: ViewComponent<PanelViewProps>
+  title: ViewComponent<PanelViewProps>
+}
+
+/**
+ * A panel's view-component slot — the module-federation expose for one island.
+ * @public
+ */
+export type PanelComponent = keyof PanelViewComponents
+
+/**
+ * The components each interface type exposes, keyed by type.
+ * @public
+ */
+export interface ViewComponentsByType {
+  panel: PanelViewComponents
+}
+
+/**
+ * The result of `unstable_defineView`: the author's component(s), the view type,
+ * and the internal contract version the build artifact targets.
+ * @public
+ */
+export interface DefinedView<TType extends InterfaceType = InterfaceType> {
+  readonly components: ViewComponentsByType[TType]
+  readonly type: TType
+  /** @internal */
+  readonly version: typeof VIEW_CONTRACT_VERSION
+}
+
+/**
+ * Define a Sanity Workbench view. The first argument narrows the component shape
+ * and the props each component receives — `"panel"` yields a `{title, panel}`
+ * record whose components are typed with the panel props.
+ *
+ * Returns the component(s) tagged with their type and the contract version, for
+ * the CLI build to generate render artifacts from. Used as the default export of
+ * a view's `src` file.
+ * @public
+ */
+export function unstable_defineView<TType extends InterfaceType>(
+  type: TType,
+  components: ViewComponentsByType[TType],
+): DefinedView<TType> {
+  return {components, type, version: VIEW_CONTRACT_VERSION}
+}

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -7,6 +7,7 @@ import {
   buildDebug,
   resolveVendorBuildConfig,
 } from '@sanity/cli-build/_internal/build'
+import {type DefineAppInput} from '@sanity/cli-build/_internal/federation'
 import {
   type CliConfig,
   getCliTelemetry,
@@ -18,7 +19,6 @@ import {
   UserViteConfig,
 } from '@sanity/cli-core'
 import {confirm, logSymbols, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
-import {type DefineAppInput} from '@sanity/federation'
 import {parse as semverParse} from 'semver'
 
 import {getAppId} from '../../util/appId.js'

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -8,6 +8,7 @@ import {
   resolveVendorBuildConfig,
   StudioBuildTrace,
 } from '@sanity/cli-build/_internal/build'
+import {type DefineAppInput} from '@sanity/cli-build/_internal/federation'
 import {
   type CliConfig,
   getCliTelemetry,
@@ -19,7 +20,6 @@ import {
   UserViteConfig,
 } from '@sanity/cli-core'
 import {confirm, logSymbols, select, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
-import {type DefineAppInput} from '@sanity/federation'
 import {parse as semverParse} from 'semver'
 
 import {getAppId} from '../../util/appId.js'

--- a/packages/@sanity/cli/src/actions/dev/__tests__/testHelpers.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/testHelpers.ts
@@ -1,5 +1,5 @@
+import {unstable_defineApp} from '@sanity/cli-build/_internal/federation'
 import {type CliConfig, type Output} from '@sanity/cli-core'
-import {unstable_defineApp} from '@sanity/federation'
 // eslint-disable-next-line import-x/no-extraneous-dependencies
 import {afterEach, beforeEach, type Mock, vi} from 'vitest'
 

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
@@ -1,7 +1,7 @@
+import {unstable_defineApp} from '@sanity/cli-build/_internal/federation'
 import {type CliConfig, exitCodes, studioWorkerTask} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
-import {unstable_defineApp} from '@sanity/federation'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 

--- a/packages/@sanity/cli/src/exports/index.ts
+++ b/packages/@sanity/cli/src/exports/index.ts
@@ -4,12 +4,13 @@ export {defineCliConfig} from '../config/defineCliConfig.js'
 export type {CliApiConfig} from '../types.js'
 export {type CliClientOptions, getCliClient} from '../util/cliClient.js'
 export {loadEnv} from '../util/loadEnv.js'
-export type {CliConfig, UserViteConfig} from '@sanity/cli-core'
+// Module-federation application extension API (config-time). Canonical
+// implementation lives in `@sanity/cli-build` (alongside the vite plugin that
+// shares its contract); re-exported here so `sanity/cli` can surface it to app
+// authors via `import {unstable_defineApp} from 'sanity/cli'`. The runtime
+// helpers `unstable_defineView`/`unstable_defineService` are NOT here — they
+// bundle to the browser, so they live on the browser-safe `@sanity/cli/runtime`
+// entry to keep `cli-core` out of the frontend bundle.
+export {type DefineAppInput, unstable_defineApp} from '@sanity/cli-build/_internal/federation'
 
-// Workbench application extension API (config-time). Canonical implementation
-// in `@sanity/federation`; re-exported here so `sanity/cli` can surface it to
-// app authors via `import {unstable_defineApp} from 'sanity/cli'`.
-// The runtime helper `unstable_defineView` is NOT here — it bundles to the
-// browser, so it lives on the browser-safe `@sanity/cli/runtime` entry to keep
-// `cli-core` out of the frontend bundle.
-export {type DefineAppInput, unstable_defineApp} from '@sanity/federation'
+export type {CliConfig, UserViteConfig} from '@sanity/cli-core'

--- a/packages/@sanity/cli/src/exports/runtime.ts
+++ b/packages/@sanity/cli/src/exports/runtime.ts
@@ -1,11 +1,24 @@
-// Browser-safe runtime authoring helpers for the workbench extension API.
+// Browser-safe runtime authoring helpers for the module-federation extension API.
 //
 // View/service src files bundle to the browser, so this entry re-exports ONLY
-// from `@sanity/federation` (a pure, dependency-light package) — it must never
-// import `@sanity/cli-core` or anything Node-only, or it would drag the CLI
-// into the frontend bundle. The `sanity` runtime package re-exports from here,
-// so the same constraint protects it.
+// from dependency-light, browser-safe modules — it must never import
+// `@sanity/cli-core` or anything Node-only, or it would drag the CLI into the
+// frontend bundle. The `sanity` runtime package re-exports from here, so the
+// same constraint protects it.
 //
 // `unstable_defineApp` is config-time (Node) and stays on the main `@sanity/cli`
 // entry; only the runtime helpers live here.
-export {unstable_defineService, unstable_defineView} from '@sanity/federation'
+export type {
+  DefinedService,
+  DefinedView,
+  InterfaceType,
+  PanelComponent,
+  PanelViewComponents,
+  PanelViewProps,
+  ServiceCallback,
+  ServiceContext,
+  ServiceInfo,
+  ServiceType,
+  ViewComponentsByType,
+} from '@sanity/cli-build/_internal/federation'
+export {unstable_defineService, unstable_defineView} from '@sanity/cli-build/_internal/federation'


### PR DESCRIPTION
### Description

Unbundling `@sanity/federation` (SDK-1737), 1/2. Moves the `unstable_define*` helpers + their contract into `@sanity/cli-build`; `@sanity/cli` re-exports them, so `sanity/cli` and `sanity` are unchanged.

Why cli-build and not cli: it shares one contract with the vite plugin (#1270) → single source of truth, no duplication.

### What to review

- Faithful port of the authoring half of `@sanity/federation`; wire-format unions stay with `@sanity/workbench`.
- New `_internal/federation` entry is zod-only → `@sanity/cli/runtime` stays browser-safe.

Base: `feat/workbench`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public `sanity/cli` extension surface and build-time validation for apps/views/services; behavior is intended to be a faithful port but any drift would affect workbench builds and deploy paths.
> 
> **Overview**
> Moves the **module-federation / Workbench authoring API** from `@sanity/federation` into `@sanity/cli-build` as the single source of truth (alongside the Vite plugin contract). Adds a zod-only **`./_internal/federation`** export with `unstable_defineApp`, `unstable_defineView`, `unstable_defineService`, shared **contract schemas**, and **contract version** stamping.
> 
> **`@sanity/cli`** now re-exports from that entry instead of `@sanity/federation`: config-time `unstable_defineApp` on the main entry, browser-safe view/service helpers and types on **`runtime`**. Build actions and tests import **`@sanity/cli-build/_internal/federation`** directly. Public `sanity/cli` and `sanity` import paths stay the same; behavior is covered by new **vitest** suites for define helpers and validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 452adfbb6c959ed83cc4637cfae7bb5444cb4714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

