### PR TITLE
fix(workbench): keep the registry in sync when an interface-set rebuild fails or moves ports

### DIFF
--- a/.changeset/pr-1289.md
+++ b/.changeset/pr-1289.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): keep the registry in sync when an interface-set rebuild fails or moves ports

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.unit.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.unit.test.ts
@@ -54,7 +54,7 @@ function mockRegistrationHandle() {
 }
 
 /** Pull the rebuild handler devAction passed into startDevServerRegistration. */
-function passedInterfaceSetChange(): (() => Promise<void>) | undefined {
+function passedInterfaceSetChange(): (() => Promise<unknown>) | undefined {
   return mockStartDevServerRegistration.mock.calls[0][0].onInterfaceSetChange
 }
 
@@ -256,7 +256,21 @@ describe('devAction', () => {
       )
     })
 
-    test('close stays safe when the rebuilt app server reports an expected early exit', async () => {
+    test('rebuild hook resolves with the recreated server so the registration can re-read its address', async () => {
+      // Workbench projects run with non-strict ports — the replacement server
+      // can bind a different port than the one registered at startup.
+      const secondServer = mockServer({port: 3335})
+      mockStartAppDevServer
+        .mockResolvedValueOnce(mockServer({port: 3334}))
+        .mockResolvedValueOnce(secondServer)
+      mockGetCliConfigUncached.mockResolvedValue(workbenchCliConfig())
+
+      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}))
+
+      await expect(passedInterfaceSetChange()!()).resolves.toBe(secondServer.server)
+    })
+
+    test('rebuild hook rejects when the restart reports an expected early exit, and close stays safe', async () => {
       const firstClose = vi.fn().mockResolvedValue(undefined)
       mockStartAppDevServer
         .mockResolvedValueOnce({...mockServer({port: 3334}), close: firstClose})
@@ -268,7 +282,11 @@ describe('devAction', () => {
         createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}),
       )
 
-      await passedInterfaceSetChange()!()
+      // The registration must see the failure — a resolved hook would commit
+      // the new interface set against a server that never came back.
+      await expect(passedInterfaceSetChange()!()).rejects.toThrow(
+        'Dev server did not restart after the view/service change',
+      )
 
       // The old server was closed during the rebuild; close() must not call it
       // again or trip over the missing replacement.

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -1,6 +1,7 @@
 import {styleText} from 'node:util'
 
 import {getCliConfigUncached, isWorkbenchApp} from '@sanity/cli-core'
+import {type ViteDevServer} from 'vite'
 
 import {getSharedServerConfig} from '../../util/getSharedServerConfig.js'
 import {startDevServerRegistration} from './registration/startDevServerRegistration.js'
@@ -93,17 +94,28 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   // codegen artifacts are computed once at server start, so a newly-declared
   // interface has no expose until the server is recreated. `server.restart()`
   // can't do it — it re-uses the inline config — so we tear the app server down
-  // and bring it back up on the same port with a freshly-loaded config. The
+  // and bring it back up with a freshly-loaded config. The
   // workbench page then reloads (driven by the registry watch in the workbench
   // server) to re-fetch the rebuilt remote. A view/service *source* edit doesn't
   // change the interface set, so it stays on the HMR path untouched.
   // Studios declare views/services the same way (only `entry` is rejected,
   // FR-026), so they get the same rebuild — `startApp` routes to the right
-  // server for both.
-  const onInterfaceSetChange = async () => {
+  // server for both. The recreated server is returned so the registration can
+  // re-read its actual address: workbench projects run with non-strict ports,
+  // so the replacement isn't guaranteed to land on the port registered at
+  // startup. A restart that doesn't produce a listening server throws — the
+  // registration must not advertise the new interface set on a dead port, and
+  // the watcher's failure path leaves the rebuild eligible for a retry on the
+  // next config save.
+  const onInterfaceSetChange = async (): Promise<ViteDevServer> => {
     const freshConfig = await getCliConfigUncached(workDir)
     await closeAppDevServer()
-    await startApp(freshConfig)
+    const result = await startApp(freshConfig)
+    if (!result.started) {
+      // The server already reported why (e.g. organizationId was removed).
+      throw new Error('Dev server did not restart after the view/service change')
+    }
+    return result.server
   }
 
   // Workbench is opted into solely by calling `unstable_defineApp` — its

--- a/packages/@sanity/cli/src/actions/dev/registration/__tests__/interfaceSetId.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/__tests__/interfaceSetId.test.ts
@@ -48,19 +48,24 @@ describe('interfaceSetId', () => {
 
 describe('trackInterfaceSet', () => {
   test('reports no change for the seeded set, the same set, or a reorder', () => {
-    const changed = trackInterfaceSet([panel('a'), worker('b')])
-    expect(changed([panel('a'), worker('b')])).toBe(false)
-    expect(changed([worker('b'), panel('a')])).toBe(false)
+    const set = trackInterfaceSet([panel('a'), worker('b')])
+    expect(set.changed([panel('a'), worker('b')])).toBe(false)
+    expect(set.changed([worker('b'), panel('a')])).toBe(false)
   })
 
-  test('reports the change once, then settles on the new set', () => {
-    const changed = trackInterfaceSet([panel('a')])
-    expect(changed([panel('a'), panel('b')])).toBe(true) // added
-    expect(changed([panel('a'), panel('b')])).toBe(false) // same again
-    expect(changed([panel('a')])).toBe(true) // removed
+  test('detection does not commit — `changed` stays true until `commit` advances the baseline', () => {
+    const set = trackInterfaceSet([panel('a')])
+    // Repeated detection without a commit keeps reporting the change, so a
+    // rebuild that threw (never committed) is retried on the next pass instead
+    // of being skipped — the self-healing property the registry relies on.
+    expect(set.changed([panel('a'), panel('b')])).toBe(true)
+    expect(set.changed([panel('a'), panel('b')])).toBe(true)
+    set.commit([panel('a'), panel('b')])
+    expect(set.changed([panel('a'), panel('b')])).toBe(false)
+    expect(set.changed([panel('a')])).toBe(true) // removed — a new change off the committed set
   })
 
   test('treats undefined and empty as the same set', () => {
-    expect(trackInterfaceSet(undefined)([])).toBe(false)
+    expect(trackInterfaceSet(undefined).changed([])).toBe(false)
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/registration/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/__tests__/startDevServerRegistration.test.ts
@@ -442,6 +442,68 @@ describe('startDevServerRegistration', () => {
     expect(onInterfaceSetChange).not.toHaveBeenCalled()
   })
 
+  test('retries the rebuild on the next pass when it fails — the registry stays unpatched in between', async () => {
+    const onInterfaceSetChange = vi
+      .fn()
+      // e.g. the recreated server never came up (organizationId removed)
+      .mockRejectedValueOnce(new Error('Dev server did not restart after the view/service change'))
+      .mockResolvedValueOnce(mockServer({port: 3334}))
+    const update = vi.fn()
+    mockRegisterDevServer.mockReturnValue({release: vi.fn(), update})
+
+    await startDevServerRegistration({
+      cliConfig: {app: workbenchApp()}, // no interfaces yet
+      isApp: true,
+      onInterfaceSetChange,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+    const watcherUpdate = mockStartDevManifestWatcher.mock.calls[0][0].update
+
+    // The failure must reach the watcher (it owns the warning), and the
+    // registry must not advertise the new set on a server that never came back.
+    await expect(
+      watcherUpdate({interfaces: [feed], manifest: undefined, manifestUpdatedAt: 'a'}),
+    ).rejects.toThrow('Dev server did not restart')
+    expect(update).not.toHaveBeenCalled()
+
+    // Same declarations on the next save: the set id was not committed by the
+    // failed pass, so the rebuild runs again instead of being skipped.
+    await watcherUpdate({interfaces: [feed], manifest: undefined, manifestUpdatedAt: 'b'})
+    expect(onInterfaceSetChange).toHaveBeenCalledTimes(2)
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  test('patches the registry with the rebuilt server address after an interface-set change', async () => {
+    // Non-strict ports: the recreated server can land on a different port than
+    // the one captured at initial registration.
+    const onInterfaceSetChange = vi
+      .fn()
+      .mockResolvedValue(mockServer({host: 'mydev.local', port: 4444}))
+    const update = vi.fn()
+    mockRegisterDevServer.mockReturnValue({release: vi.fn(), update})
+
+    await startDevServerRegistration({
+      cliConfig: {app: workbenchApp()}, // no interfaces yet
+      isApp: true,
+      onInterfaceSetChange,
+      output: createMockOutput(),
+      server: mockServer({port: 3334}) as any,
+      workDir: '/tmp/sanity-project',
+    })
+    const watcherUpdate = mockStartDevManifestWatcher.mock.calls[0][0].update
+
+    await watcherUpdate({interfaces: [feed], manifest: undefined, manifestUpdatedAt: 'a'})
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({host: 'mydev.local', interfaces: [feed], port: 4444}),
+    )
+
+    // A manifest-only pass (same set) must not rewrite the address.
+    await watcherUpdate({interfaces: [feed], manifest: undefined, manifestUpdatedAt: 'b'})
+    expect(update).toHaveBeenLastCalledWith(expect.not.objectContaining({host: expect.anything()}))
+  })
+
   test('still patches the registry when no rebuild handler is passed', async () => {
     const update = vi.fn()
     mockRegisterDevServer.mockReturnValue({release: vi.fn(), update})

--- a/packages/@sanity/cli/src/actions/dev/registration/interfaceSetId.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/interfaceSetId.ts
@@ -23,20 +23,24 @@ export function interfaceSetId(interfaces: readonly DevServerInterface[] | undef
 }
 
 /**
- * Track the declared interface *set* across config reloads. The returned
- * predicate reports `true` the first time it sees a set whose id differs from
- * the previous one — an added, removed, renamed, or repointed view/service —
- * and `false` for a reorder or a manifest-only/source-file edit (the set is
- * unchanged, so HMR handles it). Seed it with the initially registered set.
+ * Track the declared interface *set* across config reloads — an added, removed,
+ * renamed, or repointed view/service. `changed` reports whether a set differs
+ * from the last *committed* one (a reorder or manifest-only/source-file edit
+ * leaves it unchanged, so HMR handles it) without advancing the committed set;
+ * `commit` advances it. Splitting the two lets the caller commit only after the
+ * rebuild that depends on the new set has succeeded — a thrown rebuild leaves
+ * the set uncommitted, so the next config save retries it instead of skipping.
+ * Seed it with the initially registered set.
  */
-export function trackInterfaceSet(
-  initial: readonly DevServerInterface[] | undefined,
-): (interfaces: readonly DevServerInterface[] | undefined) => boolean {
+export function trackInterfaceSet(initial: readonly DevServerInterface[] | undefined): {
+  changed: (interfaces: readonly DevServerInterface[] | undefined) => boolean
+  commit: (interfaces: readonly DevServerInterface[] | undefined) => void
+} {
   let lastId = interfaceSetId(initial)
-  return (interfaces) => {
-    const id = interfaceSetId(interfaces)
-    if (id === lastId) return false
-    lastId = id
-    return true
+  return {
+    changed: (interfaces) => interfaceSetId(interfaces) !== lastId,
+    commit: (interfaces) => {
+      lastId = interfaceSetId(interfaces)
+    },
   }
 }

--- a/packages/@sanity/cli/src/actions/dev/registration/startDevServerRegistration.ts
+++ b/packages/@sanity/cli/src/actions/dev/registration/startDevServerRegistration.ts
@@ -24,12 +24,34 @@ interface DevServerRegistrationOptions {
    * interface, so the caller's rebuild has to complete first. A view/service
    * *source* edit doesn't change the set and never fires this. Studios
    * declare views/services the same way apps do, so both pass a rebuild.
+   *
+   * Resolves with the recreated dev server so the registry entry can be
+   * patched with its actual address — workbench projects run with non-strict
+   * ports, so the replacement isn't guaranteed to bind the port registered at
+   * startup. Must reject when the restart doesn't produce a listening server:
+   * the set id stays uncommitted so the next config save retries the rebuild
+   * instead of advertising the new interface set on a dead port.
    */
-  onInterfaceSetChange?: () => Promise<void>
+  onInterfaceSetChange?: () => Promise<ViteDevServer>
 }
 
 interface DevServerRegistrationHandle {
   close: () => Promise<void>
+}
+
+/**
+ * The address a dev server actually bound, preferring the live socket over the
+ * configured port — with non-strict ports the two can disagree. Used for the
+ * initial registration and again after an interface-set rebuild recreates the
+ * server, so the registry never advertises a port nothing listens on.
+ */
+function serverAddress(server: ViteDevServer) {
+  const resolvedHost = server.config.server.host
+  const addr = server.httpServer?.address()
+  return {
+    host: typeof resolvedHost === 'string' ? resolvedHost : 'localhost',
+    port: typeof addr === 'object' && addr ? addr.port : server.config.server.port,
+  }
 }
 
 /**
@@ -45,11 +67,7 @@ export async function startDevServerRegistration(
 
   checkForDeprecatedAppId({cliConfig, output})
 
-  const resolvedHost = server.config.server.host
-  const appHost = typeof resolvedHost === 'string' ? resolvedHost : 'localhost'
-
-  const addr = server.httpServer?.address()
-  const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
+  const {host: appHost, port: appPort} = serverAddress(server)
 
   // Interfaces (panels/workers/app view) are derived from the branded
   // `unstable_defineApp` config and forwarded on the registry entry (alongside,
@@ -69,10 +87,11 @@ export async function startDevServerRegistration(
     workDir,
   })
 
-  // Reports whether a watcher pass changed the *set* of interfaces (rebuild
+  // Tracks whether a watcher pass changed the *set* of interfaces (rebuild
   // needed) vs. only the manifest (title/icon) or a view/service source file
-  // (HMR handles it — the set is unchanged).
-  const interfaceSetChanged = trackInterfaceSet(interfaces)
+  // (HMR handles it — the set is unchanged). Committed separately from the
+  // detection so a failed rebuild stays eligible for retry (see below).
+  const interfaceSet = trackInterfaceSet(interfaces)
 
   const watcher = await startDevManifestWatcher({
     extract: isApp
@@ -99,13 +118,24 @@ export async function startDevServerRegistration(
     extraWatchFilenames: isApp ? undefined : ['sanity.cli.js', 'sanity.cli.ts'],
     output,
     update: async (patch) => {
-      if (interfaceSetChanged(patch.interfaces)) {
-        // Rebuild the app remote (so the new view/service has an expose +
-        // artifact) before patching the registry — see `onInterfaceSetChange`
-        // for why the ordering matters.
-        await onInterfaceSetChange?.()
+      if (!interfaceSet.changed(patch.interfaces)) {
+        // Set unchanged (reorder, or a manifest-only/source-file edit) — patch
+        // the registry and let HMR handle the rest; no rebuild needed.
+        registration.update(patch)
+        return
       }
-      registration.update(patch)
+      // Rebuild the app remote first (so the new view/service has an expose +
+      // artifact), THEN patch the registry — the registry patch is what reloads
+      // the workbench page, and it must re-fetch a remote that already exposes
+      // the new interface.
+      const rebuiltServer = await onInterfaceSetChange?.()
+      // Commit only after the rebuild resolves: a thrown rebuild surfaces
+      // through the watcher's failure path with the set uncommitted, so the
+      // next pass over the same declarations retries instead of skipping.
+      interfaceSet.commit(patch.interfaces)
+      // The recreated server can bind a different port (non-strict ports), so
+      // the patch carries its actual address alongside the manifest fields.
+      registration.update(rebuiltServer ? {...patch, ...serverAddress(rebuiltServer)} : patch)
     },
     workDir,
   })


### PR DESCRIPTION
The interface-set rebuild wasn't transactional with the dev registry — a restart that returned `started: false` or bound a different (non-strict) port left the workbench reloading into a dead or stale port, and a thrown rebuild was never retried ([Bugbot review of 5a42492](https://github.com/sanity-io/cli/pull/907#discussion_r3403576103)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workbench dev registration and hot-reload orchestration for view/service changes; failures are handled more safely but incorrect ordering could still break local workbench routing until the next successful rebuild.
> 
> **Overview**
> Makes workbench dev-server registry updates **transactional** with interface-set rebuilds: the registry is not patched with a new view/service set until the Vite app/studio server has successfully restarted, and it records the **live** host/port after rebuild (non-strict ports can shift).
> 
> **`onInterfaceSetChange`** in `devAction` now **resolves with the recreated `ViteDevServer`** and **throws** when restart returns `started: false`, so registration never advertises interfaces on a dead port.
> 
> **`trackInterfaceSet`** splits **detect** (`changed`) from **commit** (`commit`): the interface-set id advances only after a successful rebuild, so a failed pass **retries on the next config save** instead of being treated as already applied.
> 
> **`startDevServerRegistration`** watcher flow: unchanged set → patch only; changed set → await rebuild → commit id → `registration.update` with manifest plus **`serverAddress(rebuiltServer)`** when applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5645e02f4e73cb453a126633390c6bb8ede0c43e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
