### PR TITLE
test(cli): Convert more studio build tests to unit tests

### DIFF
--- a/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.unit.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.unit.test.ts
@@ -38,16 +38,20 @@ vi.mock('../getEnvironmentVariables.js', () => ({
   getStudioEnvironmentVariables: mockGetStudioEnvironmentVariables,
 }))
 
-vi.mock('@sanity/cli-build/_internal/build', () => ({
-  buildDebug: vi.fn(),
-  checkStudioDependencyVersions: vi.fn().mockResolvedValue(undefined),
-  resolveVendorBuildConfig: vi.fn().mockResolvedValue({
-    entries: {},
-    namesByChunkName: {},
-    specifiersByChunkName: {},
-  }),
-  StudioBuildTrace: {},
-}))
+vi.mock('@sanity/cli-build/_internal/build', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sanity/cli-core/ux')>()
+  return {
+    ...original,
+    buildDebug: vi.fn(),
+    checkStudioDependencyVersions: vi.fn().mockResolvedValue(undefined),
+    resolveVendorBuildConfig: vi.fn().mockResolvedValue({
+      entries: {},
+      namesByChunkName: {},
+      specifiersByChunkName: {},
+    }),
+    StudioBuildTrace: {},
+  }
+})
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const original = await importOriginal<typeof import('@sanity/cli-core')>()

--- a/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.unit.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.unit.test.ts
@@ -1,5 +1,4 @@
 import {Output} from '@sanity/cli-core'
-import {spinner} from '@sanity/cli-core/ux'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 const FLAGS = {

--- a/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.unit.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.unit.test.ts
@@ -173,7 +173,7 @@ describe('#buildStudio', () => {
     await buildStudio({
       autoUpdatesEnabled: true,
       cliConfig: {},
-      flags: {...FLAGS, yes: true},
+      flags: FLAGS,
       outDir: '/tmp/dist',
       output,
       workDir: '/tmp',

--- a/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.unit.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/buildStudio.unit.test.ts
@@ -1,5 +1,6 @@
 import {Output} from '@sanity/cli-core'
-import {describe, expect, test, vi} from 'vitest'
+import {spinner} from '@sanity/cli-core/ux'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 const FLAGS = {
   'auto-updates': true,
@@ -7,10 +8,24 @@ const FLAGS = {
   minify: true,
   'source-maps': true,
   stats: true,
-  yes: true,
+  yes: false,
 } as const
 
+const mockedSelect = vi.hoisted(() => vi.fn())
+const mockedSpinner = vi.hoisted(() => vi.fn())
+const mockedConfirm = vi.hoisted(() => vi.fn())
+const mockedCompareDependencyVersions = vi.hoisted(() => vi.fn())
 const mockGetStudioEnvironmentVariables = vi.hoisted(() => vi.fn().mockReturnValue({}))
+const mockedUpgradePackages = vi.hoisted(() => vi.fn())
+const mockedIsInteractive = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../util/compareDependencyVersions.js', () => ({
+  compareDependencyVersions: mockedCompareDependencyVersions,
+}))
+
+vi.mock('../../../util/packageManager/upgradePackages.js', () => ({
+  upgradePackages: mockedUpgradePackages,
+}))
 
 vi.mock('../buildStaticFiles.js', () => ({
   buildStaticFiles: vi.fn().mockResolvedValue({chunks: []}),
@@ -35,6 +50,25 @@ vi.mock('@sanity/cli-build/_internal/build', () => ({
   StudioBuildTrace: {},
 }))
 
+vi.mock('@sanity/cli-core', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sanity/cli-core')>()
+  return {
+    ...original,
+    isInteractive: mockedIsInteractive,
+  }
+})
+
+vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sanity/cli-core/ux')>()
+  mockedSpinner.mockImplementation(original.spinner)
+  return {
+    ...original,
+    confirm: mockedConfirm,
+    select: mockedSelect,
+    spinner: mockedSpinner,
+  }
+})
+
 // Import after mocks are set up
 const {buildStudio} = await import('../buildStudio.js')
 
@@ -47,6 +81,18 @@ function createMockOutput(): Output {
 }
 
 describe('#buildStudio', () => {
+  beforeEach(() => {
+    mockedIsInteractive.mockReturnValue(true)
+    mockedConfirm.mockResolvedValue(true)
+    mockedSelect.mockResolvedValue('upgrade-and-proceed')
+    mockedCompareDependencyVersions.mockResolvedValue({mismatched: [], unresolvedPrerelease: []})
+    mockedUpgradePackages.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   test('outputs included environment variables', async () => {
     const output = createMockOutput()
 
@@ -64,5 +110,79 @@ describe('#buildStudio', () => {
     })
 
     expect(output.log).toHaveBeenCalledWith(expect.stringContaining('SANITY_STUDIO_TEST_VAR'))
+  })
+
+  test('should skip version mismatch prompt after disabling auto-updates for prerelease', async () => {
+    const output = createMockOutput()
+
+    mockedCompareDependencyVersions.mockResolvedValue({
+      mismatched: [{installed: '3.0.0', pkg: '@sanity/vision', remote: '3.1.0'}],
+      unresolvedPrerelease: [{pkg: 'sanity', version: '5.11.1-alpha.14'}],
+    })
+    // First select call is for prerelease prompt
+    mockedSelect.mockResolvedValue('disable-auto-updates')
+
+    await buildStudio({
+      autoUpdatesEnabled: true,
+      cliConfig: {},
+      flags: FLAGS,
+      outDir: '/tmp/dist',
+      output,
+      workDir: '/tmp',
+    })
+
+    expect(mockedSpinner).toHaveBeenCalledWith('Build Sanity Studio')
+    // select should only be called once (for the prerelease prompt), not twice
+    expect(mockedSelect).toHaveBeenCalledTimes(1)
+    expect(mockedUpgradePackages).not.toHaveBeenCalled()
+  })
+
+  test('should skip version prompt in unattended mode and show warning', async () => {
+    const output = createMockOutput()
+
+    mockedCompareDependencyVersions.mockResolvedValue({
+      mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
+      unresolvedPrerelease: [],
+    })
+
+    await buildStudio({
+      autoUpdatesEnabled: true,
+      cliConfig: {},
+      flags: {...FLAGS, yes: true},
+      outDir: '/tmp/dist',
+      output,
+      workDir: '/tmp',
+    })
+
+    expect(mockedSelect).not.toHaveBeenCalled()
+    expect(output.warn).toHaveBeenCalledWith(
+      expect.stringContaining('local version: 3.0.0, runtime version: 3.1.0'),
+    )
+    expect(mockedSpinner).toHaveBeenCalledWith('Build Sanity Studio')
+  })
+
+  test('should skip version prompt in non-interactive mode and show warning', async () => {
+    const output = createMockOutput()
+
+    mockedIsInteractive.mockReturnValue(false)
+    mockedCompareDependencyVersions.mockResolvedValue({
+      mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
+      unresolvedPrerelease: [],
+    })
+
+    await buildStudio({
+      autoUpdatesEnabled: true,
+      cliConfig: {},
+      flags: {...FLAGS, yes: true},
+      outDir: '/tmp/dist',
+      output,
+      workDir: '/tmp',
+    })
+
+    expect(mockedSelect).not.toHaveBeenCalled()
+    expect(output.warn).toHaveBeenCalledWith(
+      expect.stringContaining('local version: 3.0.0, runtime version: 3.1.0'),
+    )
+    expect(mockedSpinner).toHaveBeenCalledWith('Build Sanity Studio')
   })
 })

--- a/packages/@sanity/cli/src/commands/__tests__/build.studio.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/build.studio.test.ts
@@ -338,63 +338,6 @@ describe('#build studio', {timeout: (platform() === 'win32' ? 120 : 60) * 1000},
     expect(mockedUpgradePackages).not.toHaveBeenCalled()
   })
 
-  test('should skip version mismatch prompt after disabling auto-updates for prerelease', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    mockedCompareDependencyVersions.mockResolvedValue({
-      mismatched: [{installed: '3.0.0', pkg: '@sanity/vision', remote: '3.1.0'}],
-      unresolvedPrerelease: [{pkg: 'sanity', version: '5.11.1-alpha.14'}],
-    })
-    // First select call is for prerelease prompt
-    mockedSelect.mockResolvedValue('disable-auto-updates')
-
-    const {error, stderr} = await testCommand(BuildCommand, [])
-
-    if (error) throw error
-    expect(stderr).toContain('Build Sanity Studio')
-    // select should only be called once (for the prerelease prompt), not twice
-    expect(mockedSelect).toHaveBeenCalledTimes(1)
-    expect(mockedUpgradePackages).not.toHaveBeenCalled()
-  })
-
-  test('should skip version prompt in unattended mode and show warning', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    mockedCompareDependencyVersions.mockResolvedValue({
-      mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
-      unresolvedPrerelease: [],
-    })
-
-    const {error, stderr} = await testCommand(BuildCommand, ['--yes'], {
-      config: {root: cwd},
-    })
-
-    if (error) throw error
-    expect(mockedSelect).not.toHaveBeenCalled()
-    expect(stderr).toContain('local version: 3.0.0, runtime version: 3.1.0')
-    expect(stderr).toContain('Build Sanity Studio')
-  })
-
-  test('should skip version prompt in non-interactive mode and show warning', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    mockedIsInteractive.mockReturnValue(false)
-    mockedCompareDependencyVersions.mockResolvedValue({
-      mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
-      unresolvedPrerelease: [],
-    })
-
-    const {error, stderr} = await testCommand(BuildCommand, [])
-
-    if (error) throw error
-    expect(mockedSelect).not.toHaveBeenCalled()
-    expect(stderr).toContain('local version: 3.0.0, runtime version: 3.1.0')
-    expect(stderr).toContain('Build Sanity Studio')
-  })
-
   test.each([
     {
       config:


### PR DESCRIPTION
### Description

This PR converts a few more tests into unit tests. These tests just verify the interactive and unattended mode logic and do not need to build a studio.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; behavior is preserved by equivalent unit coverage.
> 
> **Overview**
> Moves three **studio build** interaction scenarios out of the integration `build.studio.test.ts` suite into **`buildStudio.unit.test.ts`**, where `buildStudio` is exercised directly with heavier mocks (UX prompts, dependency comparison, upgrades, interactivity).
> 
> The relocated cases cover **skipping the version-mismatch prompt after disabling auto-updates for a prerelease**, and **skipping prompts with a warning** in **`--yes`** and **non-interactive** modes. Default test flags in the unit file now use **`yes: false`** so unattended behavior is asserted explicitly where needed.
> 
> The integration suite keeps full **`BuildCommand`** / fixture builds; only the redundant slow paths for this logic are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3209abefc5b98899f4e6728fa0620871e4b92ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->