### PR TITLE
chore(workbench-cli): keep the package low-profile on npm

### DIFF
--- a/packages/@sanity/workbench-cli/ARCHITECTURE.md
+++ b/packages/@sanity/workbench-cli/ARCHITECTURE.md
@@ -1,0 +1,58 @@
+# @sanity/workbench-cli
+
+Workbench is the opt-in path for shipping federated app views and background
+services from a Sanity studio or SDK app. This package holds the Workbench
+implementation that used to live inside `@sanity/cli-build` and `@sanity/cli`,
+behind a deliberately small interface so it can be pulled back out if Workbench
+doesn't graduate from `unstable_`.
+
+> Experimental. Everything here is gated behind `unstable_defineApp`. Projects
+> that never call it keep the CLI's normal dev/build/deploy behaviour.
+
+## What lives here
+
+- The authoring API — `unstable_defineApp`, `unstable_defineView`,
+  `unstable_defineService` and their types.
+- The Vite module-federation stack — the `federation` plugin and the
+  Sanity-specific plugins it composes (environment, extension artifacts,
+  federation runtime), plus the remote render helper and artifact types.
+
+## The interface (the part that has to stay clean)
+
+Core touches Workbench in exactly three places. Removing Workbench means
+deleting this package and reverting these three seams — nothing else.
+
+1. **The opt-in signal — a global brand symbol.**
+   `unstable_defineApp` stamps `Symbol.for('sanity.workbench.defineApp')` on its
+   result. `@sanity/cli-core` discriminates on that symbol in `isWorkbenchApp`
+   without importing this package (it re-derives the same global symbol), which
+   keeps cli-core — the hot path for every command — free of a Workbench
+   dependency. The shared contract is just the symbol string.
+
+2. **The authoring API entry — `@sanity/workbench-cli` (`.`).**
+   Browser-safe, zod-only. `@sanity/cli` re-exports it on `sanity/cli`
+   (`unstable_defineApp`) and the `sanity` runtime entry (`unstable_defineView` /
+   `unstable_defineService`). App authors only ever import the `sanity` path.
+
+3. **The build entry — `@sanity/workbench-cli/vite`.**
+   Node-only. `@sanity/cli-build`'s `getViteConfig` swaps in the `federation`
+   plugin (and uses the artifact types) when `isWorkbenchApp` is set, instead of
+   the normal client plugins.
+
+## Dependency direction
+
+```
+@sanity/cli  ──►  @sanity/cli-build  ──►  @sanity/workbench-cli  ──►  @sanity/cli-core
+     └──────────────────────────────────────────►──────────────────────┘
+```
+
+`@sanity/workbench-cli` depends only on `@sanity/cli-core` (type-only). Nothing
+in cli-core depends back on it — the brand symbol is the only thing they share.
+
+## Not yet extracted
+
+The dev-server orchestration (registry/lock, dev registration, the workbench
+dev server) and the deploy guards still live in `@sanity/cli`. They depend on
+core dev-server internals, so moving them needs a small extension interface on
+the `dev`/`deploy` commands rather than a straight file move. Tracked as the
+next step.

--- a/packages/@sanity/workbench-cli/README.md
+++ b/packages/@sanity/workbench-cli/README.md
@@ -1,58 +1,10 @@
 # @sanity/workbench-cli
 
-Workbench is the opt-in path for shipping federated app views and background
-services from a Sanity studio or SDK app. This package holds the Workbench
-implementation that used to live inside `@sanity/cli-build` and `@sanity/cli`,
-behind a deliberately small interface so it can be pulled back out if Workbench
-doesn't graduate from `unstable_`.
+Internal implementation detail of the [Sanity CLI](https://github.com/sanity-io/cli).
+It backs the CLI's **unstable** workbench support and is not meant to be installed
+or imported directly — its API can change or be removed without notice.
 
-> Experimental. Everything here is gated behind `unstable_defineApp`. Projects
-> that never call it keep the CLI's normal dev/build/deploy behaviour.
+Workbench is opt-in per project via `unstable_defineApp` in `sanity.cli.ts`; use it
+through the `sanity` CLI, not this package.
 
-## What lives here
-
-- The authoring API — `unstable_defineApp`, `unstable_defineView`,
-  `unstable_defineService` and their types.
-- The Vite module-federation stack — the `federation` plugin and the
-  Sanity-specific plugins it composes (environment, extension artifacts,
-  federation runtime), plus the remote render helper and artifact types.
-
-## The interface (the part that has to stay clean)
-
-Core touches Workbench in exactly three places. Removing Workbench means
-deleting this package and reverting these three seams — nothing else.
-
-1. **The opt-in signal — a global brand symbol.**
-   `unstable_defineApp` stamps `Symbol.for('sanity.workbench.defineApp')` on its
-   result. `@sanity/cli-core` discriminates on that symbol in `isWorkbenchApp`
-   without importing this package (it re-derives the same global symbol), which
-   keeps cli-core — the hot path for every command — free of a Workbench
-   dependency. The shared contract is just the symbol string.
-
-2. **The authoring API entry — `@sanity/workbench-cli` (`.`).**
-   Browser-safe, zod-only. `@sanity/cli` re-exports it on `sanity/cli`
-   (`unstable_defineApp`) and the `sanity` runtime entry (`unstable_defineView` /
-   `unstable_defineService`). App authors only ever import the `sanity` path.
-
-3. **The build entry — `@sanity/workbench-cli/vite`.**
-   Node-only. `@sanity/cli-build`'s `getViteConfig` swaps in the `federation`
-   plugin (and uses the artifact types) when `isWorkbenchApp` is set, instead of
-   the normal client plugins.
-
-## Dependency direction
-
-```
-@sanity/cli  ──►  @sanity/cli-build  ──►  @sanity/workbench-cli  ──►  @sanity/cli-core
-     └──────────────────────────────────────────►──────────────────────┘
-```
-
-`@sanity/workbench-cli` depends only on `@sanity/cli-core` (type-only). Nothing
-in cli-core depends back on it — the brand symbol is the only thing they share.
-
-## Not yet extracted
-
-The dev-server orchestration (registry/lock, dev registration, the workbench
-dev server) and the deploy guards still live in `@sanity/cli`. They depend on
-core dev-server internals, so moving them needs a small extension interface on
-the `dev`/`deploy` commands rather than a straight file move. Tracked as the
-next step.
+Maintainers: see `ARCHITECTURE.md` (not published) for how this package fits together.

--- a/packages/@sanity/workbench-cli/package.json
+++ b/packages/@sanity/workbench-cli/package.json
@@ -1,14 +1,7 @@
 {
   "name": "@sanity/workbench-cli",
   "version": "1.0.0",
-  "description": "Workbench extension for the Sanity CLI: federated app/studio authoring API and Vite federation build. Opt-in via unstable_defineApp.",
-  "keywords": [
-    "cli",
-    "federation",
-    "module-federation",
-    "sanity",
-    "workbench"
-  ],
+  "description": "Internal implementation detail of the Sanity CLI's unstable workbench support. Not intended for direct use.",
   "homepage": "https://github.com/sanity-io/cli",
   "bugs": "https://github.com/sanity-io/cli/issues",
   "license": "MIT",


### PR DESCRIPTION
### Description

`@sanity/workbench-cli` has to be published — `@sanity/cli` and `@sanity/cli-build` depend on it at `^1.0.0`, so the released CLI 404s if it isn't on npm. That rules out the usual "hide it" levers: it can't be `private`, and it can't go in the changesets `ignore` list (that hard-errors — changesets demands its non-private dependents be ignored too, which would stop the CLI from publishing).

It's an unstable, internal implementation detail, so this just trims its npm footprint:

- Drop `keywords` (less searchable).
- Rewrite the `description` and README as "internal, not intended for direct use."
- Move the architecture notes to `ARCHITECTURE.md`, which `files: ["./dist"]` keeps out of the published tarball — repo-only for maintainers.

It already stays out of changelogs / the "Version Packages" PR (no changeset bumps it) and publishes silently at `1.0.0` via `changeset publish`.

### What to review

- The package **stays published** (required by cli/cli-build) — this only reduces discoverability and metadata, nothing structural.
- The publishable surface (`name`, `version`, `files`, `exports`) is unchanged, so it still publishes the same artifact.
- `ARCHITECTURE.md` is excluded from the npm tarball by `files`; the published README is the terse internal note.

### Testing

Metadata/docs only — no code or publishable-surface changes. `files`/`exports`/`version` are untouched and `publint` stays clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and package metadata only; publish surface (`files`, `exports`, version) is unchanged.
> 
> **Overview**
> Reduces npm discoverability of `@sanity/workbench-cli` while keeping it published for `@sanity/cli` / `@sanity/cli-build` dependents.
> 
> **`package.json`** drops the `keywords` array and replaces the description with wording that marks the package as an internal, unstable CLI detail—not for direct install or import.
> 
> **README** is shortened to that same “internal, use via `sanity` CLI” message and points maintainers at repo-only architecture notes.
> 
> **`ARCHITECTURE.md`** is added with the former README content (opt-in model, three integration seams, dependency graph, extraction TODO). It is not in the published tarball because `files` still only ships `./dist`, so npm consumers see the terse README only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb4ee48d1c0f01bee337d8c21d939e490ef1d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->