### PR TITLE
fix(workbench): validate unstable_defineApp config (build fails, dev warns)

### DIFF
--- a/.changeset/pr-1330.md
+++ b/.changeset/pr-1330.md
@@ -1,8 +1,5 @@
 <!-- auto-generated -->
 ---
-'@sanity/cli-build': patch
-'@sanity/cli-core': patch
-'@sanity/cli-test': patch
 '@sanity/cli': patch
 '@sanity/workbench-cli': patch
 ---

--- a/.changeset/pr-1330.md
+++ b/.changeset/pr-1330.md
@@ -1,5 +1,8 @@
 <!-- auto-generated -->
 ---
+'@sanity/cli-build': patch
+'@sanity/cli-core': patch
+'@sanity/cli-test': patch
 '@sanity/cli': patch
 '@sanity/workbench-cli': patch
 ---

--- a/.changeset/pr-1330.md
+++ b/.changeset/pr-1330.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+'@sanity/workbench-cli': patch
+---
+
+fix(workbench): validate unstable_defineApp config (build fails, dev warns)

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -19,7 +19,7 @@ import {
   UserViteConfig,
 } from '@sanity/cli-core'
 import {confirm, logSymbols, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
-import {type DefineAppInput} from '@sanity/workbench-cli'
+import {type DefineAppInput, validateWorkbenchApp} from '@sanity/workbench-cli'
 import {resolveWorkbenchApp} from '@sanity/workbench-cli/build'
 import {parse as semverParse} from 'semver'
 
@@ -67,6 +67,16 @@ export async function buildApp(options: BuildOptions): Promise<void> {
   // `views`/`services` live on the branded `unstable_defineApp` result, not the
   // legacy `app` config object — resolve the workbench capability to read them.
   const workbench = resolveWorkbenchApp(cliConfig)
+
+  // `unstable_defineApp` doesn't validate its input, so fail the build on an
+  // invalid workbench config (bad name, missing title, duplicate view/service
+  // names) — `sanity dev` warns on the same check instead.
+  if (workbench) {
+    const invalid = validateWorkbenchApp(app)
+    if (invalid) {
+      output.error(invalid, {exit: 1})
+    }
+  }
 
   await internalBuildApp({
     appId: getAppId(cliConfig),

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -21,7 +21,7 @@ import {
   UserViteConfig,
 } from '@sanity/cli-core'
 import {confirm, logSymbols, select, spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
-import {type DefineAppInput} from '@sanity/workbench-cli'
+import {type DefineAppInput, validateWorkbenchApp} from '@sanity/workbench-cli'
 import {resolveWorkbenchApp} from '@sanity/workbench-cli/build'
 import {parse as semverParse} from 'semver'
 
@@ -72,6 +72,17 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
   // `views`/`services` live on the branded `unstable_defineApp` result — resolve
   // the workbench capability so it's gated on the brand, like the app build.
   const workbench = resolveWorkbenchApp(cliConfig)
+
+  // `unstable_defineApp` doesn't validate its input, so fail the build on an
+  // invalid workbench config — `sanity dev` warns on the same check instead.
+  if (workbench) {
+    const invalid = validateWorkbenchApp(
+      cliConfig && 'app' in cliConfig ? cliConfig.app : undefined,
+    )
+    if (invalid) {
+      output.error(invalid, {exit: 1})
+    }
+  }
 
   const upgradePkgs = async (options: {
     packages: [name: string, version: string][]

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.unit.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.unit.test.ts
@@ -5,6 +5,7 @@ import {
   createBaseDevOptions,
   createMockOutput,
   DEV_FLAGS,
+  workbenchApp,
   workbenchCliConfig,
 } from './testHelpers.js'
 
@@ -120,6 +121,22 @@ describe('devAction', () => {
 
     expect(mockStartAppDevServer).toHaveBeenCalled()
     expect(mockStartStudioDevServer).not.toHaveBeenCalled()
+  })
+
+  test('warns but still starts dev when the workbench config is invalid', async () => {
+    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+    const output = createMockOutput()
+
+    const result = await devAction(
+      createBaseDevOptions({
+        cliConfig: workbenchCliConfig({app: workbenchApp({name: 'bad name'})}),
+        output,
+      }),
+    )
+
+    expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('unstable_defineApp'))
+    expect(result.close).toBeTypeOf('function')
+    expect(mockStartStudioDevServer).toHaveBeenCalled()
   })
 
   test('cleans up workbench and re-throws when app/studio startup fails', async () => {

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -1,6 +1,7 @@
 import {styleText} from 'node:util'
 
 import {getCliConfigUncached, isWorkbenchApp} from '@sanity/cli-core'
+import {validateWorkbenchApp} from '@sanity/workbench-cli'
 import {type ViteDevServer} from 'vite'
 
 import {getSharedServerConfig} from '../../util/getSharedServerConfig.js'
@@ -39,6 +40,17 @@ function toDisplayHost(host: string | undefined): string {
  */
 export async function devAction(options: DevActionOptions): Promise<{close: () => Promise<void>}> {
   const {cliConfig, flags, output, workDir} = options
+
+  // `unstable_defineApp` is a pure identity wrapper, so this is the first place
+  // its config is validated. In dev we warn and keep going — the server still
+  // starts so the author can fix it live — whereas `sanity build` fails the same
+  // check.
+  if (isWorkbenchApp(cliConfig?.app)) {
+    const invalid = validateWorkbenchApp(cliConfig.app)
+    if (invalid) {
+      output.warn(invalid)
+    }
+  }
 
   const {httpHost, httpPort} = getSharedServerConfig({
     cliConfig,

--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -6,6 +6,7 @@ import {
   type DefineAppResult,
   type DockGroup,
   unstable_defineApp,
+  validateWorkbenchApp,
 } from '../defineApp.js'
 
 // The brand is a global-registry symbol; re-derive it the way the CLI loader
@@ -223,5 +224,35 @@ describe('type surface', () => {
 
   test('does not expose the internal applicationType', () => {
     expectTypeOf<DefineAppResult>().not.toHaveProperty('applicationType')
+  })
+})
+
+describe('validateWorkbenchApp', () => {
+  test('returns null for a valid app', () => {
+    expect(
+      validateWorkbenchApp({name: 'drop-desk', organizationId: 'org-1', title: 'Drop'}),
+    ).toBeNull()
+  })
+
+  test('reports an invalid name', () => {
+    expect(
+      validateWorkbenchApp({name: 'drop desk', organizationId: 'org-1', title: 'Drop'}),
+    ).toMatch(/name/)
+  })
+
+  test('reports a missing title', () => {
+    expect(validateWorkbenchApp({name: 'drop-desk', organizationId: 'org-1'})).toMatch(/title/)
+  })
+
+  test('reports a studio that declares an entry', () => {
+    expect(
+      validateWorkbenchApp({
+        applicationType: 'studio',
+        entry: './src/App.tsx',
+        name: 'fernway',
+        organizationId: 'org-1',
+        title: 'Fernway',
+      }),
+    ).toMatch(/not implemented yet/)
   })
 })

--- a/packages/@sanity/workbench-cli/src/_exports/index.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/index.ts
@@ -9,7 +9,7 @@
 // reachable from here ships in the frontend bundle. The Node-only build glue
 // lives behind the separate `./vite` entry and never leaks in.
 export type {InterfaceType, ServiceType} from '../contract.js'
-export {unstable_defineApp} from '../defineApp.js'
+export {unstable_defineApp, validateWorkbenchApp} from '../defineApp.js'
 export type {DefineAppInput, DefineAppResult, DockGroup} from '../defineApp.js'
 export {unstable_defineService} from '../defineService.js'
 export type {

--- a/packages/@sanity/workbench-cli/src/defineApp.ts
+++ b/packages/@sanity/workbench-cli/src/defineApp.ts
@@ -99,6 +99,27 @@ export const DefineAppInputSchema = z
   )
 
 /**
+ * Validate a resolved branded `app` config against {@link DefineAppInputSchema}.
+ * Returns a human-readable, multi-line message describing what's wrong, or
+ * `null` when valid. Returns the message rather than throwing so each caller
+ * picks its own policy — `sanity build` fails on it, `sanity dev` warns — and so
+ * the studio app-view rule (which needs the resolved `applicationType`) is only
+ * enforced once `parseWorkbenchCliConfig` has settled the type.
+ * @internal
+ */
+export function validateWorkbenchApp(app: unknown): string | null {
+  const result = DefineAppInputSchema.safeParse(app)
+  if (result.success) return null
+  const issues = result.error.issues
+    .map((issue) => {
+      const at = issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
+      return `  - ${at}${issue.message}`
+    })
+    .join('\n')
+  return `Invalid \`unstable_defineApp\` config:\n${issues}`
+}
+
+/**
  * User-facing input for `unstable_defineApp`. Excludes the internal
  * `applicationType` — that field is validated by the schema but is not part of
  * the public surface (Sanity-owned apps set it via `@ts-expect-error`).


### PR DESCRIPTION
`unstable_defineApp` is a pure identity wrapper and its `DefineAppInputSchema` was never run on a real config, so an illegal `name`, missing `title`, or duplicate view/service names loaded fine and only surfaced later in dev or deploy ([#907 review](https://github.com/sanity-io/cli/pull/907#discussion_r3413596775)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only config validation using an existing Zod schema; no runtime auth, data, or deploy behavior changes beyond failing builds on already-invalid configs.
> 
> **Overview**
> Adds **`validateWorkbenchApp`** in `@sanity/workbench-cli`, running the existing `DefineAppInputSchema` on the resolved branded app config and returning a formatted error string (or `null`). Because `unstable_defineApp` stays a pure identity wrapper, this is the first time that schema is enforced on real `sanity.cli.ts` configs.
> 
> **`sanity build`** (app and studio paths) calls the validator when a workbench app is detected and **exits with code 1** on failure. **`sanity dev`** runs the same check for branded apps but **warns and still starts** the dev servers so authors can fix config live.
> 
> Invalid cases surfaced early include bad `name`, missing `title`, duplicate view/service names, and studio configs that declare `entry`. Tests cover the helper and dev warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43872705166da1b0d68276e5eea88da59727faed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->