### PR TITLE
chore(test): convert a cli installation check to unit test

### DIFF
--- a/packages/@sanity/cli/src/actions/doctor/__tests__/cliInstallationCheck.test.ts
+++ b/packages/@sanity/cli/src/actions/doctor/__tests__/cliInstallationCheck.test.ts
@@ -23,24 +23,6 @@ describe('cliInstallationCheck', () => {
     vi.clearAllMocks()
   })
 
-  test('shows success message with version when no issues found', async () => {
-    const cwd = path.join(fixturesDir, 'clean-npm-install')
-
-    const result = await cliInstallationCheck.run({cwd})
-
-    expect(result.status).toBe('passed')
-    // Should have a brief success message, not verbose info dump
-    const successMsg = result.messages.find((m) => m.type === 'success')
-    expect(successMsg).toBeDefined()
-    expect(successMsg?.text).toContain('sanity@')
-    expect(successMsg?.text).toContain('no issues found')
-
-    // Should NOT have info-dump messages about workspace type, execution context
-    const infoMessages = result.messages.filter((m) => m.type === 'info')
-    expect(infoMessages.filter((m) => m.text.startsWith('Workspace:'))).toHaveLength(0)
-    expect(infoMessages.filter((m) => m.text.startsWith('Running CLI from:'))).toHaveLength(0)
-  })
-
   test('returns error status when sanity is declared but not installed', async () => {
     const cwd = path.join(fixturesDir, 'standalone-npm')
 

--- a/packages/@sanity/cli/src/actions/doctor/checks/__tests__/cliInstallation.unit.test.ts
+++ b/packages/@sanity/cli/src/actions/doctor/checks/__tests__/cliInstallation.unit.test.ts
@@ -1,0 +1,52 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+const mockDetectCliInstallation = vi.hoisted(() => vi.fn())
+
+vi.mock(
+  import('../../../../util/packageManager/installationInfo/detectCliInstallation.js'),
+  async (importOriginal) => {
+    const actual = await importOriginal()
+    return {
+      ...actual,
+      detectCliInstallation: mockDetectCliInstallation,
+    }
+  },
+)
+
+const {cliInstallationCheck} = await import('../cliInstallation.js')
+
+describe('cliInstallationCheck.run', () => {
+  beforeEach(() => {
+    mockDetectCliInstallation.mockResolvedValue({packages: {sanity: {}}})
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns hint to run in studio dir if detectCliInstallation returns no sanity package info', async () => {
+    mockDetectCliInstallation.mockResolvedValue({issues: [], packages: {}})
+    const result = await cliInstallationCheck.run({cwd: 'no importa'})
+
+    expect(result.status).toBe('passed')
+    // Should have a brief info message
+    const infoMsg = result.messages.find((m) => m.type === 'info')
+    expect(infoMsg).toBeDefined()
+    expect(infoMsg?.text).toContain('No Sanity studio detected')
+  })
+
+  test('returns success message with version when no issues found', async () => {
+    mockDetectCliInstallation.mockResolvedValue({issues: [], packages: {sanity: {declared: true}}})
+    const result = await cliInstallationCheck.run({cwd: 'no importa'})
+
+    expect(result.status).toBe('passed')
+    // Should have a brief success message, not verbose info dump
+    const successMsg = result.messages.find((m) => m.type === 'success')
+    expect(successMsg).toBeDefined()
+    expect(successMsg?.text).toMatch(/no issues found/i)
+
+    // Should NOT have info-dump messages about workspace type, execution context
+    const infoMessages = result.messages.filter((m) => m.type === 'info')
+    expect(infoMessages.filter((m) => m.text.startsWith('Workspace:'))).toHaveLength(0)
+    expect(infoMessages.filter((m) => m.text.startsWith('Running CLI from:'))).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
### Description

Convert a heavy integration test for happy path of cli installation check to a unit test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production or runtime behavior changes.
> 
> **Overview**
> Moves the **CLI installation doctor check** happy-path coverage out of fixture-based integration tests into a new **`cliInstallation.unit.test.ts`** that **mocks `detectCliInstallation`**.
> 
> The integration suite **`cliInstallationCheck.test.ts`** drops the **`clean-npm-install`** success scenario; error/fixture cases (e.g. declared-but-not-installed, multiple lockfiles) stay there. The unit file adds cases for **no Sanity package info** (info hint to run in a studio dir) and **clean install with no issues** (brief success, no workspace/execution info dump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a52ac693657b5facfe1c8dcf46467a64a3ae88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->