### PR TITLE
feat(workbench): generate federated remote types for TypeScript projects

### DIFF
--- a/.changeset/pr-1282.md
+++ b/.changeset/pr-1282.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+---
+
+feat(workbench): generate federated remote types for TypeScript projects

--- a/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-module-federation.node.test.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-module-federation.node.test.ts
@@ -1,0 +1,70 @@
+import {type Environment, type Plugin} from 'vite'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {FEDERATION_DIR_NAME} from '../constants.js'
+import {pluginModuleFederation} from './plugin-module-federation.js'
+
+const mockFederation = vi.hoisted(() => vi.fn())
+
+vi.mock('@module-federation/vite', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@module-federation/vite')>()
+  return {...actual, federation: mockFederation}
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function runPlugin(): (Plugin | Promise<Plugin>)[] {
+  return pluginModuleFederation({exposes: {}, name: 'test-app'}) as (Plugin | Promise<Plugin>)[]
+}
+
+function appliesTo(plugin: Plugin, name: string, command: 'build' | 'serve'): boolean {
+  const apply = plugin.applyToEnvironment
+  expect(typeof apply).toBe('function')
+  if (typeof apply !== 'function') throw new Error('unreachable')
+  return apply({config: {command}, name} as unknown as Environment) === true
+}
+
+describe('pluginModuleFederation', () => {
+  it('leaves dts at module-federation defaults so type generation stays conditional on tsconfig.json', () => {
+    mockFederation.mockReturnValue([])
+
+    runPlugin()
+
+    expect(mockFederation).toHaveBeenCalledTimes(1)
+    expect(mockFederation.mock.calls[0][0]).not.toHaveProperty('dts')
+  })
+
+  it('scopes plugins to the dev server and the federation build environment', () => {
+    mockFederation.mockReturnValue([{name: 'mf-core'} satisfies Plugin])
+
+    const [plugin] = runPlugin()
+    if (plugin instanceof Promise) throw new Error('expected a sync plugin')
+
+    expect(plugin.name).toBe('mf-core')
+    expect(appliesTo(plugin, 'client', 'serve')).toBe(true)
+    expect(appliesTo(plugin, FEDERATION_DIR_NAME, 'build')).toBe(true)
+    expect(appliesTo(plugin, 'client', 'build')).toBe(false)
+  })
+
+  it('keeps the promise-delivered dts plugins intact and scopes them once resolved', async () => {
+    // mirrors loadPluginDts: a promise resolving to an array of plugins
+    mockFederation.mockReturnValue([
+      Promise.resolve([
+        {name: 'mf-dts-serve'} satisfies Plugin,
+        {name: 'mf-dts-build'} satisfies Plugin,
+      ]),
+    ])
+
+    const [plugin] = runPlugin()
+
+    expect(plugin).toBeInstanceOf(Promise)
+    const resolved = (await plugin) as unknown as Plugin[]
+    expect(resolved.map((p) => p.name)).toEqual(['mf-dts-serve', 'mf-dts-build'])
+    for (const dtsPlugin of resolved) {
+      expect(appliesTo(dtsPlugin, FEDERATION_DIR_NAME, 'build')).toBe(true)
+      expect(appliesTo(dtsPlugin, 'client', 'build')).toBe(false)
+    }
+  })
+})

--- a/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-module-federation.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-module-federation.ts
@@ -21,10 +21,6 @@ export function pluginModuleFederation({exposes, name}: FederationOptions): Plug
       disableDynamicRemoteTypeHints: true,
       remoteHmr: true,
     },
-    // TODO: this should be conditional based on whether the project uses typescript or not...
-    dts: {
-      generateTypes: false,
-    },
     exposes,
     filename: `${FEDERATION_FILE_NAME}.js`,
     manifest: true,
@@ -41,13 +37,22 @@ export function pluginModuleFederation({exposes, name}: FederationOptions): Plug
     shared: {},
   })
 
-  return mfPlugins.map((plugin): Plugin => {
+  // module-federation delivers its dts plugin as a Promise resolving to an
+  // array of plugins; spreading a promise (or an array) yields a junk object,
+  // which silently drops the plugin. Recurse through the PluginOption shape so
+  // every actual plugin gets scoped.
+  const scopeToEnvironment = (option: PluginOption): PluginOption => {
+    if (!option) return option
+    if (option instanceof Promise) return option.then((resolved) => scopeToEnvironment(resolved))
+    if (Array.isArray(option)) return option.map((entry) => scopeToEnvironment(entry))
     return {
-      ...plugin,
+      ...option,
       // In dev, MF must run on client — the dev server serves through it.
       // In build, scope to the federation environment to keep the library build clean.
       applyToEnvironment: (env) =>
         env.config.command === 'serve' || env.name === FEDERATION_DIR_NAME,
-    }
-  })
+    } satisfies Plugin
+  }
+
+  return mfPlugins.map((plugin: PluginOption) => scopeToEnvironment(plugin))
 }


### PR DESCRIPTION
### Description

Implements the TODO the module-federation plugin has carried since day one: federated remote types now generate conditionally — only for TypeScript projects.

Upstream already implements exactly that check. When `dts` is omitted, `@module-federation/vite` enables type generation only if a `tsconfig.json` exists at the vite root (`isTSProject`). So the `generateTypes: false` override is dropped rather than replaced with our own detection.

Removing it surfaced a second bug: `federation()` delivers its dts plugins as a `Promise<Plugin[]>` inside the plugin array, and our environment-scoping map spread that promise into an inert `{applyToEnvironment}` object — the dts machinery never ran, regardless of config. The scoping now recurses through the `PluginOption` shape (promises, arrays), so the dts plugins survive and get the same environment scoping as everything else.

Verified on `fixtures/federated-studio`: with `tsconfig.json` the build emits `@mf-types.zip` + `@mf-types.d.ts`, without it nothing extra; `sanity dev` boots and logs "Federated types created correctly".

### What to review

- The recursive `scopeToEnvironment` — promises and nested plugin arrays keep their scoping now.
- Whether we want the dts machinery awake at all: it was dead code until now, and it includes the remote-types download/extract path (the one Socket flagged via `adm-zip`).

### Testing

Unit tests cover the dts option staying at its default, environment scoping, and the promise-delivered plugins surviving the scoping map. Fixture builds above for the end-to-end behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-time federation and dts generation paths change (including remote type download/extract), which can affect workbench dev/build outputs though behavior is gated on tsconfig presence.
> 
> **Overview**
> **Federated remote TypeScript types** are turned back on for workbench builds by removing the hard-coded `dts.generateTypes: false` override on `@module-federation/vite`, so type generation follows upstream behavior (enabled when a `tsconfig.json` exists at the Vite root).
> 
> The module-federation wrapper no longer flattens plugin options with a shallow map: it **recursively** applies `applyToEnvironment` across promises and nested plugin arrays so the library’s promise-delivered **dts** plugins are not dropped and still scope to dev (`serve` / client) and the federation build environment only.
> 
> New **Vitest** coverage asserts default dts options, environment scoping, and promise-resolved dts plugins surviving scoping. Changeset marks `@sanity/cli-build` as a minor release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2e6c6f759e23c798b852f9d6b23932c546a285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->