### PR TITLE
fix(workbench): release dev servers and lock when registration fails

### DIFF
--- a/.changeset/pr-1329.md
+++ b/.changeset/pr-1329.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(workbench): release dev servers and lock when registration fails

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.unit.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.unit.test.ts
@@ -177,6 +177,30 @@ describe('devAction', () => {
       expect(mockStartDevServerRegistration).not.toHaveBeenCalled()
     })
 
+    test('tears down both servers and re-throws when registration fails', async () => {
+      // Registration runs after both servers are up, so a failure here must not
+      // leak the workbench lock or the dev servers.
+      const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
+      const mockAppClose = vi.fn().mockResolvedValue(undefined)
+      mockStartWorkbenchDevServer.mockResolvedValue({
+        close: mockWorkbenchClose,
+        httpHost: 'localhost',
+        workbenchAvailable: true,
+        workbenchPort: 3333,
+      })
+      mockStartStudioDevServer.mockResolvedValue({...mockServer({port: 3334}), close: mockAppClose})
+      const registrationError = new Error('deriveInterfaces failed')
+      mockStartDevServerRegistration.mockRejectedValue(registrationError)
+
+      const thrown = await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()})).catch(
+        (err) => err,
+      )
+
+      expect(thrown).toBe(registrationError)
+      expect(mockWorkbenchClose).toHaveBeenCalled()
+      expect(mockAppClose).toHaveBeenCalled()
+    })
+
     test('passes isApp: true for app mode', async () => {
       mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
 

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -110,17 +110,26 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
   // branded identity is the only signal. The workbench remote is the exception:
   // it's the shell itself, not a dock app, so it never registers into the
   // shared workbench registry.
-  const registration =
-    isWorkbenchApp(cliConfig?.app) && !isWorkbenchRemote
-      ? await startDevServerRegistration({
-          cliConfig,
-          isApp: options.isApp,
-          onInterfaceSetChange,
-          output,
-          server,
-          workDir,
-        })
-      : undefined
+  let registration: Awaited<ReturnType<typeof startDevServerRegistration>> | undefined
+  try {
+    registration =
+      isWorkbenchApp(cliConfig?.app) && !isWorkbenchRemote
+        ? await startDevServerRegistration({
+            cliConfig,
+            isApp: options.isApp,
+            onInterfaceSetChange,
+            output,
+            server,
+            workDir,
+          })
+        : undefined
+  } catch (err) {
+    // Registration runs only after both servers are already up. If it throws
+    // (e.g. `deriveInterfaces` rejects), tear them down before rethrowing —
+    // otherwise the workbench lock and dev servers leak until the next run.
+    await Promise.allSettled([closeWorkbenchServer(), closeAppDevServer()])
+    throw err
+  }
 
   if (workbenchAvailable) {
     const workbenchUrl = `http://${toDisplayHost(workbenchHost)}:${workbenchPort}`


### PR DESCRIPTION
Workbench registration runs after both dev servers are up but outside any try/catch, so a failure (e.g. `deriveInterfaces` throwing) left the workbench lock and dev servers running until the next run pruned them ([#907 review](https://github.com/sanity-io/cli/pull/907#discussion_r3438554584)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change in the dev CLI with a matching unit test; no production runtime or auth/data paths.
> 
> **Overview**
> Fixes a **resource leak** in workbench dev mode when `startDevServerRegistration` throws after the workbench and app/studio servers are already running (for example when `deriveInterfaces` fails).
> 
> `devAction` now wraps registration in **try/catch**. On failure it calls `closeWorkbenchServer` and `closeAppDevServer` via `Promise.allSettled`, then **rethrows** the original error so callers still see the failure. A unit test asserts both servers are closed and the error propagates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2385d4c56ef914889d819bbae3803a943584492c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->