### PR TITLE
fix(workbench): keep the ./src/App default for non-branded apps

### DIFF
--- a/.changeset/pr-1328.md
+++ b/.changeset/pr-1328.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': patch
+'@sanity/cli': patch
+---
+
+fix(workbench): keep the ./src/App default for non-branded apps

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/resolveEntries.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/resolveEntries.test.ts
@@ -1,0 +1,32 @@
+import {describe, expect, test} from 'vitest'
+
+import {resolveEntries} from '../writeSanityRuntime.js'
+
+describe('resolveEntries', () => {
+  // For apps, `resolveEntries` is pure path math (no studio-config lookup), so a
+  // real absolute cwd is enough; the runtime dir defaults to `<cwd>/.sanity/runtime`,
+  // which is always two levels below `<cwd>/src/...`.
+  const cwd = process.cwd()
+
+  test('a non-branded app without an entry keeps the ./src/App default', async () => {
+    // Regression guard: gating the dock-only stub on `isApp` regressed legacy
+    // (non-branded) SDK apps that rely on the `./src/App` default to "no app view".
+    const {relativeEntry} = await resolveEntries({cwd, isApp: true, isWorkbenchApp: false})
+    expect(relativeEntry).toBe('../../src/App')
+  })
+
+  test('a branded app without an entry has no app view (null → dock-only)', async () => {
+    const {relativeEntry} = await resolveEntries({cwd, isApp: true, isWorkbenchApp: true})
+    expect(relativeEntry).toBeNull()
+  })
+
+  test('a branded app with an explicit entry resolves it', async () => {
+    const {relativeEntry} = await resolveEntries({
+      cwd,
+      entry: './src/Main.tsx',
+      isApp: true,
+      isWorkbenchApp: true,
+    })
+    expect(relativeEntry).toBe('../../src/Main.tsx')
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
+++ b/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
@@ -21,6 +21,7 @@ interface RuntimeOptions {
   basePath?: string
   entry?: string
   isApp?: boolean
+  isWorkbenchApp?: boolean
 }
 
 /**
@@ -35,7 +36,7 @@ export async function writeSanityRuntime(options: RuntimeOptions): Promise<{
   entries: {relativeConfigLocation: string | null; relativeEntry: string | null}
   watcher: FSWatcher | undefined
 }> {
-  const {appTitle, basePath, cwd, entry, isApp, reactStrictMode, watch} = options
+  const {appTitle, basePath, cwd, entry, isApp, isWorkbenchApp, reactStrictMode, watch} = options
   const runtimeDir = path.join(cwd, '.sanity', 'runtime')
 
   buildDebug('Making runtime directory')
@@ -78,6 +79,7 @@ export async function writeSanityRuntime(options: RuntimeOptions): Promise<{
     cwd,
     entry,
     isApp,
+    isWorkbenchApp,
     runtimeDir,
   })
   const appJsContent = getEntryModule({
@@ -107,9 +109,10 @@ export async function resolveEntries(options: {
   cwd: string
   entry?: string
   isApp?: boolean
+  isWorkbenchApp?: boolean
   runtimeDir?: string
 }): Promise<{relativeConfigLocation: string | null; relativeEntry: string | null}> {
-  const {cwd, entry, isApp} = options
+  const {cwd, entry, isApp, isWorkbenchApp} = options
   const runtimeDir = options.runtimeDir ?? path.join(cwd, '.sanity', 'runtime')
 
   let relativeConfigLocation: string | null = null
@@ -120,11 +123,14 @@ export async function resolveEntries(options: {
       : null
   }
 
-  // A branded app that declares no `entry` has no navigable app view (sanity-io/workbench spec 002-workbench-extension-api, US5):
-  // `null` entry tells the runtime/federation to skip the `./App` render path.
-  // Studios ignore `relativeEntry`, so the legacy `./src/App` default is fine.
+  // Only a *branded* app (`unstable_defineApp`) that declares no `entry` has no
+  // navigable app view (sanity-io/workbench spec 002-workbench-extension-api,
+  // US5): `null` entry tells the runtime/federation to skip the `./App` render
+  // path. Non-branded (legacy SDK) apps keep the historical `./src/App` default,
+  // and studios ignore `relativeEntry` — so gating on `isApp` here would regress
+  // non-opted-in apps to the dock-only stub.
   const relativeEntry =
-    isApp && !entry
+    isWorkbenchApp && !entry
       ? null
       : toForwardSlashes(path.relative(runtimeDir, path.resolve(cwd, entry || './src/App')))
 

--- a/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStaticFiles.ts
@@ -86,7 +86,7 @@ export async function buildStaticFiles(
    */
   if (isWorkbenchApp) {
     buildDebug('Resolving entries for federation build')
-    const entries = await resolveEntries({cwd, entry, isApp})
+    const entries = await resolveEntries({cwd, entry, isApp, isWorkbenchApp})
 
     buildDebug('Resolving vite config (federation)')
     let viteConfig = await getViteConfig({
@@ -132,6 +132,7 @@ export async function buildStaticFiles(
     cwd,
     entry,
     isApp,
+    isWorkbenchApp,
     reactStrictMode: false,
     watch: false,
   })

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -74,6 +74,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     cwd,
     entry,
     isApp,
+    isWorkbenchApp,
     reactStrictMode,
     watch: true,
   })


### PR DESCRIPTION
Gating the dock-only "no app view" stub on `isApp` instead of `isWorkbenchApp` regressed non-branded (legacy SDK) apps that omit `entry` to the empty stub instead of the documented `./src/App` default — a behavior change for projects that never opted into workbench ([#907 review](https://github.com/sanity-io/cli/pull/907#discussion_r3411964987)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted CLI runtime entry-resolution fix with regression tests; behavior change only restores pre-regression defaults for non-workbench apps.
> 
> **Overview**
> Fixes a regression where **any** app without an `entry` got a `null` runtime entry (dock-only / no app view). Entry resolution now applies that behavior only when **`isWorkbenchApp`** is true (branded `unstable_defineApp` workbench apps), not for all `isApp` projects.
> 
> Legacy SDK apps that omit `entry` again resolve to **`./src/App`** as before. Branded workbench apps with no `entry` still get `null`; explicit entries are unchanged. **`isWorkbenchApp`** is threaded through `writeSanityRuntime`, dev server, and federation/static build paths, with **`resolveEntries`** unit tests covering the three cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ee04d886b56c6e815ae1dd7982aa38b1dfd563d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->