### PR TITLE
fix(cli): stop init crashing on a stalled npm version lookup

### DIFF
--- a/.changeset/fix-init-version-lookup-hang.md
+++ b/.changeset/fix-init-version-lookup-hang.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+fix(cli): prevent `init` from crashing when an npm version lookup stalls

--- a/packages/@sanity/cli/src/util/__tests__/resolveLatestVersions.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/resolveLatestVersions.test.ts
@@ -11,6 +11,7 @@ vi.mock('get-latest-version', () => ({
 describe('resolveLatestVersions', () => {
   afterEach(() => {
     vi.clearAllMocks()
+    vi.useRealTimers()
   })
 
   test('passes through valid semver ranges without looking them up', async () => {
@@ -60,5 +61,16 @@ describe('resolveLatestVersions', () => {
     })
     expect(mockGetLatestVersion).toHaveBeenCalledTimes(1)
     expect(mockGetLatestVersion).toHaveBeenCalledWith('@sanity/vision', {range: 'latest'})
+  })
+
+  test('falls back to the `latest` tag when a lookup never settles', async () => {
+    vi.useFakeTimers()
+    // A lookup that never resolves — without the cap, this hangs the CLI.
+    mockGetLatestVersion.mockReturnValueOnce(new Promise<string>(() => {}))
+
+    const resolved = resolveLatestVersions({sanity: 'latest'})
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    await expect(resolved).resolves.toEqual({sanity: 'latest'})
   })
 })

--- a/packages/@sanity/cli/src/util/resolveLatestVersions.ts
+++ b/packages/@sanity/cli/src/util/resolveLatestVersions.ts
@@ -1,6 +1,10 @@
 import {getLatestVersion} from 'get-latest-version'
 import promiseProps from 'promise-props-recursive'
 
+// Cap each lookup so a stuck npm request can't hang `init` (or crash it with Node's
+// "unsettled top-level await" exit, code 13). On timeout, fall back to the `latest` tag.
+const LOOKUP_TIMEOUT_MS = 30_000
+
 /**
  * Resolve the latest versions of given packages within their defined ranges
  *
@@ -13,7 +17,9 @@ export function resolveLatestVersions(
   const lookups: Record<string, Promise<string> | string> = {}
   for (const [packageName, range] of Object.entries(pkgs)) {
     lookups[packageName] =
-      range === 'latest' ? getLatestVersion(packageName, {range}).then(caretify) : range
+      range === 'latest'
+        ? withTimeout(getLatestVersion(packageName, {range}).then(caretify), 'latest')
+        : range
   }
 
   return promiseProps(lookups)
@@ -21,4 +27,19 @@ export function resolveLatestVersions(
 
 function caretify(version: string | undefined) {
   return version ? `^${version}` : 'latest'
+}
+
+/**
+ * Resolve `fallback` if `promise` stalls past the timeout. The timer is deliberately not
+ * `unref`'d — keeping the event loop alive is what prevents the exit-13.
+ */
+function withTimeout(promise: Promise<string>, fallback: string): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<string>((resolve) => {
+    timer = setTimeout(() => resolve(fallback), LOOKUP_TIMEOUT_MS)
+  })
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer)
+  })
 }


### PR DESCRIPTION
### Description

Sometimes `sanity init` dies halfway through with a cryptic Node crash — exit code 13, "unsettled top-level await". It happens when one of the npm version lookups hangs and never comes back: the process runs out of other work, so Node gives up mid-init. That's the flaky e2e failure in [this run](https://github.com/sanity-io/cli/actions/runs/27828788243/attempts/1).

Each version lookup now gets a 30s cap. If one stalls, we fall back to the `latest` tag (npm resolves it at install time anyway) and carry on, instead of letting a single stuck request freeze the whole command.

### What to review

The timer is deliberately not `unref`'d — keeping it on the event loop is the whole trick, since that's what stops Node exiting early. Real lookup errors still bubble up and fail init like before; only the "hangs forever" case falls back.

I tried `AbortSignal.timeout()` first since it'd be the tidier, more native option — but its internal timer is `unref`'d, so the loop can still drain and crash before it fires. It wouldn't actually fix this, hence the plain referenced `setTimeout`.

### Testing

One unit test reproduces the hang (a lookup that never resolves) and checks we fall back to `latest`. It fails on `main` and passes with this change.