### PR TITLE
feat(cli-build): preconnect and modulepreload the CDN sanity module for auto-update studios

### DIFF
--- a/.changeset/pr-1276.md
+++ b/.changeset/pr-1276.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+---
+
+feat(cli-build): preconnect and modulepreload the CDN sanity module for auto-update studios

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
@@ -215,6 +215,7 @@ describe('tests the runtime TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT', () => {
     expect(preloadHref).toBe(
       'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000',
     )
+    expect(preloadLinks[0].getAttribute('crossorigin')).toBe('anonymous')
 
     const importMapEl = dom.window.document.querySelector('script[type="importmap"]')
     const runtimeImportMap = JSON.parse(importMapEl?.textContent || '{}') as {
@@ -223,6 +224,14 @@ describe('tests the runtime TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT', () => {
     // The preload href must equal what the importmap resolves `sanity` to,
     // otherwise the browser fetches the largest chunk twice.
     expect(preloadHref).toBe(runtimeImportMap.imports?.sanity)
+  })
+
+  test('emits no hints when sanity resolves to a non-CDN host', () => {
+    const importMap = {imports: {sanity: 'https://example.com/modules/sanity/index.js'}}
+    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+    const dom = createRuntimeDom(result)
+    expect(dom.window.document.querySelectorAll('link[rel="preconnect"]')).toHaveLength(0)
+    expect(dom.window.document.querySelectorAll('link[rel="modulepreload"]')).toHaveLength(0)
   })
 
   test('emits no hints when no import resolves to a sanity-cdn host', () => {

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
@@ -188,4 +188,66 @@ describe('tests the runtime TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT', () => {
       'https://example.com/styles/external.css',
     ])
   })
+
+  test('warms the CDN connection with a crossorigin preconnect to the module origin', () => {
+    const importMap = {
+      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
+    }
+    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+    const dom = createRuntimeDom(result)
+
+    const preconnectLinks = dom.window.document.querySelectorAll('link[rel="preconnect"]')
+    expect(preconnectLinks).toHaveLength(1)
+    expect(preconnectLinks[0].getAttribute('href')).toBe('https://sanity-cdn.com')
+    expect(preconnectLinks[0].getAttribute('crossorigin')).toBe('anonymous')
+  })
+
+  test('modulepreloads sanity with a timestamp matching the importmap entry (no double fetch)', () => {
+    const importMap = {
+      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
+    }
+    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+    const dom = createRuntimeDom(result)
+
+    const preloadLinks = dom.window.document.querySelectorAll('link[rel="modulepreload"]')
+    expect(preloadLinks).toHaveLength(1)
+    const preloadHref = preloadLinks[0].getAttribute('href')
+    expect(preloadHref).toBe(
+      'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000',
+    )
+
+    const importMapEl = dom.window.document.querySelector('script[type="importmap"]')
+    const runtimeImportMap = JSON.parse(importMapEl?.textContent || '{}') as {
+      imports?: Record<string, string>
+    }
+    // The preload href must equal what the importmap resolves `sanity` to,
+    // otherwise the browser fetches the largest chunk twice.
+    expect(preloadHref).toBe(runtimeImportMap.imports?.sanity)
+  })
+
+  test('emits no hints when no import resolves to a sanity-cdn host', () => {
+    const importMap = {
+      imports: {external: 'https://example.com/modules/external/index.js'},
+    }
+    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+    const dom = createRuntimeDom(result)
+
+    expect(dom.window.document.querySelectorAll('link[rel="preconnect"]')).toHaveLength(0)
+    expect(dom.window.document.querySelectorAll('link[rel="modulepreload"]')).toHaveLength(0)
+  })
+
+  test('uses the staging CDN host for the hints when imports point at sanity-cdn.work', () => {
+    const importMap = {
+      imports: {sanity: 'https://sanity-cdn.work/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
+    }
+    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+    const dom = createRuntimeDom(result)
+
+    expect(dom.window.document.querySelector('link[rel="preconnect"]')?.getAttribute('href')).toBe(
+      'https://sanity-cdn.work',
+    )
+    expect(
+      dom.window.document.querySelector('link[rel="modulepreload"]')?.getAttribute('href'),
+    ).toBe('https://sanity-cdn.work/v1/modules/sanity/default/%5E3.2.0/t1700000000')
+  })
 })

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/addTimestampImportMapScriptToHtml.ts
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/addTimestampImportMapScriptToHtml.ts
@@ -49,6 +49,36 @@ const TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT = `<script>
     linkEl.href = replaceTimestamp(cssUrl);
     document.head.appendChild(linkEl);
   }
+
+  // Warm the CDN module connection during head parse so the cross-origin
+  // \`sanity\` fetch can start before the entry script discovers the import.
+  const firstCdnImport = Object.values(imports).find((urlStr) => {
+    try {
+      return /^sanity-cdn\\.[a-zA-Z]+$/.test(new URL(urlStr).hostname);
+    } catch {
+      return false;
+    }
+  });
+
+  if (firstCdnImport) {
+    const preconnectEl = document.createElement('link');
+    preconnectEl.rel = 'preconnect';
+    preconnectEl.href = new URL(firstCdnImport).origin;
+    // Module fetches are CORS; without crossorigin the warmed socket is not reused.
+    preconnectEl.crossOrigin = 'anonymous';
+    document.head.appendChild(preconnectEl);
+  }
+
+  // Start downloading the timestamped \`sanity\` module during head parse. The
+  // href reuses replaceTimestamp so it matches the importmap entry exactly —
+  // a stale timestamp here would double-fetch the largest chunk.
+  const sanityModuleUrl = imports['sanity'];
+  if (typeof sanityModuleUrl === 'string') {
+    const preloadEl = document.createElement('link');
+    preloadEl.rel = 'modulepreload';
+    preloadEl.href = replaceTimestamp(sanityModuleUrl);
+    document.head.appendChild(preloadEl);
+  }
 </script>`
 
 /**

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/addTimestampImportMapScriptToHtml.ts
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/addTimestampImportMapScriptToHtml.ts
@@ -34,6 +34,14 @@ const TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT = `<script>
     }
   }
 
+  function isSanityCdnUrl(urlStr) {
+    try {
+      return /^sanity-cdn\\.[a-zA-Z]+$/.test(new URL(urlStr).hostname);
+    } catch {
+      return false;
+    }
+  }
+
   importMapEl.textContent = JSON.stringify({
     imports: Object.fromEntries(
       Object.entries(imports).map(([specifier, path]) => [specifier, replaceTimestamp(path)])
@@ -52,13 +60,7 @@ const TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT = `<script>
 
   // Warm the CDN module connection during head parse so the cross-origin
   // \`sanity\` fetch can start before the entry script discovers the import.
-  const firstCdnImport = Object.values(imports).find((urlStr) => {
-    try {
-      return /^sanity-cdn\\.[a-zA-Z]+$/.test(new URL(urlStr).hostname);
-    } catch {
-      return false;
-    }
-  });
+  const firstCdnImport = Object.values(imports).find(isSanityCdnUrl);
 
   if (firstCdnImport) {
     const preconnectEl = document.createElement('link');
@@ -73,10 +75,14 @@ const TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT = `<script>
   // href reuses replaceTimestamp so it matches the importmap entry exactly —
   // a stale timestamp here would double-fetch the largest chunk.
   const sanityModuleUrl = imports['sanity'];
-  if (typeof sanityModuleUrl === 'string') {
+  if (typeof sanityModuleUrl === 'string' && isSanityCdnUrl(sanityModuleUrl)) {
     const preloadEl = document.createElement('link');
     preloadEl.rel = 'modulepreload';
     preloadEl.href = replaceTimestamp(sanityModuleUrl);
+    // Must match the preconnect's credentials mode, otherwise the browser
+    // treats them as separate connections and the warmed cross-origin socket
+    // is not reused for this fetch.
+    preloadEl.crossOrigin = 'anonymous';
     document.head.appendChild(preloadEl);
   }
 </script>`

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/addTimestampImportMapScriptToHtml.ts
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/addTimestampImportMapScriptToHtml.ts
@@ -25,7 +25,7 @@ const TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT = `<script>
   function replaceTimestamp(urlStr) {
     try {
       const url = new URL(urlStr);
-      if (/^sanity-cdn\\.[a-zA-Z]+$/.test(url.hostname)) {
+      if (isSanityCdnUrl(urlStr)) {
         url.pathname = url.pathname.replace(/\\/t\\d+/, newTimestamp);
       }
       return url.toString();


### PR DESCRIPTION
### Description

For auto-updating studios the main `sanity` module loads cross-origin from the CDN, and the browser only discovers it needs that module after downloading and executing the small entry script - a serial waterfall on every load.

This PR adds two resource hints inside the existing runtime import-map injector (`TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT` in `addTimestampImportMapScriptToHtml.ts`): a `preconnect` to the CDN module origin and a `modulepreload` for the `sanity` module, so the connection is warmed and the download starts during head parse instead of after entry execution. Both hints set `crossorigin="anonymous"` to match the module's CORS-anonymous fetch, and the `modulepreload` href reuses the runtime `replaceTimestamp(...)` value so it matches the import-map entry and the largest chunk is not fetched twice.

Scoped to auto-update studios by construction: the injector runs only when an import map is present and hints emit only when an import resolves to a sanity-cdn host, so non-auto-update studios are unchanged. This is the one quick win from a wider Studio auth-ready p95 investigation; the expected saving is modest (roughly 0.25-0.8s per auto-update load) because the dominant pre-mount cost is CPU parse/execute, not download.

### What to review

- The only production change is the inline injector string in `addTimestampImportMapScriptToHtml.ts`. Confirm the no-importMap early return and the CSS-link loop are unchanged.
- Both hints are gated on the shared `isSanityCdnUrl` host check, so the bridge host `core.sanity-cdn.com` is excluded and only the module host is targeted (`sanity-cdn.com`, or `sanity-cdn.work` on staging).
- The `modulepreload` href uses the same timestamp as the import map, and both hints set `crossorigin="anonymous"`, so the warmed connection is reused and the module is not fetched twice.
- The `preconnect` has marginal value: the module URL 302-redirects from `sanity-cdn.com` to `modules.sanity-cdn.com`, where the chunks actually download, so the `preconnect` warms the redirector host rather than the asset host. Worth deciding whether to keep it.

### Testing

Four JSDOM runtime tests assert against the executed DOM: `preconnect` emitted with `crossorigin` to the module origin; `modulepreload` href carries the fresh timestamp and equals the import-map's resolved `sanity` entry (the no-double-fetch guarantee); no hints when no import resolves to a sanity-cdn host; and staging-host support. All tests in the file pass, and a mutation check confirmed the new tests fail when the hint code is removed.

Verified on a real build: `sanity build --auto-updates` on the `basic-studio` fixture, served and loaded in Chromium against the live CDN. The injector runs with no errors of its own, the `modulepreload` href matches the import-map `sanity` entry, and the `sanity` module entry URL is requested exactly once (the `modulepreload` and the entry-script import coalesce - no double fetch). The remaining deployed-preview DevTools check is now confirmatory rather than load-bearing. Build, type-check, lint, and format pass.
