### PR TITLE
feat(cli-build)!: require organizationId in unstable_defineApp

### DIFF
--- a/.changeset/pr-1279.md
+++ b/.changeset/pr-1279.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': major
+'@sanity/cli': major
+---
+
+feat(cli-build)!: require organizationId in unstable_defineApp

--- a/fixtures/federated-studio/sanity.cli.ts
+++ b/fixtures/federated-studio/sanity.cli.ts
@@ -10,6 +10,7 @@ export default defineCliConfig({
   // `sanity.config.ts` is present, so it resolves to `applicationType: 'studio'`).
   app: unstable_defineApp({
     name: 'federated-studio',
+    organizationId: 'oSyH1iET5',
   }),
   deployment: {
     autoUpdates: true,

--- a/packages/@sanity/cli-build/src/workbench/__tests__/defineApp.test.ts
+++ b/packages/@sanity/cli-build/src/workbench/__tests__/defineApp.test.ts
@@ -14,18 +14,18 @@ const WORKBENCH_APP = Symbol.for('sanity.workbench.defineApp')
 
 describe('unstable_defineApp', () => {
   test('is identity at runtime — returns the same object reference', () => {
-    const input = {name: 'drop-desk', title: 'Drop Desk'}
+    const input = {name: 'drop-desk', organizationId: 'org-1', title: 'Drop Desk'}
     expect(unstable_defineApp(input)).toBe(input)
   })
 
   test('brands the result so the CLI can discriminate it', () => {
-    const app = unstable_defineApp({name: 'drop-desk', title: 'Drop Desk'})
+    const app = unstable_defineApp({name: 'drop-desk', organizationId: 'org-1', title: 'Drop Desk'})
     expect(Object.getOwnPropertyDescriptor(app, WORKBENCH_APP)?.value).toBe(true)
   })
 
   test('leaves the brand non-enumerable so it does not leak into config spreads', () => {
-    const app = unstable_defineApp({name: 'drop-desk', title: 'Drop Desk'})
-    expect(Object.keys(app)).toEqual(['name', 'title'])
+    const app = unstable_defineApp({name: 'drop-desk', organizationId: 'org-1', title: 'Drop Desk'})
+    expect(Object.keys(app)).toEqual(['name', 'organizationId', 'title'])
     expect(Object.getOwnPropertySymbols({...app})).not.toContain(WORKBENCH_APP)
   })
 
@@ -33,6 +33,7 @@ describe('unstable_defineApp', () => {
     const app = unstable_defineApp({
       icon: './icon.svg',
       name: 'athlete-desk',
+      organizationId: 'org-1',
       title: 'Athlete Desk',
     })
     expect(app.name).toBe('athlete-desk')
@@ -41,7 +42,7 @@ describe('unstable_defineApp', () => {
   })
 
   test('is recognised by `@sanity/cli-core`s `isWorkbenchApp` (shared Symbol.for contract)', () => {
-    const app = unstable_defineApp({name: 'drop-desk', title: 'Drop Desk'})
+    const app = unstable_defineApp({name: 'drop-desk', organizationId: 'org-1', title: 'Drop Desk'})
     // The whole point of branding via `Symbol.for`: cli-core re-derives the same
     // global symbol and discriminates on it without importing this module.
     expect(isWorkbenchApp(app as CliConfig['app'])).toBe(true)
@@ -50,30 +51,51 @@ describe('unstable_defineApp', () => {
 
 describe('DefineAppInputSchema (build-time validation)', () => {
   test('accepts a valid name', () => {
-    const parsed = DefineAppInputSchema.parse({name: 'drop_desk-1', title: 'Drop'})
+    const parsed = DefineAppInputSchema.parse({
+      name: 'drop_desk-1',
+      organizationId: 'org-1',
+      title: 'Drop',
+    })
     expect(parsed.name).toBe('drop_desk-1')
   })
 
   test('rejects a name with illegal characters', () => {
-    const result = DefineAppInputSchema.safeParse({name: 'drop desk!', title: 'Drop'})
+    const result = DefineAppInputSchema.safeParse({
+      name: 'drop desk!',
+      organizationId: 'org-1',
+      title: 'Drop',
+    })
     expect(result.success).toBe(false)
     expect(result.error?.issues[0]?.message).toMatch(/must match/)
   })
 
   test('requires a title', () => {
-    expect(DefineAppInputSchema.safeParse({name: 'drop-desk'}).success).toBe(false)
+    expect(
+      DefineAppInputSchema.safeParse({name: 'drop-desk', organizationId: 'org-1'}).success,
+    ).toBe(false)
+  })
+
+  test('requires an organizationId with a pointed error', () => {
+    const result = DefineAppInputSchema.safeParse({name: 'drop-desk', title: 'Drop'})
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toMatch(/organizationId.*required/)
   })
 
   test('validates the internal applicationType when present', () => {
     const parsed = DefineAppInputSchema.parse({
       applicationType: 'system',
       name: 'media',
+      organizationId: 'org-1',
       title: 'Media',
     })
     expect(parsed.applicationType).toBe('system')
     expect(
-      DefineAppInputSchema.safeParse({applicationType: 'not-a-type', name: 'media', title: 'Media'})
-        .success,
+      DefineAppInputSchema.safeParse({
+        applicationType: 'not-a-type',
+        name: 'media',
+        organizationId: 'org-1',
+        title: 'Media',
+      }).success,
     ).toBe(false)
   })
 
@@ -81,20 +103,26 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     const parsed = DefineAppInputSchema.parse({
       group: 'dock.system',
       name: 'drop-desk',
+      organizationId: 'org-1',
       priority: 20,
       title: 'Drop',
     })
     expect(parsed.group).toBe('dock.system')
     expect(parsed.priority).toBe(20)
     expect(
-      DefineAppInputSchema.safeParse({group: 'dock.nope', name: 'drop-desk', title: 'Drop'})
-        .success,
+      DefineAppInputSchema.safeParse({
+        group: 'dock.nope',
+        name: 'drop-desk',
+        organizationId: 'org-1',
+        title: 'Drop',
+      }).success,
     ).toBe(false)
   })
 
   test('accepts a panel view declaration', () => {
     const parsed = DefineAppInputSchema.parse({
       name: 'drop-desk',
+      organizationId: 'org-1',
       title: 'Drop',
       views: [{name: 'feed', src: './src/panel.tsx', type: 'panel'}],
     })
@@ -105,6 +133,7 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     expect(
       DefineAppInputSchema.safeParse({
         name: 'drop-desk',
+        organizationId: 'org-1',
         title: 'Drop',
         views: [{name: 'feed', src: './src/panel.tsx', type: 'sidebar'}],
       }).success,
@@ -114,6 +143,7 @@ describe('DefineAppInputSchema (build-time validation)', () => {
   test('rejects duplicate view names within an app', () => {
     const result = DefineAppInputSchema.safeParse({
       name: 'drop-desk',
+      organizationId: 'org-1',
       title: 'Drop',
       views: [
         {name: 'feed', src: './src/a.tsx', type: 'panel'},
@@ -128,12 +158,14 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     expect(
       DefineAppInputSchema.safeParse({
         name: 'drop-desk',
+        organizationId: 'org-1',
         services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
         title: 'Drop',
       }).success,
     ).toBe(true)
     const dupes = DefineAppInputSchema.safeParse({
       name: 'drop-desk',
+      organizationId: 'org-1',
       services: [
         {name: 'unread', src: './src/a.ts', type: 'worker'},
         {name: 'unread', src: './src/b.ts', type: 'worker'},
@@ -149,6 +181,7 @@ describe('DefineAppInputSchema (build-time validation)', () => {
       applicationType: 'studio',
       entry: './src/App.tsx',
       name: 'fernway',
+      organizationId: 'org-1',
       title: 'Fernway',
     })
     expect(result.success).toBe(false)
@@ -158,14 +191,19 @@ describe('DefineAppInputSchema (build-time validation)', () => {
 
   test('accepts `entry` for an SDK app (no applicationType / coreApp)', () => {
     expect(
-      DefineAppInputSchema.safeParse({entry: './src/App.tsx', name: 'drop-desk', title: 'Drop'})
-        .success,
+      DefineAppInputSchema.safeParse({
+        entry: './src/App.tsx',
+        name: 'drop-desk',
+        organizationId: 'org-1',
+        title: 'Drop',
+      }).success,
     ).toBe(true)
     expect(
       DefineAppInputSchema.safeParse({
         applicationType: 'coreApp',
         entry: './src/App.tsx',
         name: 'drop-desk',
+        organizationId: 'org-1',
         title: 'Drop',
       }).success,
     ).toBe(true)
@@ -178,7 +216,7 @@ describe('type surface', () => {
     expectTypeOf<DefineAppResult['title']>().toEqualTypeOf<string>()
     expectTypeOf<DefineAppResult['icon']>().toEqualTypeOf<string | undefined>()
     expectTypeOf<DefineAppResult['entry']>().toEqualTypeOf<string | undefined>()
-    expectTypeOf<DefineAppResult['organizationId']>().toEqualTypeOf<string | undefined>()
+    expectTypeOf<DefineAppResult['organizationId']>().toEqualTypeOf<string>()
     expectTypeOf<DefineAppResult['group']>().toEqualTypeOf<DockGroup | undefined>()
     expectTypeOf<DefineAppResult['priority']>().toEqualTypeOf<number | undefined>()
   })

--- a/packages/@sanity/cli-build/src/workbench/defineApp.ts
+++ b/packages/@sanity/cli-build/src/workbench/defineApp.ts
@@ -55,8 +55,10 @@ export const DefineAppInputSchema = z
     icon: z.optional(z.string()),
     /** Unique app identifier — matches `/^[a-zA-Z0-9_-]+$/`. */
     name: z.string().check(z.regex(APP_NAME_PATTERN, 'App `name` must match /^[a-zA-Z0-9_-]+$/')),
-    /** Organization that owns the app — required to run and deploy an SDK app. */
-    organizationId: z.optional(z.string()),
+    /** Organization that owns the app — the workbench runs and deploys against it. */
+    organizationId: z.string(
+      "App `organizationId` is required — pass the owning organization's ID to `unstable_defineApp`",
+    ),
     /** Sort position within the group, ascending. Defaults to `100` when omitted. */
     priority: z.optional(z.number()),
     /**

--- a/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/deploy.studio.external.test.ts
@@ -848,6 +848,7 @@ describe('#deploy studio (external)', () => {
       // deployStudio (the only path that accepts --external).
       const app = unstable_defineApp({
         name: 'test-studio',
+        organizationId: 'org-1',
         title: 'Test Studio',
       }) as unknown as NonNullable<CliConfig['app']> & {applicationType?: string}
       app.applicationType = 'studio'


### PR DESCRIPTION
### Description

Port of https://github.com/sanity-io/workbench/pull/250, applied here directly since #1269 moved the module-federation extension API into `cli-build`. `unstable_defineApp` is the workbench opt-in and the organization ID is what the workbench runs and deploys against, so it's part of the contract: required in `DefineAppInputSchema` and the `DefineAppInput`/`DefineAppResult` types, with a pointed validation message:

```
App `organizationId` is required — pass the owning organization's ID to `unstable_defineApp`
```

Pairs with #1265, which removes the CLI's dev-time project-lookup fallback — together they make the ID a declaration instead of a resolution.

The `federated-studio` fixture and the `deploy.studio.external` test now pass `organizationId` (the former overlaps with #1265's identical change; whichever lands second rebases trivially).

### What to review

Known follow-up, same as noted on #1265: the `--unstable--workbench` init template for studios brands with `name`/`title` only — it needs to supply `organizationId` now that the type requires it. The studio init flow doesn't know the org ID yet, so that's not part of this PR.

### Testing

Schema tests assert the new requirement and its message; the type-surface test pins `organizationId` to `string`. Full affected-test run passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major breaking API change for all workbench opt-ins; runtime validation will fail configs that omit `organizationId`, though scope is limited to the unstable federation CLI surface.
> 
> **Overview**
> **Breaking change:** `unstable_defineApp` now requires `organizationId` as part of the workbench contract—the org ID is what run/deploy targets, not something inferred later.
> 
> `DefineAppInputSchema` treats `organizationId` as a required string with an explicit validation message when it’s missing. Public types move from optional to required (`DefineAppResult['organizationId']` is `string`). `@sanity/cli-build` and `@sanity/cli` are bumped **major** in the changeset.
> 
> Call sites in the **federated-studio** fixture and **deploy** tests pass `organizationId`. Schema/type-surface tests cover the new requirement. Studio init templates that only set `name`/`title` are called out as follow-up outside this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25030e4a709b7199702d4db83e18458250cfaf22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->