### PR TITLE
feat(workbench): enable being able to develop the workbench remote

### DIFF
--- a/.changeset/serve-workbench-remote-on-configured-port.md
+++ b/.changeset/serve-workbench-remote-on-configured-port.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): serve the workbench remote on its configured port in dev

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.test.ts
@@ -404,4 +404,43 @@ describe('devAction', () => {
     // No registration should have happened because the app never started
     expect(mockStartDevServerRegistration).not.toHaveBeenCalled()
   })
+
+  describe('workbench remote', () => {
+    // The remote is the shell content host apps load, not a host. It opts into
+    // this path via an internal env var set by its own dev script.
+    afterEach(() => {
+      vi.unstubAllEnvs()
+    })
+
+    test('serves on the configured port with no shell and no registration', async () => {
+      vi.stubEnv('SANITY_INTERNAL_IS_WORKBENCH_REMOTE', 'true')
+      mockGetSharedServerConfig.mockReturnValue({httpHost: 'localhost', httpPort: 5173})
+      mockStartAppDevServer.mockResolvedValue(mockServer({port: 5173}))
+
+      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}))
+
+      // No second shell, so no single-workbench lock contention.
+      expect(mockStartWorkbenchDevServer).not.toHaveBeenCalled()
+      // Keeps the configured port — flags pass through untouched, never bumped to
+      // `workbenchPort + 1` the way a host app's server is.
+      expect(mockStartAppDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flags: expect.objectContaining({port: DEV_FLAGS.port}),
+          workbenchAvailable: false,
+        }),
+      )
+      // Not a dock app — never registers into the shared workbench registry.
+      expect(mockStartDevServerRegistration).not.toHaveBeenCalled()
+    })
+
+    test('ignores the env var for a non-workbench (plain) project', async () => {
+      vi.stubEnv('SANITY_INTERNAL_IS_WORKBENCH_REMOTE', 'true')
+      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
+
+      await devAction(createBaseDevOptions())
+
+      // The brand is the gate — without it the normal workbench path still runs.
+      expect(mockStartWorkbenchDevServer).toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -38,12 +38,22 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     workDir,
   })
 
+  /**
+   * The workbench remote is the app that renders "workbench ready" apps, thereby it can't render itself.
+   * But it still wants to be deployed as a singleton in the sanity ecosystem. Therefore, this internal flag
+   * allows us to develop the workbench remote correctly – as a standalone app.
+   */
+  const isWorkbenchRemote =
+    isWorkbenchApp(cliConfig?.app) && process.env.SANITY_INTERNAL_IS_WORKBENCH_REMOTE === 'true'
+
   const {
     close: closeWorkbenchServer,
     httpHost: workbenchHost,
     workbenchAvailable,
     workbenchPort,
-  } = await startWorkbenchDevServer({...options, httpHost, httpPort})
+  } = isWorkbenchRemote
+    ? {close: noop, httpHost, workbenchAvailable: false, workbenchPort: httpPort}
+    : await startWorkbenchDevServer({...options, httpHost, httpPort})
 
   // A running workbench claims the configured port, so the app server is
   // pushed to the next one. Without a workbench the flags pass through
@@ -97,17 +107,20 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   }
 
   // Workbench is opted into solely by calling `unstable_defineApp` — its
-  // branded identity is the only signal.
-  const registration = isWorkbenchApp(cliConfig?.app)
-    ? await startDevServerRegistration({
-        cliConfig,
-        isApp: options.isApp,
-        onInterfaceSetChange,
-        output,
-        server,
-        workDir,
-      })
-    : undefined
+  // branded identity is the only signal. The workbench remote is the exception:
+  // it's the shell itself, not a dock app, so it never registers into the
+  // shared workbench registry.
+  const registration =
+    isWorkbenchApp(cliConfig?.app) && !isWorkbenchRemote
+      ? await startDevServerRegistration({
+          cliConfig,
+          isApp: options.isApp,
+          onInterfaceSetChange,
+          output,
+          server,
+          workDir,
+        })
+      : undefined
 
   if (workbenchAvailable) {
     const workbenchUrl = `http://${toDisplayHost(workbenchHost)}:${workbenchPort}`


### PR DESCRIPTION
### Description

The workbench remote renders other "workbench-ready" apps, so it can't be run as one itself. `sanity dev` currently treats it like a host app and never serves it on the port those apps load it from, so it can't be developed locally. This adds an internal opt-in so `sanity dev` runs it as the standalone federation remote it is.

### What to review

The opt-in branch in `devAction`; every other app/studio/plain-project path is unchanged.
