### PR TITLE
revert(workbench): keep federated remote type generation off

### DIFF
--- a/.changeset/pr-1288.md
+++ b/.changeset/pr-1288.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': patch
+---
+
+revert(workbench): keep federated remote type generation off

--- a/fixtures/federated-studio/tsconfig.json
+++ b/fixtures/federated-studio/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-module-federation.node.test.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-module-federation.node.test.ts
@@ -27,13 +27,18 @@ function appliesTo(plugin: Plugin, name: string, command: 'build' | 'serve'): bo
 }
 
 describe('pluginModuleFederation', () => {
-  it('leaves dts at module-federation defaults so type generation stays conditional on tsconfig.json', () => {
+  // Regression test for TYPE-001: upstream defaults dts generation on for any
+  // project with a tsconfig.json, but it compiles the generated .js/.jsx
+  // expose shims with the user's compiler options — tsc rejects them without
+  // allowJs (TS6504), and declaration emit of the user's noEmit app code fails
+  // on its own (TS2742/TS4082). Type generation must stay explicitly off.
+  it('disables dts type generation so the user tsconfig never compiles the generated exposes', () => {
     mockFederation.mockReturnValue([])
 
     runPlugin()
 
     expect(mockFederation).toHaveBeenCalledTimes(1)
-    expect(mockFederation.mock.calls[0][0]).not.toHaveProperty('dts')
+    expect(mockFederation.mock.calls[0][0].dts).toEqual({generateTypes: false})
   })
 
   it('scopes plugins to the dev server and the federation build environment', () => {

--- a/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-module-federation.ts
+++ b/packages/@sanity/cli-build/src/workbench/vite/plugins/plugin-module-federation.ts
@@ -21,6 +21,15 @@ export function pluginModuleFederation({exposes, name}: FederationOptions): Plug
       disableDynamicRemoteTypeHints: true,
       remoteHmr: true,
     },
+    // Remote type generation stays off: it compiles the exposes with the
+    // project's tsconfig, and that breaks twice over on real projects.
+    // The exposes are generated .js/.jsx shims, which tsc refuses without
+    // allowJs (TYPE-001/TS6504) — no app template sets it. And with allowJs
+    // worked around, declaration emit pulls in the user's own modules, which
+    // are noEmit projects never written to be declaration-emittable: TS2742
+    // (non-portable inferred types, endemic under pnpm) and TS4082 (private
+    // names in default exports) then fail the compile just the same.
+    dts: {generateTypes: false},
     exposes,
     filename: `${FEDERATION_FILE_NAME}.js`,
     manifest: true,


### PR DESCRIPTION
### Description

Reverts the behavior change from #1282 — federated remote type generation goes back to explicitly off. `sanity dev` started failing with TYPE-001 on real TS apps right after it merged.

It breaks twice over. The exposes are generated `.js`/`.jsx` shims, and the dts plugin compiles them with the user's tsconfig — tsc refuses JS inputs without `allowJs` (TS6504), which no app template sets. I tried fixing that with a shim tsconfig that extends the project's and switches `allowJs` on, and it works — but then declaration emit pulls in the user's own modules, and those fail on their own: TS2742 (non-portable inferred types, endemic under pnpm — hit immediately on a real app via i18next) and TS4082 (private names in default exports). Workbench apps are `noEmit` projects; their code was never written to be declaration-emittable, and we can't fix that from the plugin. `abortOnError: false` doesn't help either — the TYPE-001 wall of text prints inside `compileTs` before the error is caught.

#1282's verification only passed because `fixtures/federated-studio` set `allowJs: true` — removed here so the fixture matches real templates and reproduces this class of failure.

The recursive plugin scoping from #1282 stays: it's correct regardless of whether dts runs.

### What to review

- `dts: {generateTypes: false}` is back, now with a comment carrying both failure modes so the next attempt starts from the full picture.
- The regression test pins `generateTypes: false` — it's the guard against upstream's tsconfig-existence default sneaking back in.

### Testing

Unit test asserts dts stays off. Verified `sanity build` and `sanity dev` on `fixtures/federated-studio` (without `allowJs`): no TYPE-001, no stray `@mf-types` artifacts. The TS2742/TS4082 failure mode was confirmed by running the fixed-config tsc compile against a real app where #1282's build fails today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/workbench plugin configuration only; restores prior safe behavior and avoids breaking `sanity dev` on standard TS apps.
> 
> **Overview**
> Reverts enabling federated remote **dts** type generation from #1282 by setting **`dts: {generateTypes: false}`** again on the module-federation Vite plugin, with comments documenting TYPE-001/TS6504 and TS2742/TS4082 failure modes.
> 
> The unit test now **asserts** that option instead of only checking that `dts` is unset. **`fixtures/federated-studio/tsconfig.json`** drops **`allowJs`** so the fixture matches typical app templates and can catch regressions where type generation runs against real tsconfigs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d472d1bf948e4113a42f9c8ed955885c26ac922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->