### PR TITLE
refactor(cli-build): move the module-federation vite plugin in-tree

### DIFF
--- a/packages/@sanity/cli-build/package.json
+++ b/packages/@sanity/cli-build/package.json
@@ -58,10 +58,10 @@
     "watch": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ --watch src"
   },
   "dependencies": {
+    "@module-federation/vite": "1.16.0",
     "@oclif/core": "catalog:",
     "@rolldown/plugin-babel": "^0.2.3",
     "@sanity/cli-core": "workspace:^",
-    "@sanity/federation": "0.1.0-alpha.10",
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/schema": "catalog:",
     "@sanity/telemetry": "catalog:",

--- a/packages/@sanity/cli-build/src/_exports/_internal/build.ts
+++ b/packages/@sanity/cli-build/src/_exports/_internal/build.ts
@@ -15,3 +15,5 @@ export {resolveEntries, writeSanityRuntime} from '../../actions/build/writeSanit
 export {SANITY_CACHE_DIR} from '../../constants.js'
 export {AppBuildTrace, StudioBuildTrace} from '../../telemetry/build.telemetry.js'
 export {copyDir} from '../../util/copyDir.js'
+export {type ServiceArtifact} from '../../workbench/services/artifact.js'
+export {type InterfaceArtifact} from '../../workbench/views/artifact.js'

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
@@ -58,7 +58,7 @@ vi.mock('../vite/plugin-sanity-runtime-rewrite.js', () => ({
   sanityRuntimeRewritePlugin: vi.fn(() => ({name: 'sanity-runtime-rewrite'})),
 }))
 
-vi.mock('@sanity/federation/vite', () => ({
+vi.mock('../../../workbench/vite/plugin.js', () => ({
   federation: mockFederationPlugin.mockReturnValue({
     name: 'sanity/federation',
   }),

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -8,11 +8,6 @@ import {
   readPackageJson,
   type UserViteConfig,
 } from '@sanity/cli-core'
-import {
-  type InterfaceArtifact,
-  type ServiceArtifact,
-  federation as viteFederation,
-} from '@sanity/federation/vite'
 import viteReact, {reactCompilerPreset} from '@vitejs/plugin-react'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import debug from 'debug'
@@ -27,6 +22,9 @@ import {
 } from 'vite'
 
 import {SANITY_CACHE_DIR} from '../../constants.js'
+import {type ServiceArtifact} from '../../workbench/services/artifact.js'
+import {type InterfaceArtifact} from '../../workbench/views/artifact.js'
+import {federation as viteFederation} from '../../workbench/vite/plugin.js'
 import {sanitySchemaExtractionPlugin} from '../schema/vite/plugin-schema-extraction.js'
 import {type AutoUpdatesBuildConfig} from './autoUpdates.js'
 import {VENDOR_DIR} from './constants.js'

--- a/packages/@sanity/cli-build/src/workbench/artifact.ts
+++ b/packages/@sanity/cli-build/src/workbench/artifact.ts
@@ -1,0 +1,52 @@
+/**
+ * What a {@link GeneratedArtifact.source} builder receives from the build — the
+ * one thing it can't compute on its own, since only the build knows where the
+ * runtime dir sits relative to the app's `src`.
+ */
+interface ArtifactContext {
+  /** Import specifier for an app `src` file, relative to this artifact. */
+  resolveImport: (src: string) => string
+}
+
+/**
+ * One file the federation build generates into the runtime dir for a declared
+ * interface. Each interface type — views, services — expands its declarations
+ * into a flat list of these; the build then writes them and maps the ones the
+ * host loads directly into the module-federation manifest.
+ *
+ * Adding an interface type is adding a builder that returns
+ * `GeneratedArtifact[]` — the write loop and the expose mapping never change.
+ */
+export interface GeneratedArtifact {
+  /** Path relative to the federation runtime dir, e.g. `views/feed/panel.js`. */
+  path: string
+  /** Build the file's contents. */
+  source: (context: ArtifactContext) => string
+
+  /**
+   * Module-federation expose key when the host loads this artifact directly —
+   * a view component `./views/feed/panel`, a service loader `./services/unread`.
+   * Omitted for a file the host never loads on its own, like a worker bundle
+   * (reached through its sibling loader).
+   */
+  expose?: string
+}
+
+/**
+ * Map the artifacts the host loads directly (those with an `expose`) to their
+ * runtime-dir paths, for the module-federation `exposes` field. `toExposePath`
+ * turns a runtime-relative artifact path into the value federation wants — the
+ * caller owns the runtime-dir location and any entry resolution.
+ */
+export function artifactExposes(
+  artifacts: readonly GeneratedArtifact[],
+  toExposePath: (artifactPath: string) => string,
+): Record<string, string> {
+  const exposes: Record<string, string> = {}
+  for (const artifact of artifacts) {
+    if (artifact.expose) {
+      exposes[artifact.expose] = toExposePath(artifact.path)
+    }
+  }
+  return exposes
+}

--- a/packages/@sanity/cli-build/src/workbench/contract.ts
+++ b/packages/@sanity/cli-build/src/workbench/contract.ts
@@ -40,12 +40,20 @@ export interface ViewComponentBaseProps<TView> {
 }
 
 /**
+ * Component slots each interface type exposes, in render order — the source of
+ * truth for {@link InterfaceType} and for the build (the vite plugin expands a
+ * view into one render artifact per component). Add a type by registering it here.
+ * @internal
+ */
+export const VIEW_COMPONENTS = {
+  panel: ['title', 'panel'],
+} as const satisfies Record<string, readonly string[]>
+
+/**
  * Every supported interface type — the first argument to `unstable_defineView`.
- * The build's component registry (`VIEW_COMPONENTS`, which expands a view into
- * one render artifact per component) ships with the vite plugin.
  * @public
  */
-export type InterfaceType = 'panel'
+export type InterfaceType = keyof typeof VIEW_COMPONENTS
 
 /**
  * Every supported service type — the first argument to `unstable_defineService`.

--- a/packages/@sanity/cli-build/src/workbench/render-remote.ts
+++ b/packages/@sanity/cli-build/src/workbench/render-remote.ts
@@ -1,0 +1,82 @@
+/**
+ * Every entry the federation build generates — the studio/app remote entries
+ * and the per-view-component artifacts — is the same thing: a *render-contract
+ * module* that owns its own React, renders into a host node via
+ * `render(rootElement, props, renderOptions)`, and returns a disposer.
+ *
+ * They differ only in *what* they render. So each module binds an `App` to that
+ * (the SDK app, a `Studio` with config, a view component) and the render body —
+ * identical everywhere — just renders `App`. {@link renderRemote} assembles a
+ * module from a `preamble` (its imports), the `app` expression, and, optionally,
+ * the shared HMR snippet.
+ */
+
+/**
+ * Hot-reload: on an update, re-render every live root through the new module —
+ * so whatever it now binds `App` to (a recompiled component, a new studio
+ * config) takes effect without a full page reload. Stripped from prod builds.
+ */
+const HMR_REMOUNT = `if (import.meta.hot) {
+  import.meta.hot.accept((next) => {
+    if (!next) return
+    for (const [rootElement, args] of renderArgs) {
+      rootMap.get(rootElement)?.unmount()
+      rootMap.delete(rootElement)
+      next.render(rootElement, args.props, args.renderOptions)
+    }
+  })
+}`
+
+/**
+ * Assemble a render-contract module: its `preamble` (imports), the `App` it
+ * renders, the render body, and — when `hmr` — the shared HMR snippet.
+ *
+ * - `app` is the expression bound to `App`; omit it when the preamble imports an
+ *   `App` directly (the SDK-app entry).
+ * - `version` is an expression the host reads to check contract compatibility;
+ *   omit it when the module carries no version (the studio/app entries).
+ */
+export function renderRemote({
+  app,
+  hmr = false,
+  preamble,
+  version,
+}: {
+  app?: string
+  hmr?: boolean
+  preamble: string
+  version?: string
+}): string {
+  return `\
+// This file is auto-generated on 'sanity build' / 'sanity dev'
+// Modifications to this file are automatically discarded
+import { createElement, StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+${preamble}
+${app ? `\nconst App = ${app}\n` : ''}${version ? `\nexport const version = ${version}\n` : ''}
+const rootMap = new Map()
+const renderArgs = new Map()
+
+function mount(rootElement, args) {
+  let root = rootMap.get(rootElement)
+  if (!root) {
+    root = createRoot(rootElement)
+    rootMap.set(rootElement, root)
+  }
+  const element = createElement(App, args.props)
+  root.render(args?.renderOptions?.reactStrictMode ? createElement(StrictMode, null, element) : element)
+}
+
+export function render(rootElement, props, renderOptions) {
+  const args = { props, renderOptions }
+  renderArgs.set(rootElement, args)
+  mount(rootElement, args)
+  return () => {
+    const root = rootMap.get(rootElement)
+    rootMap.delete(rootElement)
+    renderArgs.delete(rootElement)
+    root?.unmount()
+  }
+}${hmr ? `\n\n${HMR_REMOUNT}` : ''}
+`
+}

--- a/packages/@sanity/cli-build/src/workbench/services/artifact.ts
+++ b/packages/@sanity/cli-build/src/workbench/services/artifact.ts
@@ -1,0 +1,147 @@
+import {type GeneratedArtifact} from '../artifact.js'
+import {SERVICE_CONTRACT_VERSION, type ServiceType} from '../contract.js'
+
+/** Subdirectory under the federation runtime dir where service artifacts live. */
+const SERVICES_DIR_NAME = 'services'
+
+const SERVICE_TYPES: readonly ServiceType[] = ['worker']
+
+/**
+ * A service to generate a worker artifact for. The `src` file default-exports
+ * an `unstable_defineService(...)` result; the build emits a self-contained Web
+ * Worker bundle plus a loader module that hands the host its URL.
+ * @public
+ */
+export interface ServiceArtifact {
+  /** Service name, unique within the app. */
+  name: string
+  /** Path to the service `src` file, relative to the app root (or absolute). */
+  src: string
+  /** Service type, e.g. `"worker"`. */
+  type: string
+}
+
+/**
+ * Expand each service into its two generated artifacts: a self-contained worker
+ * bundle (imports the user's `src`, runs the callback) and a loader module the
+ * host loads to read the worker's URL. Only the loader is a federation expose —
+ * the host reaches the worker bundle through it, never directly.
+ */
+export function serviceArtifacts(services: readonly ServiceArtifact[]): GeneratedArtifact[] {
+  return services
+    .filter((service) => (SERVICE_TYPES as readonly string[]).includes(service.type))
+    .flatMap((service): GeneratedArtifact[] => {
+      const dir = `${SERVICES_DIR_NAME}/${service.name}`
+      return [
+        {
+          path: `${dir}/worker.js`,
+          source: ({resolveImport}) =>
+            serviceWorkerArtifactSource({
+              importPath: resolveImport(service.src),
+              service,
+            }),
+        },
+        {
+          expose: `./${dir}`,
+          path: `${dir}/index.js`,
+          source: () => serviceLoaderArtifactSource({service}),
+        },
+      ]
+    })
+}
+
+/**
+ * Source for one service's **worker** bundle — the Web Worker entry. Imports
+ * the user's `unstable_defineService` result and runs its callback with the
+ * service's own declaration (mirroring how a view component receives its
+ * `view`), then wires the returned disposer to the host's terminate message.
+ * Crashes — and the worker's `console.*`, which is patched to forward to the
+ * host — are surfaced through the host logger (the host owns logging; a worker's
+ * own console isn't visible in the page DevTools anyway).
+ */
+function serviceWorkerArtifactSource(input: {
+  importPath: string
+  service: {name: string; type: string}
+}): string {
+  return `\
+// This file is auto-generated on 'sanity build' / 'sanity dev'
+// Modifications to this file are automatically discarded
+import service from ${JSON.stringify(input.importPath)}
+
+const SERVICE = { type: ${JSON.stringify(input.service.type)}, name: ${JSON.stringify(input.service.name)} }
+
+// Bridge the worker's console to the host. A worker's own console isn't visible
+// in the page DevTools, so patch console.* to forward each call as a message
+// the host re-emits through the workbench logger — any console.log in the
+// service (or its deps) just shows up in the page console.
+const __format = (arg) => {
+  if (typeof arg === 'string') return arg
+  try { return JSON.stringify(arg) } catch (_) { return String(arg) }
+}
+for (const __level of ['log', 'info', 'warn', 'error', 'debug']) {
+  const __native = typeof console[__level] === 'function' ? console[__level].bind(console) : () => {}
+  console[__level] = (...args) => {
+    __native(...args)
+    try {
+      self.postMessage({ kind: 'workbench.worker.log', payload: { level: __level, message: args.map(__format).join(' ') } })
+    } catch (_) {}
+  }
+}
+
+let dispose
+try {
+  const result = service.run({ service: SERVICE })
+  if (typeof result === 'function') dispose = result
+} catch (error) {
+  self.postMessage({ kind: 'workbench.worker.error', payload: { message: String(error) } })
+}
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.kind === 'workbench.worker.terminate') {
+    try { dispose && dispose() } finally { self.close() }
+  }
+})
+
+self.addEventListener('error', (event) => {
+  self.postMessage({ kind: 'workbench.worker.error', payload: { message: String(event.message || event) } })
+})
+
+// An async run callback (or async work it kicks off) rejects without hitting
+// the synchronous try/catch above; module workers surface that as
+// 'unhandledrejection' on self, not 'error'. Forward it so the crash reaches
+// the host either way.
+self.addEventListener('unhandledrejection', (event) => {
+  self.postMessage({ kind: 'workbench.worker.error', payload: { message: String(event.reason) } })
+})
+`
+}
+
+/**
+ * Source for one service's **loader** — the module-federation expose. Hands the
+ * host the worker bundle's URL (via Vite `?worker&url`) plus the service's
+ * type/version.
+ *
+ * A URL (not an inlined worker) on purpose: the host can't `new Worker()` it
+ * directly — cross-origin in dev/prod, and `?worker&inline` only self-contains
+ * the worker in a build, not under `sanity dev`. Instead the host bootstraps a
+ * same-origin worker that dynamically `import()`s this URL, so the worker
+ * resolves its own imports against the app origin. Works in dev and build alike.
+ *
+ * No HMR boundary: a worker lives in its own `?worker&url` module graph with no
+ * accepting importer, so Vite full-reloads the page on a `src` edit (which
+ * re-loads the worker with the new code) — in-place worker HMR isn't possible.
+ */
+function serviceLoaderArtifactSource(input: {service: {name: string; type: string}}): string {
+  return `\
+// This file is auto-generated on 'sanity build' / 'sanity dev'
+// Modifications to this file are automatically discarded
+import workerUrl from './worker.js?worker&url'
+
+/** URL of the worker bundle, on the app's origin. */
+export const url = workerUrl
+/** Service type and contract version, surfaced for the host to dispatch on. */
+export const type = ${JSON.stringify(input.service.type)}
+export const name = ${JSON.stringify(input.service.name)}
+export const version = ${SERVICE_CONTRACT_VERSION}
+`
+}

--- a/packages/@sanity/cli-build/src/workbench/views/artifact.ts
+++ b/packages/@sanity/cli-build/src/workbench/views/artifact.ts
@@ -1,0 +1,50 @@
+import {type GeneratedArtifact} from '../artifact.js'
+import {type InterfaceType, VIEW_COMPONENTS} from '../contract.js'
+import {renderRemote} from '../render-remote.js'
+
+/** Subdirectory under the federation runtime dir where view artifacts are written. */
+const VIEWS_DIR_NAME = 'views'
+
+/**
+ * An interface to generate render artifacts for. The `src` file default-exports
+ * an `unstable_defineView(...)` result; the build emits one render-contract
+ * artifact per component the interface type exposes.
+ * @public
+ */
+export interface InterfaceArtifact {
+  /** Interface name, unique within the app. */
+  name: string
+  /** Path to the interface `src` file, relative to the app root (or absolute). */
+  src: string
+  /** Interface type — selects which components the build expands. */
+  type: InterfaceType
+}
+
+/**
+ * Expand each view into one generated artifact per component it exposes. A
+ * panel's `title` and `panel` each become their own render-contract module and
+ * module-federation expose, so the host renders each as an independent island.
+ *
+ * Each artifact binds its component as the `App` the render contract renders —
+ * a single-component view exports a bare function, a multi-component one keys by
+ * name — behind an HMR boundary so view edits re-render through the new module.
+ */
+export function viewArtifacts(views: readonly InterfaceArtifact[]): GeneratedArtifact[] {
+  const artifacts: GeneratedArtifact[] = []
+  for (const view of views) {
+    for (const component of VIEW_COMPONENTS[view.type]) {
+      artifacts.push({
+        expose: `./${VIEWS_DIR_NAME}/${view.name}/${component}`,
+        path: `${VIEWS_DIR_NAME}/${view.name}/${component}.js`,
+        source: ({resolveImport}) =>
+          renderRemote({
+            app: `typeof view.components === 'function' ? view.components : view.components[${JSON.stringify(component)}]`,
+            hmr: true,
+            preamble: `import view from ${JSON.stringify(resolveImport(view.src))}`,
+            version: `view.version`,
+          }),
+      })
+    }
+  }
+  return artifacts
+}

--- a/packages/@sanity/cli-build/src/workbench/vite/constants.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/constants.ts
@@ -1,0 +1,3 @@
+export const FEDERATION_FILE_NAME = 'remote-entry'
+export const FEDERATION_DIR_NAME = 'federation'
+export const RUNTIME_DIR = `.sanity/${FEDERATION_DIR_NAME}`

--- a/packages/@sanity/cli-build/src/workbench/vite/plugin.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/plugin.ts
@@ -1,0 +1,144 @@
+import path from 'node:path'
+
+import {type ModuleFederationOptions} from '@module-federation/vite'
+import {type PackageJson} from '@sanity/cli-core'
+import {type PluginOption} from 'vite'
+
+import {artifactExposes} from '../artifact.js'
+import {type ServiceArtifact, serviceArtifacts} from '../services/artifact.js'
+import {type InterfaceArtifact, viewArtifacts} from '../views/artifact.js'
+import {FEDERATION_FILE_NAME, RUNTIME_DIR} from './constants.js'
+import {type FederationOptions, pluginModuleFederation} from './plugins/plugin-module-federation.js'
+import {sanityEnvironmentPlugin} from './plugins/plugin-sanity-environment.js'
+import {sanityExtensionArtifacts} from './plugins/plugin-sanity-extension-artifacts.js'
+import {
+  type FederationRuntimeOptions,
+  sanityFederationRuntime,
+} from './plugins/plugin-sanity-federation-runtime.js'
+import {invariant} from './utils/invariant.js'
+
+interface FederationPluginOptionsBase extends Omit<Partial<FederationOptions>, 'exposes'> {
+  exposes?: Record<string, string>
+  pkgJson?: PackageJson
+  /**
+   * Background services the app declares. Each is built into a self-contained
+   * worker bundle plus a loader module exposed as `./services/<name>`, so the
+   * workbench host can fetch the worker URL and run it.
+   */
+  services?: readonly ServiceArtifact[]
+  /**
+   * Views the app declares. Each component of a view is built into a
+   * render-contract artifact and exposed as `./views/<view>/<component>` so the
+   * workbench host can load each as its own island.
+   */
+  views?: readonly InterfaceArtifact[]
+  /**
+   * Current working directory to read package.json from, defaults to process.cwd()
+   */
+  workDir?: string
+}
+
+interface AppFederationPluginOptions extends FederationPluginOptionsBase {
+  isApp: true
+
+  /**
+   * Relative path to the App entry from the runtime directory, e.g.
+   * `../../src/App.tsx`. Omit it for a dock-only app that declares no `entry`:
+   * no `./App` is exposed and the remote serves only its views.
+   */
+  appEntry?: string
+  studioConfigPath?: never
+}
+
+interface StudioFederationPluginOptions extends FederationPluginOptionsBase {
+  /** relative path to the Studio config file from the runtime directory (e.g. `../../sanity.config.ts`). */
+  studioConfigPath: string
+
+  appEntry?: never
+  /** @defaultValue false */
+  isApp?: false
+}
+
+/**
+ * Plugin options for the federation vite plugin.
+ *
+ * Discriminated on `isApp`:
+ * - `isApp: true`  → requires `appEntry`
+ * - `isApp: false` (default) → requires `studioConfigPath`
+ *
+ * @internal
+ */
+type FederationPluginOptions = AppFederationPluginOptions | StudioFederationPluginOptions
+
+/**
+ * @public
+ */
+export const federation = (options: FederationPluginOptions): PluginOption => {
+  const {
+    exposes: defaultExposes = {},
+    name: defaultName,
+    pkgJson,
+    services = [],
+    views = [],
+    workDir = process.cwd(),
+  } = options
+
+  let name = defaultName
+
+  if (!name) {
+    name = pkgJson?.name
+  }
+
+  invariant(name, '"name" option is required but could not be inferred from package.json')
+
+  const generatedEntry = `./${RUNTIME_DIR}/${FEDERATION_FILE_NAME}.jsx`
+
+  function resolveEntryPath(entry: string) {
+    const resolvedPath = path.resolve(workDir, entry)
+
+    invariant(
+      resolvedPath,
+      `Could not resolve path for entry "${entry}". Resolved to "${resolvedPath}". Please check that the file exists and the path is correct.`,
+    )
+
+    return resolvedPath
+  }
+
+  const entryPath = resolveEntryPath(generatedEntry)
+
+  const resolvedExposes: Record<string, string> = {}
+  for (const [key, exposePath] of Object.entries(defaultExposes)) {
+    resolvedExposes[key] = resolveEntryPath(exposePath) ?? exposePath
+  }
+
+  // Each view component (`./views/<view>/<component>`) and each service loader
+  // (`./services/<name>`) is exposed straight to the host, pointing at the file
+  // the extension-artifacts plugin generates under RUNTIME_DIR. A service's
+  // worker bundle carries no expose — the host reaches it through its loader.
+  const interfaceExposes = artifactExposes(
+    [...viewArtifacts(views), ...serviceArtifacts(services)],
+    (artifactPath) => resolveEntryPath(`./${RUNTIME_DIR}/${artifactPath}`),
+  )
+
+  // A dock-only app (`isApp` with no `appEntry`) has no navigable full-page
+  // view, so it exposes no `./App` — only its views. Studios and apps with an
+  // entry expose `./App` (the generated render entry).
+  const exposesApp = !options.isApp || options.appEntry !== undefined
+
+  const exposes: NonNullable<ModuleFederationOptions['exposes']> = {
+    ...(exposesApp ? {'./App': entryPath} : {}),
+    ...resolvedExposes,
+    ...interfaceExposes,
+  }
+
+  const runtimeOptions: FederationRuntimeOptions = options.isApp
+    ? {appEntry: options.appEntry, isApp: true}
+    : {isApp: false, studioConfigPath: options.studioConfigPath}
+
+  return [
+    sanityEnvironmentPlugin({input: entryPath}),
+    sanityFederationRuntime(runtimeOptions),
+    sanityExtensionArtifacts({services, views}),
+    pluginModuleFederation({exposes, name}),
+  ]
+}

--- a/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-module-federation.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-module-federation.ts
@@ -1,0 +1,53 @@
+import {federation as moduleFederation, type ModuleFederationOptions} from '@module-federation/vite'
+import {type Plugin, type PluginOption} from 'vite'
+
+import {FEDERATION_DIR_NAME, FEDERATION_FILE_NAME} from '../constants.js'
+
+/**
+ * @public
+ */
+export interface FederationOptions extends Pick<ModuleFederationOptions, 'exposes'> {
+  /**
+   * namespace of the federation build, used as the global variable name for the exposed modules
+   * e.g `@acme/studio` would then allow you to import modules like `import ("@acme/studio/Button")`
+   * defaults to your package.json name if not provided.
+   */
+  name: string
+}
+
+export function pluginModuleFederation({exposes, name}: FederationOptions): PluginOption {
+  const mfPlugins = moduleFederation({
+    dev: {
+      disableDynamicRemoteTypeHints: true,
+      remoteHmr: true,
+    },
+    // TODO: this should be conditional based on whether the project uses typescript or not...
+    dts: {
+      generateTypes: false,
+    },
+    exposes,
+    filename: `${FEDERATION_FILE_NAME}.js`,
+    manifest: true,
+    name,
+    // This is needed for module-federation to resolve the path of the remote entry
+    // relative to the manifest, rather than the host origin
+    publicPath: 'auto',
+    // @module-federation/vite auto-shares every package.json dependency
+    // that exposes an `exports` field. That breaks for workspace packages with
+    // subpath-only exports (no `.` entry) like `@sanity/cli-build` and
+    // `@sanity/workbench`, because vite tries to resolve them as bare imports
+    // and fails. Workbench remotes manage runtime sharing through the host's
+    // federation runtime, so we opt out of auto-share entirely.
+    shared: {},
+  })
+
+  return mfPlugins.map((plugin): Plugin => {
+    return {
+      ...plugin,
+      // In dev, MF must run on client — the dev server serves through it.
+      // In build, scope to the federation environment to keep the library build clean.
+      applyToEnvironment: (env) =>
+        env.config.command === 'serve' || env.name === FEDERATION_DIR_NAME,
+    }
+  })
+}

--- a/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-sanity-environment.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-sanity-environment.ts
@@ -1,0 +1,32 @@
+import {type Plugin} from 'vite'
+
+import {FEDERATION_DIR_NAME} from '../constants.js'
+
+interface EnvironmentOptions {
+  input: string
+}
+
+export function sanityEnvironmentPlugin(options: EnvironmentOptions): Plugin {
+  return {
+    config() {
+      return {
+        builder: {
+          async buildApp(builder) {
+            await builder.build(builder.environments[FEDERATION_DIR_NAME])
+          },
+        },
+        environments: {
+          [FEDERATION_DIR_NAME]: {
+            build: {
+              copyPublicDir: false,
+              outDir: `dist`,
+              rollupOptions: {input: options.input},
+            },
+            consumer: 'client',
+          },
+        },
+      }
+    },
+    name: 'sanity/environment',
+  }
+}

--- a/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-sanity-extension-artifacts.node.test.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-sanity-extension-artifacts.node.test.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {type ResolvedConfig} from 'vite'
+import {afterEach, describe, expect, it} from 'vitest'
+
+import {sanityExtensionArtifacts} from './plugin-sanity-extension-artifacts.js'
+
+const tmpRoots: string[] = []
+
+function makeRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ext-artifacts-'))
+  tmpRoots.push(root)
+  return root
+}
+
+function runConfigResolved(
+  plugin: ReturnType<typeof sanityExtensionArtifacts>,
+  root: string,
+): void {
+  const hook = plugin.configResolved
+  const handler = typeof hook === 'function' ? hook : hook?.handler
+  handler?.call(
+    // The plugin only reads `root` off the resolved config.
+    {} as never,
+    {root} as ResolvedConfig,
+  )
+}
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) {
+    fs.rmSync(root, {force: true, recursive: true})
+  }
+})
+
+describe('sanityExtensionArtifacts', () => {
+  it('emits one render-contract artifact per component of each view', () => {
+    const root = makeRoot()
+    runConfigResolved(
+      sanityExtensionArtifacts({
+        views: [{name: 'feed', src: './src/panel.tsx', type: 'panel'}],
+      }),
+      root,
+    )
+
+    // A panel exposes `title` and `panel` — one island, one artifact each.
+    const feedDir = path.join(root, '.sanity/federation/views/feed')
+    expect(fs.readdirSync(feedDir).toSorted()).toEqual(['panel.js', 'title.js'])
+  })
+
+  it('binds each artifact to its component and exposes the island render', () => {
+    const root = makeRoot()
+    runConfigResolved(
+      sanityExtensionArtifacts({
+        views: [{name: 'feed', src: './src/panel.tsx', type: 'panel'}],
+      }),
+      root,
+    )
+
+    const panel = fs.readFileSync(path.join(root, '.sanity/federation/views/feed/panel.js'), 'utf8')
+    // From .sanity/federation/views/feed/panel.js back up to <root>/src/panel.tsx.
+    expect(panel).toContain('import view from "../../../../src/panel.tsx"')
+    expect(panel).toContain('view.components["panel"]')
+    expect(panel).toContain('export function render(rootElement, props')
+    // The artifact is its own HMR boundary so view edits hot-reload in place
+    // instead of triggering a full page reload.
+    expect(panel).toContain('import.meta.hot.accept')
+
+    const title = fs.readFileSync(path.join(root, '.sanity/federation/views/feed/title.js'), 'utf8')
+    expect(title).toContain('view.components["title"]')
+  })
+
+  it('writes nothing when no views are declared', () => {
+    const root = makeRoot()
+    runConfigResolved(sanityExtensionArtifacts({views: []}), root)
+    expect(fs.existsSync(path.join(root, '.sanity/federation/views'))).toBe(false)
+  })
+
+  it('emits a worker bundle and loader for each service', () => {
+    const root = makeRoot()
+    runConfigResolved(
+      sanityExtensionArtifacts({
+        services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+        views: [],
+      }),
+      root,
+    )
+
+    const dir = path.join(root, '.sanity/federation/services/unread')
+    expect(fs.readdirSync(dir).toSorted()).toEqual(['index.js', 'worker.js'])
+
+    const worker = fs.readFileSync(path.join(dir, 'worker.js'), 'utf8')
+    // The worker imports the user's src, runs it with its `service`
+    // declaration, and listens for the host's terminate message.
+    expect(worker).toContain('import service from "../../../../src/service.ts"')
+    expect(worker).toContain('service.run({ service: SERVICE })')
+    expect(worker).toContain('workbench.worker.terminate')
+
+    const loader = fs.readFileSync(path.join(dir, 'index.js'), 'utf8')
+    // The loader hands the host the worker bundle's URL via Vite's `?worker&url`;
+    // the host bootstraps a worker that imports it.
+    expect(loader).toContain('./worker.js?worker&url')
+    expect(loader).toContain('export const url')
+  })
+})

--- a/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-sanity-extension-artifacts.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-sanity-extension-artifacts.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {type Plugin} from 'vite'
+
+import {type GeneratedArtifact} from '../../artifact.js'
+import {type ServiceArtifact, serviceArtifacts} from '../../services/artifact.js'
+import {type InterfaceArtifact, viewArtifacts} from '../../views/artifact.js'
+import {RUNTIME_DIR} from '../constants.js'
+
+function relativeImport(fromFile: string, toFile: string): string {
+  const rel = path.relative(path.dirname(fromFile), toFile).split(path.sep).join('/')
+  return rel.startsWith('.') ? rel : `./${rel}`
+}
+
+/** Write each generated artifact into the runtime dir under the app root. */
+function writeArtifacts(root: string, artifacts: readonly GeneratedArtifact[]): void {
+  for (const artifact of artifacts) {
+    const artifactPath = path.resolve(root, RUNTIME_DIR, artifact.path)
+    fs.mkdirSync(path.dirname(artifactPath), {recursive: true})
+    fs.writeFileSync(
+      artifactPath,
+      artifact.source({
+        resolveImport: (src) => relativeImport(artifactPath, path.resolve(root, src)),
+      }),
+    )
+  }
+}
+
+/**
+ * Emits one render-contract artifact per view component into
+ * `RUNTIME_DIR/views/<view>/<component>.js`. The artifacts are exposed through
+ * module federation (`./views/<view>/<component>`) by the `federation` plugin,
+ * so the workbench host can load and render each component as its own island.
+ * Each service likewise emits a self-contained worker bundle plus a loader
+ * module under `RUNTIME_DIR/services/<name>/`, exposed as `./services/<name>`.
+ *
+ * The per-type knowledge lives in `views/artifact` and `services/artifact`;
+ * this plugin only writes what those modules resolve.
+ */
+export function sanityExtensionArtifacts(options: {
+  services?: readonly ServiceArtifact[]
+  views: readonly InterfaceArtifact[]
+}): Plugin {
+  return {
+    configResolved(config) {
+      writeArtifacts(config.root, [
+        ...viewArtifacts(options.views),
+        ...serviceArtifacts(options.services ?? []),
+      ])
+    },
+    name: 'sanity/extension-artifacts',
+  }
+}

--- a/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-sanity-federation-runtime.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-sanity-federation-runtime.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {type EnvironmentModuleNode, type Plugin} from 'vite'
+
+import {renderRemote} from '../../render-remote.js'
+import {FEDERATION_FILE_NAME, RUNTIME_DIR} from '../constants.js'
+
+const REMOTE_ENTRY_FILE = `${FEDERATION_FILE_NAME}.jsx`
+
+// The studio wraps `Studio` with the user's config; HMR re-renders through the
+// new module so a config edit takes effect.
+const STUDIO_ENTRY = renderRemote({
+  app: `(props) => createElement(Studio, { config, ...props })`,
+  hmr: true,
+  preamble: `import { Studio } from 'sanity'
+import config from %STUDIO_CONFIG%`,
+})
+
+// An SDK app's default export is the component; it Fast-Refreshes through its
+// own dev server, so the wrapper needs no HMR boundary.
+const APP_ENTRY = renderRemote({preamble: `import App from %APP_ENTRY%`})
+
+// A branded app that declares no `entry` (e.g. a dock-only panel/worker app)
+// has no navigable full-page view, so there's no `App` to import. The runtime
+// still needs a valid module for the federation build input, but it exposes no
+// `./App` (see `plugin.ts`) — its `render` is unreachable and throws if reached.
+const HEADLESS_APP_ENTRY = `\
+// This file is auto-generated on 'sanity dev'
+// Modifications to this file are automatically discarded
+// This application declares no app view (no \`entry\`): it isn't navigable as a
+// full-page app, only its panels/services are exposed.
+export function render() {
+  throw new Error('This application has no app view: it declares no \`entry\`.')
+}
+`
+
+export type FederationRuntimeOptions =
+  | {appEntry?: string; isApp: true}
+  | {isApp: false; studioConfigPath: string}
+
+export function sanityFederationRuntime(options: FederationRuntimeOptions): Plugin {
+  let content: string
+  if (options.isApp) {
+    content = options.appEntry
+      ? APP_ENTRY.replace(/%APP_ENTRY%/, JSON.stringify(options.appEntry))
+      : HEADLESS_APP_ENTRY
+  } else {
+    content = STUDIO_ENTRY.replace(/%STUDIO_CONFIG%/, JSON.stringify(options.studioConfigPath))
+  }
+
+  let entryFileAbsPath = ''
+
+  return {
+    configResolved(config) {
+      const dir = path.resolve(config.root, RUNTIME_DIR)
+      entryFileAbsPath = path.join(dir, REMOTE_ENTRY_FILE)
+
+      fs.mkdirSync(dir, {recursive: true})
+      fs.writeFileSync(entryFileAbsPath, content)
+    },
+    hotUpdate({file, modules, timestamp}) {
+      if (options.isApp) return
+      if (this.environment.name !== 'client') return
+
+      const {moduleGraph} = this.environment
+      const studioMods = moduleGraph.getModulesByFile(entryFileAbsPath)
+      if (!studioMods?.size) return
+
+      // Is the changed file reachable from the studio entry?
+      const visited = new Set<EnvironmentModuleNode>()
+      const queue: EnvironmentModuleNode[] = [...studioMods]
+      while (queue.length > 0) {
+        const mod = queue.pop()!
+        if (visited.has(mod)) continue
+        visited.add(mod)
+        if (mod.file === file) {
+          // The walk from `file` up through importers dead-ends at federation
+          // gaps, so invalidate changed modules ourselves and route HMR to the
+          // self-accepting studio entry.
+          const seen = new Set<EnvironmentModuleNode>()
+          for (const m of modules) {
+            moduleGraph.invalidateModule(m, seen, timestamp, true)
+          }
+          return [...studioMods]
+        }
+        for (const dep of mod.importedModules) queue.push(dep)
+      }
+    },
+    name: 'sanity/federation-runtime',
+  }
+}

--- a/packages/@sanity/cli-build/src/workbench/vite/utils/invariant.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/utils/invariant.ts
@@ -1,0 +1,3 @@
+export function invariant(value: unknown, message: string): asserts value {
+  if (!value) throw new Error(message)
+}

--- a/packages/@sanity/cli-core/src/config/cli/workbenchApp.ts
+++ b/packages/@sanity/cli-core/src/config/cli/workbenchApp.ts
@@ -6,24 +6,24 @@ import {type CliConfig} from './types/cliConfig.js'
 
 /**
  * The brand `unstable_defineApp` stamps on its result, registered in the global
- * symbol registry. Inlined here rather than imported from `@sanity/federation`
- * so cli-core — the hot path for every CLI command, most of which never touch
- * workbench — doesn't pull that package (and its transitive deps) into startup
- * just for this identity check. `Symbol.for` keys the same global symbol that
- * federation stamps, so the check is identical; the only shared contract is the
- * symbol string, which cli-core already mirrors (see `APPLICATION_TYPES` below).
+ * symbol registry. `unstable_defineApp` lives in `@sanity/cli-build`, which
+ * depends on cli-core — so cli-core can't import the brand without a cycle, and
+ * wouldn't pull the build package into startup just for this identity check
+ * anyway (cli-core is the hot path for every CLI command, most of which never
+ * touch workbench). `Symbol.for` keys the same global symbol `unstable_defineApp`
+ * stamps, so the check is identical; the only shared contract is the symbol
+ * string, which cli-core mirrors (see `APPLICATION_TYPES` below).
  */
 const WORKBENCH_APP_BRAND = Symbol.for('sanity.workbench.defineApp')
 
 /**
  * Whether `app` is a branded `unstable_defineApp(...)` result — the sole
- * workbench opt-in. Mirrors `@sanity/federation`'s `isWorkbenchApp` without the
- * runtime dependency, narrowing to the shared `app` config plus the
- * workbench-only fields a branded result carries: its `name`, dock panel
- * `views`, and background worker `services`. The shape is inlined rather than
- * a named export since callers reach it only through this predicate; `type`
- * uses the same literals federation does so `views`/`services` stay assignable
- * to `DefineAppInput['views' | 'services']` downstream.
+ * workbench opt-in. Narrows to the shared `app` config plus the workbench-only
+ * fields a branded result carries: its `name`, dock panel `views`, and
+ * background worker `services`. The shape is inlined rather than a named export
+ * since callers reach it only through this predicate; `type` uses the same
+ * literals the `DefineAppInput` schema does so `views`/`services` stay
+ * assignable to `DefineAppInput['views' | 'services']` downstream.
  */
 export function isWorkbenchApp(app: CliConfig['app']): app is NonNullable<CliConfig['app']> & {
   name: string
@@ -42,9 +42,9 @@ const STUDIO_CONFIG_FILES = [
   'sanity.config.cjs',
 ]
 
-// Mirrors `@sanity/federation`'s `ApplicationType` enum. `unstable_defineApp`
-// is a pure identity wrapper that doesn't validate its input, so the loader is
-// the first place an explicit `applicationType` can be checked.
+// Mirrors the `ApplicationType` enum in `@sanity/cli-build`'s `defineApp` schema.
+// `unstable_defineApp` is a pure identity wrapper that doesn't validate its
+// input, so the loader is the first place an explicit `applicationType` can be checked.
 const APPLICATION_TYPES = [
   'coreApp',
   'studio',
@@ -75,7 +75,7 @@ function detectApplicationType(projectDir: string): ApplicationType {
  * The branded `app` bypasses the legacy `app` object schema (which would strip
  * its identity fields and the brand symbol); every other field is still
  * validated. The brand is preserved so downstream code relies on the
- * `isWorkbenchApp` identity (from `@sanity/federation`) instead of a flag.
+ * `isWorkbenchApp` identity (above) instead of a flag.
  *
  * Resolves `applicationType` here — as early as possible — so studio-vs-app
  * classification is settled once and read off the app everywhere else. The

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -84,7 +84,6 @@
     "@sanity/codegen": "catalog:",
     "@sanity/descriptors": "^1.3.0",
     "@sanity/export": "^6.2.0",
-    "@sanity/federation": "0.1.0-alpha.10",
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/id-utils": "^1.0.0",
     "@sanity/import": "^6.0.2",

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -7,12 +7,13 @@ import {
   extendViteConfigWithUserConfig,
   finalizeViteConfig,
   getViteConfig,
+  type InterfaceArtifact,
   resolveEntries,
+  type ServiceArtifact,
   writeFavicons,
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {type CliConfig, type UserViteConfig} from '@sanity/cli-core'
-import {type InterfaceArtifact, type ServiceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {build, createBuilder} from 'vite'
 

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.app.test.ts
@@ -1,6 +1,6 @@
+import {unstable_defineApp} from '@sanity/cli-build/_internal/federation'
 import {confirm, input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
-import {unstable_defineApp} from '@sanity/federation'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.test.ts
@@ -1,7 +1,7 @@
+import {unstable_defineApp} from '@sanity/cli-build/_internal/federation'
 import {type CliConfig, exitCodes, getCliTelemetry, studioWorkerTask} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
-import {unstable_defineApp} from '@sanity/federation'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -1,10 +1,11 @@
 import {
   extendViteConfigWithUserConfig,
   getViteConfig,
+  type InterfaceArtifact,
+  type ServiceArtifact,
   writeSanityRuntime,
 } from '@sanity/cli-build/_internal/build'
 import {CliConfig, getCliTelemetry, type UserViteConfig} from '@sanity/cli-core'
-import {type InterfaceArtifact, type ServiceArtifact} from '@sanity/federation/vite'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {type FSWatcher} from 'chokidar'
 import {createServer, type InlineConfig, type ViteDevServer} from 'vite'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,13 +241,13 @@ importers:
     devDependencies:
       sanity:
         specifier: 'catalog:'
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
 
   fixtures/basic-studio:
     dependencies:
       '@sanity/vision':
         specifier: 'catalog:'
-        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.6)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.6)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       react:
         specifier: ^19.2.5
         version: 19.2.6
@@ -256,7 +256,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       sanity:
         specifier: 'catalog:'
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       styled-components:
         specifier: ^6.4.0
         version: 6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -281,7 +281,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       sanity:
         specifier: 'catalog:'
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       styled-components:
         specifier: ^6.4.0
         version: 6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -297,7 +297,7 @@ importers:
     dependencies:
       '@sanity/vision':
         specifier: 'catalog:'
-        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.6)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.6)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       react:
         specifier: ^19.2.5
         version: 19.2.6
@@ -306,7 +306,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       sanity:
         specifier: 'catalog:'
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       styled-components:
         specifier: ^6.4.0
         version: 6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -322,7 +322,7 @@ importers:
     dependencies:
       '@sanity/vision':
         specifier: 'catalog:'
-        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.6)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.6)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       react:
         specifier: ^19.2.5
         version: 19.2.6
@@ -331,7 +331,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       sanity:
         specifier: 'catalog:'
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       styled-components:
         specifier: ^6.4.0
         version: 6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -397,7 +397,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       sanity:
         specifier: 'catalog:'
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       styled-components:
         specifier: ^6.4.0
         version: 6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -413,10 +413,10 @@ importers:
     dependencies:
       '@sanity/code-input':
         specifier: ^7.1.0
-        version: 7.1.2(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 7.1.2(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@sanity/vision':
         specifier: 'catalog:'
-        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.6)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.6)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       react:
         specifier: ^19.2.5
         version: 19.2.6
@@ -425,10 +425,10 @@ importers:
         version: 19.2.6(react@19.2.6)
       sanity:
         specifier: 'catalog:'
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       sanity-plugin-media:
         specifier: ^4.1.1
-        version: 4.3.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 4.3.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       styled-components:
         specifier: ^6.4.0
         version: 6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -542,9 +542,6 @@ importers:
       '@sanity/export':
         specifier: ^6.2.0
         version: 6.2.0
-      '@sanity/federation':
-        specifier: 0.1.0-alpha.10
-        version: 0.1.0-alpha.10(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -812,7 +809,7 @@ importers:
         version: 6.1.3
       sanity:
         specifier: 'catalog:'
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -822,6 +819,9 @@ importers:
 
   packages/@sanity/cli-build:
     dependencies:
+      '@module-federation/vite':
+        specifier: 1.16.0
+        version: 1.16.0(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@oclif/core':
         specifier: 'catalog:'
         version: 4.11.4
@@ -831,9 +831,6 @@ importers:
       '@sanity/cli-core':
         specifier: workspace:^
         version: link:../cli-core
-      '@sanity/federation':
-        specifier: 0.1.0-alpha.10
-        version: 0.1.0-alpha.10(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
@@ -954,7 +951,7 @@ importers:
         version: 0.3.21
       sanity:
         specifier: 'catalog:'
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       styled-components:
         specifier: ^6.4.2
         version: 6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1069,7 +1066,7 @@ importers:
         version: 0.3.21
       sanity:
         specifier: 'catalog:'
-        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+        version: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -13459,7 +13456,7 @@ snapshots:
       nanoid: 3.3.12
       rxjs: 7.8.2
 
-  '@sanity/code-input@7.1.2(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@sanity/code-input@7.1.2(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-java': 6.0.2
@@ -13479,7 +13476,7 @@ snapshots:
       '@uiw/codemirror-themes': 4.25.10(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       '@uiw/react-codemirror': 4.25.10(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
-      sanity: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+      sanity: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       styled-components: 6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@babel/runtime'
@@ -13569,19 +13566,6 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
-
-  '@sanity/federation@0.1.0-alpha.10(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@module-federation/runtime': 2.5.1
-      '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      vite: 8.0.16(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - bufferutil
-      - node-fetch
-      - typescript
-      - utf-8-validate
-      - vue-tsc
 
   '@sanity/federation@0.1.0-alpha.10(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -14017,7 +14001,34 @@ snapshots:
       - use-sync-external-store
       - xstate
 
-  '@sanity/sdk@2.12.0(@types/react@19.2.16)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.0)':
+  '@sanity/sdk@2.12.0(@types/react@19.2.16)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))(xstate@5.32.0)':
+    dependencies:
+      '@sanity/bifur-client': 1.0.0
+      '@sanity/client': 7.22.1
+      '@sanity/comlink': 4.0.1
+      '@sanity/diff-match-patch': 3.2.0
+      '@sanity/diff-patch': 6.0.0
+      '@sanity/id-utils': 1.0.0
+      '@sanity/image-url': 2.1.1
+      '@sanity/json-match': 1.0.5
+      '@sanity/message-protocol': 0.23.0
+      '@sanity/mutate': 0.16.1(xstate@5.32.0)
+      '@sanity/telemetry': 1.1.0(react@19.2.6)
+      '@sanity/types': 5.30.0(@types/react@19.2.16)
+      groq: 3.88.1-typegen-experimental.0
+      groq-js: 1.30.2
+      reselect: 5.2.0
+      rxjs: 7.8.2
+      zustand: 5.0.14(@types/react@19.2.16)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - supports-color
+      - use-sync-external-store
+      - xstate
+
+  '@sanity/sdk@2.12.0(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.0)':
     dependencies:
       '@sanity/bifur-client': 1.0.0
       '@sanity/client': 7.22.1
@@ -14035,7 +14046,7 @@ snapshots:
       groq-js: 1.30.2
       reselect: 5.2.0
       rxjs: 7.8.2
-      zustand: 5.0.14(@types/react@19.2.16)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+      zustand: 5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -14144,7 +14155,7 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/vision@5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.6)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@sanity/vision@5.31.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.6)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.10.3
@@ -14170,7 +14181,7 @@ snapshots:
       react: 19.2.6
       react-rx: 4.2.2(react@19.2.6)(rxjs@7.8.2)
       rxjs: 7.8.2
-      sanity: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+      sanity: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       styled-components: 6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@babel/runtime'
@@ -18481,7 +18492,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity-plugin-media@4.3.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  sanity-plugin-media@4.3.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3))(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
       '@hookform/resolvers': 3.10.0(react-hook-form@7.77.0(react@19.2.6))
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.16)(react@19.2.6)(redux@5.0.1))(react@19.2.6)
@@ -18511,7 +18522,7 @@ snapshots:
       redux: 5.0.1
       redux-observable: 3.0.0-rc.2(redux@5.0.1)(rxjs@7.8.2)
       rxjs: 7.8.2
-      sanity: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+      sanity: 5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       styled-components: 6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -18519,7 +18530,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3):
+  sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3):
     dependencies:
       '@algorithm.ts/lcs': 4.0.6
       '@date-fns/tz': 1.5.0
@@ -18565,7 +18576,7 @@ snapshots:
       '@sanity/preview-url-secret': 4.0.7(@sanity/client@7.22.1)
       '@sanity/prism-groq': 1.1.2
       '@sanity/schema': 5.31.1(@types/react@19.2.16)
-      '@sanity/sdk': 2.12.0(@types/react@19.2.16)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.0)
+      '@sanity/sdk': 2.12.0(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.0)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
       '@sanity/types': 5.31.1(@types/react@19.2.16)
       '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -18687,6 +18698,127 @@ snapshots:
       '@sanity/prism-groq': 1.1.2
       '@sanity/schema': 5.31.1(@types/react@19.2.16)
       '@sanity/sdk': 2.12.0(@types/react@19.2.16)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))(xstate@5.32.0)
+      '@sanity/telemetry': 1.1.0(react@19.2.6)
+      '@sanity/types': 5.31.1(@types/react@19.2.16)
+      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@sanity/util': 5.31.1(@types/react@19.2.16)
+      '@sanity/uuid': 3.0.2
+      '@sentry/react': 8.55.2(react@19.2.6)
+      '@tanstack/react-table': 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-virtual': 3.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@xstate/react': 6.1.0(@types/react@19.2.16)(react@19.2.6)(xstate@5.32.0)
+      classnames: 2.5.1
+      color2k: 2.0.3
+      dataloader: 2.2.3
+      date-fns: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      exif-component: 1.0.1
+      fast-deep-equal: 3.1.3
+      groq-js: 1.30.2
+      history: 5.3.0
+      i18next: 26.3.0(typescript@5.9.3)
+      is-hotkey-esm: 1.0.0
+      isomorphic-dompurify: 2.26.0
+      json-reduce: 3.0.0
+      json-stable-stringify: 1.3.0
+      lodash-es: 4.18.1
+      mendoza: 3.0.8
+      motion: 12.40.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      nano-pubsub: 3.0.0
+      nanoid: 3.3.12
+      observable-callback: 1.0.3(rxjs@7.8.2)
+      path-to-regexp: 6.3.0
+      player.style: 0.1.10(react@19.2.6)
+      polished: 4.3.1
+      quick-lru: 7.3.0
+      raf: 3.4.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-fast-compare: 3.2.2
+      react-focus-lock: 2.13.7(@types/react@19.2.16)(react@19.2.6)
+      react-i18next: 17.0.8(i18next@26.3.0(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      react-is: 19.2.7
+      react-refractor: 4.0.0(react@19.2.6)
+      react-rx: 4.2.2(react@19.2.6)(rxjs@7.8.2)
+      refractor: 5.0.0
+      rxjs: 7.8.2
+      rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.2)
+      rxjs-mergemap-array: 0.1.0(rxjs@7.8.2)
+      scroll-into-view-if-needed: 3.1.0
+      scrollmirror: 1.2.4
+      semver: 7.8.1
+      shallow-equals: 1.0.0
+      speakingurl: 14.0.1
+      styled-components: 6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      urlpattern-polyfill: 10.1.0
+      use-device-pixel-ratio: 1.1.2(react@19.2.6)
+      use-hot-module-reload: 2.0.0(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
+      uuid: 11.1.1
+      web-vitals: 5.3.0
+      xstate: 5.32.0
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@oclif/core'
+      - '@sanity/cli-core'
+      - '@types/react'
+      - '@types/react-dom'
+      - bufferutil
+      - canvas
+      - immer
+      - prismjs
+      - react-native
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3):
+    dependencies:
+      '@algorithm.ts/lcs': 4.0.6
+      '@date-fns/tz': 1.5.0
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.6)
+      '@isaacs/ttlcache': 1.4.1
+      '@mux/mux-player-react': 3.13.0(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@portabletext/editor': 6.6.5(@types/react@19.2.16)(react@19.2.6)
+      '@portabletext/html': 1.0.2
+      '@portabletext/patches': 2.0.4
+      '@portabletext/plugin-markdown-shortcuts': 7.0.29(@portabletext/editor@6.6.5(@types/react@19.2.16)(react@19.2.6))(@types/react@19.2.16)(react@19.2.6)
+      '@portabletext/plugin-one-line': 6.0.28(@portabletext/editor@6.6.5(@types/react@19.2.16)(react@19.2.6))(react@19.2.6)
+      '@portabletext/plugin-paste-link': 3.0.28(@portabletext/editor@6.6.5(@types/react@19.2.16)(react@19.2.6))(react@19.2.6)
+      '@portabletext/plugin-typography': 7.0.28(@portabletext/editor@6.6.5(@types/react@19.2.16)(react@19.2.6))(@types/react@19.2.16)(react@19.2.6)
+      '@portabletext/react': 6.2.0(react@19.2.6)
+      '@portabletext/sanity-bridge': 3.1.0(@types/react@19.2.16)
+      '@portabletext/to-html': 5.0.2
+      '@portabletext/toolkit': 5.0.2
+      '@rexxars/react-json-inspector': 9.0.1(react@19.2.6)
+      '@sanity/asset-utils': 2.3.0
+      '@sanity/bifur-client': 1.0.0
+      '@sanity/cli': link:packages/@sanity/cli
+      '@sanity/client': 7.22.1
+      '@sanity/color': 3.0.6
+      '@sanity/comlink': 4.0.1
+      '@sanity/diff': 5.31.1
+      '@sanity/diff-match-patch': 3.2.0
+      '@sanity/diff-patch': 5.0.0
+      '@sanity/eventsource': 5.0.2
+      '@sanity/icons': 3.7.4(react@19.2.6)
+      '@sanity/id-utils': 1.0.0
+      '@sanity/image-url': 2.1.1
+      '@sanity/insert-menu': 3.0.8(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.31.1(@types/react@19.2.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@sanity/logos': 2.2.2(react@19.2.6)
+      '@sanity/media-library-types': 1.4.0
+      '@sanity/message-protocol': 0.23.0
+      '@sanity/migrate': 6.1.2(@oclif/core@4.11.4)(@sanity/cli-core@packages+@sanity+cli-core)(@types/react@19.2.16)(xstate@5.32.0)
+      '@sanity/mutate': 0.18.0(xstate@5.32.0)
+      '@sanity/mutator': 5.31.1(@types/react@19.2.16)
+      '@sanity/presentation-comlink': 2.1.0(@sanity/client@7.22.1)(@sanity/types@5.31.1(@types/react@19.2.16))
+      '@sanity/preview-url-secret': 4.0.7(@sanity/client@7.22.1)
+      '@sanity/prism-groq': 1.1.2
+      '@sanity/schema': 5.31.1(@types/react@19.2.16)
+      '@sanity/sdk': 2.12.0(@types/react@19.2.16)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))(xstate@5.32.0)
       '@sanity/telemetry': 1.1.0(react@19.2.6)
       '@sanity/types': 5.31.1(@types/react@19.2.16)
       '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(styled-components@6.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
@@ -19782,9 +19914,8 @@ snapshots:
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)
 
-  zustand@5.0.14(@types/react@19.2.16)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+  zustand@5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:
       '@types/react': 19.2.16
-      immer: 11.1.8
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)


### PR DESCRIPTION
### Description

Unbundling `@sanity/federation` (SDK-1737), 2/2. Moves the `federation` vite plugin + artifact generators into `@sanity/cli-build`, next to #1269's contract — so the build reads `VIEW_COMPONENTS` directly, no duplication.

The plugin stays internal; only the build-output types (`InterfaceArtifact`/`ServiceArtifact`) are exposed, on `_internal/build`. `@sanity/federation` is dropped from `@sanity/cli` + `@sanity/cli-build`, and cli-core's brand-check comments are updated to name `@sanity/cli-build` (the helper's new home).

### What to review

- Faithful port of the workbench plugin; only import paths rewired.
- No public `./vite` — artifacts are build outputs, so they ride on `_internal/build` (avoids a cli→workbench dep).
- The `@sanity/cli-core/workbenchApp.ts` change is comment-only.

Base: #1269.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `sanity dev`/`build` federation paths and generated remote entries; behavior should match the prior package but regressions in HMR, exposes, or worker artifacts would affect all workbench apps.
> 
> **Overview**
> **Inlines** the workbench module-federation Vite stack into `@sanity/cli-build` and **drops** `@sanity/federation` from `@sanity/cli` and `@sanity/cli-build`, adding `@module-federation/vite` directly on cli-build.
> 
> New code under `workbench/` covers artifact generation (`GeneratedArtifact`, view/service expanders), shared `renderRemote` modules, and the `federation` Vite plugin (runtime entry, extension artifacts, MF wiring). `VIEW_COMPONENTS` moves into `contract.ts` so the build and plugin share one registry. `getViteConfig` and `_internal/build` now import the in-tree plugin and re-export `InterfaceArtifact` / `ServiceArtifact`; CLI dev/build/deploy tests import `unstable_defineApp` from `@sanity/cli-build/_internal/federation` instead of `@sanity/federation`.
> 
> `cli-core/workbenchApp.ts` only updates comments to reference `@sanity/cli-build` (no behavioral change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2afe33630f32bd0b0759c571c75d5f8b465bc1bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

