### PR TITLE
chore(knip): restore the @types/debug ignore for cli-build

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -69,6 +69,8 @@ const baseConfig = {
         'src/**/*.worker.ts',
         'package.config.ts',
       ],
+      // debug is used for type checking
+      ignoreDependencies: ['@types/debug'],
       project,
     },
     'packages/@sanity/cli-core': {


### PR DESCRIPTION
### Description

Adds `ignoreDependencies: ['@types/debug']` back to the cli-build workspace in `knip.config.ts` — reverting that part of f46736fe. `debug` is imported in `getViteConfig.ts` and `@types/debug` only matters for type checking, which knip doesn't always connect.

Heads-up: locally `pnpm check:deps` exits 0 with this change, but knip emits a configuration hint (`@types/debug — Remove from ignoreDependencies`), i.e. it currently considers the ignore unnecessary. This PR doubles as the CI check for whether that hint stays non-fatal.

### What to review

- That the depcheck workflow stays green with the restored ignore.

### Testing

`pnpm check:deps` locally: exit 0, one configuration hint, no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Knip configuration only; no runtime or application behavior changes.
> 
> **Overview**
> Restores **`ignoreDependencies: ['@types/debug']`** on the `@sanity/cli-build` Knip workspace (with a short comment that `debug` is used for typing), undoing part of an earlier Knip cleanup.
> 
> This keeps `pnpm check:deps` from flagging `@types/debug` when Knip does not tie it to the `debug` import in `getViteConfig.ts`. Knip may still print a non-fatal hint to remove the ignore; CI is the check that the workflow stays green.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfae6b40cad6969f6c037a697cc5d38746dae570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->