### PR TITLE
docs(cli-e2e): note registry-mode guard for unreleased features

### DIFF
--- a/.claude/skills/writing-cli-e2e-tests/SKILL.md
+++ b/.claude/skills/writing-cli-e2e-tests/SKILL.md
@@ -289,6 +289,22 @@ test('no token triggers login prompt', async () => {
 })
 ```
 
+## Testing Features Not Yet on `latest`
+
+The scheduled workflow runs the suite against `sanity@latest` from npm, not the working tree (see the README's CI section). A test for a feature that hasn't shipped to the `latest` dist-tag yet passes on PRs (working-tree CLI) but breaks the hourly scheduled run — it hits a published binary that doesn't have the feature.
+
+Guard those tests so they only run against a CLI that has the feature:
+
+```typescript
+const isRegistryMode = process.env.E2E_REGISTRY_MODE === 'true'
+
+describe.skipIf(isRegistryMode)('sanity dev (workbench)', () => {
+  // ...
+})
+```
+
+Remove the guard once the feature lands on `latest`.
+
 ## Timeouts
 
 Set timeouts at the `describe` block level. The vitest config provides defaults (`testTimeout: 30_000`). If a group of tests needs more time, set it once:
@@ -424,6 +440,7 @@ test('rejects deprecated --reconfigure flag', async () => {
 | Multiple abort tests at different prompt stages | One abort test at the earliest prompt is sufficient |
 | `describe` blocks that just label categories | Only use `describe` for shared setup/teardown or parameterization |
 | `skipIf(!hasToken)` for unauthed tests | Override with `env: {SANITY_AUTH_TOKEN: ''}` |
+| Testing an unreleased feature unguarded | `skipIf(isRegistryMode)` — it breaks the scheduled run against `sanity@latest` |
 | Asserting on dynamic API content | Use structural regex patterns |
 | Mutating `process.env` directly | Use `vi.stubEnv()` for env overrides |
 | Mocking functions, APIs, or services | Never mock in e2e tests — test real infrastructure |


### PR DESCRIPTION
### Description

The workbench e2e specs passed on PRs but broke the scheduled run against `sanity@latest` (the feature isn't published yet); document the `skipIf(isRegistryMode)` guard in the e2e skill so the next unreleased-feature test doesn't repeat it. Follow-up to #1332.

### What to review

A short section in the `writing-cli-e2e-tests` skill plus one row in its Common Mistakes table. Docs only.

### Testing

N/A — documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a Claude skill file; no runtime or test code modified.
> 
> **Overview**
> Documents why PR e2e runs can pass while the **scheduled** job against `sanity@latest` fails when a test covers a feature not yet on npm’s `latest` dist-tag.
> 
> The **writing-cli-e2e-tests** skill now includes a **Testing Features Not Yet on `latest`** section: use `describe.skipIf(isRegistryMode)` when `E2E_REGISTRY_MODE === 'true'`, and remove the guard after the feature ships. The **Common Mistakes** table adds a row for leaving unreleased-feature tests unguarded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6beac30d4e232ed46979d0da877f97d88a87c7ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->