### PR TITLE
test(cli): Convert env var output test to unit test

### DIFF
--- a/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.test.ts
@@ -1,0 +1,68 @@
+import {Output} from '@sanity/cli-core'
+import {describe, expect, test, vi} from 'vitest'
+
+const FLAGS = {
+  'auto-updates': true,
+  json: false,
+  minify: true,
+  'source-maps': true,
+  stats: true,
+  yes: true,
+} as const
+
+const mockGetStudioEnvironmentVariables = vi.hoisted(() => vi.fn().mockReturnValue({}))
+
+vi.mock('../buildStaticFiles.js', () => ({
+  buildStaticFiles: vi.fn().mockResolvedValue({chunks: []}),
+}))
+
+vi.mock('../checkRequiredDependencies.js', () => ({
+  checkRequiredDependencies: vi.fn().mockResolvedValue({installedSanityVersion: '3.0.0'}),
+}))
+
+vi.mock('../getEnvironmentVariables.js', () => ({
+  getStudioEnvironmentVariables: mockGetStudioEnvironmentVariables,
+}))
+
+vi.mock('@sanity/cli-build/_internal/build', () => ({
+  buildDebug: vi.fn(),
+  checkStudioDependencyVersions: vi.fn().mockResolvedValue(undefined),
+  resolveVendorBuildConfig: vi.fn().mockResolvedValue({
+    entries: {},
+    namesByChunkName: {},
+    specifiersByChunkName: {},
+  }),
+  StudioBuildTrace: {},
+}))
+
+// Import after mocks are set up
+const {buildStudio} = await import('../buildStudio.js')
+
+function createMockOutput(): Output {
+  return {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as Output
+}
+
+describe('#buildStudio', () => {
+  test('outputs included environment variables', async () => {
+    const output = createMockOutput()
+
+    mockGetStudioEnvironmentVariables.mockImplementation(() => ({
+      SANITY_STUDIO_TEST_VAR: 'test-value',
+    }))
+
+    await buildStudio({
+      autoUpdatesEnabled: false,
+      cliConfig: {},
+      flags: FLAGS,
+      outDir: '/tmp/dist',
+      output,
+      workDir: '/tmp',
+    })
+
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('SANITY_STUDIO_TEST_VAR'))
+  })
+})

--- a/packages/@sanity/cli/src/commands/__tests__/build.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/build.studio.test.ts
@@ -117,27 +117,6 @@ describe('#build studio', {timeout: (platform() === 'win32' ? 120 : 60) * 1000},
     expect(stdout).toContain('SANITY_STUDIO_TEST_VAR')
   })
 
-  test('should not include non-prefixed env vars in build output', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    vi.stubEnv('SANITY_STUDIO_BUNDLE_VAR', 'studio-value')
-    vi.stubEnv('NEXT_PUBLIC_LEAKED', 'next-value')
-    vi.stubEnv('VITE_LEAKED', 'vite-value')
-
-    const {error, stdout} = await testCommand(BuildCommand, ['--yes'], {
-      config: {root: cwd},
-    })
-
-    if (error) throw error
-
-    // Prefixed var should appear in the build output env var listing
-    expect(stdout).toContain('SANITY_STUDIO_BUNDLE_VAR')
-    // Non-prefixed vars must NOT appear
-    expect(stdout).not.toContain('NEXT_PUBLIC_LEAKED')
-    expect(stdout).not.toContain('VITE_LEAKED')
-  })
-
   test('should error when styled-components is not installed', async () => {
     const cwd = await testFixture('basic-studio', {
       tempDir: tmpdir(),


### PR DESCRIPTION
### Description

This is the first step in converting some tests into unit tests when sufficient coverage exists to warrant it.

The test case `should not include non-prefixed env vars in build output` is mostly covered by packages/@sanity/cli/src/actions/build/__tests__/getEnvironmentVariables.test.ts and the output logic is not covered in packages/@sanity/cli/src/actions/build/__tests__/buildStudio.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; coverage is shifted from integration to unit tests.
> 
> **Overview**
> Moves studio build **environment-variable logging** coverage from a slow integration test into a focused **`buildStudio` unit test**, and drops redundant integration coverage.
> 
> Adds `buildStudio.test.ts`, which mocks the build pipeline and asserts `output.log` includes keys returned by `getStudioEnvironmentVariables`. Removes the integration case `should not include non-prefixed env vars in build output` from `build.studio.test.ts`; **prefix filtering** stays in `getEnvironmentVariables.test.ts`, while the integration test `should build with --source-maps and --stats flags and injects environment variables` still checks prefixed vars appear in full command output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44f7a149df38e8a924c043b36ae18e46fd74cf1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->