### PR TITLE
fix(workbench): stop wiping studio interfaces from the dev registry

### DIFF
--- a/.changeset/pr-1284.md
+++ b/.changeset/pr-1284.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): stop wiping studio interfaces from the dev registry

--- a/packages/@sanity/cli/src/actions/dev/registration/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/__tests__/startDevServerRegistration.test.ts
@@ -233,9 +233,16 @@ describe('startDevServerRegistration', () => {
     expect(mockExtractCoreAppManifest).toHaveBeenCalledWith({workDir: '/tmp/sanity-project'})
   })
 
-  test('wires extractStudioManifest into the studio watcher (no interfaces)', async () => {
+  test('wires extractStudioManifest into the studio watcher and re-derives interfaces', async () => {
     const studioManifest = {version: 3, workspaces: []}
     mockExtractStudioManifest.mockResolvedValue(studioManifest)
+    // Studios declare panels/workers in `sanity.cli.ts` too — the watcher must
+    // re-derive them. A hardcoded `interfaces: undefined` would wipe the
+    // registered set on the first regeneration (the registry patch is a
+    // shallow merge).
+    mockGetCliConfigUncached.mockResolvedValue({
+      app: workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]}),
+    })
 
     await startDevServerRegistration({
       cliConfig: workbenchCliConfig(),
@@ -248,7 +255,10 @@ describe('startDevServerRegistration', () => {
     const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
     await expect(
       extract({configPath: '/tmp/sanity-project/sanity.config.ts', workDir: '/tmp/sanity-project'}),
-    ).resolves.toEqual({interfaces: undefined, manifest: studioManifest})
+    ).resolves.toEqual({
+      interfaces: [{entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'}],
+      manifest: studioManifest,
+    })
     expect(mockExtractStudioManifest).toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/actions/dev/registration/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/startDevManifestWatcher.ts
@@ -26,8 +26,9 @@ interface ManifestPatch<T> {
   /**
    * Workbench interfaces (views/services/app view) re-derived from the config
    * on each change, so editing `views`/`services`/`entry` in `sanity.cli.ts`
-   * re-syncs live like `title`/`icon` (FR-024). `undefined` for project types
-   * that don't declare interfaces (e.g. studios).
+   * re-syncs live like `title`/`icon` (FR-024). `undefined` only for
+   * non-branded configs — the registry patch is a shallow merge, so extractors
+   * must re-derive rather than omit, or the registered set gets wiped.
    */
   interfaces?: DevServerInterface[] | undefined
 }

--- a/packages/@sanity/cli/src/actions/dev/registration/startDevServerRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/startDevServerRegistration.ts
@@ -82,8 +82,15 @@ export async function startDevServerRegistration(
           interfaces: deriveInterfaces((await getCliConfigUncached(wd)).app, {isApp}),
           manifest: await extractCoreAppManifest({workDir: wd}),
         })
-      : (params) =>
-          extractStudioManifest(params).then((manifest) => ({interfaces: undefined, manifest})),
+      : async (params) => ({
+          // Studios declare views/services in `sanity.cli.ts` too — re-derive
+          // them like the app extract does. The registry patch is a shallow
+          // merge, so a hardcoded `interfaces: undefined` here would wipe the
+          // panels/workers forwarded by the initial registration on the very
+          // first regeneration.
+          interfaces: deriveInterfaces((await getCliConfigUncached(params.workDir)).app, {isApp}),
+          manifest: await extractStudioManifest(params),
+        }),
     output,
     update: async (patch) => {
       const nextInterfaceSetId = interfaceSetId(patch.interfaces)


### PR DESCRIPTION
### Description

Fixes the registry wipe Bugbot found on #907 (https://github.com/sanity-io/cli/pull/907#discussion_r3403192736) — and it's worse than reported: the manifest watcher fires an initial regeneration at startup, so a studio's registered panels/workers were wiped seconds after `sanity dev` started, not just after a config save.

Root cause: the studio extract hardcoded `interfaces: undefined` while `registration.update` is a shallow spread — an explicit `undefined` own-property overwrites the field. Studios can declare `views`/`services` in `unstable_defineApp` (only `entry` is rejected, FR-026), and the initial registration forwards them; the watcher then immediately threw them away.

The studio extract now re-derives interfaces from a fresh config read, exactly like the core-app extract. This also makes the `interfaceSetId` comparison meaningful for studios, which the rebuild-hook fix builds on (separate PR).

### What to review

- The studio extract mirrors the core-app one — `deriveInterfaces` + `getCliConfigUncached` were already imported for it.
- A studio that gains `entry` mid-session makes `deriveInterfaces` throw; the watcher already catches extract errors and warns, keeping the previous manifest.

### Testing

Updated the studio-extract unit test to assert re-derived interfaces (it previously pinned the buggy `interfaces: undefined` shape).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dev-server registry updates used by the workbench at startup; wrong interface derivation could still break local panels/workers, but the change aligns studio behavior with the existing core-app path and is covered by an updated unit test.
> 
> **Overview**
> Fixes a workbench dev-registry bug where **studio** panels/workers disappeared right after `sanity dev` started (and on later manifest regenerations), because the studio manifest watcher always patched `interfaces: undefined` and `registration.update` shallow-merges patches.
> 
> The studio watcher **extract** path now mirrors core apps: it re-reads `sanity.cli.ts` via `getCliConfigUncached` and runs `deriveInterfaces`, so registered interfaces stay in sync on the watcher’s initial run and on config edits. Comments in `startDevManifestWatcher` clarify that `undefined` must not be used when interfaces should be preserved.
> 
> The studio wiring test was updated to expect re-derived interfaces instead of `interfaces: undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b6e15df8ed635841d7f881bf1e80d7e9c6679b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->