### PR TITLE
fix(build): fail fast when a workbench studio has no sanity config

### DIFF
--- a/.changeset/pr-1287.md
+++ b/.changeset/pr-1287.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': patch
+---
+
+fix(build): fail fast when a workbench studio has no sanity config

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
@@ -536,6 +536,65 @@ describe('#getViteConfig', () => {
     expect(config.server?.strictPort).toBe(false)
   })
 
+  test('should reject when a workbench studio has no sanity config', async () => {
+    // Reachable state: an explicit `applicationType: 'studio'` wins over
+    // detection, so the project can be a workbench studio with no config file.
+    const options = {
+      cwd: mockTestCwd,
+      entries: {relativeConfigLocation: null, relativeEntry: null},
+      getEnvironmentVariables,
+      isWorkbenchApp: true,
+      mode: 'development' as const,
+      reactCompiler: undefined,
+    }
+
+    await expect(getViteConfig(options)).rejects.toThrow(
+      'Workbench studios need a sanity.config.js or sanity.config.ts file. ' +
+        "Add one, or remove `applicationType: 'studio'` from `unstable_defineApp` " +
+        'to let the CLI infer the application type.',
+    )
+    expect(mockFederationPlugin).not.toHaveBeenCalled()
+  })
+
+  test('should not require a sanity config for workbench apps', async () => {
+    const options = {
+      cwd: mockTestCwd,
+      entries: {relativeConfigLocation: null, relativeEntry: '../../src/App'},
+      getEnvironmentVariables,
+      isApp: true,
+      isWorkbenchApp: true,
+      mode: 'development' as const,
+      reactCompiler: undefined,
+    }
+
+    const config = await getViteConfig(options)
+
+    expect(mockFederationPlugin).toHaveBeenCalledWith({
+      appEntry: '../../src/App',
+      isApp: true,
+      pkgJson: {name: 'sanity'},
+      workDir: mockTestCwd,
+    })
+    expect(config.plugins).toContainEqual({name: 'sanity/federation'})
+  })
+
+  test('should not require a sanity config for non-workbench studios', async () => {
+    // The legacy build path has a designed no-config fallback
+    // (`noConfigEntryModule`), so it must keep working without one.
+    const options = {
+      cwd: mockTestCwd,
+      entries: {relativeConfigLocation: null, relativeEntry: null},
+      getEnvironmentVariables,
+      mode: 'development' as const,
+      reactCompiler: undefined,
+    }
+
+    const config = await getViteConfig(options)
+
+    expect(mockFederationPlugin).not.toHaveBeenCalled()
+    expect(config.root).toBe(mockTestCwd)
+  })
+
   test('should not include federation plugin when disabled', async () => {
     const options = {
       cwd: mockTestCwd,

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -217,8 +217,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
                   }
                 : {
                     isApp: false as const,
-                    // TODO: fix this non-null assertion
-                    studioConfigPath: entries.relativeConfigLocation!,
+                    studioConfigPath: requireStudioConfigPath(entries.relativeConfigLocation),
                   }),
               pkgJson: await readPackageJson(path.join(cwd, 'package.json')),
               services,
@@ -343,6 +342,26 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
   }
 
   return viteConfig
+}
+
+/**
+ * An explicit `applicationType: 'studio'` in `unstable_defineApp` wins over
+ * auto-detection, so the workbench federation studio path is reachable without
+ * a sanity config on disk. The legacy (non-federation) studio path has a
+ * designed no-config fallback in `getEntryModule`, but the federation runtime
+ * would bake `null` into the generated remote entry and import its config from
+ * "null" — a broken build with no hint at the cause. Fail here instead.
+ */
+function requireStudioConfigPath(relativeConfigLocation: string | null): string {
+  if (relativeConfigLocation === null) {
+    throw new Error(
+      'Workbench studios need a sanity.config.js or sanity.config.ts file. ' +
+        "Add one, or remove `applicationType: 'studio'` from `unstable_defineApp` " +
+        'to let the CLI infer the application type.',
+    )
+  }
+
+  return relativeConfigLocation
 }
 
 function onRolldownWarn(warning: Rolldown.RolldownLog, warn: Rolldown.LoggingFunction) {


### PR DESCRIPTION
### Description

Bugbot flagged the non-null assertion on `entries.relativeConfigLocation` in the workbench federation branch of `getViteConfig`: https://github.com/sanity-io/cli/pull/907#discussion_r3403192742

The state is reachable: an explicit `applicationType: 'studio'` in `unstable_defineApp` wins over auto-detection, so a project can land on the federation studio path with no `sanity.config.(ts|js)` on disk. The `!` then let `null` flow into the federation runtime template, which bakes a remote entry that imports its config from `"null"` — a broken build that fails far from the cause.

Now the studio path validates the config location up front and throws an actionable error: add a config file, or drop `applicationType: 'studio'` and let the CLI infer the type.

### What to review

`requireStudioConfigPath` in `getViteConfig.ts`. It only guards the workbench studio branch — apps and legacy (non-federation) studios are untouched, and the legacy path keeps its designed no-config fallback (`noConfigEntryModule`).

### Testing

Added unit tests: a workbench studio with `relativeConfigLocation: null` rejects with the new message, while workbench apps and non-workbench studios still accept a null config. Full `@sanity/cli-build` package passes (164/164).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to workbench federation studio config validation; apps and legacy studio builds are explicitly unchanged and covered by tests.
> 
> **Overview**
> **Workbench federation studio builds** now validate that a `sanity.config.js` or `sanity.config.ts` exists before wiring Vite federation. The workbench studio branch no longer uses a non-null assertion on `relativeConfigLocation`; it calls **`requireStudioConfigPath`**, which throws a clear error when the path is missing (e.g. when `applicationType: 'studio'` forces the studio path without a config on disk). That avoids baking `"null"` into the federation remote entry and failing later with an opaque build error.
> 
> **Workbench apps** and **legacy non-workbench studios** are unchanged: apps can still omit a config, and the legacy path keeps its no-config fallback.
> 
> New unit tests cover rejection for workbench studios without a config, plus the two cases that must still succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47dbca5436fc74edbddaa4749f836db5d561a5b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->