### PR TITLE
refactor: remove hardcoded auth callback port list

### DIFF
--- a/packages/@sanity/cli/src/actions/auth/__tests__/authServer.test.ts
+++ b/packages/@sanity/cli/src/actions/auth/__tests__/authServer.test.ts
@@ -15,7 +15,7 @@ vi.mock('node:http', async (importOriginal) => {
 })
 
 function useMockServer(
-  listen: (server: http.Server) => void,
+  listen: (server: http.Server, port?: number) => void,
   address: ReturnType<http.Server['address']> = null,
 ) {
   mockCreateServer.mockImplementationOnce(() => {
@@ -25,8 +25,8 @@ function useMockServer(
       emit(event: string, ...args: unknown[]) {
         for (const h of listeners.get(event) ?? []) h(...args)
       },
-      listen: function () {
-        listen(server as unknown as http.Server)
+      listen: function (port?: number) {
+        listen(server as unknown as http.Server, port)
         return server
       },
       on(event: string, handler: (...args: unknown[]) => void) {
@@ -40,7 +40,64 @@ function useMockServer(
 
 describe('startServerForTokenCallback', () => {
   afterEach(() => {
+    vi.unstubAllEnvs()
     vi.clearAllMocks()
+  })
+
+  test('falls back to an OS-assigned port when the preferred port is busy', async () => {
+    vi.stubEnv('SANITY_CLI_CALLBACK_PORT', '1234')
+
+    const attemptedPorts: (number | undefined)[] = []
+    useMockServer(
+      (server, port) => {
+        attemptedPorts.push(port)
+        if (attemptedPorts.length === 1) {
+          // Preferred port is busy, should fall back to an OS-assigned port (0)
+          setImmediate(() =>
+            server.emit('error', Object.assign(new Error('In use'), {code: 'EADDRINUSE'})),
+          )
+        } else {
+          setImmediate(() => server.emit('listening'))
+        }
+      },
+      {address: '127.0.0.1', family: 'IPv4', port: 54_321},
+    )
+
+    const {loginUrl} = await startServerForTokenCallback('https://api.sanity.io/auth/google')
+
+    expect(attemptedPorts).toEqual([1234, 0])
+    // The login URL must use the port the OS actually assigned, not the requested `0`
+    expect(loginUrl.searchParams.get('origin')).toBe('http://localhost:54321/callback')
+  })
+
+  test('rejects on EADDRINUSE for an OS-assigned port instead of retrying forever', async () => {
+    vi.stubEnv('SANITY_CLI_CALLBACK_PORT', '0')
+
+    useMockServer((server) =>
+      setImmediate(() =>
+        server.emit('error', Object.assign(new Error('In use'), {code: 'EADDRINUSE'})),
+      ),
+    )
+
+    await expect(startServerForTokenCallback('https://api.sanity.io/auth/google')).rejects.toThrow(
+      'In use',
+    )
+  })
+
+  test('rejects when SANITY_CLI_CALLBACK_PORT is not a port number', async () => {
+    vi.stubEnv('SANITY_CLI_CALLBACK_PORT', 'not-a-port')
+
+    await expect(startServerForTokenCallback('https://api.sanity.io/auth/google')).rejects.toThrow(
+      'Invalid SANITY_CLI_CALLBACK_PORT value: "not-a-port"',
+    )
+  })
+
+  test('rejects when SANITY_CLI_CALLBACK_PORT is out of range', async () => {
+    vi.stubEnv('SANITY_CLI_CALLBACK_PORT', '70000')
+
+    await expect(startServerForTokenCallback('https://api.sanity.io/auth/google')).rejects.toThrow(
+      'Invalid SANITY_CLI_CALLBACK_PORT value: "70000"',
+    )
   })
 
   test('rejects with non-EADDRINUSE server errors', async () => {

--- a/packages/@sanity/cli/src/actions/auth/authServer.ts
+++ b/packages/@sanity/cli/src/actions/auth/authServer.ts
@@ -7,8 +7,40 @@ import {getTokenDetails} from '../../services/auth.js'
 import {type TokenDetails} from './types.js'
 
 const debug = subdebug('auth')
-const callbackPorts = [4321, 4000, 3003, 1234, 8080, 13_333]
+const defaultCallbackPort = 4321
 const callbackEndpoint = '/callback'
+
+/**
+ * Get the port to first attempt binding the auth callback server to.
+ *
+ * The auth backend accepts any `http://localhost:<port>` origin for token
+ * callbacks, but we prefer a predictable port: it is friendlier for users who
+ * need to allow or forward the port (e.g. logging in from a remote machine over
+ * an SSH tunnel). If the preferred port is taken, we fall back to an
+ * OS-assigned ephemeral port.
+ *
+ * The `SANITY_CLI_CALLBACK_PORT` environment variable overrides the preferred
+ * port (`0` for an OS-assigned port). The override exists primarily for tests,
+ * where OS-assigned ports prevent collisions between tests running in parallel.
+ *
+ * @returns Port number to attempt first
+ * @internal
+ */
+function getPreferredCallbackPort(): number {
+  const override = process.env.SANITY_CLI_CALLBACK_PORT
+  if (!override) {
+    return defaultCallbackPort
+  }
+
+  debug('Using callback port from SANITY_CLI_CALLBACK_PORT: %s', override)
+
+  const port = Number.parseInt(override.trim(), 10)
+  if (Number.isNaN(port) || port < 0 || port > 65_535) {
+    throw new Error(`Invalid SANITY_CLI_CALLBACK_PORT value: "${override}"`)
+  }
+
+  return port
+}
 
 const platformNames: Record<string, string | undefined> = {
   aix: 'AIX',
@@ -28,7 +60,7 @@ const platformNames: Record<string, string | undefined> = {
  * do a request to the `/auth/fetch` endpoint with to get the actual auth token,
  * invalidating the SID in the process.
  *
- * If we fail to bind to the first port, we retry with the next port in the list.
+ * If we fail to bind to the preferred port, we retry with an OS-assigned port.
  *
  * @param providerUrl - The URL of the login provider
  * @returns Resolves with HTTP server instance, a login URL to send user to, and a `token` promise
@@ -39,9 +71,6 @@ export function startServerForTokenCallback(
 ): Promise<{loginUrl: URL; server: Server; token: Promise<TokenDetails>}> {
   const sanityUrl = getSanityUrl()
 
-  const attemptPorts = [...callbackPorts]
-  let callbackPort = attemptPorts.shift()
-
   // note: replace with `Promise.withResolvers()` when minimum Node.js is 22+
   let resolveToken: (resolvedToken: PromiseLike<TokenDetails> | TokenDetails) => void
   let rejectToken: (reason: Error) => void
@@ -51,6 +80,8 @@ export function startServerForTokenCallback(
   })
 
   return new Promise((resolve, reject) => {
+    let callbackPort = getPreferredCallbackPort()
+
     const server = createServer(async function onCallbackServerRequest(req, res) {
       function failLoginRequest(code = '') {
         res.writeHead(303, 'See Other', {
@@ -110,14 +141,13 @@ export function startServerForTokenCallback(
     })
 
     server.on('error', function onCallbackServerError(err) {
-      if ('code' in err && err.code === 'EADDRINUSE') {
-        callbackPort = attemptPorts.shift()
-        if (!callbackPort) {
-          reject(new Error('Failed to find port number to bind auth callback server to'))
-          return
-        }
-
-        debug('Port busy, trying %d', callbackPort)
+      // The auth backend accepts any localhost port in the callback origin, so if
+      // the preferred port is busy we fall back to an OS-assigned ephemeral port.
+      // Port 0 cannot itself be "in use" - an EADDRINUSE there means something is
+      // genuinely wrong, so only fall back once.
+      if ('code' in err && err.code === 'EADDRINUSE' && callbackPort !== 0) {
+        debug('Port %d busy, falling back to OS-assigned port', callbackPort)
+        callbackPort = 0
         server.listen(callbackPort)
       } else {
         reject(err)

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -147,6 +147,32 @@ function httpGetStatus(url: string | URL): Promise<number> {
 }
 
 /**
+ * Bind an HTTP server to an OS-assigned port, to deliberately occupy it.
+ * Used with the `SANITY_CLI_CALLBACK_PORT` override to exercise the login
+ * command's port fallback behavior without hardcoding port numbers.
+ */
+async function startBlockingServer(): Promise<{close: () => Promise<void>; port: number}> {
+  const server = http.createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, () => resolve())
+  })
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to bind blocking server')
+  }
+
+  return {
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve())
+      }),
+    port: address.port,
+  }
+}
+
+/**
  * Helper to set up the standard provider + token exchange mocks for a single-provider happy path.
  */
 function mockSingleProviderLogin(sessionId = 'test-session-id') {
@@ -181,6 +207,7 @@ describe('#login', {timeout: 10_000}, () => {
     for (const startup of mockedStartServerForTokenCallback.mock.settledResults) {
       if (startup.type === 'fulfilled') startup.value.server.close()
     }
+    vi.unstubAllEnvs()
     vi.clearAllMocks()
     mockedIsInteractive.mockReturnValue(true)
     const pending = pendingMocks()
@@ -929,22 +956,20 @@ describe('#login', {timeout: 10_000}, () => {
   })
 
   describe('Auth Server and Token Exchange', () => {
-    test('falls back to next port when first port is busy', async () => {
+    test('falls back to an OS-assigned port when the preferred port is busy', async () => {
       mockedGetCliToken.mockResolvedValue('')
       mockedCanLaunchBrowser.mockReturnValue(true)
 
       mockSingleProviderLogin()
 
-      // Block port 4321
-      const blockingServer = http.createServer()
-      await new Promise<void>((resolve) => {
-        blockingServer.listen(4321, () => resolve())
-      })
+      // Occupy a port, and configure the login command to prefer it
+      const blocker = await startBlockingServer()
+      vi.stubEnv('SANITY_CLI_CALLBACK_PORT', `${blocker.port}`)
 
       try {
         const commandPromise = testCommand(LoginCommand, [])
         const callbackUrl = await waitForCallbackUrl(commandPromise)
-        expect(callbackUrl.port).not.toBe('4321')
+        expect(Number(callbackUrl.port)).not.toBe(blocker.port)
 
         await simulateOAuthCallback(commandPromise, 'test-session-id')
         const {error} = await commandPromise
@@ -955,59 +980,7 @@ describe('#login', {timeout: 10_000}, () => {
         const loginUrl = new URL(mockedOpen.mock.calls[0][0] as string)
         expect(loginUrl.searchParams.get('origin')).toBe(callbackUrl.href)
       } finally {
-        await new Promise<void>((resolve) => {
-          blockingServer.close(() => resolve())
-        })
-      }
-    }, 10_000)
-
-    test('throws error when all ports are busy', async () => {
-      mockedGetCliToken.mockResolvedValue('')
-
-      mockApi({
-        apiVersion: AUTH_API_VERSION,
-        method: 'get',
-        uri: '/auth/providers',
-      }).reply(200, {
-        providers: [{name: 'google', title: 'Google', url: 'https://api.sanity.io/auth/google'}],
-      })
-
-      // Block all callback ports
-      const ports = [4321, 4000, 3003, 1234, 8080, 13_333]
-      const blockingServers: http.Server[] = []
-
-      for (const port of ports) {
-        const server = http.createServer()
-        server.on('error', () => {
-          // Port may already be in use, which is fine for our purposes
-        })
-        await new Promise<void>((resolve) => {
-          server.once('listening', () => {
-            blockingServers.push(server)
-            resolve()
-          })
-          server.once('error', () => {
-            // Port already blocked, that works too
-            resolve()
-          })
-          server.listen(port)
-        })
-      }
-
-      try {
-        const {error} = await testCommand(LoginCommand, [])
-
-        expect(error).toBeDefined()
-        expect(error?.message).toContain('Failed to find port number to bind auth callback server')
-      } finally {
-        await Promise.all(
-          blockingServers.map(
-            (server) =>
-              new Promise<void>((resolve) => {
-                server.close(() => resolve())
-              }),
-          ),
-        )
+        await blocker.close()
       }
     }, 10_000)
 


### PR DESCRIPTION
The auth backend accepts any localhost port in the callback origin, so the predefined fallback list (4321, 4000, 3003, 1234, 8080, 13333) is unnecessary. The login callback server now prefers port 4321 (kept for predictability, e.g. SSH port forwarding) and falls back once to an OS-assigned ephemeral port when it is taken. This removes the 'Failed to find port number' failure mode entirely.

The SANITY_CLI_CALLBACK_PORT env var overrides the preferred port, primarily so tests can exercise the fallback without binding hardcoded ports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI login/OAuth local callback binding; behavior change when preferred port is busy (ephemeral port instead of scanning a list), though the backend already allows any localhost port.
> 
> **Overview**
> Replaces the CLI OAuth callback server’s **multi-port retry list** with a **single preferred port (4321)** and **one fallback** to an OS-assigned ephemeral port (`listen(0)`), since the auth backend accepts any `localhost` callback origin.
> 
> Adds **`SANITY_CLI_CALLBACK_PORT`** to override the preferred port (including `0` for ephemeral binding), with validation for invalid/out-of-range values. On **`EADDRINUSE`**, the server retries only once (preferred → `0`); if binding on `0` still fails, it rejects instead of looping. This removes the **“Failed to find port number”** error when every fixed port was busy.
> 
> Tests cover fallback behavior, env validation, and integration login flows using a dynamic blocking server instead of hardcoded ports; the **“all ports busy”** integration test is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54e4c5bc3b687d9513a0c71dc50eb6bfcb9a7d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->