### PR TITLE
test(cli-e2e): skip workbench e2e in registry mode

### DIFF
--- a/packages/@sanity/cli-e2e/__tests__/dev/dev.workbench.test.ts
+++ b/packages/@sanity/cli-e2e/__tests__/dev/dev.workbench.test.ts
@@ -3,12 +3,15 @@ import {describe, expect, test} from 'vitest'
 
 import {runCli} from '../../helpers/runCli.js'
 
+// Workbench isn't on the published `latest` CLI yet, so skip against the registry.
+const isRegistryMode = process.env.E2E_REGISTRY_MODE === 'true'
+
 // The federated-studio fixture opts into workbench via `unstable_defineApp` and
 // pins the `sanity` workbench dist-tag, so `sanity/workbench` resolves and
 // `sanity dev` starts the real workbench host dev server. This is the only place
 // that orchestration runs unmocked, end-to-end, through the actual binary — the
 // in-process command test stubs `startWorkbenchDevServer`.
-describe('sanity dev (workbench/federation)', {timeout: 120_000}, () => {
+describe.skipIf(isRegistryMode)('sanity dev (workbench/federation)', {timeout: 120_000}, () => {
   test('starts the workbench host and pushes the studio to the next port', async () => {
     const cwd = await testFixture('federated-studio')
     const port = 9332

--- a/packages/@sanity/cli-e2e/__tests__/init/init.workbench.test.ts
+++ b/packages/@sanity/cli-e2e/__tests__/init/init.workbench.test.ts
@@ -9,10 +9,13 @@ const orgId = getE2EOrganizationId()
 const projectId = getE2EProjectId()
 const dataset = getE2EDataset()
 
+// Workbench isn't on the published `latest` CLI yet, so skip against the registry.
+const isRegistryMode = process.env.E2E_REGISTRY_MODE === 'true'
+
 // `--unstable--workbench` swaps the scaffolded `sanity.cli.ts` over to the
 // `unstable_defineApp` variant (the sole federation opt-in). It applies to both
 // the studio and SDK-app templates, which use different workbench config shapes.
-describe('sanity init - workbench', {timeout: 120_000}, () => {
+describe.skipIf(isRegistryMode)('sanity init - workbench', {timeout: 120_000}, () => {
   let tmp: Awaited<ReturnType<typeof createTmpDir>>
 
   beforeEach(async () => {


### PR DESCRIPTION
### Description

The scheduled e2e run installs `sanity@latest` (6.1.0, no workbench yet — it merged in #907 but only ships under the `workbench` dist-tag), so the new init/dev workbench specs fail against it; skip them when `E2E_REGISTRY_MODE` is set.

### What to review

`describe.skipIf(isRegistryMode)` on the two workbench specs. Drop the guard once workbench reaches the `latest` dist-tag.

### Testing

Existing specs; only gated by registry mode. Branch e2e (built from source) still runs them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only gating with no production or CLI behavior changes.
> 
> **Overview**
> Registry-mode e2e installs **`sanity@latest`**, which does not ship workbench yet, so the **`sanity dev`** and **`sanity init`** workbench specs would fail on scheduled runs.
> 
> Both suites now use **`describe.skipIf(isRegistryMode)`** when **`E2E_REGISTRY_MODE`** is **`true`**, with a short comment that the guard can be removed once workbench is on **`latest`**. Source-built branch e2e still runs these tests unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08731023c225118d6499c6b5f531f839621b0aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->