### PR TITLE
test(login): wait for callback server before simulating oauth callback

### DIFF
--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -96,23 +96,38 @@ function mockStdin(input: string, options: {isTTY?: boolean} = {}) {
  * Waits until the login command's local callback server is listening, and
  * returns the callback URL it actually bound. The port can differ from 4321
  * when the server falls back to another port.
+ *
+ * Rejects with the command's error if it exits before the server starts.
  */
-async function waitForCallbackUrl(): Promise<URL> {
-  const {loginUrl} = await vi.waitFor(() => {
-    const [startup] = mockedStartServerForTokenCallback.mock.settledResults
-    if (startup?.type !== 'fulfilled') throw new Error('Callback server is not listening yet')
-    return startup.value
-  }, 9000)
+async function waitForCallbackUrl(commandPromise: Promise<{error?: Error}>): Promise<URL> {
+  const commandExit = commandPromise.then(({error}) => {
+    throw error ?? new Error('Login command exited before the callback server started')
+  })
 
-  return new URL(loginUrl.searchParams.get('origin')!)
+  const startup = await Promise.race([
+    vi.waitFor(() => {
+      const [result] = mockedStartServerForTokenCallback.mock.settledResults
+      if (!result || result.type === 'incomplete') {
+        throw new Error('Callback server has not started yet')
+      }
+      return result
+    }, 9000),
+    commandExit,
+  ])
+
+  if (startup.type === 'rejected') throw startup.value
+  return new URL(startup.value.loginUrl.searchParams.get('origin')!)
 }
 
 /**
  * Simulates the OAuth provider redirecting back to the local callback server.
  * Waits for the server to be listening, then makes an actual HTTP request to it.
  */
-async function simulateOAuthCallback(sessionId: string): Promise<number> {
-  const callbackUrl = await waitForCallbackUrl()
+async function simulateOAuthCallback(
+  commandPromise: Promise<{error?: Error}>,
+  sessionId: string,
+): Promise<number> {
+  const callbackUrl = await waitForCallbackUrl(commandPromise)
   const url = `${callbackUrl.href}?url=${encodeURIComponent(
     `https://api.sanity.io/auth/fetch?sid=${sessionId}`,
   )}`
@@ -503,7 +518,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       const commandPromise = testCommand(LoginCommand, [])
-      const statusCode = await simulateOAuthCallback('test-session-id')
+      const statusCode = await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -551,7 +566,7 @@ describe('#login', {timeout: 10_000}, () => {
       })
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -589,7 +604,7 @@ describe('#login', {timeout: 10_000}, () => {
       }).reply(200, {label: 'Test Session', token: 'new-auth-token'})
 
       const commandPromise = testCommand(LoginCommand, ['--provider', 'github'])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -637,7 +652,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockInput.mockResolvedValue('test-org')
 
       const commandPromise = testCommand(LoginCommand, ['--experimental'])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -744,7 +759,7 @@ describe('#login', {timeout: 10_000}, () => {
       }).reply(200, {label: 'Test Session', token: 'new-auth-token'})
 
       const commandPromise = testCommand(LoginCommand, ['--sso', 'my-org'])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -799,7 +814,7 @@ describe('#login', {timeout: 10_000}, () => {
       })
 
       const commandPromise = testCommand(LoginCommand, ['--sso', 'my-org'])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -850,7 +865,7 @@ describe('#login', {timeout: 10_000}, () => {
       }).reply(200, {label: 'Test Session', token: 'new-auth-token'})
 
       const commandPromise = testCommand(LoginCommand, ['--sso', 'my-org'])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -868,7 +883,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -890,7 +905,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       const commandPromise = testCommand(LoginCommand, ['--no-open'])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -904,7 +919,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -928,15 +943,17 @@ describe('#login', {timeout: 10_000}, () => {
 
       try {
         const commandPromise = testCommand(LoginCommand, [])
-        // Should fall back to port 4000
-        await simulateOAuthCallback('test-session-id')
+        const callbackUrl = await waitForCallbackUrl(commandPromise)
+        expect(callbackUrl.port).not.toBe('4321')
+
+        await simulateOAuthCallback(commandPromise, 'test-session-id')
         const {error} = await commandPromise
 
         expect(error).toBeUndefined()
 
         // Verify login URL uses fallback port
-        const loginUrl = mockedOpen.mock.calls[0][0] as string
-        expect(loginUrl).toContain('4000')
+        const loginUrl = new URL(mockedOpen.mock.calls[0][0] as string)
+        expect(loginUrl.searchParams.get('origin')).toBe(callbackUrl.href)
       } finally {
         await new Promise<void>((resolve) => {
           blockingServer.close(() => resolve())
@@ -1007,7 +1024,7 @@ describe('#login', {timeout: 10_000}, () => {
 
       const commandPromise = testCommand(LoginCommand, [])
 
-      const callbackUrl = await waitForCallbackUrl()
+      const callbackUrl = await waitForCallbackUrl(commandPromise)
 
       // Missing url parameter
       const missingUrlStatus = await httpGetStatus(callbackUrl)
@@ -1034,7 +1051,7 @@ describe('#login', {timeout: 10_000}, () => {
 
       const commandPromise = testCommand(LoginCommand, [])
 
-      const callbackUrl = await waitForCallbackUrl()
+      const callbackUrl = await waitForCallbackUrl(commandPromise)
 
       // URL present but no sid parameter
       const missingSidStatus = await httpGetStatus(
@@ -1068,7 +1085,7 @@ describe('#login', {timeout: 10_000}, () => {
       }).reply(400, {message: 'Invalid session ID'})
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback('bad-session')
+      await simulateOAuthCallback(commandPromise, 'bad-session')
       const {error} = await commandPromise
 
       expect(error).toBeDefined()
@@ -1082,7 +1099,7 @@ describe('#login', {timeout: 10_000}, () => {
 
       const commandPromise = testCommand(LoginCommand, [])
 
-      const callbackUrl = await waitForCallbackUrl()
+      const callbackUrl = await waitForCallbackUrl(commandPromise)
 
       // Make request to non-callback endpoint
       const statusCode = await httpGetStatus(new URL('/other', callbackUrl))
@@ -1090,7 +1107,7 @@ describe('#login', {timeout: 10_000}, () => {
       expect(statusCode).toBe(404)
 
       // Complete the login
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error} = await commandPromise
       expect(error).toBeUndefined()
     })
@@ -1123,7 +1140,7 @@ describe('#login', {timeout: 10_000}, () => {
         .reply(200)
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -1141,7 +1158,7 @@ describe('#login', {timeout: 10_000}, () => {
       }).reply(401, {message: 'Unauthorized'})
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback('session-401')
+      await simulateOAuthCallback(commandPromise, 'session-401')
       const {error, stderr} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -1176,7 +1193,7 @@ describe('#login', {timeout: 10_000}, () => {
         .reply(500, {message: 'Internal Server Error'})
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stderr} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -1201,7 +1218,7 @@ describe('#login', {timeout: 10_000}, () => {
         })
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stderr} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -1230,7 +1247,7 @@ describe('#login', {timeout: 10_000}, () => {
         .reply(200)
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stderr} = await commandPromise
 
       if (error) throw error
@@ -1331,7 +1348,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       if (error) throw error
@@ -1381,7 +1398,7 @@ describe('#login', {timeout: 10_000}, () => {
         '--sso-provider',
         'Okta SSO',
       ])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       if (error) throw error
@@ -1431,7 +1448,7 @@ describe('#login', {timeout: 10_000}, () => {
         '--sso-provider',
         'okta sso',
       ])
-      await simulateOAuthCallback('test-session-id')
+      await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       if (error) throw error

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -6,6 +6,7 @@ import {cleanAll, pendingMocks} from 'nock'
 import open from 'open'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
+import {startServerForTokenCallback} from '../../actions/auth/authServer.js'
 import {AUTH_API_VERSION} from '../../services/auth.js'
 import {USERS_API_VERSION} from '../../services/user.js'
 import {canLaunchBrowser} from '../../util/canLaunchBrowser.js'
@@ -35,6 +36,16 @@ vi.mock('open')
 vi.mock('../../util/canLaunchBrowser.js', () => ({
   canLaunchBrowser: vi.fn().mockReturnValue(true),
 }))
+
+// Wrap the real callback server so tests can await its startup and read the
+// port it actually bound.
+vi.mock('../../actions/auth/authServer.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../actions/auth/authServer.js')>()
+  return {
+    ...actual,
+    startServerForTokenCallback: vi.fn(actual.startServerForTokenCallback),
+  }
+})
 
 const mockConfigStoreDelete = vi.hoisted(() => vi.fn())
 
@@ -67,6 +78,7 @@ vi.mock('@sanity/cli-core', async () => {
 
 const mockedOpen = vi.mocked(open)
 const mockedCanLaunchBrowser = vi.mocked(canLaunchBrowser)
+const mockedStartServerForTokenCallback = vi.mocked(startServerForTokenCallback)
 const originalStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin')
 type MockStdin = Readable & {isTTY?: boolean}
 
@@ -81,20 +93,34 @@ function mockStdin(input: string, options: {isTTY?: boolean} = {}) {
 }
 
 /**
- * Simulates OAuth provider redirecting back to local callback server.
- * Makes actual HTTP request to the running local server in test.
+ * Waits until the login command's local callback server is listening, and
+ * returns the callback URL it actually bound. The port can differ from 4321
+ * when the server falls back to another port.
  */
-async function simulateOAuthCallback(
-  port: number,
-  sessionId: string,
-  delay = 100,
-): Promise<number> {
-  await new Promise((resolve) => setTimeout(resolve, delay))
+async function waitForCallbackUrl(): Promise<URL> {
+  const {loginUrl} = await vi.waitFor(() => {
+    const [startup] = mockedStartServerForTokenCallback.mock.settledResults
+    if (startup?.type !== 'fulfilled') throw new Error('Callback server is not listening yet')
+    return startup.value
+  }, 9000)
 
-  const url = `http://localhost:${port}/callback?url=${encodeURIComponent(
+  return new URL(loginUrl.searchParams.get('origin')!)
+}
+
+/**
+ * Simulates the OAuth provider redirecting back to the local callback server.
+ * Waits for the server to be listening, then makes an actual HTTP request to it.
+ */
+async function simulateOAuthCallback(sessionId: string): Promise<number> {
+  const callbackUrl = await waitForCallbackUrl()
+  const url = `${callbackUrl.href}?url=${encodeURIComponent(
     `https://api.sanity.io/auth/fetch?sid=${sessionId}`,
   )}`
 
+  return httpGetStatus(url)
+}
+
+function httpGetStatus(url: string | URL): Promise<number> {
   return new Promise((resolve, reject) => {
     http
       .get(url, (res) => {
@@ -134,6 +160,11 @@ describe('#login', {timeout: 10_000}, () => {
   afterEach(() => {
     if (originalStdinDescriptor) {
       Object.defineProperty(process, 'stdin', originalStdinDescriptor)
+    }
+    // Close any callback server still listening so it can't swallow the next
+    // test's callbacks or API mocks.
+    for (const startup of mockedStartServerForTokenCallback.mock.settledResults) {
+      if (startup.type === 'fulfilled') startup.value.server.close()
     }
     vi.clearAllMocks()
     mockedIsInteractive.mockReturnValue(true)
@@ -472,7 +503,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       const commandPromise = testCommand(LoginCommand, [])
-      const statusCode = await simulateOAuthCallback(4321, 'test-session-id')
+      const statusCode = await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -520,7 +551,7 @@ describe('#login', {timeout: 10_000}, () => {
       })
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -558,7 +589,7 @@ describe('#login', {timeout: 10_000}, () => {
       }).reply(200, {label: 'Test Session', token: 'new-auth-token'})
 
       const commandPromise = testCommand(LoginCommand, ['--provider', 'github'])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -606,7 +637,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockInput.mockResolvedValue('test-org')
 
       const commandPromise = testCommand(LoginCommand, ['--experimental'])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -713,7 +744,7 @@ describe('#login', {timeout: 10_000}, () => {
       }).reply(200, {label: 'Test Session', token: 'new-auth-token'})
 
       const commandPromise = testCommand(LoginCommand, ['--sso', 'my-org'])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -768,7 +799,7 @@ describe('#login', {timeout: 10_000}, () => {
       })
 
       const commandPromise = testCommand(LoginCommand, ['--sso', 'my-org'])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -819,7 +850,7 @@ describe('#login', {timeout: 10_000}, () => {
       }).reply(200, {label: 'Test Session', token: 'new-auth-token'})
 
       const commandPromise = testCommand(LoginCommand, ['--sso', 'my-org'])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -837,7 +868,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -859,7 +890,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       const commandPromise = testCommand(LoginCommand, ['--no-open'])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -873,7 +904,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -898,7 +929,7 @@ describe('#login', {timeout: 10_000}, () => {
       try {
         const commandPromise = testCommand(LoginCommand, [])
         // Should fall back to port 4000
-        await simulateOAuthCallback(4000, 'test-session-id')
+        await simulateOAuthCallback('test-session-id')
         const {error} = await commandPromise
 
         expect(error).toBeUndefined()
@@ -976,18 +1007,10 @@ describe('#login', {timeout: 10_000}, () => {
 
       const commandPromise = testCommand(LoginCommand, [])
 
-      // Wait for server to start
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      const callbackUrl = await waitForCallbackUrl()
 
       // Missing url parameter
-      const missingUrlStatus = await new Promise<number>((resolve, reject) => {
-        http
-          .get('http://localhost:4321/callback', (res) => {
-            res.resume()
-            resolve(res.statusCode || 0)
-          })
-          .on('error', reject)
-      })
+      const missingUrlStatus = await httpGetStatus(callbackUrl)
 
       // Should get 303 redirect to error page
       expect(missingUrlStatus).toBe(303)
@@ -1011,21 +1034,12 @@ describe('#login', {timeout: 10_000}, () => {
 
       const commandPromise = testCommand(LoginCommand, [])
 
-      // Wait for server to start
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      const callbackUrl = await waitForCallbackUrl()
 
       // URL present but no sid parameter
-      const missingSidStatus = await new Promise<number>((resolve, reject) => {
-        const url = `http://localhost:4321/callback?url=${encodeURIComponent(
-          'https://api.sanity.io/auth/fetch',
-        )}`
-        http
-          .get(url, (res) => {
-            res.resume()
-            resolve(res.statusCode || 0)
-          })
-          .on('error', reject)
-      })
+      const missingSidStatus = await httpGetStatus(
+        `${callbackUrl.href}?url=${encodeURIComponent('https://api.sanity.io/auth/fetch')}`,
+      )
 
       expect(missingSidStatus).toBe(303)
 
@@ -1054,7 +1068,7 @@ describe('#login', {timeout: 10_000}, () => {
       }).reply(400, {message: 'Invalid session ID'})
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback(4321, 'bad-session')
+      await simulateOAuthCallback('bad-session')
       const {error} = await commandPromise
 
       expect(error).toBeDefined()
@@ -1068,23 +1082,15 @@ describe('#login', {timeout: 10_000}, () => {
 
       const commandPromise = testCommand(LoginCommand, [])
 
-      // Wait for server to start
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      const callbackUrl = await waitForCallbackUrl()
 
       // Make request to non-callback endpoint
-      const statusCode = await new Promise<number>((resolve, reject) => {
-        http
-          .get('http://localhost:4321/other', (res) => {
-            res.resume()
-            resolve(res.statusCode || 0)
-          })
-          .on('error', reject)
-      })
+      const statusCode = await httpGetStatus(new URL('/other', callbackUrl))
 
       expect(statusCode).toBe(404)
 
       // Complete the login
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error} = await commandPromise
       expect(error).toBeUndefined()
     })
@@ -1117,7 +1123,7 @@ describe('#login', {timeout: 10_000}, () => {
         .reply(200)
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -1135,7 +1141,7 @@ describe('#login', {timeout: 10_000}, () => {
       }).reply(401, {message: 'Unauthorized'})
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback(4321, 'session-401')
+      await simulateOAuthCallback('session-401')
       const {error, stderr} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -1170,7 +1176,7 @@ describe('#login', {timeout: 10_000}, () => {
         .reply(500, {message: 'Internal Server Error'})
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stderr} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -1195,7 +1201,7 @@ describe('#login', {timeout: 10_000}, () => {
         })
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stderr} = await commandPromise
 
       expect(error).toBeUndefined()
@@ -1224,7 +1230,7 @@ describe('#login', {timeout: 10_000}, () => {
         .reply(200)
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stderr} = await commandPromise
 
       if (error) throw error
@@ -1325,7 +1331,7 @@ describe('#login', {timeout: 10_000}, () => {
       mockSingleProviderLogin()
 
       const commandPromise = testCommand(LoginCommand, [])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       if (error) throw error
@@ -1375,7 +1381,7 @@ describe('#login', {timeout: 10_000}, () => {
         '--sso-provider',
         'Okta SSO',
       ])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       if (error) throw error
@@ -1425,7 +1431,7 @@ describe('#login', {timeout: 10_000}, () => {
         '--sso-provider',
         'okta sso',
       ])
-      await simulateOAuthCallback(4321, 'test-session-id')
+      await simulateOAuthCallback('test-session-id')
       const {error, stdout} = await commandPromise
 
       if (error) throw error


### PR DESCRIPTION
### Description

`login.test.ts` fails regularly on CI, also on main ([example run](https://github.com/sanity-io/cli/actions/runs/27423213442/job/81054215544)). The root cause is a race: the OAuth callback helper slept a fixed 100ms and then fired at a hardcoded `localhost:4321`. On slow runners the login command hasn't bound its callback server within that window, so the callback gets ECONNREFUSED and the test fails. The abandoned login command then keeps running in the background — it squats on port 4321 and consumes nock mocks meant for later tests, which is where the cascading `pending mocks` and `Nock: No match` failures come from.

`startServerForTokenCallback` is now wrapped with a pass-through spy, so tests await the real server startup and read the port it actually bound (the fallback ports too, no more guessing 4321 vs 4000). `afterEach` closes any server still listening, so a single failure can't cascade through the rest of the file.

Side effects:

- The file runs in ~1.5s instead of ~17s, since the unconditional sleeps are gone.
- The port-fallback test asserts against the port the server really bound instead of assuming 4000.

### What to review

`waitForCallbackUrl()` and the `afterEach` server cleanup in `login.test.ts` — the rest is call sites losing their port argument.

### Testing

Test-only change. 48/48 pass, stable across repeated runs, including together with `login.vercel.test.ts`.