### PR TITLE
fix(workbench): rebuild federated studios when their interface set changes

### DIFF
--- a/.changeset/pr-1286.md
+++ b/.changeset/pr-1286.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): rebuild federated studios when their interface set changes

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -253,12 +253,29 @@ describe('devAction', () => {
       expect(firstClose).toHaveBeenCalledTimes(1)
     })
 
-    test('passes no rebuild hook for studios (they declare no interfaces)', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+    test('rebuilds the studio server with a freshly-loaded config when the interface set changes', async () => {
+      // Studios declare views/services in `sanity.cli.ts` like apps do (only
+      // `entry` is rejected, FR-026) — they need the same rebuild hook.
+      const firstClose = vi.fn().mockResolvedValue(undefined)
+      const secondClose = vi.fn().mockResolvedValue(undefined)
+      mockStartStudioDevServer
+        .mockResolvedValueOnce({...mockServer({port: 3334}), close: firstClose})
+        .mockResolvedValueOnce({...mockServer({port: 3334}), close: secondClose})
+      const freshConfig = workbenchCliConfig()
+      mockGetCliConfigUncached.mockResolvedValue(freshConfig)
 
       await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: false}))
 
-      expect(passedInterfaceSetChange()).toBeUndefined()
+      const onSetChange = passedInterfaceSetChange()
+      expect(onSetChange).toBeInstanceOf(Function)
+
+      await onSetChange!()
+
+      expect(firstClose).toHaveBeenCalledTimes(1)
+      expect(mockStartStudioDevServer).toHaveBeenCalledTimes(2)
+      expect(mockStartStudioDevServer).toHaveBeenLastCalledWith(
+        expect.objectContaining({cliConfig: freshConfig}),
+      )
     })
   })
 

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -88,14 +88,14 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   // workbench page then reloads (driven by the registry watch in the workbench
   // server) to re-fetch the rebuilt remote. A view/service *source* edit doesn't
   // change the interface set, so it stays on the HMR path untouched.
-  // Studios declare no interfaces, so they get no rebuild hook.
-  const onInterfaceSetChange = options.isApp
-    ? async () => {
-        const freshConfig = await getCliConfigUncached(workDir)
-        await closeAppDevServer()
-        await startApp(freshConfig)
-      }
-    : undefined
+  // Studios declare views/services the same way (only `entry` is rejected,
+  // FR-026), so they get the same rebuild — `startApp` routes to the right
+  // server for both.
+  const onInterfaceSetChange = async () => {
+    const freshConfig = await getCliConfigUncached(workDir)
+    await closeAppDevServer()
+    await startApp(freshConfig)
+  }
 
   // Workbench is opted into solely by calling `unstable_defineApp` — its
   // branded identity is the only signal.

--- a/packages/@sanity/cli/src/actions/dev/registration/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/__tests__/startDevManifestWatcher.test.ts
@@ -191,6 +191,38 @@ describe('startDevManifestWatcher', () => {
     await watcher.close()
   })
 
+  test('regenerates on extraWatchFilenames events too', async () => {
+    const update = vi.fn()
+    const watcher = await startDevManifestWatcher({
+      extract: mockExtract,
+      // A studio's project root resolves to sanity.config.ts, but its
+      // workbench interfaces live in sanity.cli.ts — both must regenerate.
+      extraWatchFilenames: ['sanity.cli.js', 'sanity.cli.ts'],
+      output: createMockOutput(),
+      update,
+      workDir: WORK_DIR,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockExtract).toHaveBeenCalledTimes(1)
+
+    fakeWatcher.emitChange('sanity.cli.ts')
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockExtract).toHaveBeenCalledTimes(2)
+
+    // The resolved config file keeps working alongside the extras.
+    fakeWatcher.emitChange('sanity.config.ts')
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockExtract).toHaveBeenCalledTimes(3)
+
+    // Unrelated files are still ignored.
+    fakeWatcher.emitChange('package.json')
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockExtract).toHaveBeenCalledTimes(3)
+
+    await watcher.close()
+  })
+
   test('logs a warning and keeps running when extraction fails', async () => {
     const output = createMockOutput()
     const update = vi.fn()

--- a/packages/@sanity/cli/src/actions/dev/registration/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/__tests__/startDevServerRegistration.test.ts
@@ -188,7 +188,12 @@ describe('startDevServerRegistration', () => {
     })
 
     expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
-      expect.objectContaining({workDir: '/tmp/sanity-project'}),
+      expect.objectContaining({
+        // The studio project root resolves to sanity.config.*, but views/
+        // services live in sanity.cli.* — the watcher must react to both.
+        extraWatchFilenames: ['sanity.cli.js', 'sanity.cli.ts'],
+        workDir: '/tmp/sanity-project',
+      }),
     )
   })
 
@@ -204,6 +209,8 @@ describe('startDevServerRegistration', () => {
     expect(mockStartDevManifestWatcher).toHaveBeenCalledWith(
       expect.objectContaining({extract: expect.any(Function), workDir: '/tmp/sanity-project'}),
     )
+    // App roots already resolve to sanity.cli.* — no extra filenames needed.
+    expect(mockStartDevManifestWatcher.mock.calls[0][0].extraWatchFilenames).toBeUndefined()
   })
 
   test('wires extractCoreAppManifest into the core-app watcher and re-derives interfaces', async () => {

--- a/packages/@sanity/cli/src/actions/dev/registration/startDevManifestWatcher.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/startDevManifestWatcher.ts
@@ -52,6 +52,14 @@ interface StartDevManifestWatcherOptions<T> {
    */
   update: (patch: ManifestPatch<T>) => Promise<void> | void
   workDir: string
+
+  /**
+   * Extra config filenames (basenames in the project root directory) that also
+   * trigger a regeneration. Studios resolve their project root via
+   * `sanity.config.*` but declare workbench interfaces in `sanity.cli.*`, so
+   * their watcher needs to react to both files.
+   */
+  extraWatchFilenames?: readonly string[]
 }
 
 /**
@@ -71,6 +79,7 @@ interface StartDevManifestWatcherOptions<T> {
  */
 export async function startDevManifestWatcher<T>({
   extract,
+  extraWatchFilenames,
   output,
   update,
   workDir,
@@ -122,14 +131,14 @@ export async function startDevManifestWatcher<T>({
   // Canonicalize to the real long path so `fs.watch` doesn't abort on Windows
   // short-path dirs. See `canonicalizeWatchDir`.
   const configDir = canonicalizeWatchDir(dirname(configPath))
-  const configFilename = basename(configPath)
+  const watchFilenames = new Set([basename(configPath), ...(extraWatchFilenames ?? [])])
 
   let debounceTimer: ReturnType<typeof setTimeout> | undefined
 
   const onEvent = (_event: string, filename: Buffer | string | null) => {
     if (!filename) return
     const name = typeof filename === 'string' ? filename : filename.toString('utf8')
-    if (name !== configFilename) return
+    if (!watchFilenames.has(name)) return
     clearTimeout(debounceTimer)
     debounceTimer = setTimeout(() => {
       void regenerate()

--- a/packages/@sanity/cli/src/actions/dev/registration/startDevServerRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/startDevServerRegistration.ts
@@ -22,8 +22,8 @@ interface DevServerRegistrationOptions {
    * registry is patched — the registry patch is what reloads the workbench
    * page, and it must re-fetch a remote that already exposes the new
    * interface, so the caller's rebuild has to complete first. A view/service
-   * *source* edit doesn't change the set and never fires this. Studios declare
-   * no interfaces, so they pass nothing.
+   * *source* edit doesn't change the set and never fires this. Studios
+   * declare views/services the same way apps do, so both pass a rebuild.
    */
   onInterfaceSetChange?: () => Promise<void>
 }
@@ -91,6 +91,11 @@ export async function startDevServerRegistration(
           interfaces: deriveInterfaces((await getCliConfigUncached(params.workDir)).app, {isApp}),
           manifest: await extractStudioManifest(params),
         }),
+    // A studio's project root resolves to `sanity.config.*`, but its workbench
+    // interfaces live in `sanity.cli.*` — watch that too so adding/removing a
+    // view or service regenerates without a manual restart. Apps already
+    // resolve their root to `sanity.cli.*`.
+    extraWatchFilenames: isApp ? undefined : ['sanity.cli.js', 'sanity.cli.ts'],
     output,
     update: async (patch) => {
       const nextInterfaceSetId = interfaceSetId(patch.interfaces)


### PR DESCRIPTION
### Description

Fixes the second studio gap Bugbot found on #907 (https://github.com/sanity-io/cli/pull/907#discussion_r3403192747). Stacked on #1284 — that PR makes the studio watcher re-derive interfaces; this one makes the derived changes actually do something.

Studios declare `views`/`services` in `unstable_defineApp` like apps do (only `entry` is rejected, FR-026), but the dev flow assumed they couldn't, in two places:

- `devAction` only handed the interface-set rebuild hook to apps, so a studio's federation remote kept its stale `exposes` map until a manual restart.
- The manifest watcher watches the resolved project root — `sanity.config.*` for studios — while the declarations live in `sanity.cli.*`, so studio config edits never even triggered a regeneration.

The rebuild hook now applies to both (`startApp` already routes to the right server), and the watcher takes `extraWatchFilenames` so studios react to `sanity.cli.*` alongside their resolved config file.

### What to review

- The un-gated rebuild closes and recreates the studio dev server on an interface-set change — same lifecycle apps already had.
- `extraWatchFilenames` assumes `sanity.cli.*` sits next to `sanity.config.*` in the project root, which is what the root resolution already requires.

### Testing

Flipped the test that pinned the old behavior ("passes no rebuild hook for studios") into a studio-rebuild test, plus watcher coverage for the extra filenames. The pre-existing `registry.test.ts` fs.watch flake fails on the clean base too — unrelated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dev-server lifecycle (close/restart) and file watching for all workbench-enabled studio runs; limited to local dev, but incorrect ordering could briefly break federation until reload.
> 
> **Overview**
> **Federated workbench dev** now treats **studios** like apps when `views`/`services` change in `sanity.cli.*`: the interface-set rebuild hook is always registered (not app-only), so the studio Vite server is torn down and restarted with a fresh config so module-federation `exposes` stay in sync.
> 
> The manifest watcher gains **`extraWatchFilenames`**. Studio registration passes `sanity.cli.js` / `sanity.cli.ts` because project root resolution still points at `sanity.config.*`, so CLI edits that declare interfaces trigger regeneration without a manual restart. Apps keep watching only their resolved `sanity.cli.*` root.
> 
> Tests replace the old “studios get no rebuild hook” expectation with studio rebuild coverage and watcher tests for the extra filenames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 574b5c729a87bb7849ccc22305fa9ef1d9b58e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->