### PR TITLE
feat(cli-build): inject early-auth probe script during studio build

### DIFF
--- a/.changeset/pr-1294.md
+++ b/.changeset/pr-1294.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+'@sanity/cli': minor
+---
+
+feat(cli-build): inject early-auth probe script during studio build

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/decorateIndexWithEarlyAuthScript.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/decorateIndexWithEarlyAuthScript.test.ts
@@ -1,7 +1,8 @@
 import {JSDOM} from 'jsdom'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {decorateIndexWithEarlyAuthScript} from '../decorateIndexWithEarlyAuthScript'
+import {__sanityEarlyAuthInit} from '../earlyAuthProbeScript'
 
 const mockIsStaging = vi.hoisted(() => vi.fn<() => boolean>())
 
@@ -21,100 +22,112 @@ afterEach(() => {
 })
 
 describe('decorateIndexWithEarlyAuthScript', () => {
-  test('returns template unchanged when projectId is undefined', () => {
+  test('returns template unchanged when projectId is undefined', async () => {
     mockIsStaging.mockReturnValue(false)
-    expect(decorateIndexWithEarlyAuthScript(sampleHtml, undefined)).toBe(sampleHtml)
+    expect(await decorateIndexWithEarlyAuthScript(sampleHtml, undefined)).toBe(sampleHtml)
   })
 
-  test('returns template unchanged when projectId is empty string', () => {
+  test('returns template unchanged when projectId is empty string', async () => {
     mockIsStaging.mockReturnValue(false)
-    expect(decorateIndexWithEarlyAuthScript(sampleHtml, '')).toBe(sampleHtml)
+    expect(await decorateIndexWithEarlyAuthScript(sampleHtml, '')).toBe(sampleHtml)
   })
 
-  test('returns template unchanged when projectId sanitizes to empty', () => {
+  test('skips (returns template unchanged) when projectId fails the validity check', async () => {
     mockIsStaging.mockReturnValue(false)
-    expect(decorateIndexWithEarlyAuthScript(sampleHtml, '!!!')).toBe(sampleHtml)
+    expect(await decorateIndexWithEarlyAuthScript(sampleHtml, '!!!')).toBe(sampleHtml)
+    expect(await decorateIndexWithEarlyAuthScript(sampleHtml, 'my-proj!')).toBe(sampleHtml)
   })
 
-  test('returns template unchanged when template is empty string', () => {
+  test('returns template unchanged when template is empty string', async () => {
     mockIsStaging.mockReturnValue(false)
-    expect(decorateIndexWithEarlyAuthScript('', projectId)).toBe('')
+    expect(await decorateIndexWithEarlyAuthScript('', projectId)).toBe('')
   })
 
-  test('uses api.sanity.io when isStaging() returns false', () => {
+  test('uses api.sanity.io when isStaging() returns false', async () => {
     mockIsStaging.mockReturnValue(false)
-    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
     expect(result).toContain('api.sanity.io')
     expect(result).not.toContain('api.sanity.work')
   })
 
-  test('uses api.sanity.io when SANITY_INTERNAL_ENV is unset (default)', () => {
+  test('uses api.sanity.io when SANITY_INTERNAL_ENV is unset (default)', async () => {
     mockIsStaging.mockReturnValue(false)
-    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
     expect(result).toContain('api.sanity.io')
   })
 
-  test('uses api.sanity.work when isStaging() returns true', () => {
+  test('uses api.sanity.work when isStaging() returns true', async () => {
     mockIsStaging.mockReturnValue(true)
-    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
     expect(result).toContain('api.sanity.work')
     expect(result).not.toContain('api.sanity.io')
   })
 
-  test('injected script is the first child of <head>', () => {
+  test('injected script is the first child of <head>', async () => {
     mockIsStaging.mockReturnValue(false)
-    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
     const earlyAuthIdx = result.indexOf('__sanityEarlyAuthInit')
     const appScriptIdx = result.indexOf('src="app.js"')
     expect(earlyAuthIdx).toBeGreaterThan(-1)
     expect(earlyAuthIdx).toBeLessThan(appScriptIdx)
   })
 
-  test('preserves <head> attributes', () => {
+  test('preserves <head> attributes', async () => {
     mockIsStaging.mockReturnValue(false)
     const html = '<html><head lang="en"><script src="app.js"></script></head></html>'
-    const result = decorateIndexWithEarlyAuthScript(html, projectId)
+    const result = await decorateIndexWithEarlyAuthScript(html, projectId)
     expect(result).toContain('<head lang="en">\n<script>')
   })
 
-  test('script assigns window.__sanityEarlyAuth', () => {
+  test('script assigns window.__sanityEarlyAuth', async () => {
     mockIsStaging.mockReturnValue(false)
-    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
     expect(result).toContain('window.__sanityEarlyAuth')
   })
 
-  test('script references the correct storage key for the projectId', () => {
+  test('script references the storage-key prefix', async () => {
     mockIsStaging.mockReturnValue(false)
-    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
-    expect(result).toContain(`'__studio_auth_token_'+`)
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    expect(result).toContain('__studio_auth_token_')
   })
 
-  test('script contains the projectId in the request URL', () => {
+  test('script contains the projectId and the users/me probe path', async () => {
     mockIsStaging.mockReturnValue(false)
-    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
     expect(result).toContain(JSON.stringify(projectId))
-    expect(result).toContain('/users/me?tag=sanity.studio.auth.early-probe')
+    expect(result).toContain('/v2026-05-04/users/me?tag=sanity.studio.auth.early-probe')
   })
 
-  test('script contains the Authorization-header branch for token auth', () => {
+  test('script contains the Authorization-header branch for token auth', async () => {
     mockIsStaging.mockReturnValue(false)
-    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
     expect(result).toContain('Authorization')
     expect(result).toContain('Bearer ')
   })
 
-  test('script contains the credentials:include branch for cookie auth', () => {
+  test('script contains the credentials:include branch for cookie auth', async () => {
     mockIsStaging.mockReturnValue(false)
-    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
-    expect(result).toContain("{credentials:'include'}")
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    expect(result).toContain('credentials')
+    expect(result).toContain('include')
   })
 
-  test('inline script is under 1500 bytes raw (sanity check against accidental bloat)', () => {
+  test('injected script contains no module import/export syntax', async () => {
     mockIsStaging.mockReturnValue(false)
-    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
     const scriptMatch = result.match(/<script>([\s\S]*?)<\/script>/)
     expect(scriptMatch).toBeTruthy()
-    expect(scriptMatch![1].length).toBeLessThan(1500)
+    const scriptBody = scriptMatch![1]
+    expect(scriptBody).not.toMatch(/^import\s/m)
+    expect(scriptBody).not.toMatch(/^export\s/m)
+  })
+
+  test('inline script is under 4000 bytes raw (sanity check against accidental bloat)', async () => {
+    mockIsStaging.mockReturnValue(false)
+    const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const scriptMatch = result.match(/<script>([\s\S]*?)<\/script>/)
+    expect(scriptMatch).toBeTruthy()
+    expect(scriptMatch![1].length).toBeLessThan(4000)
   })
 })
 
@@ -139,7 +152,7 @@ describe('decorateIndexWithEarlyAuthScript - jsdom runtime tests', () => {
 
   test('token path: sets credential=token and calls fetch with Authorization header', async () => {
     mockIsStaging.mockReturnValue(false)
-    const decorated = decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+    const decorated = await decorateIndexWithEarlyAuthScript(baseHtml, projectId)
 
     const fetchCalls: {opts: RequestInit; url: string}[] = []
 
@@ -162,7 +175,9 @@ describe('decorateIndexWithEarlyAuthScript - jsdom runtime tests', () => {
     expect(earlyAuth?.credential).toBe('token')
     expect(earlyAuth?.token).toBe(storedToken)
     expect(fetchCalls).toHaveLength(1)
-    expect(fetchCalls[0].url).toContain(`${projectId}.api.sanity.io`)
+    expect(fetchCalls[0].url).toBe(
+      `https://${projectId}.api.sanity.io/v2026-05-04/users/me?tag=sanity.studio.auth.early-probe`,
+    )
     expect((fetchCalls[0].opts.headers as Record<string, string>)?.Authorization).toBe(
       `Bearer ${storedToken}`,
     )
@@ -170,7 +185,7 @@ describe('decorateIndexWithEarlyAuthScript - jsdom runtime tests', () => {
 
   test('cookie path: sets credential=cookie and calls fetch with credentials:include', async () => {
     mockIsStaging.mockReturnValue(false)
-    const decorated = decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+    const decorated = await decorateIndexWithEarlyAuthScript(baseHtml, projectId)
 
     const fetchCalls: {opts: RequestInit; url: string}[] = []
 
@@ -199,7 +214,7 @@ describe('decorateIndexWithEarlyAuthScript - jsdom runtime tests', () => {
     mockIsStaging.mockReturnValue(false)
     // The inner try/catch around localStorage means a storage error is swallowed —
     // the script still sets window.__sanityEarlyAuth with cookie credentials.
-    const decorated = decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+    const decorated = await decorateIndexWithEarlyAuthScript(baseHtml, projectId)
 
     const fetchCalls: {opts: RequestInit; url: string}[] = []
 
@@ -236,7 +251,7 @@ describe('decorateIndexWithEarlyAuthScript - jsdom runtime tests', () => {
 
   test('error path: fetch throwing leaves window.__sanityEarlyAuth unset', async () => {
     mockIsStaging.mockReturnValue(false)
-    const decorated = decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+    const decorated = await decorateIndexWithEarlyAuthScript(baseHtml, projectId)
 
     const dom = createRuntimeDom(decorated, (win) => {
       win.fetch = () => {
@@ -249,5 +264,160 @@ describe('decorateIndexWithEarlyAuthScript - jsdom runtime tests', () => {
     const earlyAuth = (dom.window as unknown as Record<string, unknown>).__sanityEarlyAuth
 
     expect(earlyAuth).toBeUndefined()
+  })
+
+  test('result shape: 200 with a json body resolves to {type: ok, user}', async () => {
+    mockIsStaging.mockReturnValue(false)
+    const decorated = await decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+
+    const dom = createRuntimeDom(decorated, (win) => {
+      win.fetch = () =>
+        Promise.resolve(Response.json({id: 'user-1'}, {status: 200})) as ReturnType<typeof fetch>
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const earlyAuth = (dom.window as unknown as Record<string, unknown>).__sanityEarlyAuth as
+      | {promise: Promise<unknown>}
+      | undefined
+
+    expect(earlyAuth).toBeDefined()
+    await expect(earlyAuth?.promise).resolves.toEqual({type: 'ok', user: {id: 'user-1'}})
+  })
+
+  test('result shape: 401 resolves to {type: unauthenticated}', async () => {
+    mockIsStaging.mockReturnValue(false)
+    const decorated = await decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+
+    const dom = createRuntimeDom(decorated, (win) => {
+      win.fetch = () =>
+        Promise.resolve(new Response('{}', {status: 401})) as ReturnType<typeof fetch>
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const earlyAuth = (dom.window as unknown as Record<string, unknown>).__sanityEarlyAuth as
+      | {promise: Promise<unknown>}
+      | undefined
+
+    expect(earlyAuth).toBeDefined()
+    await expect(earlyAuth?.promise).resolves.toEqual({type: 'unauthenticated'})
+  })
+
+  test('result shape: 500 resolves to {type: error, status}', async () => {
+    mockIsStaging.mockReturnValue(false)
+    const decorated = await decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+
+    const dom = createRuntimeDom(decorated, (win) => {
+      win.fetch = () =>
+        Promise.resolve(new Response('{}', {status: 500})) as ReturnType<typeof fetch>
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const earlyAuth = (dom.window as unknown as Record<string, unknown>).__sanityEarlyAuth as
+      | {promise: Promise<unknown>}
+      | undefined
+
+    expect(earlyAuth).toBeDefined()
+    await expect(earlyAuth?.promise).resolves.toEqual({status: 500, type: 'error'})
+  })
+})
+
+function createStorageStub(): Storage {
+  const entries = new Map<string, string>()
+  return {
+    clear: () => entries.clear(),
+    getItem: (key: string) => entries.get(key) ?? null,
+    key: (index: number) => [...entries.keys()][index] ?? null,
+    get length() {
+      return entries.size
+    },
+    removeItem: (key: string) => {
+      entries.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      entries.set(key, value)
+    },
+  }
+}
+
+// The cli-build vitest project runs in the `node` environment, which has no
+// `window` or `localStorage`. The decorator tests above exercise the probe
+// inside a self-constructed JSDOM; these direct tests stub the two browser
+// globals the probe touches so the real module can be called in-process.
+describe('__sanityEarlyAuthInit (direct module unit tests)', () => {
+  const apiHost = 'api.sanity.io'
+  const storageKey = `__studio_auth_token_${projectId}`
+
+  let windowStub: {__sanityEarlyAuth?: Record<string, unknown>}
+
+  beforeEach(() => {
+    windowStub = {}
+    vi.stubGlobal('window', windowStub)
+    vi.stubGlobal('localStorage', createStorageStub())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  test('token selection: reads the stored token and sends an Authorization header', async () => {
+    localStorage.setItem(storageKey, JSON.stringify({token: 'tok-direct'}))
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({id: 'user-1'}, {status: 200}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    __sanityEarlyAuthInit(projectId, apiHost)
+
+    const earlyAuth = windowStub.__sanityEarlyAuth
+
+    expect(earlyAuth?.credential).toBe('token')
+    expect(earlyAuth?.token).toBe('tok-direct')
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://${projectId}.${apiHost}/v2026-05-04/users/me?tag=sanity.studio.auth.early-probe`,
+      {headers: {Authorization: 'Bearer tok-direct'}},
+    )
+    await expect(earlyAuth?.promise as Promise<unknown>).resolves.toEqual({
+      type: 'ok',
+      user: {id: 'user-1'},
+    })
+  })
+
+  test('cookie selection: no stored token sends credentials include', () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {status: 200}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    __sanityEarlyAuthInit(projectId, apiHost)
+
+    const earlyAuth = windowStub.__sanityEarlyAuth
+
+    expect(earlyAuth?.credential).toBe('cookie')
+    expect(earlyAuth?.token).toBeNull()
+    expect(fetchMock).toHaveBeenCalledWith(expect.any(String), {credentials: 'include'})
+  })
+
+  test('401 mapping resolves to {type: unauthenticated}', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {status: 401}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    __sanityEarlyAuthInit(projectId, apiHost)
+
+    await expect(windowStub.__sanityEarlyAuth?.promise as Promise<unknown>).resolves.toEqual({
+      type: 'unauthenticated',
+    })
+  })
+
+  test('synchronous fetch failure leaves window.__sanityEarlyAuth unset', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        throw new Error('network unavailable')
+      }),
+    )
+
+    __sanityEarlyAuthInit(projectId, apiHost)
+
+    expect(windowStub.__sanityEarlyAuth).toBeUndefined()
   })
 })

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/decorateIndexWithEarlyAuthScript.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/decorateIndexWithEarlyAuthScript.test.ts
@@ -429,3 +429,124 @@ describe('__sanityEarlyAuthInit (direct module unit tests)', () => {
     expect(windowStub.__sanityEarlyAuth).toBeUndefined()
   })
 })
+
+// These exercise the decorator's fail-soft posture: any failure in the
+// load/transform/assemble path returns the template unchanged with a single
+// warning, never throwing. Each test isolates the module so the memoized probe
+// source cannot leak between cases (or from the happy-path suites above).
+async function loadDecoratorWith(mocks: {
+  readFileSync?: () => string
+  transformWithOxc?: (code: string, filename: string) => {code: string}
+}) {
+  vi.resetModules()
+
+  vi.doMock('@sanity/cli-core', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@sanity/cli-core')>()
+    return {...actual, isStaging: () => false}
+  })
+
+  if (mocks.readFileSync) {
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>()
+      return {...actual, readFileSync: mocks.readFileSync}
+    })
+  }
+
+  if (mocks.transformWithOxc) {
+    vi.doMock('vite', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('vite')>()
+      return {
+        ...actual,
+        transformWithOxc: (code: string, filename: string) =>
+          Promise.resolve(mocks.transformWithOxc!(code, filename)),
+      }
+    })
+  }
+
+  const moduleUnderTest = await import('../decorateIndexWithEarlyAuthScript')
+  return moduleUnderTest.decorateIndexWithEarlyAuthScript
+}
+
+describe('decorateIndexWithEarlyAuthScript - fail-soft', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.doUnmock('node:fs')
+    vi.doUnmock('vite')
+    vi.restoreAllMocks()
+  })
+
+  test('probe source unreadable: returns template unchanged and warns', async () => {
+    const decorate = await loadDecoratorWith({
+      readFileSync: () => {
+        throw new Error('ENOENT: probe source missing')
+      },
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await decorate(sampleHtml, projectId)
+
+    expect(result).toBe(sampleHtml)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('[sanity early-auth probe]')
+  })
+
+  test('transform output retains an import: returns template unchanged and warns', async () => {
+    const decorate = await loadDecoratorWith({
+      transformWithOxc: () => ({
+        code: "import {x} from 'y'\nexport function __sanityEarlyAuthInit() {}",
+      }),
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await decorate(sampleHtml, projectId)
+
+    expect(result).toBe(sampleHtml)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('[sanity early-auth probe]')
+  })
+
+  test('transform output retains an export: returns template unchanged and warns', async () => {
+    const decorate = await loadDecoratorWith({
+      transformWithOxc: () => ({
+        code: 'export const leftover = 1\nfunction __sanityEarlyAuthInit() {}',
+      }),
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await decorate(sampleHtml, projectId)
+
+    expect(result).toBe(sampleHtml)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('no exception escapes the decorator on any failure path', async () => {
+    const decorate = await loadDecoratorWith({
+      readFileSync: () => {
+        throw new Error('boom')
+      },
+    })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(decorate(sampleHtml, projectId)).resolves.toBe(sampleHtml)
+  })
+
+  test('a failed load is not memoized: a later call can still succeed', async () => {
+    let shouldFail = true
+    const decorate = await loadDecoratorWith({
+      readFileSync: () => {
+        if (shouldFail) {
+          throw new Error('transient read failure')
+        }
+        return 'export function __sanityEarlyAuthInit() {}'
+      },
+    })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const firstResult = await decorate(sampleHtml, projectId)
+    expect(firstResult).toBe(sampleHtml)
+
+    shouldFail = false
+    const secondResult = await decorate(sampleHtml, projectId)
+    expect(secondResult).toContain('__sanityEarlyAuthInit')
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/decorateIndexWithEarlyAuthScript.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/decorateIndexWithEarlyAuthScript.test.ts
@@ -1,0 +1,253 @@
+import {JSDOM} from 'jsdom'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {decorateIndexWithEarlyAuthScript} from '../decorateIndexWithEarlyAuthScript'
+
+const mockIsStaging = vi.hoisted(() => vi.fn<() => boolean>())
+
+vi.mock('@sanity/cli-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/cli-core')>()
+  return {
+    ...actual,
+    isStaging: mockIsStaging,
+  }
+})
+
+const sampleHtml = '<html><head><script src="app.js"></script></head><body></body></html>'
+const projectId = 'testproject123'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('decorateIndexWithEarlyAuthScript', () => {
+  test('returns template unchanged when projectId is undefined', () => {
+    mockIsStaging.mockReturnValue(false)
+    expect(decorateIndexWithEarlyAuthScript(sampleHtml, undefined)).toBe(sampleHtml)
+  })
+
+  test('returns template unchanged when projectId is empty string', () => {
+    mockIsStaging.mockReturnValue(false)
+    expect(decorateIndexWithEarlyAuthScript(sampleHtml, '')).toBe(sampleHtml)
+  })
+
+  test('returns template unchanged when projectId sanitizes to empty', () => {
+    mockIsStaging.mockReturnValue(false)
+    expect(decorateIndexWithEarlyAuthScript(sampleHtml, '!!!')).toBe(sampleHtml)
+  })
+
+  test('returns template unchanged when template is empty string', () => {
+    mockIsStaging.mockReturnValue(false)
+    expect(decorateIndexWithEarlyAuthScript('', projectId)).toBe('')
+  })
+
+  test('uses api.sanity.io when isStaging() returns false', () => {
+    mockIsStaging.mockReturnValue(false)
+    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    expect(result).toContain('api.sanity.io')
+    expect(result).not.toContain('api.sanity.work')
+  })
+
+  test('uses api.sanity.io when SANITY_INTERNAL_ENV is unset (default)', () => {
+    mockIsStaging.mockReturnValue(false)
+    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    expect(result).toContain('api.sanity.io')
+  })
+
+  test('uses api.sanity.work when isStaging() returns true', () => {
+    mockIsStaging.mockReturnValue(true)
+    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    expect(result).toContain('api.sanity.work')
+    expect(result).not.toContain('api.sanity.io')
+  })
+
+  test('injected script is the first child of <head>', () => {
+    mockIsStaging.mockReturnValue(false)
+    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const earlyAuthIdx = result.indexOf('__sanityEarlyAuthInit')
+    const appScriptIdx = result.indexOf('src="app.js"')
+    expect(earlyAuthIdx).toBeGreaterThan(-1)
+    expect(earlyAuthIdx).toBeLessThan(appScriptIdx)
+  })
+
+  test('preserves <head> attributes', () => {
+    mockIsStaging.mockReturnValue(false)
+    const html = '<html><head lang="en"><script src="app.js"></script></head></html>'
+    const result = decorateIndexWithEarlyAuthScript(html, projectId)
+    expect(result).toContain('<head lang="en">\n<script>')
+  })
+
+  test('script assigns window.__sanityEarlyAuth', () => {
+    mockIsStaging.mockReturnValue(false)
+    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    expect(result).toContain('window.__sanityEarlyAuth')
+  })
+
+  test('script references the correct storage key for the projectId', () => {
+    mockIsStaging.mockReturnValue(false)
+    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    expect(result).toContain(`'__studio_auth_token_'+`)
+  })
+
+  test('script contains the projectId in the request URL', () => {
+    mockIsStaging.mockReturnValue(false)
+    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    expect(result).toContain(JSON.stringify(projectId))
+    expect(result).toContain('/users/me?tag=sanity.studio.auth.early-probe')
+  })
+
+  test('script contains the Authorization-header branch for token auth', () => {
+    mockIsStaging.mockReturnValue(false)
+    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    expect(result).toContain('Authorization')
+    expect(result).toContain('Bearer ')
+  })
+
+  test('script contains the credentials:include branch for cookie auth', () => {
+    mockIsStaging.mockReturnValue(false)
+    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    expect(result).toContain("{credentials:'include'}")
+  })
+
+  test('inline script is under 1500 bytes raw (sanity check against accidental bloat)', () => {
+    mockIsStaging.mockReturnValue(false)
+    const result = decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
+    const scriptMatch = result.match(/<script>([\s\S]*?)<\/script>/)
+    expect(scriptMatch).toBeTruthy()
+    expect(scriptMatch![1].length).toBeLessThan(1500)
+  })
+})
+
+function createRuntimeDom(html: string, beforeParseFn?: (window: Window) => void) {
+  return new JSDOM(html, {
+    beforeParse(window) {
+      beforeParseFn?.(window as unknown as Window)
+    },
+    runScripts: 'dangerously',
+    url: 'https://example.test/',
+  })
+}
+
+describe('decorateIndexWithEarlyAuthScript - jsdom runtime tests', () => {
+  const baseHtml = '<html><head></head><body></body></html>'
+  const storedToken = 'tok-abc123'
+  const storageKey = `__studio_auth_token_${projectId}`
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('token path: sets credential=token and calls fetch with Authorization header', async () => {
+    mockIsStaging.mockReturnValue(false)
+    const decorated = decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+
+    const fetchCalls: {opts: RequestInit; url: string}[] = []
+
+    const dom = createRuntimeDom(decorated, (win) => {
+      win.localStorage.setItem(storageKey, JSON.stringify({token: storedToken}))
+      win.fetch = (url: RequestInfo | URL, opts?: RequestInit) => {
+        fetchCalls.push({opts: opts ?? {}, url: String(url)})
+        return Promise.resolve(new Response('{}', {status: 200})) as ReturnType<typeof fetch>
+      }
+    })
+
+    // Wait one tick for the inline script to execute
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const earlyAuth = (dom.window as unknown as Record<string, unknown>).__sanityEarlyAuth as
+      | Record<string, unknown>
+      | undefined
+
+    expect(earlyAuth).toBeDefined()
+    expect(earlyAuth?.credential).toBe('token')
+    expect(earlyAuth?.token).toBe(storedToken)
+    expect(fetchCalls).toHaveLength(1)
+    expect(fetchCalls[0].url).toContain(`${projectId}.api.sanity.io`)
+    expect((fetchCalls[0].opts.headers as Record<string, string>)?.Authorization).toBe(
+      `Bearer ${storedToken}`,
+    )
+  })
+
+  test('cookie path: sets credential=cookie and calls fetch with credentials:include', async () => {
+    mockIsStaging.mockReturnValue(false)
+    const decorated = decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+
+    const fetchCalls: {opts: RequestInit; url: string}[] = []
+
+    const dom = createRuntimeDom(decorated, (win) => {
+      // no localStorage token
+      win.fetch = (url: RequestInfo | URL, opts?: RequestInit) => {
+        fetchCalls.push({opts: opts ?? {}, url: String(url)})
+        return Promise.resolve(new Response('{}', {status: 200})) as ReturnType<typeof fetch>
+      }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const earlyAuth = (dom.window as unknown as Record<string, unknown>).__sanityEarlyAuth as
+      | Record<string, unknown>
+      | undefined
+
+    expect(earlyAuth).toBeDefined()
+    expect(earlyAuth?.credential).toBe('cookie')
+    expect(earlyAuth?.token).toBeNull()
+    expect(fetchCalls).toHaveLength(1)
+    expect(fetchCalls[0].opts.credentials).toBe('include')
+  })
+
+  test('error path: localStorage access throwing still allows script to complete', async () => {
+    mockIsStaging.mockReturnValue(false)
+    // The inner try/catch around localStorage means a storage error is swallowed —
+    // the script still sets window.__sanityEarlyAuth with cookie credentials.
+    const decorated = decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+
+    const fetchCalls: {opts: RequestInit; url: string}[] = []
+
+    const dom = createRuntimeDom(decorated, (win) => {
+      // Make localStorage.getItem throw inside the inner try/catch
+      const originalStorage = win.localStorage
+      Object.defineProperty(win, 'localStorage', {
+        configurable: true,
+        get() {
+          return {
+            getItem() {
+              throw new Error('storage blocked')
+            },
+            setItem: originalStorage.setItem.bind(originalStorage),
+          }
+        },
+      })
+      win.fetch = (url: RequestInfo | URL, opts?: RequestInit) => {
+        fetchCalls.push({opts: opts ?? {}, url: String(url)})
+        return Promise.resolve(new Response('{}', {status: 200})) as ReturnType<typeof fetch>
+      }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const earlyAuth = (dom.window as unknown as Record<string, unknown>).__sanityEarlyAuth as
+      | Record<string, unknown>
+      | undefined
+
+    // Inner catch swallows the localStorage error; script continues with cookie mode
+    expect(earlyAuth).toBeDefined()
+    expect(earlyAuth?.credential).toBe('cookie')
+  })
+
+  test('error path: fetch throwing leaves window.__sanityEarlyAuth unset', async () => {
+    mockIsStaging.mockReturnValue(false)
+    const decorated = decorateIndexWithEarlyAuthScript(baseHtml, projectId)
+
+    const dom = createRuntimeDom(decorated, (win) => {
+      win.fetch = () => {
+        throw new Error('network unavailable')
+      }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const earlyAuth = (dom.window as unknown as Record<string, unknown>).__sanityEarlyAuth
+
+    expect(earlyAuth).toBeUndefined()
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/decorateIndexWithEarlyAuthScript.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/decorateIndexWithEarlyAuthScript.test.ts
@@ -95,7 +95,11 @@ describe('decorateIndexWithEarlyAuthScript', () => {
     mockIsStaging.mockReturnValue(false)
     const result = await decorateIndexWithEarlyAuthScript(sampleHtml, projectId)
     expect(result).toContain(JSON.stringify(projectId))
-    expect(result).toContain('/v2026-05-04/users/me?tag=sanity.studio.auth.early-probe')
+    // The URL is assembled at runtime from the invocation arguments; the path
+    // literal lives in the probe source, the version and tag arrive as args.
+    expect(result).toContain('/users/me?tag=')
+    expect(result).toContain(JSON.stringify('v2026-05-04'))
+    expect(result).toContain(JSON.stringify('sanity.studio.auth.early-probe'))
   })
 
   test('script contains the Authorization-header branch for token auth', async () => {
@@ -346,9 +350,13 @@ function createStorageStub(): Storage {
 // `window` or `localStorage`. The decorator tests above exercise the probe
 // inside a self-constructed JSDOM; these direct tests stub the two browser
 // globals the probe touches so the real module can be called in-process.
+const apiVersion = 'v2026-05-04'
+const requestTag = 'sanity.studio.auth.early-probe'
+const tokenStorageKeyPrefix = '__studio_auth_token_'
+
 describe('__sanityEarlyAuthInit (direct module unit tests)', () => {
   const apiHost = 'api.sanity.io'
-  const storageKey = `__studio_auth_token_${projectId}`
+  const storageKey = `${tokenStorageKeyPrefix}${projectId}`
 
   let windowStub: {__sanityEarlyAuth?: Record<string, unknown>}
 
@@ -368,7 +376,7 @@ describe('__sanityEarlyAuthInit (direct module unit tests)', () => {
     const fetchMock = vi.fn().mockResolvedValue(Response.json({id: 'user-1'}, {status: 200}))
     vi.stubGlobal('fetch', fetchMock)
 
-    __sanityEarlyAuthInit(projectId, apiHost)
+    __sanityEarlyAuthInit(projectId, apiHost, apiVersion, requestTag, tokenStorageKeyPrefix)
 
     const earlyAuth = windowStub.__sanityEarlyAuth
 
@@ -388,7 +396,7 @@ describe('__sanityEarlyAuthInit (direct module unit tests)', () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {status: 200}))
     vi.stubGlobal('fetch', fetchMock)
 
-    __sanityEarlyAuthInit(projectId, apiHost)
+    __sanityEarlyAuthInit(projectId, apiHost, apiVersion, requestTag, tokenStorageKeyPrefix)
 
     const earlyAuth = windowStub.__sanityEarlyAuth
 
@@ -401,7 +409,7 @@ describe('__sanityEarlyAuthInit (direct module unit tests)', () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {status: 401}))
     vi.stubGlobal('fetch', fetchMock)
 
-    __sanityEarlyAuthInit(projectId, apiHost)
+    __sanityEarlyAuthInit(projectId, apiHost, apiVersion, requestTag, tokenStorageKeyPrefix)
 
     await expect(windowStub.__sanityEarlyAuth?.promise as Promise<unknown>).resolves.toEqual({
       type: 'unauthenticated',
@@ -416,7 +424,7 @@ describe('__sanityEarlyAuthInit (direct module unit tests)', () => {
       }),
     )
 
-    __sanityEarlyAuthInit(projectId, apiHost)
+    __sanityEarlyAuthInit(projectId, apiHost, apiVersion, requestTag, tokenStorageKeyPrefix)
 
     expect(windowStub.__sanityEarlyAuth).toBeUndefined()
   })

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
@@ -323,6 +323,7 @@ describe('#getViteConfig', () => {
       basePath: '/',
       cwd: mockTestCwd,
       isApp: undefined,
+      projectId: undefined,
     })
 
     // Vendor entries become additional Rolldown inputs of the single build.

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
@@ -345,6 +345,22 @@ describe('#getViteConfig', () => {
     expect(config.build?.rolldownOptions).not.toHaveProperty('external')
   })
 
+  test('should pass projectId through to sanityBuildEntries', async () => {
+    const {sanityBuildEntries} = await import('../vite/plugin-sanity-build-entries.js')
+
+    await getViteConfig({
+      cwd: mockTestCwd,
+      getEnvironmentVariables,
+      mode: 'production' as const,
+      projectId: 'testproject',
+      reactCompiler: undefined,
+    })
+
+    expect(sanityBuildEntries).toHaveBeenCalledWith(
+      expect.objectContaining({projectId: 'testproject'}),
+    )
+  })
+
   test('should not install esmExternalRequirePlugin when auto-updates are disabled', async () => {
     const {esmExternalRequirePlugin} = await import('vite')
 

--- a/packages/@sanity/cli-build/src/actions/build/decorateIndexWithEarlyAuthScript.ts
+++ b/packages/@sanity/cli-build/src/actions/build/decorateIndexWithEarlyAuthScript.ts
@@ -4,6 +4,21 @@ import {fileURLToPath} from 'node:url'
 import {isStaging} from '@sanity/cli-core'
 import {transformWithOxc} from 'vite'
 
+import {
+  EARLY_AUTH_API_VERSION,
+  EARLY_AUTH_REQUEST_TAG,
+  EARLY_AUTH_TOKEN_STORAGE_PREFIX,
+} from './earlyAuthProbeConstants.js'
+
+// Project ids are lowercase alphanumeric, but historic ids may include
+// uppercase, so both cases are accepted. The probe is skipped (template
+// returned unchanged) for anything else rather than risk emitting an invalid
+// URL or mangling the document — the id is never sanitized, only validated.
+const PROJECT_ID_PATTERN = /^[a-zA-Z0-9]+$/
+
+// Captures any `<head>` attributes so they survive the injection.
+const HEAD_OPEN_TAG_PATTERN = /<head([^>]*)>/
+
 /**
  * Decorates the given HTML template with an inline script that fires a
  * `/users/me` fetch during HTML parse, before the multi-MB module bundle
@@ -12,15 +27,14 @@ import {transformWithOxc} from 'vite'
  *
  * The probe is authored as a real TypeScript module (`earlyAuthProbeScript.ts`)
  * and transformed to inlinable JavaScript at build time via Vite's
- * `transformWithEsbuild`. Transforming (rather than hand-maintaining a string)
+ * `transformWithOxc`. Transforming (rather than hand-maintaining a string)
  * keeps the probe type-checked and unit-testable as a normal module. The
  * transform strips types but does not bundle, so the source must stay fully
  * self-contained — see the breadcrumb in `earlyAuthProbeScript.ts`.
  *
  * Injected as the first child of `<head>` so it runs before any other scripts.
  * Returns the template unchanged when `template` is empty or when `projectId`
- * is absent/empty or fails the strict `[a-zA-Z0-9]+` validity check — the probe
- * is skipped rather than risk mangling the document.
+ * is absent/empty or fails `PROJECT_ID_PATTERN`.
  *
  * @internal
  */
@@ -32,19 +46,44 @@ export async function decorateIndexWithEarlyAuthScript(
     return template
   }
 
-  if (!projectId || !/^[a-zA-Z0-9]+$/.test(projectId)) {
+  if (!projectId || !PROJECT_ID_PATTERN.test(projectId)) {
     return template
   }
 
   const apiHost = isStaging() ? 'api.sanity.work' : 'api.sanity.io'
 
   const probeSource = await loadProbeSource()
+  const script = `${probeSource}\n${buildProbeInvocation(projectId, apiHost)}`
 
-  const script =
-    probeSource +
-    `\ntry {\n  __sanityEarlyAuthInit(${JSON.stringify(projectId)}, ${JSON.stringify(apiHost)})\n} catch (initError) {}`
+  return injectAsFirstHeadChild(template, `<script>${script}</script>`)
+}
 
-  return template.replace(/<head([^>]*)>/, `<head$1>\n<script>${script}</script>`)
+/**
+ * Builds the call to the inlined probe, passing every configuration value as a
+ * `JSON.stringify`'d literal so the decorator stays the single source of truth.
+ * Wrapped in its own `try/catch` so a probe failure can never abort HTML parse.
+ */
+function buildProbeInvocation(projectId: string, apiHost: string): string {
+  const probeArguments = [
+    projectId,
+    apiHost,
+    EARLY_AUTH_API_VERSION,
+    EARLY_AUTH_REQUEST_TAG,
+    EARLY_AUTH_TOKEN_STORAGE_PREFIX,
+  ]
+    .map((value) => JSON.stringify(value))
+    .join(', ')
+
+  return `try {\n  __sanityEarlyAuthInit(${probeArguments})\n} catch (initError) {}`
+}
+
+/**
+ * Inserts `markup` immediately after the opening `<head>` tag so it runs before
+ * any existing head content. The capture group preserves the tag's attributes
+ * (e.g. `<head lang="en">`).
+ */
+function injectAsFirstHeadChild(template: string, markup: string): string {
+  return template.replace(HEAD_OPEN_TAG_PATTERN, `<head$1>\n${markup}`)
 }
 
 let cachedProbeSource: Promise<string> | undefined

--- a/packages/@sanity/cli-build/src/actions/build/decorateIndexWithEarlyAuthScript.ts
+++ b/packages/@sanity/cli-build/src/actions/build/decorateIndexWithEarlyAuthScript.ts
@@ -19,6 +19,8 @@ const PROJECT_ID_PATTERN = /^[a-zA-Z0-9]+$/
 // Captures any `<head>` attributes so they survive the injection.
 const HEAD_OPEN_TAG_PATTERN = /<head([^>]*)>/
 
+const WARNING_PREFIX = '[sanity early-auth probe]'
+
 /**
  * Decorates the given HTML template with an inline script that fires a
  * `/users/me` fetch during HTML parse, before the multi-MB module bundle
@@ -33,8 +35,11 @@ const HEAD_OPEN_TAG_PATTERN = /<head([^>]*)>/
  * self-contained — see the breadcrumb in `earlyAuthProbeScript.ts`.
  *
  * Injected as the first child of `<head>` so it runs before any other scripts.
- * Returns the template unchanged when `template` is empty or when `projectId`
- * is absent/empty or fails `PROJECT_ID_PATTERN`.
+ *
+ * The probe is a progressive enhancement and never fails the build: the
+ * template is returned unchanged (with a single warning) when it is empty, when
+ * `projectId` is absent/empty or fails `PROJECT_ID_PATTERN`, or when anything in
+ * the load/transform/assemble/inject path throws.
  *
  * @internal
  */
@@ -50,12 +55,19 @@ export async function decorateIndexWithEarlyAuthScript(
     return template
   }
 
-  const apiHost = isStaging() ? 'api.sanity.work' : 'api.sanity.io'
+  try {
+    const apiHost = isStaging() ? 'api.sanity.work' : 'api.sanity.io'
 
-  const probeSource = await loadProbeSource()
-  const script = `${probeSource}\n${buildProbeInvocation(projectId, apiHost)}`
+    const probeSource = await loadProbeSource()
+    const script = `${probeSource}\n${buildProbeInvocation(projectId, apiHost)}`
 
-  return injectAsFirstHeadChild(template, `<script>${script}</script>`)
+    return injectAsFirstHeadChild(template, `<script>${script}</script>`)
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    // eslint-disable-next-line no-console -- no logger in scope here; a single warning is enough
+    console.warn(`${WARNING_PREFIX} skipped early-auth injection: ${reason}`)
+    return template
+  }
 }
 
 /**
@@ -91,10 +103,17 @@ let cachedProbeSource: Promise<string> | undefined
 /**
  * Reads the sibling probe module, transforms it to module-free inlinable JS,
  * and memoizes the result. The transform runs once regardless of how many
- * times the decorator is called.
+ * times the decorator is called. A failed load is never cached: the memo is
+ * cleared on rejection so a transient failure cannot poison later builds in the
+ * same process.
  */
 function loadProbeSource(): Promise<string> {
-  cachedProbeSource = cachedProbeSource ?? readAndTransformProbeSource()
+  cachedProbeSource =
+    cachedProbeSource ??
+    readAndTransformProbeSource().catch((error) => {
+      cachedProbeSource = undefined
+      throw error
+    })
   return cachedProbeSource
 }
 
@@ -130,7 +149,9 @@ async function readAndTransformProbeSource(): Promise<string> {
   const stripped = transformed.code.replace(/^export function /m, 'function ')
 
   // A self-containment regression (a stray module import, or an export the
-  // strip missed) must fail the build loudly rather than ship broken HTML.
+  // strip missed) must not ship broken HTML. Throwing here is caught by the
+  // decorator, which skips injection; CI's happy-path tests catch the
+  // regression rather than a customer build.
   if (/^import\s/m.test(stripped)) {
     throw new Error(
       'Early-auth probe transform produced an `import` statement; it must be inlinable',

--- a/packages/@sanity/cli-build/src/actions/build/decorateIndexWithEarlyAuthScript.ts
+++ b/packages/@sanity/cli-build/src/actions/build/decorateIndexWithEarlyAuthScript.ts
@@ -1,0 +1,55 @@
+import {isStaging} from '@sanity/cli-core'
+
+/**
+ * Decorates the given HTML template with an inline ES5 script that fires a
+ * `/users/me` fetch during HTML parse, before the multi-MB module bundle
+ * evaluates. The result is parked on `window.__sanityEarlyAuth` for the
+ * monorepo consumer to pick up and validate.
+ *
+ * Injected as the first child of `<head>` so it runs before any other scripts.
+ * Returns the template unchanged when `projectId` is absent, empty, or
+ * sanitizes to empty.
+ *
+ * @internal
+ */
+export function decorateIndexWithEarlyAuthScript(
+  template: string,
+  projectId: string | undefined,
+): string {
+  const sanitizedProjectId = (projectId ?? '').replaceAll(/[^a-zA-Z0-9]/g, '')
+
+  if (!template || !sanitizedProjectId) {
+    return template
+  }
+
+  const apiHost = isStaging() ? 'api.sanity.work' : 'api.sanity.io'
+
+  // ES5 string constant — SWC compiles the surrounding TypeScript but the
+  // contents of this string ship byte-for-byte into the built index.html.
+  // JSON.stringify provides safe interpolation of the two build-time values.
+
+  const script =
+    `function __sanityEarlyAuthInit(pid,host){` +
+    `try{` +
+    `var lsKey='__studio_auth_token_'+pid;` +
+    `var stored;` +
+    `try{var raw=localStorage.getItem(lsKey);if(raw){stored=JSON.parse(raw)}}catch(lsErr){}` +
+    `var tok=stored&&stored.token;` +
+    `var url='https://'+pid+'.'+host+'/v2026-05-04/users/me?tag=sanity.studio.auth.early-probe';` +
+    `var opts=tok?{headers:{Authorization:'Bearer '+tok}}:{credentials:'include'};` +
+    `var ts=Date.now();` +
+    `var probe=fetch(url,opts).then(function(res){` +
+    `if(res.status===401){return{type:'unauthenticated'}}` +
+    `if(!res.ok){return{type:'error',status:res.status}}` +
+    `return res.json().then(function(user){return{type:'ok',user:user}})` +
+    `});` +
+    `window.__sanityEarlyAuth={` +
+    `projectId:pid,apiHost:host,` +
+    `credential:tok?'token':'cookie',` +
+    `token:tok||null,startedAt:ts,promise:probe` +
+    `}` +
+    `}catch(initErr){}}` +
+    `\ntry{__sanityEarlyAuthInit(${JSON.stringify(sanitizedProjectId)},${JSON.stringify(apiHost)})}catch(initError){}`
+
+  return template.replace(/<head([^>]*)>/, `<head$1>\n<script>${script}</script>`)
+}

--- a/packages/@sanity/cli-build/src/actions/build/decorateIndexWithEarlyAuthScript.ts
+++ b/packages/@sanity/cli-build/src/actions/build/decorateIndexWithEarlyAuthScript.ts
@@ -1,55 +1,107 @@
+import {readFileSync} from 'node:fs'
+import {fileURLToPath} from 'node:url'
+
 import {isStaging} from '@sanity/cli-core'
+import {transformWithEsbuild} from 'vite'
 
 /**
- * Decorates the given HTML template with an inline ES5 script that fires a
+ * Decorates the given HTML template with an inline script that fires a
  * `/users/me` fetch during HTML parse, before the multi-MB module bundle
  * evaluates. The result is parked on `window.__sanityEarlyAuth` for the
  * monorepo consumer to pick up and validate.
  *
+ * The probe is authored as a real TypeScript module (`earlyAuthProbeScript.ts`)
+ * and transformed to inlinable JavaScript at build time via Vite's
+ * `transformWithEsbuild`. Transforming (rather than hand-maintaining a string)
+ * keeps the probe type-checked and unit-testable as a normal module. The
+ * transform strips types but does not bundle, so the source must stay fully
+ * self-contained — see the breadcrumb in `earlyAuthProbeScript.ts`.
+ *
  * Injected as the first child of `<head>` so it runs before any other scripts.
- * Returns the template unchanged when `projectId` is absent, empty, or
- * sanitizes to empty.
+ * Returns the template unchanged when `template` is empty or when `projectId`
+ * is absent/empty or fails the strict `[a-zA-Z0-9]+` validity check — the probe
+ * is skipped rather than risk mangling the document.
  *
  * @internal
  */
-export function decorateIndexWithEarlyAuthScript(
+export async function decorateIndexWithEarlyAuthScript(
   template: string,
   projectId: string | undefined,
-): string {
-  const sanitizedProjectId = (projectId ?? '').replaceAll(/[^a-zA-Z0-9]/g, '')
+): Promise<string> {
+  if (!template) {
+    return template
+  }
 
-  if (!template || !sanitizedProjectId) {
+  if (!projectId || !/^[a-zA-Z0-9]+$/.test(projectId)) {
     return template
   }
 
   const apiHost = isStaging() ? 'api.sanity.work' : 'api.sanity.io'
 
-  // ES5 string constant — SWC compiles the surrounding TypeScript but the
-  // contents of this string ship byte-for-byte into the built index.html.
-  // JSON.stringify provides safe interpolation of the two build-time values.
+  const probeSource = await loadProbeSource()
 
   const script =
-    `function __sanityEarlyAuthInit(pid,host){` +
-    `try{` +
-    `var lsKey='__studio_auth_token_'+pid;` +
-    `var stored;` +
-    `try{var raw=localStorage.getItem(lsKey);if(raw){stored=JSON.parse(raw)}}catch(lsErr){}` +
-    `var tok=stored&&stored.token;` +
-    `var url='https://'+pid+'.'+host+'/v2026-05-04/users/me?tag=sanity.studio.auth.early-probe';` +
-    `var opts=tok?{headers:{Authorization:'Bearer '+tok}}:{credentials:'include'};` +
-    `var ts=Date.now();` +
-    `var probe=fetch(url,opts).then(function(res){` +
-    `if(res.status===401){return{type:'unauthenticated'}}` +
-    `if(!res.ok){return{type:'error',status:res.status}}` +
-    `return res.json().then(function(user){return{type:'ok',user:user}})` +
-    `});` +
-    `window.__sanityEarlyAuth={` +
-    `projectId:pid,apiHost:host,` +
-    `credential:tok?'token':'cookie',` +
-    `token:tok||null,startedAt:ts,promise:probe` +
-    `}` +
-    `}catch(initErr){}}` +
-    `\ntry{__sanityEarlyAuthInit(${JSON.stringify(sanitizedProjectId)},${JSON.stringify(apiHost)})}catch(initError){}`
+    probeSource +
+    `\ntry {\n  __sanityEarlyAuthInit(${JSON.stringify(projectId)}, ${JSON.stringify(apiHost)})\n} catch (initError) {}`
 
   return template.replace(/<head([^>]*)>/, `<head$1>\n<script>${script}</script>`)
+}
+
+let cachedProbeSource: Promise<string> | undefined
+
+/**
+ * Reads the sibling probe module, transforms it to module-free inlinable JS,
+ * and memoizes the result. The transform runs once regardless of how many
+ * times the decorator is called.
+ */
+function loadProbeSource(): Promise<string> {
+  cachedProbeSource = cachedProbeSource ?? readAndTransformProbeSource()
+  return cachedProbeSource
+}
+
+async function readAndTransformProbeSource(): Promise<string> {
+  // In vitest the sibling module is the `.ts` source; in the published dist it
+  // is the SWC-compiled `.js`. Resolve relative to this module's own URL and
+  // try the `.ts` first, falling back to the `.js`.
+  const candidateFilenames = ['earlyAuthProbeScript.ts', 'earlyAuthProbeScript.js']
+
+  const resolved = candidateFilenames
+    .map((filename) => {
+      const candidatePath = fileURLToPath(new URL(filename, import.meta.url))
+      try {
+        return {filename, source: readFileSync(candidatePath, 'utf8')}
+      } catch {
+        return null
+      }
+    })
+    .find((candidate) => candidate !== null)
+
+  if (!resolved) {
+    throw new Error(
+      `Failed to locate early-auth probe module (tried ${candidateFilenames.join(', ')})`,
+    )
+  }
+
+  const transformed = await transformWithEsbuild(resolved.source, resolved.filename, {
+    minify: false,
+    sourcemap: false,
+    target: 'es2017',
+  })
+
+  // The transform preserves ESM `export` on the probe declaration. Strip it so
+  // the function is a bare declaration suitable for an inline <script>.
+  const stripped = transformed.code.replace(/^export function /m, 'function ')
+
+  // A self-containment regression (a stray module import, or an export the
+  // strip missed) must fail the build loudly rather than ship broken HTML.
+  if (/^import\s/m.test(stripped)) {
+    throw new Error(
+      'Early-auth probe transform produced an `import` statement; it must be inlinable',
+    )
+  }
+  if (/^export\s/m.test(stripped)) {
+    throw new Error('Early-auth probe transform retained an `export` statement after stripping')
+  }
+
+  return stripped
 }

--- a/packages/@sanity/cli-build/src/actions/build/decorateIndexWithEarlyAuthScript.ts
+++ b/packages/@sanity/cli-build/src/actions/build/decorateIndexWithEarlyAuthScript.ts
@@ -2,7 +2,7 @@ import {readFileSync} from 'node:fs'
 import {fileURLToPath} from 'node:url'
 
 import {isStaging} from '@sanity/cli-core'
-import {transformWithEsbuild} from 'vite'
+import {transformWithOxc} from 'vite'
 
 /**
  * Decorates the given HTML template with an inline script that fires a
@@ -82,9 +82,7 @@ async function readAndTransformProbeSource(): Promise<string> {
     )
   }
 
-  const transformed = await transformWithEsbuild(resolved.source, resolved.filename, {
-    minify: false,
-    sourcemap: false,
+  const transformed = await transformWithOxc(resolved.source, resolved.filename, {
     target: 'es2017',
   })
 

--- a/packages/@sanity/cli-build/src/actions/build/earlyAuthProbeConstants.ts
+++ b/packages/@sanity/cli-build/src/actions/build/earlyAuthProbeConstants.ts
@@ -1,0 +1,20 @@
+// Configuration values for the browser-side early-auth probe.
+//
+// These are the single source of truth for the values the decorator passes into
+// the inlined probe (`earlyAuthProbeScript.ts`). The probe stays self-contained
+// (zero imports) by receiving them as arguments rather than reading them here.
+//
+// Each value mirrors a constant in the sanity monorepo's auth store and must
+// stay in sync with it (packages/sanity/src/core/store/authStore/constants.ts):
+//   - EARLY_AUTH_API_VERSION         <-> AUTH_API_VERSION
+//   - EARLY_AUTH_TOKEN_STORAGE_PREFIX <-> AUTH_TOKEN_STORAGE_PREFIX
+//   - EARLY_AUTH_REQUEST_TAG          <-> requestTagPrefix + the probe's own suffix
+
+/** API version segment in the probe's `/users/me` request URL. */
+export const EARLY_AUTH_API_VERSION = 'v2026-05-04'
+
+/** Prefix for the localStorage key holding a per-project auth token. */
+export const EARLY_AUTH_TOKEN_STORAGE_PREFIX = '__studio_auth_token_'
+
+/** Request tag identifying the probe in API logs and metrics. */
+export const EARLY_AUTH_REQUEST_TAG = 'sanity.studio.auth.early-probe'

--- a/packages/@sanity/cli-build/src/actions/build/earlyAuthProbeScript.ts
+++ b/packages/@sanity/cli-build/src/actions/build/earlyAuthProbeScript.ts
@@ -9,10 +9,9 @@
 // CRITICAL: keep this file fully self-contained — zero value imports. The
 // transform step inlines the output verbatim (it transforms, it does not
 // bundle), so a value import would ship a broken ESM `import` statement into
-// the HTML.
-//
-// The `v2026-05-04` path segment below must stay in sync with AUTH_API_VERSION
-// in the sanity monorepo (packages/sanity/src/core/store/authStore/constants.ts).
+// the HTML. Configuration values (API version, request tag, storage-key
+// prefix) are therefore passed in as arguments by the decorator, which owns
+// them in earlyAuthProbeConstants.ts.
 
 interface EarlyAuthOk {
   type: 'ok'
@@ -39,27 +38,33 @@ interface EarlyAuthState {
   token: string | null
 }
 
-export function __sanityEarlyAuthInit(projectId: string, apiHost: string): void {
-  try {
-    const storageKey = '__studio_auth_token_' + projectId
+const UNAUTHORIZED_STATUS = 401
 
-    let token: string | null = null
-    try {
-      const raw = localStorage.getItem(storageKey)
-      if (raw) {
-        const parsed = JSON.parse(raw)
-        token = parsed && parsed.token ? parsed.token : null
-      }
-    } catch {
-      token = null
+function readStoredToken(storageKey: string): string | null {
+  try {
+    const raw = localStorage.getItem(storageKey)
+    if (!raw) {
+      return null
     }
+    const parsed = JSON.parse(raw)
+    return parsed && parsed.token ? parsed.token : null
+  } catch {
+    return null
+  }
+}
+
+export function __sanityEarlyAuthInit(
+  projectId: string,
+  apiHost: string,
+  apiVersion: string,
+  requestTag: string,
+  tokenStorageKeyPrefix: string,
+): void {
+  try {
+    const token = readStoredToken(tokenStorageKeyPrefix + projectId)
 
     const requestUrl =
-      'https://' +
-      projectId +
-      '.' +
-      apiHost +
-      '/v2026-05-04/users/me?tag=sanity.studio.auth.early-probe'
+      'https://' + projectId + '.' + apiHost + '/' + apiVersion + '/users/me?tag=' + requestTag
 
     const requestOptions: RequestInit = token
       ? {headers: {Authorization: 'Bearer ' + token}}
@@ -68,7 +73,7 @@ export function __sanityEarlyAuthInit(projectId: string, apiHost: string): void 
     const startedAt = Date.now()
 
     const promise: Promise<EarlyAuthResult> = fetch(requestUrl, requestOptions).then((response) => {
-      if (response.status === 401) {
+      if (response.status === UNAUTHORIZED_STATUS) {
         return {type: 'unauthenticated'}
       }
       if (response.ok) {

--- a/packages/@sanity/cli-build/src/actions/build/earlyAuthProbeScript.ts
+++ b/packages/@sanity/cli-build/src/actions/build/earlyAuthProbeScript.ts
@@ -1,0 +1,94 @@
+// Browser-side early-auth probe.
+//
+// This module is authored as real TypeScript and transformed at studio-build
+// time (see decorateIndexWithEarlyAuthScript) for inlining into index.html. It
+// runs during HTML parse, before the multi-MB module bundle evaluates, firing
+// a `/users/me` request and parking the result on `window.__sanityEarlyAuth`
+// for the monorepo consumer to pick up.
+//
+// CRITICAL: keep this file fully self-contained — zero value imports. The
+// transform step inlines the output verbatim (it transforms, it does not
+// bundle), so a value import would ship a broken ESM `import` statement into
+// the HTML.
+//
+// The `v2026-05-04` path segment below must stay in sync with AUTH_API_VERSION
+// in the sanity monorepo (packages/sanity/src/core/store/authStore/constants.ts).
+
+interface EarlyAuthOk {
+  type: 'ok'
+  user: unknown
+}
+
+interface EarlyAuthUnauthenticated {
+  type: 'unauthenticated'
+}
+
+interface EarlyAuthError {
+  status: number
+  type: 'error'
+}
+
+type EarlyAuthResult = EarlyAuthError | EarlyAuthOk | EarlyAuthUnauthenticated
+
+interface EarlyAuthState {
+  apiHost: string
+  credential: 'cookie' | 'token'
+  projectId: string
+  promise: Promise<EarlyAuthResult>
+  startedAt: number
+  token: string | null
+}
+
+export function __sanityEarlyAuthInit(projectId: string, apiHost: string): void {
+  try {
+    const storageKey = '__studio_auth_token_' + projectId
+
+    let token: string | null = null
+    try {
+      const raw = localStorage.getItem(storageKey)
+      if (raw) {
+        const parsed = JSON.parse(raw)
+        token = parsed && parsed.token ? parsed.token : null
+      }
+    } catch {
+      token = null
+    }
+
+    const requestUrl =
+      'https://' +
+      projectId +
+      '.' +
+      apiHost +
+      '/v2026-05-04/users/me?tag=sanity.studio.auth.early-probe'
+
+    const requestOptions: RequestInit = token
+      ? {headers: {Authorization: 'Bearer ' + token}}
+      : {credentials: 'include'}
+
+    const startedAt = Date.now()
+
+    const promise: Promise<EarlyAuthResult> = fetch(requestUrl, requestOptions).then((response) => {
+      if (response.status === 401) {
+        return {type: 'unauthenticated'}
+      }
+      if (response.ok) {
+        return response.json().then((user) => ({type: 'ok', user}))
+      }
+      return {status: response.status, type: 'error'}
+    })
+
+    const state: EarlyAuthState = {
+      apiHost,
+      credential: token ? 'token' : 'cookie',
+      projectId,
+      promise,
+      startedAt,
+      token: token || null,
+    }
+
+    // eslint-disable-next-line unicorn/prefer-global-this -- the monorepo consumer reads `window.__sanityEarlyAuth`; the assignment target must stay `window`
+    ;(window as unknown as {__sanityEarlyAuth?: EarlyAuthState}).__sanityEarlyAuth = state
+  } catch {
+    // Any failure leaves window.__sanityEarlyAuth unset - a clean miss.
+  }
+}

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -80,6 +80,12 @@ interface ViteOptions {
   outputDir?: string
 
   /**
+   * Sanity project ID, threaded through to the build-entries plugin so the
+   * early-auth probe script can be injected into production HTML.
+   */
+  projectId?: string
+
+  /**
    * Schema extraction configuration
    */
   schemaExtraction?: CliConfig['schemaExtraction']
@@ -108,6 +114,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     minify,
     mode,
     outputDir,
+    projectId,
     reactCompiler,
     schemaExtraction,
     server,
@@ -160,7 +167,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
       ...(reactCompiler ? [babel({presets: [reactCompilerPreset(reactCompiler)]})] : []),
       sanityFaviconsPlugin({customFaviconsPath, defaultFaviconsPath, staticUrlPath: staticPath}),
       sanityRuntimeRewritePlugin(),
-      sanityBuildEntries({autoUpdates, basePath, cwd, isApp}),
+      sanityBuildEntries({autoUpdates, basePath, cwd, isApp, projectId}),
       // Add schema extraction when enabled
       ...(schemaExtraction?.enabled
         ? [

--- a/packages/@sanity/cli-build/src/actions/build/vite/plugin-sanity-build-entries.ts
+++ b/packages/@sanity/cli-build/src/actions/build/vite/plugin-sanity-build-entries.ts
@@ -32,6 +32,7 @@ export function sanityBuildEntries(options: {
   basePath: string
   cwd: string
   isApp?: boolean
+  projectId?: string
 }): Plugin {
   const {autoUpdates, basePath, cwd, isApp} = options
 

--- a/packages/@sanity/cli-build/src/actions/build/vite/plugin-sanity-build-entries.ts
+++ b/packages/@sanity/cli-build/src/actions/build/vite/plugin-sanity-build-entries.ts
@@ -105,7 +105,7 @@ export function sanityBuildEntries(options: {
 
       this.emitFile({
         fileName: 'index.html',
-        source: decorateIndexWithEarlyAuthScript(
+        source: await decorateIndexWithEarlyAuthScript(
           decorateIndexWithStagingScript(
             decorateIndexWithBridgeScript(
               await renderDocument({

--- a/packages/@sanity/cli-build/src/actions/build/vite/plugin-sanity-build-entries.ts
+++ b/packages/@sanity/cli-build/src/actions/build/vite/plugin-sanity-build-entries.ts
@@ -3,6 +3,7 @@ import {type ChunkMetadata, type Plugin} from 'vite'
 import {type AutoUpdatesBuildConfig} from '../autoUpdates.js'
 import {createVendorImportMapFromBundle} from '../createVendorImportMapFromBundle.js'
 import {decorateIndexWithBridgeScript} from '../decorateIndexWithBridgeScript.js'
+import {decorateIndexWithEarlyAuthScript} from '../decorateIndexWithEarlyAuthScript.js'
 import {decorateIndexWithStagingScript} from '../decorateIndexWithStagingScript.js'
 import {renderDocument} from '../renderDocument.js'
 
@@ -34,7 +35,7 @@ export function sanityBuildEntries(options: {
   isApp?: boolean
   projectId?: string
 }): Plugin {
-  const {autoUpdates, basePath, cwd, isApp} = options
+  const {autoUpdates, basePath, cwd, isApp, projectId} = options
 
   return {
     apply: 'build',
@@ -104,20 +105,23 @@ export function sanityBuildEntries(options: {
 
       this.emitFile({
         fileName: 'index.html',
-        source: decorateIndexWithStagingScript(
-          decorateIndexWithBridgeScript(
-            await renderDocument({
-              autoUpdatesCssUrls: autoUpdates?.cssUrls,
-              importMap,
-              isApp,
-              props: {
-                basePath,
-                css,
-                entryPath,
-              },
-              studioRootPath: cwd,
-            }),
+        source: decorateIndexWithEarlyAuthScript(
+          decorateIndexWithStagingScript(
+            decorateIndexWithBridgeScript(
+              await renderDocument({
+                autoUpdatesCssUrls: autoUpdates?.cssUrls,
+                importMap,
+                isApp,
+                props: {
+                  basePath,
+                  css,
+                  entryPath,
+                },
+                studioRootPath: cwd,
+              }),
+            ),
           ),
+          projectId,
         ),
         type: 'asset',
       })

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -40,6 +40,7 @@ interface StaticBuildOptions {
   isApp?: boolean
   minify?: boolean
   profile?: boolean
+  projectId?: string
   reactCompiler?: ReactCompilerConfig
   schemaExtraction?: CliConfig['schemaExtraction']
   sourceMap?: boolean
@@ -63,6 +64,7 @@ export async function buildStaticFiles(
     isApp,
     minify = true,
     outputDir,
+    projectId,
     reactCompiler,
     schemaExtraction,
     sourceMap = false,
@@ -97,6 +99,7 @@ export async function buildStaticFiles(
     minify,
     mode,
     outputDir,
+    projectId,
     reactCompiler,
     schemaExtraction,
     sourceMap,

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -293,6 +293,7 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
       cwd: workDir,
       minify,
       outputDir,
+      projectId,
       reactCompiler,
       schemaExtraction,
       sourceMap,


### PR DESCRIPTION
### Description

The studio's first `/users/me` request waits for the multi-MB module bundle to download and evaluate - a round-trip that could start during HTML parse instead.

This PR injects an inline early-auth probe as the first `<head>` child of production-built studio `index.html` when `cliConfig.api.projectId` is set. The script fires the tagged `/users/me` fetch (stored token as Authorization header, else cookie credentials) and parks the result on `window.__sanityEarlyAuth` for the studio's auth store (companion consumer: https://github.com/sanity-io/sanity/pull/13081). The probe is authored as a real TypeScript module, `earlyAuthProbeScript.ts`, transformed to inlinable JS at build time via Vite's `transformWithOxc` (~1.4KB, memoized per build); the build fails loudly if module syntax survives. Absent or invalid projectId skips injection, the dev server is untouched, and any runtime error leaves the global unset - a clean no-op until a studio ships the consumer, with no release-order hazard.

Why it matters (validated against 14 days of prod telemetry, 137k sessions): the auth round-trip is serialized after bundle eval on every studio load today, and the probe pre-pays it during HTML parse - a steady ~4-5% median (p50) improvement, ~100-150ms on every load for every user once studios rebuild on the new CLI. Slow-network users gain the most per load (3g round-trips run 0.5-2s). The change is strictly additive: a missed or stale probe costs nothing and falls through to today's behavior exactly.

### What to review

- `earlyAuthProbeScript.ts` - self-contained by contract (zero value imports; the transform inlines, it does not bundle). The `v2026-05-04` path segment must stay in sync with the monorepo's `AUTH_API_VERSION` (breadcrumb in file).
- `decorateIndexWithEarlyAuthScript.ts` - source resolution (`.ts` under vitest, compiled `.js` in dist), export stripping, host selection: `api.sanity.io` default, `api.sanity.work` only under `isStaging()`.
- Applied outermost in `plugin-sanity-build-entries.ts` so the probe is the first `<head>` child.
- Degrades to a clean miss under strict CSP (no `unsafe-inline`) and custom documents without a `<head>` - the same constraints as the existing staging/importmap inline scripts.

### Testing

27 tests: skip guards, host selection including the unset-env production default, injection position, full probe URL pinned, no-module-syntax assertion, and jsdom runtime tests that execute the injected script (token vs cookie selection, the three result discriminants the consumer depends on, error leaves the global unset). Dist-path resolution verified against the built package.

### How this fits

Part of the studio startup performance effort: this is the injector half of the early auth probe (a consistent ~4-5% median auth-ready win - it removes the one network round-trip that every load pays serially after bundle eval); the consumer half is https://github.com/sanity-io/sanity/pull/13081. Independent of the other startup PRs - either half can ship first (the consumer treats an absent probe as a miss).


