### PR TITLE
refactor: use `output` abstraction, prevent interleaved test output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,6 +257,31 @@ describe('feature description', () => {
 - Never leave mocks active between tests
 - Never mock without verifying the mock was called - add assertions for mock calls
 
+### No Interleaved CLI Output in Tests
+
+Test runs must not print CLI messages to the terminal. When a test interleaves lines like `✔ MCP configured for Cursor` with the vitest reporter output, it means the code under test writes directly to the process streams instead of going through an injected output.
+
+The rule: all user-facing output flows through the `Output` abstraction (`{log, warn, error}` from `@sanity/cli-core`). Commands use `this.output` and pass it down; actions accept it as an `output` option and never write to the streams themselves. Do not use `ux` from `@oclif/core` in actions - `ux.stdout`/`ux.stderr` are bare `console.log`/`console.error` calls, which bypass output capture in action-level tests (vitest's own console interception is disabled in this repo).
+
+This also makes messages assertable. Tests inject a mock and assert against it instead of scraping stdout:
+
+```typescript
+const mockOutput = {
+  error: vi.fn() as never,
+  log: vi.fn(),
+  warn: vi.fn(),
+}
+
+test('reports configured editors', async () => {
+  const result = await setupMCP({mode: 'auto', output: mockOutput})
+
+  if (result.error) throw result.error
+  expect(mockOutput.log).toHaveBeenCalledWith(expect.stringContaining('MCP configured for Cursor'))
+})
+```
+
+If an action needs to terminate with a user-facing error, call `output.error(message, {exit: 1})` (it throws like `this.error` does) rather than `ux.error`. Code that runs outside a command, such as an oclif hook, owns its own stream writes and should pass a sink into any action it calls (see `telemetryDisclosure` for an example).
+
 ### Mocking Strategy: What to Mock and When
 
 Follow this hierarchy when writing tests (prefer higher levels):

--- a/packages/@sanity/cli/src/actions/backup/assertDatasetExist.ts
+++ b/packages/@sanity/cli/src/actions/backup/assertDatasetExist.ts
@@ -1,4 +1,4 @@
-import {ux} from '@oclif/core'
+import {type Output} from '@sanity/cli-core'
 import {type DatasetsResponse} from '@sanity/client'
 
 /**
@@ -6,11 +6,16 @@ import {type DatasetsResponse} from '@sanity/client'
  *
  * @param datasets - The list of datasets to check
  * @param datasetName - The name of the dataset to check for
+ * @param output - Output to raise the error through the calling command
  */
-export function assertDatasetExists(datasets: DatasetsResponse, datasetName: string): void {
+export function assertDatasetExists(
+  datasets: DatasetsResponse,
+  datasetName: string,
+  output: Output,
+): void {
   const exists = datasets.some((d) => d.name === datasetName)
   if (!exists) {
-    ux.error(
+    output.error(
       `Dataset '${datasetName}' not found in this project. Available datasets: ${datasets.map((d) => d.name).join(', ')}`,
       {exit: 1},
     )

--- a/packages/@sanity/cli/src/actions/dataset/resolveDataset.ts
+++ b/packages/@sanity/cli/src/actions/dataset/resolveDataset.ts
@@ -1,3 +1,4 @@
+import {type Output} from '@sanity/cli-core'
 import {type DatasetsResponse} from '@sanity/client'
 
 import {promptForDataset} from '../../prompts/promptForDataset.js'
@@ -5,6 +6,9 @@ import {listDatasets} from '../../services/datasets.js'
 import {assertDatasetExists} from '../backup/assertDatasetExist.js'
 
 interface ResolveDatasetOptions {
+  /** Output to use for user-facing messages from the calling command */
+  output: Output
+
   projectId: string
 
   dataset?: string
@@ -22,6 +26,7 @@ interface ResolveDatasetResult {
  */
 export async function resolveDataset({
   dataset,
+  output,
   projectId,
 }: ResolveDatasetOptions): Promise<ResolveDatasetResult> {
   const datasets = await listDatasets(projectId)
@@ -31,7 +36,7 @@ export async function resolveDataset({
   }
 
   if (dataset) {
-    assertDatasetExists(datasets, dataset)
+    assertDatasetExists(datasets, dataset, output)
   } else {
     dataset = await promptForDataset({datasets})
   }

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -189,7 +189,7 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
   async function installSkills(): Promise<void> {
     if (mcpResult.skillsToInstall.length === 0) return
     try {
-      const skillsResult = await setupSkills({agents: mcpResult.skillsToInstall})
+      const skillsResult = await setupSkills({agents: mcpResult.skillsToInstall, output})
       trace.log({
         installedAgents: skillsResult.installedAgents,
         skipped: skillsResult.skipped,

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -171,6 +171,7 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
   const mcpResult = await setupMCP({
     editors: detectedEditors,
     mode: options.mcpMode,
+    output,
     skillsMode: options.skillsMode,
   })
 

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/setupMCP.test.ts
@@ -35,6 +35,12 @@ vi.mock('../../skills/readSkillState.js', () => ({
   readSkillState: mockReadSkillState,
 }))
 
+const mockOutput = {
+  error: vi.fn() as never,
+  log: vi.fn(),
+  warn: vi.fn(),
+}
+
 function editor(overrides: Partial<Editor> & Pick<Editor, 'name'>): Editor {
   return {
     configPath: `/fake/${overrides.name}/config.json`,
@@ -60,7 +66,7 @@ describe('setupMCP', () => {
   // -------------------------------------------------------------------------
 
   test('mcpMode: skip with default skillsMode skip short-circuits', async () => {
-    const result = await setupMCP({mode: 'skip'})
+    const result = await setupMCP({mode: 'skip', output: mockOutput})
 
     expect(result.skipped).toBe(true)
     expect(result.skillsToInstall).toEqual([])
@@ -75,13 +81,16 @@ describe('setupMCP', () => {
       editor({name: 'VS Code'}),
     ])
 
-    const result = await setupMCP({mode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput})
 
     expect(mockPromptForMCPSetup).not.toHaveBeenCalled()
     expect(mockWriteMCPConfig).toHaveBeenCalledTimes(2)
     expect(result.configuredEditors).toEqual(['Cursor', 'VS Code'])
     expect(result.skillsToInstall).toEqual([])
     expect(result.skipped).toBe(false)
+    expect(mockOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining('MCP configured for Cursor, VS Code'),
+    )
   })
 
   test('mcpMode: prompt with skillsMode skip uses today’s message', async () => {
@@ -90,7 +99,7 @@ describe('setupMCP', () => {
     mockDetectAvailableEditors.mockResolvedValue(editors)
     mockPromptForMCPSetup.mockResolvedValue([{action: 'mcp-only', editor: editors[0]}])
 
-    const result = await setupMCP({mode: 'prompt'})
+    const result = await setupMCP({mode: 'prompt', output: mockOutput})
 
     expect(mockPromptForMCPSetup).toHaveBeenCalledWith(
       expect.objectContaining({message: 'Configure Sanity MCP server?'}),
@@ -102,7 +111,7 @@ describe('setupMCP', () => {
     defaultMocks()
     const editors: Editor[] = [{configPath: '/tmp/cursor', configured: false, name: 'Cursor'}]
 
-    const result = await setupMCP({editors, mode: 'auto'})
+    const result = await setupMCP({editors, mode: 'auto', output: mockOutput})
 
     expect(mockDetectAvailableEditors).not.toHaveBeenCalled()
     expect(result.configuredEditors).toEqual(['Cursor'])
@@ -115,7 +124,7 @@ describe('setupMCP', () => {
     ]
     mockDetectAvailableEditors.mockResolvedValue(editors)
 
-    const result = await setupMCP({mode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput})
 
     expect(mockWriteMCPConfig).not.toHaveBeenCalled()
     expect(result.skipped).toBe(true)
@@ -130,7 +139,7 @@ describe('setupMCP', () => {
     defaultMocks()
     mockDetectAvailableEditors.mockResolvedValue([editor({name: 'Cursor'})])
 
-    const result = await setupMCP({mode: 'auto', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput, skillsMode: 'auto'})
 
     expect(mockReadSkillState).toHaveBeenCalledWith({
       skillNames: ['sanity-best-practices', 'sanity-migration'],
@@ -144,7 +153,7 @@ describe('setupMCP', () => {
     mockReadSkillState.mockResolvedValue({installedAgentDisplayNames: new Set(['Cursor'])})
     mockDetectAvailableEditors.mockResolvedValue([editor({name: 'Cursor'})])
 
-    const result = await setupMCP({mode: 'auto', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput, skillsMode: 'auto'})
 
     expect(result.configuredEditors).toEqual(['Cursor'])
     expect(result.skillsToInstall).toEqual(['cursor'])
@@ -156,7 +165,7 @@ describe('setupMCP', () => {
       editor({authStatus: 'valid', configured: true, existingToken: 'tok', name: 'Cursor'}),
     ])
 
-    const result = await setupMCP({mode: 'auto', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput, skillsMode: 'auto'})
 
     expect(mockWriteMCPConfig).not.toHaveBeenCalled()
     expect(result.configuredEditors).toEqual([])
@@ -167,7 +176,7 @@ describe('setupMCP', () => {
     defaultMocks()
     mockDetectAvailableEditors.mockResolvedValue([editor({name: 'Zed'})])
 
-    const result = await setupMCP({mode: 'auto', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput, skillsMode: 'auto'})
 
     expect(result.configuredEditors).toEqual(['Zed'])
     expect(result.skillsToInstall).toEqual([])
@@ -180,7 +189,7 @@ describe('setupMCP', () => {
       editor({authStatus: 'valid', configured: true, existingToken: 'tok', name: 'Cursor'}),
     ])
 
-    const result = await setupMCP({mode: 'auto', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput, skillsMode: 'auto'})
 
     expect(result.skipped).toBe(true)
     expect(result.alreadyConfiguredEditors).toEqual(['Cursor'])
@@ -193,7 +202,7 @@ describe('setupMCP', () => {
       editor({authStatus: 'valid', configured: true, existingToken: 'tok', name: 'Zed'}),
     ])
 
-    const result = await setupMCP({mode: 'auto', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput, skillsMode: 'auto'})
 
     expect(result.skipped).toBe(true)
     expect(result.alreadyConfiguredEditors).toEqual(['Zed'])
@@ -208,7 +217,7 @@ describe('setupMCP', () => {
     defaultMocks()
     mockDetectAvailableEditors.mockResolvedValue([editor({name: 'Cursor'}), editor({name: 'Zed'})])
 
-    const result = await setupMCP({mode: 'skip', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'skip', output: mockOutput, skillsMode: 'auto'})
 
     // Zed (mcp-only) gets dropped; Cursor downgrades to skill-only — no MCP write
     expect(mockWriteMCPConfig).not.toHaveBeenCalled()
@@ -228,7 +237,7 @@ describe('setupMCP', () => {
       }),
     ])
 
-    const result = await setupMCP({mode: 'auto', skillsMode: 'skip'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput, skillsMode: 'skip'})
 
     expect(mockReadSkillState).not.toHaveBeenCalled()
     expect(result.configuredEditors).toEqual(['Cursor'])
@@ -239,6 +248,7 @@ describe('setupMCP', () => {
     const result = await setupMCP({
       editors: [editor({name: 'Cursor'})],
       mode: 'skip',
+      output: mockOutput,
       skillsMode: 'skip',
     })
 
@@ -257,7 +267,7 @@ describe('setupMCP', () => {
     mockDetectAvailableEditors.mockResolvedValue(editors)
     mockPromptForMCPSetup.mockResolvedValue([{action: 'mcp-and-skill', editor: editors[0]}])
 
-    await setupMCP({mode: 'prompt', skillsMode: 'prompt'})
+    await setupMCP({mode: 'prompt', output: mockOutput, skillsMode: 'prompt'})
 
     expect(mockPromptForMCPSetup).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -272,7 +282,7 @@ describe('setupMCP', () => {
     mockDetectAvailableEditors.mockResolvedValue(editors)
     mockPromptForMCPSetup.mockResolvedValue([{action: 'mcp-and-skill', editor: editors[0]}])
 
-    const result = await setupMCP({mode: 'prompt', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'prompt', output: mockOutput, skillsMode: 'auto'})
 
     expect(mockPromptForMCPSetup).toHaveBeenCalled()
     expect(result.configuredEditors).toEqual(['Cursor'])
@@ -285,7 +295,7 @@ describe('setupMCP', () => {
       editor({authStatus: 'valid', configured: true, existingToken: 'tok', name: 'Cursor'}),
     ])
 
-    const result = await setupMCP({mode: 'skip', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'skip', output: mockOutput, skillsMode: 'auto'})
 
     expect(mockPromptForMCPSetup).not.toHaveBeenCalled()
     expect(result.skillsToInstall).toEqual(['cursor'])
@@ -299,7 +309,7 @@ describe('setupMCP', () => {
     mockDetectAvailableEditors.mockResolvedValue(editors)
     mockPromptForMCPSetup.mockResolvedValue([{action: 'skill-only', editor: editors[0]}])
 
-    const result = await setupMCP({mode: 'skip', skillsMode: 'prompt'})
+    const result = await setupMCP({mode: 'skip', output: mockOutput, skillsMode: 'prompt'})
 
     expect(mockPromptForMCPSetup).toHaveBeenCalledWith(
       expect.objectContaining({message: 'Install Sanity agent skills for these editors?'}),
@@ -312,11 +322,12 @@ describe('setupMCP', () => {
     mockDetectAvailableEditors.mockResolvedValue([editor({name: 'Cursor'})])
     mockPromptForMCPSetup.mockResolvedValue(null)
 
-    const result = await setupMCP({mode: 'prompt', skillsMode: 'prompt'})
+    const result = await setupMCP({mode: 'prompt', output: mockOutput, skillsMode: 'prompt'})
 
     expect(mockWriteMCPConfig).not.toHaveBeenCalled()
     expect(result.skillsToInstall).toEqual([])
     expect(result.skipped).toBe(true)
+    expect(mockOutput.log).toHaveBeenCalledWith('MCP configuration skipped')
   })
 
   // -------------------------------------------------------------------------
@@ -332,11 +343,12 @@ describe('setupMCP', () => {
       if (e.name === 'Cursor') throw new Error('disk full')
     })
 
-    const result = await setupMCP({mode: 'auto', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput, skillsMode: 'auto'})
 
     expect(result.configuredEditors).toEqual(['Claude Code'])
     expect(result.skillsToInstall).toEqual(['claude-code'])
     expect(result.error).toBeInstanceOf(Error)
+    expect(mockOutput.warn).toHaveBeenCalledWith('Could not configure MCP for Cursor: disk full')
   })
 
   test('skill state probe failure → over-install (treat all as not installed)', async () => {
@@ -346,7 +358,7 @@ describe('setupMCP', () => {
       editor({authStatus: 'valid', configured: true, existingToken: 'tok', name: 'Cursor'}),
     ])
 
-    const result = await setupMCP({mode: 'auto', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput, skillsMode: 'auto'})
 
     expect(result.skillsToInstall).toEqual(['cursor'])
   })
@@ -358,7 +370,7 @@ describe('setupMCP', () => {
       editor({name: 'VS Code Insiders'}),
     ])
 
-    const result = await setupMCP({mode: 'auto', skillsMode: 'auto'})
+    const result = await setupMCP({mode: 'auto', output: mockOutput, skillsMode: 'auto'})
 
     expect(result.skillsToInstall).toEqual(['github-copilot'])
   })

--- a/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
+++ b/packages/@sanity/cli/src/actions/mcp/setupMCP.ts
@@ -1,5 +1,4 @@
-import {ux} from '@oclif/core'
-import {subdebug} from '@sanity/cli-core'
+import {type Output, subdebug} from '@sanity/cli-core'
 import {logSymbols} from '@sanity/cli-core/ux'
 
 import {createMCPToken, MCP_SERVER_URL} from '../../services/mcp.js'
@@ -24,6 +23,12 @@ const NO_EDITORS_DETECTED_MESSAGE = `Couldn't auto-configure Sanity MCP server f
 type Mode = 'auto' | 'prompt' | 'skip'
 
 interface MCPSetupOptions {
+  /**
+   * Output to use for user-facing messages, so they go through the calling
+   * command rather than directly to stdout/stderr.
+   */
+  output: Output
+
   /**
    * Pre-detected editors. When omitted, `detectAvailableEditors()` is called.
    * Accepting this from the caller avoids re-running detection (which probes
@@ -152,8 +157,8 @@ function getPromptMessage(mcpMode: Mode, skillsMode: Mode): string {
  * and the result includes `skillsToInstall` — agent IDs the caller should
  * install via `setupSkills`. `setupMCP` itself never installs skills.
  */
-export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResult> {
-  const {explicit = false, mode: mcpMode = 'prompt', skillsMode = 'skip'} = options ?? {}
+export async function setupMCP(options: MCPSetupOptions): Promise<MCPSetupResult> {
+  const {explicit = false, mode: mcpMode = 'prompt', output, skillsMode = 'skip'} = options
 
   // 1. Both opted out → nothing to do.
   if (mcpMode === 'skip' && skillsMode === 'skip') {
@@ -175,7 +180,7 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
 
   if (editors.length === 0) {
     if (explicit) {
-      ux.warn(NO_EDITORS_DETECTED_MESSAGE)
+      output.warn(NO_EDITORS_DETECTED_MESSAGE)
     }
     return {
       alreadyConfiguredEditors: [],
@@ -212,7 +217,7 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
   if (actionable.length === 0) {
     mcpDebug('Nothing actionable after classification + masking')
     if (explicit) {
-      ux.stdout(`${logSymbols.success} All detected editors are already configured`)
+      output.log(`${logSymbols.success} All detected editors are already configured`)
     }
     return {
       alreadyConfiguredEditors,
@@ -236,7 +241,7 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
       })
 
   if (!selected || selected.length === 0) {
-    ux.stdout('MCP configuration skipped')
+    output.log('MCP configuration skipped')
     return {
       alreadyConfiguredEditors,
       configuredEditors: [],
@@ -270,8 +275,8 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error))
         mcpDebug('Error creating MCP token', error)
-        ux.warn(`Could not configure MCP: ${err.message}`)
-        ux.warn('You can set up MCP manually later using https://mcp.sanity.io')
+        output.warn(`Could not configure MCP: ${err.message}`)
+        output.warn('You can set up MCP manually later using https://mcp.sanity.io')
         mcpError = err
       }
     }
@@ -284,15 +289,15 @@ export async function setupMCP(options?: MCPSetupOptions): Promise<MCPSetupResul
         } catch (error) {
           const err = error instanceof Error ? error : new Error(String(error))
           mcpDebug('Error writing MCP config for %s: %O', choice.editor.name, error)
-          ux.warn(`Could not configure MCP for ${choice.editor.name}: ${err.message}`)
-          ux.warn('You can set up MCP manually later using https://mcp.sanity.io')
+          output.warn(`Could not configure MCP for ${choice.editor.name}: ${err.message}`)
+          output.warn('You can set up MCP manually later using https://mcp.sanity.io')
           mcpError = err
         }
       }
     }
 
     if (configuredEditors.length > 0) {
-      ux.stdout(`${logSymbols.success} MCP configured for ${configuredEditors.join(', ')}`)
+      output.log(`${logSymbols.success} MCP configured for ${configuredEditors.join(', ')}`)
     }
   }
 

--- a/packages/@sanity/cli/src/actions/skills/__tests__/setupSkills.test.ts
+++ b/packages/@sanity/cli/src/actions/skills/__tests__/setupSkills.test.ts
@@ -13,13 +13,19 @@ vi.mock('execa', () => ({
   execa: mockExeca,
 }))
 
+const mockOutput = {
+  error: vi.fn() as never,
+  log: vi.fn(),
+  warn: vi.fn(),
+}
+
 describe('setupSkills', () => {
   afterEach(() => {
     vi.clearAllMocks()
   })
 
   test('returns skipped when no agents are passed', async () => {
-    const result = await setupSkills({agents: []})
+    const result = await setupSkills({agents: [], output: mockOutput})
 
     expect(result).toEqual({installedAgents: [], skipped: true})
     expect(mockExeca).not.toHaveBeenCalled()
@@ -28,7 +34,7 @@ describe('setupSkills', () => {
   test('installs globally for a single agent', async () => {
     mockExeca.mockResolvedValue({exitCode: 0, stderr: '', stdout: ''})
 
-    const result = await setupSkills({agents: ['cursor']})
+    const result = await setupSkills({agents: ['cursor'], output: mockOutput})
 
     expect(mockExeca).toHaveBeenCalledWith(
       process.execPath,
@@ -46,12 +52,15 @@ describe('setupSkills', () => {
       expect.objectContaining({stdio: 'pipe', timeout: 90_000}),
     )
     expect(result).toEqual({installedAgents: ['cursor'], skipped: false})
+    expect(mockOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining('Installed Sanity agent skills for cursor'),
+    )
   })
 
   test('deduplicates repeated agent IDs', async () => {
     mockExeca.mockResolvedValue({exitCode: 0, stderr: '', stdout: ''})
 
-    const result = await setupSkills({agents: ['cline', 'cline', 'cursor']})
+    const result = await setupSkills({agents: ['cline', 'cline', 'cursor'], output: mockOutput})
 
     expect(result.installedAgents).toEqual(['cline', 'cursor'])
     expect(mockExeca).toHaveBeenCalledWith(
@@ -76,7 +85,7 @@ describe('setupSkills', () => {
   test('passes every agent as a separate -a flag', async () => {
     mockExeca.mockResolvedValue({exitCode: 0, stderr: '', stdout: ''})
 
-    await setupSkills({agents: ['cursor', 'claude-code', 'github-copilot']})
+    await setupSkills({agents: ['cursor', 'claude-code', 'github-copilot'], output: mockOutput})
 
     expect(mockExeca).toHaveBeenCalledWith(
       process.execPath,
@@ -103,12 +112,15 @@ describe('setupSkills', () => {
     const installErr = new Error('skills exited 1')
     mockExeca.mockRejectedValue(installErr)
 
-    const result = await setupSkills({agents: ['cursor']})
+    const result = await setupSkills({agents: ['cursor'], output: mockOutput})
 
     expect(result.skipped).toBe(false)
     expect(result.installedAgents).toEqual([])
     expect(result.error).toBeInstanceOf(Error)
     expect(result.error?.message).toBe('skills exited 1')
+    expect(mockOutput.warn).toHaveBeenCalledWith(
+      'Could not install Sanity agent skills: skills exited 1',
+    )
   })
 
   test('installs both the best-practices and migration skills', () => {

--- a/packages/@sanity/cli/src/actions/skills/setupSkills.ts
+++ b/packages/@sanity/cli/src/actions/skills/setupSkills.ts
@@ -1,7 +1,6 @@
 import {fileURLToPath} from 'node:url'
 
-import {ux} from '@oclif/core'
-import {subdebug} from '@sanity/cli-core'
+import {type Output, subdebug} from '@sanity/cli-core'
 import {logSymbols} from '@sanity/cli-core/ux'
 import {execa} from 'execa'
 
@@ -27,6 +26,12 @@ export const SKILLS_BIN_PATH = fileURLToPath(
 interface SetupSkillsOptions {
   /** Skills-CLI agent IDs (e.g. 'cursor', 'claude-code') to install for. */
   agents: string[]
+
+  /**
+   * Output to use for user-facing messages, so they go through the calling
+   * command rather than directly to stdout/stderr.
+   */
+  output: Output
 }
 
 interface SetupSkillsResult {
@@ -43,6 +48,7 @@ interface SetupSkillsResult {
  * must not abort `sanity init`.
  */
 export async function setupSkills(options: SetupSkillsOptions): Promise<SetupSkillsResult> {
+  const {output} = options
   const uniqueAgents = [...new Set(options.agents)]
 
   if (uniqueAgents.length === 0) {
@@ -67,16 +73,16 @@ export async function setupSkills(options: SetupSkillsOptions): Promise<SetupSki
     const result = await execa(process.execPath, args, {stdio: 'pipe', timeout: 90_000})
     skillsDebug('skills stdout: %s', result.stdout)
     skillsDebug('skills stderr: %s', result.stderr)
-    ux.stdout(`${logSymbols.success} Installed Sanity agent skills for ${uniqueAgents.join(', ')}`)
+    output.log(`${logSymbols.success} Installed Sanity agent skills for ${uniqueAgents.join(', ')}`)
     return {installedAgents: uniqueAgents, skipped: false}
   } catch (error) {
     skillsDebug('Error installing skills %O', error)
     const err = toError(error)
-    ux.warn(`Could not install Sanity agent skills: ${getErrorMessage(error)}`)
+    output.warn(`Could not install Sanity agent skills: ${getErrorMessage(error)}`)
     if (error && typeof error === 'object') {
       const {stderr, stdout} = error as {stderr?: string; stdout?: string}
-      if (stdout) ux.warn(stdout)
-      if (stderr) ux.warn(stderr)
+      if (stdout) output.warn(stdout)
+      if (stderr) output.warn(stderr)
     }
     return {error: err, installedAgents: [], skipped: false}
   }

--- a/packages/@sanity/cli/src/actions/telemetry/__tests__/telemetryDisclosure.test.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/__tests__/telemetryDisclosure.test.ts
@@ -1,0 +1,59 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {telemetryDisclosure} from '../telemetryDisclosure.js'
+
+const mockIsCi = vi.hoisted(() => vi.fn())
+const mockConfigGet = vi.hoisted(() => vi.fn())
+const mockConfigSet = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/cli-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/cli-core')>()
+  return {
+    ...actual,
+    getUserConfig: vi.fn().mockReturnValue({
+      delete: vi.fn(),
+      get: mockConfigGet,
+      set: mockConfigSet,
+    }),
+    isCi: mockIsCi,
+  }
+})
+
+describe('telemetryDisclosure', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('prints the disclosure to stderr and marks it disclosed', () => {
+    mockIsCi.mockReturnValue(false)
+    mockConfigGet.mockReturnValue(undefined)
+
+    const logToStderr = vi.fn()
+    telemetryDisclosure({logToStderr})
+
+    expect(logToStderr).toHaveBeenCalledOnce()
+    expect(logToStderr.mock.calls[0][0]).toContain('collects telemetry data')
+    expect(mockConfigSet).toHaveBeenCalledWith('telemetryDisclosed', expect.any(Number))
+  })
+
+  test('does nothing in CI environments', () => {
+    mockIsCi.mockReturnValue(true)
+
+    const logToStderr = vi.fn()
+    telemetryDisclosure({logToStderr})
+
+    expect(logToStderr).not.toHaveBeenCalled()
+    expect(mockConfigSet).not.toHaveBeenCalled()
+  })
+
+  test('does nothing when already disclosed', () => {
+    mockIsCi.mockReturnValue(false)
+    mockConfigGet.mockReturnValue(1_718_000_000_000)
+
+    const logToStderr = vi.fn()
+    telemetryDisclosure({logToStderr})
+
+    expect(logToStderr).not.toHaveBeenCalled()
+    expect(mockConfigSet).not.toHaveBeenCalled()
+  })
+})

--- a/packages/@sanity/cli/src/actions/telemetry/telemetryDisclosure.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/telemetryDisclosure.ts
@@ -1,6 +1,5 @@
 import {styleText} from 'node:util'
 
-import {ux} from '@oclif/core'
 import {getUserConfig, isCi} from '@sanity/cli-core'
 import {boxen} from '@sanity/cli-core/ux'
 
@@ -9,7 +8,16 @@ import {telemetryLearnMoreMessage} from './telemetryLearnMoreMessage.js'
 
 const TELEMETRY_DISCLOSED_CONFIG_KEY = 'telemetryDisclosed'
 
-export function telemetryDisclosure(): void {
+interface TelemetryDisclosureOptions {
+  /**
+   * Writes a plain (unprefixed) line to stderr. Injected by the caller so the
+   * disclosure goes through the calling hook/command rather than directly to
+   * the process streams.
+   */
+  logToStderr: (message: string) => void
+}
+
+export function telemetryDisclosure({logToStderr}: TelemetryDisclosureOptions): void {
   const userConfig = getUserConfig()
 
   if (isCi()) {
@@ -23,7 +31,7 @@ export function telemetryDisclosure(): void {
   }
 
   // Print to stderr to prevent garbling command output
-  ux.stderr(
+  logToStderr(
     boxen(
       `The Sanity CLI now collects telemetry data on general usage and errors.
 This helps us improve Sanity and prioritize features.

--- a/packages/@sanity/cli/src/actions/tokens/validateRole.ts
+++ b/packages/@sanity/cli/src/actions/tokens/validateRole.ts
@@ -1,4 +1,4 @@
-import {ux} from '@oclif/core'
+import {type Output} from '@sanity/cli-core'
 
 import {getTokenRoles} from '../../services/tokens.js'
 
@@ -6,11 +6,16 @@ import {getTokenRoles} from '../../services/tokens.js'
  * Validate a role name
  * @param roleName - The role name to validate
  * @param projectId - The project ID
+ * @param output - Output to raise the error through the calling command
  * @returns A promise that resolves to the validated role name
  *
  * @internal
  */
-export async function validateRole(roleName: string, projectId: string): Promise<string> {
+export async function validateRole(
+  roleName: string,
+  projectId: string,
+  output: Output,
+): Promise<string> {
   const roles = await getTokenRoles(projectId)
   const robotRoles = roles.filter((role) => role.appliesToRobots)
 
@@ -20,5 +25,5 @@ export async function validateRole(roleName: string, projectId: string): Promise
   }
 
   const availableRoles = robotRoles.map((r) => r.name).join(', ')
-  ux.error(`Invalid role "${roleName}". Available roles: ${availableRoles}`, {exit: 1})
+  return output.error(`Invalid role "${roleName}". Available roles: ${availableRoles}`, {exit: 1})
 }

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -223,7 +223,7 @@ describe('#init: bootstrap-app-initialization', () => {
 
     // Skills install runs after scaffolding has completed, with the agents
     // setupMCP told us to install.
-    expect(mocks.setupSkills).toHaveBeenCalledWith({agents: ['cursor']})
+    expect(mocks.setupSkills).toHaveBeenCalledWith({agents: ['cursor'], output: expect.any(Object)})
     const bootstrapOrder = mocks.bootstrapTemplate.mock.invocationCallOrder[0]
     const skillsOrder = mocks.setupSkills.mock.invocationCallOrder[0]
     expect(skillsOrder).toBeGreaterThan(bootstrapOrder)

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.staging-env.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.staging-env.test.ts
@@ -257,7 +257,7 @@ describe('#init: staging env propagation', () => {
     if (error) throw error
 
     expect(setupSkills).toHaveBeenCalledTimes(1)
-    expect(setupSkills).toHaveBeenCalledWith({agents: ['claude-code']})
+    expect(setupSkills).toHaveBeenCalledWith({agents: ['claude-code'], output: expect.any(Object)})
   })
 
   test('writes SANITY_INTERNAL_ENV to .env when in staging (template bootstrap path)', async () => {
@@ -349,6 +349,11 @@ describe('#init: staging env propagation', () => {
       },
     )
 
-    expect(setupMCP).toHaveBeenCalledWith({editors: [], mode: 'prompt', skillsMode: 'auto'})
+    expect(setupMCP).toHaveBeenCalledWith({
+      editors: [],
+      mode: 'prompt',
+      output: expect.any(Object),
+      skillsMode: 'auto',
+    })
   })
 })

--- a/packages/@sanity/cli/src/commands/backups/disable.ts
+++ b/packages/@sanity/cli/src/commands/backups/disable.ts
@@ -72,7 +72,7 @@ export class DisableBackupCommand extends SanityCommand<typeof DisableBackupComm
     }
 
     if (dataset) {
-      assertDatasetExists(datasets, dataset)
+      assertDatasetExists(datasets, dataset, this.output)
     } else {
       dataset = await this.promptForDataset(datasets)
     }

--- a/packages/@sanity/cli/src/commands/backups/download.ts
+++ b/packages/@sanity/cli/src/commands/backups/download.ts
@@ -122,7 +122,7 @@ export class DownloadBackupCommand extends SanityCommand<typeof DownloadBackupCo
     }
 
     if (dataset) {
-      assertDatasetExists(datasets, dataset)
+      assertDatasetExists(datasets, dataset, this.output)
     } else {
       dataset = await promptForDataset({allowCreation: false, datasets})
     }

--- a/packages/@sanity/cli/src/commands/backups/enable.ts
+++ b/packages/@sanity/cli/src/commands/backups/enable.ts
@@ -75,7 +75,7 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
     }
 
     if (dataset) {
-      assertDatasetExists(datasets, dataset)
+      assertDatasetExists(datasets, dataset, this.output)
     } else {
       dataset = await promptForDataset({allowCreation: true, datasets})
 

--- a/packages/@sanity/cli/src/commands/backups/list.ts
+++ b/packages/@sanity/cli/src/commands/backups/list.ts
@@ -99,7 +99,7 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
     }
 
     if (dataset) {
-      assertDatasetExists(datasets, dataset)
+      assertDatasetExists(datasets, dataset, this.output)
     } else {
       dataset = await this.promptForDataset(datasets)
     }

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/disable.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/disable.ts
@@ -53,7 +53,7 @@ export class DatasetEmbeddingsDisableCommand extends SanityCommand<
     })
 
     try {
-      ;({dataset} = await resolveDataset({dataset, projectId}))
+      ;({dataset} = await resolveDataset({dataset, output: this.output, projectId}))
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to resolve dataset: ${message}`, error)

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/enable.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/enable.ts
@@ -76,7 +76,7 @@ export class DatasetEmbeddingsEnableCommand extends SanityCommand<
     })
 
     try {
-      ;({dataset} = await resolveDataset({dataset, projectId}))
+      ;({dataset} = await resolveDataset({dataset, output: this.output, projectId}))
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to resolve dataset: ${message}`, error)

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/status.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/status.ts
@@ -48,7 +48,7 @@ export class DatasetEmbeddingsStatusCommand extends SanityCommand<
     })
 
     try {
-      ;({dataset} = await resolveDataset({dataset, projectId}))
+      ;({dataset} = await resolveDataset({dataset, output: this.output, projectId}))
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to resolve dataset: ${message}`, error)

--- a/packages/@sanity/cli/src/commands/mcp/configure.ts
+++ b/packages/@sanity/cli/src/commands/mcp/configure.ts
@@ -43,6 +43,7 @@ export class ConfigureMcpCommand extends SanityCommand<typeof ConfigureMcpComman
       const mcpResult = await setupMCP({
         explicit: true,
         mode: isInteractive() ? 'prompt' : 'auto',
+        output: this.output,
         skillsMode: 'skip',
       })
 

--- a/packages/@sanity/cli/src/commands/tokens/add.ts
+++ b/packages/@sanity/cli/src/commands/tokens/add.ts
@@ -78,7 +78,9 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
 
     try {
       const label = givenLabel || (await this.promptForLabel())
-      const roleName = await (role ? validateRole(role, projectId) : this.promptForRole(projectId))
+      const roleName = await (role
+        ? validateRole(role, projectId, this.output)
+        : this.promptForRole(projectId))
 
       tokensAddDebug(`Creating token for project ${projectId}`, {label, roleName})
       const token = await createToken({

--- a/packages/@sanity/cli/src/hooks/prerun/setupTelemetry.ts
+++ b/packages/@sanity/cli/src/hooks/prerun/setupTelemetry.ts
@@ -21,7 +21,7 @@ import {createTelemetryStore} from '../../util/telemetry/createTelemetryStore.js
 
 export const setupTelemetry: Hook.Prerun = async function ({config}) {
   // Show telemetry disclosure
-  telemetryDisclosure()
+  telemetryDisclosure({logToStderr: (message) => process.stderr.write(`${message}\n`)})
 
   const sessionId = createSessionId()
 


### PR DESCRIPTION
Pet peeve: interleaved messages in test output. It makes test output hard to read, especially for expected conditions. Additionally, it's a (slight) code smell, as it means we're usually capturing `console.log`/stdout or similar - we can usually test this easier in the test suite by providing stubs for our `output` abstraction instead. This also ensures that for things like errors and warnings, we can show them in a more uniform way, once we introduce our design language.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no intended user-visible behavior change; callers of these actions must now pass `output`, which is already wired in-repo.
> 
> **Overview**
> Routes CLI user-facing messages through the injected **`Output`** abstraction (`log` / `warn` / `error` from `@sanity/cli-core`) instead of **`@oclif/core` `ux`**, so action-level tests no longer leak lines into the Vitest reporter.
> 
> **`setupMCP`** and **`setupSkills`** now require a required **`output`** option; **`init`**, **`mcp configure`**, and related callers pass **`this.output`**. Dataset helpers (**`assertDatasetExists`**, **`resolveDataset`**) and **`validateRole`** take **`output`** for fatal errors via **`output.error(..., {exit: 1})`**. **`telemetryDisclosure`** accepts an injected **`logToStderr`** sink; the prerun hook wires **`process.stderr.write`**.
> 
> **CONTRIBUTING.md** documents the rule: no interleaved CLI output in tests, mock **`Output`** and assert calls. Unit tests for MCP/skills/telemetry were updated accordingly; init integration tests expect **`output`** in **`setupMCP`** / **`setupSkills`** call args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf8935cfd895db349b594beab43ec1f7928a46d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->