### PR TITLE
refactor(workbench): orchestrate the workbench dev run in workbench-cli

### DIFF
--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.unit.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.unit.test.ts
@@ -1,638 +1,143 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {devAction} from '../devAction.js'
-import {
-  createBaseDevOptions,
-  createMockOutput,
-  DEV_FLAGS,
-  workbenchCliConfig,
-} from './testHelpers.js'
+import {createBaseDevOptions, workbenchCliConfig} from './testHelpers.js'
 
-const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
+const mockStartWorkbenchDev = vi.hoisted(() => vi.fn())
 const mockStartAppDevServer = vi.hoisted(() => vi.fn())
 const mockStartStudioDevServer = vi.hoisted(() => vi.fn())
-const mockStartDevServerRegistration = vi.hoisted(() => vi.fn())
 const mockGetSharedServerConfig = vi.hoisted(() => vi.fn())
-const mockGetCliConfigUncached = vi.hoisted(() => vi.fn())
-const mockCheckForDeprecatedAppId = vi.hoisted(() => vi.fn())
 const mockGetAppId = vi.hoisted(() => vi.fn())
+const mockCheckForDeprecatedAppId = vi.hoisted(() => vi.fn())
 
-// The rebuild hook re-reads the config so the recreated app server picks up the
-// new view/service set.
-vi.mock('@sanity/cli-core', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
-  getCliConfigUncached: mockGetCliConfigUncached,
-}))
-vi.mock('../servers/startAppDevServer.js', () => ({
-  startAppDevServer: mockStartAppDevServer,
-}))
+// The workbench orchestration lives in workbench-cli and is imported lazily —
+// mock the single entry the dispatcher delegates to.
+vi.mock('@sanity/workbench-cli/dev', () => ({startWorkbenchDev: mockStartWorkbenchDev}))
+vi.mock('../servers/startAppDevServer.js', () => ({startAppDevServer: mockStartAppDevServer}))
 vi.mock('../servers/startStudioDevServer.js', () => ({
   startStudioDevServer: mockStartStudioDevServer,
 }))
-// The workbench dev server + registration moved into workbench-cli; mock just
-// those two exports and keep the rest of the dev entry real.
-vi.mock('@sanity/workbench-cli/dev', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@sanity/workbench-cli/dev')>()),
-  startDevServerRegistration: mockStartDevServerRegistration,
-  startWorkbenchDevServer: mockStartWorkbenchDevServer,
+vi.mock('../../../util/getSharedServerConfig.js', () => ({
+  getSharedServerConfig: mockGetSharedServerConfig,
 }))
 vi.mock('../../../util/appId.js', () => ({
   checkForDeprecatedAppId: mockCheckForDeprecatedAppId,
   getAppId: mockGetAppId,
 }))
-vi.mock('../../../util/getSharedServerConfig.js', () => ({
-  getSharedServerConfig: mockGetSharedServerConfig,
-}))
 
-/** Create a mock Vite dev server config shape — `server.config.server.host`
- * reflects the resolved host after user-provided Vite config has been merged in. */
-function mockServer({host, port = 3334}: {host?: boolean | string; port?: number} = {}) {
+/** Minimal started app/studio dev server result. */
+function mockServer({port = 3334}: {port?: number} = {}) {
   return {
     close: vi.fn().mockResolvedValue(undefined),
-    server: {config: {server: {host, port}}},
+    server: {config: {server: {port}}},
     started: true,
   }
-}
-
-function mockRegistrationHandle() {
-  return {
-    close: vi.fn().mockResolvedValue(undefined),
-  }
-}
-
-/** Pull the rebuild handler devAction passed into startDevServerRegistration. */
-function passedInterfaceSetChange(): (() => Promise<unknown>) | undefined {
-  return mockStartDevServerRegistration.mock.calls[0][0].onInterfaceSetChange
-}
-
-/** The handler devAction installed last on SIGINT. */
-function installedSignalHandler(): (signal: NodeJS.Signals) => void {
-  return process.listeners('SIGINT').at(-1) as (signal: NodeJS.Signals) => void
 }
 
 describe('devAction', () => {
   beforeEach(() => {
     mockGetSharedServerConfig.mockReturnValue({httpHost: 'localhost', httpPort: 3333})
     mockGetAppId.mockReturnValue(undefined)
-    // Default: no workbench (federation disabled)
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: vi.fn().mockResolvedValue(undefined),
-      httpHost: 'localhost',
-      workbenchAvailable: false,
-      workbenchPort: 3333,
-    })
-    mockStartDevServerRegistration.mockResolvedValue(mockRegistrationHandle())
+    mockStartWorkbenchDev.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
+    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
+    mockStartAppDevServer.mockResolvedValue(mockServer({port: 3333}))
   })
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
   })
 
-  test('studio mode without workbench passes flags through untouched', async () => {
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
-    // No port flag: resolution must stay downstream in getDevServerConfig
-    // (flags → env → cli config → default), as it does on main.
-    const flags = {...DEV_FLAGS, port: undefined}
+  describe('plain (non-workbench) projects', () => {
+    test('starts the studio dev server directly and never delegates to the workbench', async () => {
+      const result = await devAction(createBaseDevOptions())
 
-    await devAction(createBaseDevOptions({flags}))
-
-    expect(mockStartStudioDevServer).toHaveBeenCalledWith(expect.objectContaining({flags}))
-  })
-
-  test('studio mode with workbench bumps port and logs workbench URL', async () => {
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: vi.fn().mockResolvedValue(undefined),
-      httpHost: 'localhost',
-      workbenchAvailable: true,
-      workbenchPort: 3333,
-    })
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-    const output = createMockOutput()
-
-    await devAction(createBaseDevOptions({output}))
-
-    expect(mockStartStudioDevServer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        httpPort: 3334,
-        workbenchAvailable: true,
-      }),
-    )
-    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('3333'))
-    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('3334'))
-  })
-
-  test('app mode routes to startAppDevServer', async () => {
-    mockStartAppDevServer.mockResolvedValue(mockServer({port: 3333}))
-
-    await devAction(createBaseDevOptions({isApp: true}))
-
-    expect(mockStartAppDevServer).toHaveBeenCalled()
-    expect(mockStartStudioDevServer).not.toHaveBeenCalled()
-  })
-
-  test('cleans up workbench and re-throws when app/studio startup fails', async () => {
-    const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: mockWorkbenchClose,
-      httpHost: 'localhost',
-      workbenchAvailable: true,
-      workbenchPort: 3333,
-    })
-    const startupError = new Error('Port already in use')
-    mockStartStudioDevServer.mockRejectedValue(startupError)
-
-    const thrown = await devAction(createBaseDevOptions()).catch((err) => err)
-
-    expect(thrown).toBe(startupError)
-    expect(mockWorkbenchClose).toHaveBeenCalled()
-  })
-
-  test('close handler is resilient to one close rejecting', async () => {
-    const mockWorkbenchClose = vi.fn().mockRejectedValue(new Error('workbench close failed'))
-    const mockAppClose = vi.fn().mockResolvedValue(undefined)
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: mockWorkbenchClose,
-      httpHost: 'localhost',
-      workbenchAvailable: true,
-      workbenchPort: 3333,
-    })
-    mockStartStudioDevServer.mockResolvedValue({
-      ...mockServer({port: 3334}),
-      close: mockAppClose,
-    })
-
-    const result = await devAction(createBaseDevOptions())
-
-    await expect(result.close()).resolves.toBeUndefined()
-    expect(mockWorkbenchClose).toHaveBeenCalled()
-    expect(mockAppClose).toHaveBeenCalled()
-  })
-
-  describe('dev server registration', () => {
-    test('starts registration when workbench is enabled', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
-
-      expect(mockStartDevServerRegistration).toHaveBeenCalledWith(
-        expect.objectContaining({
-          isApp: false,
-          workDir: '/tmp/sanity-project',
-        }),
+      expect(mockStartStudioDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({announceUrl: true}),
       )
+      expect(mockStartWorkbenchDev).not.toHaveBeenCalled()
+      expect(result.close).toBeTypeOf('function')
     })
 
-    test('does not start registration when workbench is disabled', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
+    test('returns a no-op close when the app server reports an expected early exit', async () => {
+      mockStartAppDevServer.mockResolvedValue({reason: 'missing-organization-id', started: false})
 
-      await devAction(createBaseDevOptions())
+      const result = await devAction(createBaseDevOptions({isApp: true}))
 
-      expect(mockStartDevServerRegistration).not.toHaveBeenCalled()
+      await expect(result.close()).resolves.toBeUndefined()
+      expect(mockStartWorkbenchDev).not.toHaveBeenCalled()
     })
+  })
 
-    // The deprecated `app.id`/`deployment.appId` check is CLI-domain, so it runs
-    // here (before registration) rather than inside the workbench package.
-    test('runs the deprecated-id check before registering a workbench app', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-      const output = createMockOutput()
-
-      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), output}))
-
-      expect(mockCheckForDeprecatedAppId).toHaveBeenCalledWith(expect.objectContaining({output}))
-    })
-
-    test('surfaces the deprecated-id error when app.id and deployment.appId are both set', async () => {
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-      mockCheckForDeprecatedAppId.mockImplementation(({output}: {output: any}) => {
-        output.error('Found both app.id (deprecated) and deployment.appId', {exit: 1})
-      })
-      const output = createMockOutput()
-
-      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), output}))
-
-      expect(output.error).toHaveBeenCalledWith(
-        expect.stringContaining('Found both app.id (deprecated) and deployment.appId'),
-        expect.objectContaining({exit: 1}),
-      )
-    })
-
-    test('tears down both servers and re-throws when registration fails', async () => {
-      // Registration runs after both servers are up, so a failure here must not
-      // leak the workbench lock or the dev servers.
-      const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
-      const mockAppClose = vi.fn().mockResolvedValue(undefined)
-      mockStartWorkbenchDevServer.mockResolvedValue({
-        close: mockWorkbenchClose,
-        httpHost: 'localhost',
-        workbenchAvailable: true,
-        workbenchPort: 3333,
-      })
-      mockStartStudioDevServer.mockResolvedValue({...mockServer({port: 3334}), close: mockAppClose})
-      const registrationError = new Error('deriveInterfaces failed')
-      mockStartDevServerRegistration.mockRejectedValue(registrationError)
-
-      const thrown = await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()})).catch(
-        (err) => err,
-      )
-
-      expect(thrown).toBe(registrationError)
-      expect(mockWorkbenchClose).toHaveBeenCalled()
-      expect(mockAppClose).toHaveBeenCalled()
-    })
-
-    test('passes isApp: true for app mode', async () => {
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}))
-
-      expect(mockStartDevServerRegistration).toHaveBeenCalledWith(
-        expect.objectContaining({isApp: true}),
-      )
-    })
-
-    test('passes the vite dev server to the registration', async () => {
-      const server = mockServer({port: 3334})
-      mockStartStudioDevServer.mockResolvedValue(server)
-
-      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
-
-      expect(mockStartDevServerRegistration).toHaveBeenCalledWith(
-        expect.objectContaining({server: server.server}),
-      )
-    })
-
-    test('calls registration close on close', async () => {
-      const handle = mockRegistrationHandle()
-      mockStartDevServerRegistration.mockResolvedValue(handle)
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
+  describe('workbench projects', () => {
+    test('delegates to startWorkbenchDev with the injected CLI-domain pieces', async () => {
+      mockGetAppId.mockReturnValue('app-abc')
+      const orchestratorClose = vi.fn().mockResolvedValue(undefined)
+      mockStartWorkbenchDev.mockResolvedValue({close: orchestratorClose})
 
       const result = await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
 
-      await result.close()
-      expect(handle.close).toHaveBeenCalled()
+      expect(mockStartStudioDevServer).not.toHaveBeenCalled()
+      expect(mockStartWorkbenchDev).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: 'app-abc',
+          cacheDir: expect.stringMatching(/\/vite$/),
+          checkForDeprecatedAppId: expect.any(Function),
+          extractManifest: expect.any(Function),
+          httpHost: 'localhost',
+          httpPort: 3333,
+          isApp: false,
+          reactStrictMode: expect.any(Boolean),
+          startAppServer: expect.any(Function),
+        }),
+      )
+      // The orchestrator's close is handed straight back.
+      expect(result.close).toBe(orchestratorClose)
     })
 
-    test('rebuilds the app server with a freshly-loaded config when the interface set changes', async () => {
-      const firstClose = vi.fn().mockResolvedValue(undefined)
-      const secondClose = vi.fn().mockResolvedValue(undefined)
-      mockStartAppDevServer
-        .mockResolvedValueOnce({...mockServer({port: 3334}), close: firstClose})
-        .mockResolvedValueOnce({...mockServer({port: 3334}), close: secondClose})
-      const freshConfig = workbenchCliConfig()
-      mockGetCliConfigUncached.mockResolvedValue(freshConfig)
-
+    test('passes isApp: true through for app mode', async () => {
       await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}))
 
-      const onSetChange = passedInterfaceSetChange()
-      expect(onSetChange).toBeInstanceOf(Function)
+      expect(mockStartWorkbenchDev).toHaveBeenCalledWith(expect.objectContaining({isApp: true}))
+    })
 
-      await onSetChange!()
+    test('the injected startAppServer dispatches to the studio server and forwards intent', async () => {
+      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
 
-      expect(firstClose).toHaveBeenCalledTimes(1)
-      expect(mockStartAppDevServer).toHaveBeenCalledTimes(2)
-      expect(mockStartAppDevServer).toHaveBeenLastCalledWith(
-        expect.objectContaining({cliConfig: freshConfig}),
+      const {startAppServer} = mockStartWorkbenchDev.mock.calls[0][0]
+      const config = workbenchCliConfig()
+      await startAppServer({announceUrl: false, cliConfig: config, httpPort: 3334})
+
+      expect(mockStartStudioDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({announceUrl: false, cliConfig: config, httpPort: 3334}),
       )
     })
 
-    test('rebuild hook resolves with the recreated server so the registration can re-read its address', async () => {
-      // Workbench projects run with non-strict ports — the replacement server
-      // can bind a different port than the one registered at startup.
-      const secondServer = mockServer({port: 3335})
-      mockStartAppDevServer
-        .mockResolvedValueOnce(mockServer({port: 3334}))
-        .mockResolvedValueOnce(secondServer)
-      mockGetCliConfigUncached.mockResolvedValue(workbenchCliConfig())
-
+    test('the injected startAppServer dispatches to the app server in app mode', async () => {
       await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}))
 
-      await expect(passedInterfaceSetChange()!()).resolves.toBe(secondServer.server)
-    })
+      const {startAppServer} = mockStartWorkbenchDev.mock.calls[0][0]
+      await startAppServer({announceUrl: false, cliConfig: workbenchCliConfig(), httpPort: 3334})
 
-    test('rebuild hook rejects when the restart reports an expected early exit, and close stays safe', async () => {
-      const firstClose = vi.fn().mockResolvedValue(undefined)
-      mockStartAppDevServer
-        .mockResolvedValueOnce({...mockServer({port: 3334}), close: firstClose})
-        // e.g. the user removed organizationId from sanity.cli.ts before saving
-        .mockResolvedValueOnce({reason: 'missing-organization-id', started: false})
-      mockGetCliConfigUncached.mockResolvedValue(workbenchCliConfig())
-
-      const result = await devAction(
-        createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}),
-      )
-
-      // The registration must see the failure — a resolved hook would commit
-      // the new interface set against a server that never came back.
-      await expect(passedInterfaceSetChange()!()).rejects.toThrow(
-        'Dev server did not restart after the view/service change',
-      )
-
-      // The old server was closed during the rebuild; close() must not call it
-      // again or trip over the missing replacement.
-      await expect(result.close()).resolves.toBeUndefined()
-      expect(firstClose).toHaveBeenCalledTimes(1)
-    })
-
-    test('rebuilds the studio server with a freshly-loaded config when the interface set changes', async () => {
-      // Studios declare views/services in `sanity.cli.ts` like apps do (only
-      // `entry` is rejected, FR-026) — they need the same rebuild hook.
-      const firstClose = vi.fn().mockResolvedValue(undefined)
-      const secondClose = vi.fn().mockResolvedValue(undefined)
-      mockStartStudioDevServer
-        .mockResolvedValueOnce({...mockServer({port: 3334}), close: firstClose})
-        .mockResolvedValueOnce({...mockServer({port: 3334}), close: secondClose})
-      const freshConfig = workbenchCliConfig()
-      mockGetCliConfigUncached.mockResolvedValue(freshConfig)
-
-      await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: false}))
-
-      const onSetChange = passedInterfaceSetChange()
-      expect(onSetChange).toBeInstanceOf(Function)
-
-      await onSetChange!()
-
-      expect(firstClose).toHaveBeenCalledTimes(1)
-      expect(mockStartStudioDevServer).toHaveBeenCalledTimes(2)
-      expect(mockStartStudioDevServer).toHaveBeenLastCalledWith(
-        expect.objectContaining({cliConfig: freshConfig}),
+      expect(mockStartAppDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({announceUrl: false, httpPort: 3334}),
       )
     })
-  })
-
-  test('close() waits for an in-flight rebuild and closes the replacement server', async () => {
-    // A close() racing the rebuild would only see the already-torn-down
-    // first server — the replacement would keep running (and hold its port)
-    // with nothing left to close it.
-    const firstClose = vi.fn().mockResolvedValue(undefined)
-    const secondClose = vi.fn().mockResolvedValue(undefined)
-    let releaseStart!: () => void
-    const startGate = new Promise<void>((resolve) => {
-      releaseStart = resolve
-    })
-    mockStartAppDevServer
-      .mockResolvedValueOnce({...mockServer({port: 3334}), close: firstClose})
-      .mockImplementationOnce(async () => {
-        await startGate
-        return {...mockServer({port: 3334}), close: secondClose}
-      })
-    mockGetCliConfigUncached.mockResolvedValue(workbenchCliConfig())
-
-    const result = await devAction(
-      createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}),
-    )
-
-    // Rebuild is mid-flight (replacement server still starting) when close() runs.
-    const rebuild = passedInterfaceSetChange()!()
-    const closing = result.close()
-    releaseStart()
-
-    await rebuild
-    await closing
-    expect(secondClose).toHaveBeenCalledTimes(1)
-  })
-
-  test('close() is single-flight — a second call shares the same teardown', async () => {
-    // SIGINT followed by SIGTERM (each signal keeps its own `once` handler)
-    // or a signal racing the caller's own close() must not double-close.
-    const appClose = vi.fn().mockResolvedValue(undefined)
-    mockStartStudioDevServer.mockResolvedValue({...mockServer({port: 3334}), close: appClose})
-
-    const result = await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
-
-    await Promise.all([result.close(), result.close()])
-    expect(appClose).toHaveBeenCalledTimes(1)
-  })
-
-  test('refuses a rebuild once shutdown has started', async () => {
-    // The watcher only learns about shutdown late in the teardown sequence —
-    // a config save in that window must not boot a server nobody owns.
-    mockStartAppDevServer.mockResolvedValue(mockServer({port: 3334}))
-    mockGetCliConfigUncached.mockResolvedValue(workbenchCliConfig())
-
-    const result = await devAction(
-      createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}),
-    )
-    await result.close()
-
-    await expect(passedInterfaceSetChange()!()).rejects.toThrow('Dev server is shutting down')
-    // Only the initial startup reached startAppDevServer.
-    expect(mockStartAppDevServer).toHaveBeenCalledTimes(1)
-  })
-
-  describe('signal-triggered shutdown', () => {
-    test('re-raises the signal once teardown settles so the default exit runs', async () => {
-      // Trapping SIGINT disables Node's default exit; without the re-raise the
-      // process would linger on any surviving handle, holding the dev ports.
-      const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
-      vi.useFakeTimers()
-      try {
-        const appClose = vi.fn().mockResolvedValue(undefined)
-        mockStartStudioDevServer.mockResolvedValue({...mockServer({port: 3334}), close: appClose})
-
-        await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
-
-        installedSignalHandler()('SIGINT')
-        await vi.runAllTimersAsync()
-
-        expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGINT')
-        // Teardown completes before the re-raise.
-        expect(appClose.mock.invocationCallOrder[0]).toBeLessThan(
-          killSpy.mock.invocationCallOrder[0],
-        )
-      } finally {
-        vi.useRealTimers()
-        killSpy.mockRestore()
-      }
-    })
-
-    test('force-exits after the grace period when teardown hangs', async () => {
-      const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
-      vi.useFakeTimers()
-      try {
-        // e.g. a wedged watcher or socket — close() never settles.
-        const hangingClose = vi.fn(() => new Promise<void>(() => {}))
-        mockStartStudioDevServer.mockResolvedValue({
-          ...mockServer({port: 3334}),
-          close: hangingClose,
-        })
-
-        await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
-
-        installedSignalHandler()('SIGTERM')
-        await vi.advanceTimersByTimeAsync(5000)
-
-        expect(hangingClose).toHaveBeenCalled()
-        expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM')
-      } finally {
-        vi.useRealTimers()
-        killSpy.mockRestore()
-      }
-    })
-  })
-
-  test('registers signal handlers when the workbench is running', async () => {
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: vi.fn().mockResolvedValue(undefined),
-      httpHost: 'localhost',
-      workbenchAvailable: true,
-      workbenchPort: 3333,
-    })
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-    const sigintBefore = process.listenerCount('SIGINT')
-    const sigtermBefore = process.listenerCount('SIGTERM')
-
-    const result = await devAction(createBaseDevOptions())
-
-    expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
-    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + 1)
-
-    await result.close()
-  })
-
-  test('registers signal handlers for workbench apps even when the workbench is unavailable', async () => {
-    // The registry entry still needs cleanup on abrupt shutdown.
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
-
-    const sigintBefore = process.listenerCount('SIGINT')
-
-    const result = await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig()}))
-
-    expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
-
-    await result.close()
-  })
-
-  test('close removes signal handlers', async () => {
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: vi.fn().mockResolvedValue(undefined),
-      httpHost: 'localhost',
-      workbenchAvailable: true,
-      workbenchPort: 3333,
-    })
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-
-    const sigintBefore = process.listenerCount('SIGINT')
-    const sigtermBefore = process.listenerCount('SIGTERM')
-
-    const result = await devAction(createBaseDevOptions())
-
-    expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
-    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + 1)
-
-    await result.close()
-
-    expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
-    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)
-  })
-
-  test('registers no signal handlers for plain projects', async () => {
-    // Plain runs have no workbench lock or registry entry to clean up, so they
-    // keep the default Ctrl-C behavior (and exit code) from main.
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
-
-    const sigintBefore = process.listenerCount('SIGINT')
-    const sigtermBefore = process.listenerCount('SIGTERM')
-
-    await devAction(createBaseDevOptions())
-
-    expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
-    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)
-  })
-
-  test('uses local httpHost for workbench URL even when existing lock reports a different host', async () => {
-    // Scenario: process A started workbench on mydev.local:3333, process B starts
-    // with --host localhost. startWorkbenchDevServer returns the existing lock's host,
-    // but devAction ignores it and uses its own httpHost from getSharedServerConfig.
-    mockGetSharedServerConfig.mockReturnValue({httpHost: 'localhost', httpPort: 3333})
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: vi.fn().mockResolvedValue(undefined),
-      httpHost: 'mydev.local',
-      workbenchAvailable: true,
-      workbenchPort: 3333,
-    })
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-    const output = createMockOutput()
-
-    await devAction(createBaseDevOptions({output}))
-
-    // The workbench is running on mydev.local — the URL should reflect the
-    // existing workbench's host, not the caller's.
-    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('mydev.local:3333'))
-  })
-
-  test('displays localhost when the workbench binds a non-routable address', async () => {
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: vi.fn().mockResolvedValue(undefined),
-      httpHost: '0.0.0.0',
-      workbenchAvailable: true,
-      workbenchPort: 3333,
-    })
-    mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3334}))
-    const output = createMockOutput()
-
-    await devAction(createBaseDevOptions({output}))
-
-    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('http://localhost:3333'))
-  })
-
-  test('returns early with workbench-only close when the app server does not start', async () => {
-    // startAppDevServer reports an expected early exit when orgId is missing.
-    const mockWorkbenchClose = vi.fn().mockResolvedValue(undefined)
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: mockWorkbenchClose,
-      httpHost: 'localhost',
-      workbenchAvailable: false,
-      workbenchPort: 3333,
-    })
-    mockStartAppDevServer.mockResolvedValue({reason: 'missing-organization-id', started: false})
-
-    const result = await devAction(createBaseDevOptions({isApp: true}))
-
-    expect(result.close).toBeDefined()
-    // The close must still tear down the workbench server
-    await result.close()
-    expect(mockWorkbenchClose).toHaveBeenCalled()
-    // No registration should have happened because the app never started
-    expect(mockStartDevServerRegistration).not.toHaveBeenCalled()
   })
 
   describe('workbench remote', () => {
-    // The remote is the shell content host apps load, not a host. It opts into
-    // this path via an internal env var set by its own dev script.
-    afterEach(() => {
-      vi.unstubAllEnvs()
-    })
-
-    test('serves on the configured port with no shell and no registration', async () => {
+    // The remote is the shell that renders other workbench apps, so it can't
+    // render itself — an internal env var runs it as a plain standalone server.
+    test('runs as a plain dev server with no workbench orchestration', async () => {
       vi.stubEnv('SANITY_INTERNAL_IS_WORKBENCH_REMOTE', 'true')
-      mockGetSharedServerConfig.mockReturnValue({httpHost: 'localhost', httpPort: 5173})
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 5173}))
+      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3333}))
 
       await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}))
 
-      // No second shell, so no single-workbench lock contention.
-      expect(mockStartWorkbenchDevServer).not.toHaveBeenCalled()
-      // Keeps the configured port — flags pass through untouched, never bumped to
-      // `workbenchPort + 1` the way a host app's server is.
+      expect(mockStartWorkbenchDev).not.toHaveBeenCalled()
       expect(mockStartAppDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({
-          flags: expect.objectContaining({port: DEV_FLAGS.port}),
-          workbenchAvailable: false,
-        }),
+        expect.objectContaining({announceUrl: true}),
       )
-      // Not a dock app — never registers into the shared workbench registry.
-      expect(mockStartDevServerRegistration).not.toHaveBeenCalled()
-    })
-
-    test('ignores the env var for a non-workbench (plain) project', async () => {
-      vi.stubEnv('SANITY_INTERNAL_IS_WORKBENCH_REMOTE', 'true')
-      mockStartStudioDevServer.mockResolvedValue(mockServer({port: 3333}))
-
-      await devAction(createBaseDevOptions())
-
-      // The brand is the gate — without it the normal workbench path still runs.
-      expect(mockStartWorkbenchDevServer).toHaveBeenCalled()
     })
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -1,9 +1,5 @@
-import {styleText} from 'node:util'
-
 import {SANITY_CACHE_DIR} from '@sanity/cli-build/_internal/build'
-import {getCliConfigUncached, isWorkbenchApp} from '@sanity/cli-core'
-import {startDevServerRegistration, startWorkbenchDevServer} from '@sanity/workbench-cli/dev'
-import {type ViteDevServer} from 'vite'
+import {type CliConfig, isWorkbenchApp} from '@sanity/cli-core'
 
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
 import {getSharedServerConfig} from '../../util/getSharedServerConfig.js'
@@ -12,37 +8,18 @@ import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
 import {extractStudioManifest} from '../manifest/extractStudioManifest.js'
 import {startAppDevServer} from './servers/startAppDevServer.js'
 import {startStudioDevServer} from './servers/startStudioDevServer.js'
-import {type DevActionOptions, type StartDevServerResult} from './types.js'
+import {type DevActionOptions} from './types.js'
 
 const noop = async () => {}
 
 /**
- * How long a signal-triggered teardown may run before the process force-exits
- * by re-raising the signal — generous enough for Vite servers and watchers to
- * close, short enough not to strand a backgrounded process holding the ports.
- */
-const SHUTDOWN_GRACE_MS = 5000
-
-// Bind-only addresses ('0.0.0.0', '::') aren't routable URLs in every
-// browser (notably on Windows), so the displayed URL falls back to
-// localhost. The bind address itself is untouched — listening and the
-// lock file keep whatever the user configured.
-function toDisplayHost(host: string | undefined): string {
-  if (!host || host === '0.0.0.0' || host === '::' || host === '[::]') {
-    return 'localhost'
-  }
-  return host
-}
-
-/**
- * Orchestrates the dev servers required by the process. It will attempt to run a workbench
- * dev-server and, if successful, will run the app/studio dev server on the next available port.
- * If the workbench dev-server fails to start for an expected reason, e.g. because there is already
- * a workbench instance running or the workbench package is unavailable, it will run the app/studio
- * dev server on the configured port.
+ * Entry point for `sanity dev`. A plain studio/app starts a single dev server, as
+ * before workbench existed. A workbench app (via `unstable_defineApp`) delegates to
+ * `@sanity/workbench-cli`, injecting the CLI-domain pieces (app server, manifest
+ * extraction, app id) and loading the package lazily so plain projects never do.
  */
 export async function devAction(options: DevActionOptions): Promise<{close: () => Promise<void>}> {
-  const {cliConfig, flags, output, workDir} = options
+  const {cliConfig, flags, isApp, output, workDir} = options
 
   const {httpHost, httpPort} = getSharedServerConfig({
     cliConfig,
@@ -50,197 +27,47 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     workDir,
   })
 
-  /**
-   * The workbench remote is the app that renders "workbench ready" apps, thereby it can't render itself.
-   * But it still wants to be deployed as a singleton in the sanity ecosystem. Therefore, this internal flag
-   * allows us to develop the workbench remote correctly – as a standalone app.
-   */
+  // The workbench remote renders other workbench apps, so it can't render
+  // itself — this internal flag runs it as a plain, standalone dev server.
   const isWorkbenchRemote =
     isWorkbenchApp(cliConfig?.app) && process.env.SANITY_INTERNAL_IS_WORKBENCH_REMOTE === 'true'
 
-  const {
-    close: closeWorkbenchServer,
-    httpHost: workbenchHost,
-    workbenchAvailable,
-    workbenchPort,
-  } = isWorkbenchRemote
-    ? {close: noop, httpHost, workbenchAvailable: false, workbenchPort: httpPort}
-    : await startWorkbenchDevServer({
-        cacheDir: `${SANITY_CACHE_DIR}/vite`,
-        cliConfig,
-        httpHost,
-        httpPort,
-        output,
-        // Runtime template needs a concrete boolean; collapse an unset config to off.
-        reactStrictMode: resolveReactStrictMode(cliConfig) ?? false,
-        workDir,
-      })
+  // The app/studio server, parameterized per call; `announceUrl` is false when
+  // the workbench announces the URL on its behalf.
+  const startAppServer = (params: {announceUrl: boolean; cliConfig: CliConfig; httpPort: number}) =>
+    (isApp ? startAppDevServer : startStudioDevServer)({
+      ...options,
+      announceUrl: params.announceUrl,
+      cliConfig: params.cliConfig,
+      httpPort: params.httpPort,
+    })
 
-  // A running workbench claims the configured port, so the app server binds the
-  // next one — passed explicitly rather than by rewriting the shared flags.
-  // Without a workbench the app server resolves its port from flags/env/config
-  // downstream, exactly as it did before workbench existed.
-  const appOptions: DevActionOptions = workbenchAvailable
-    ? {...options, httpPort: workbenchPort + 1, workbenchAvailable}
-    : {...options, workbenchAvailable}
-
-  let closeAppDevServer: () => Promise<void> = noop
-
-  // Takes the config as a param so a rebuild can feed a freshly-loaded one.
-  const startApp = async (config: DevActionOptions['cliConfig']): Promise<StartDevServerResult> => {
-    const result = options.isApp
-      ? await startAppDevServer({...appOptions, cliConfig: config})
-      : await startStudioDevServer({...appOptions, cliConfig: config})
-    closeAppDevServer = result.started ? result.close : noop
-    return result
-  }
-
-  let initial: StartDevServerResult
-  try {
-    initial = await startApp(cliConfig)
-  } catch (err) {
-    await closeWorkbenchServer()
-    throw err
-  }
-
-  if (!initial.started) {
-    // The server has already reported why (e.g. missing organization ID).
-    return {close: closeWorkbenchServer}
-  }
-  const {server} = initial
-
-  // Adding/removing a view or service in `sanity.cli.ts` during dev requires
-  // rebuilding the federation remote: its module-federation `exposes` map +
-  // codegen artifacts are computed once at server start, so a newly-declared
-  // interface has no expose until the server is recreated. `server.restart()`
-  // can't do it — it re-uses the inline config — so we tear the app server
-  // down and bring it back up with a freshly-loaded config. The workbench page
-  // then reloads (driven by the registry watch in the workbench server) to
-  // re-fetch the rebuilt remote. A view/service *source* edit doesn't change
-  // the interface set, so it stays on the HMR path untouched. Studios declare
-  // views/services the same way (only `entry` is rejected, FR-026), so they
-  // get the same rebuild. The returned-server / thrown-failed-restart contract
-  // is documented on `onInterfaceSetChange` in startDevServerRegistration.
-
-  // Declared ahead of `runRebuild`, which the watcher's initial background
-  // extraction can invoke before the statements below it have run.
-  let closed = false
-
-  const runRebuild = async (): Promise<ViteDevServer> => {
-    // The watcher only learns about shutdown when its own close runs, late in
-    // the teardown sequence — refuse here so a config save during shutdown
-    // can't boot a replacement server nobody owns. Checked before the first
-    // await so a rebuild can't start after close() has read `rebuildInFlight`.
-    if (closed) {
-      throw new Error('Dev server is shutting down')
-    }
-    const freshConfig = await getCliConfigUncached(workDir)
-    await closeAppDevServer()
-    const result = await startApp(freshConfig)
-    if (!result.started) {
-      // The server already reported why (e.g. organizationId was removed).
-      throw new Error('Dev server did not restart after the view/service change')
-    }
-    return result.server
-  }
-
-  // `closeAppDevServer` is repointed at the replacement server only after
-  // `startApp` resolves — a close() racing a rebuild would tear down the old
-  // (already-closed) server and leave the replacement running with no owner,
-  // so close() waits on the rebuild in flight. Rejections are owned by the
-  // watcher (warn + retry on next save); the tracked copy swallows them so
-  // close() can't reject.
-  let rebuildInFlight: Promise<unknown> = Promise.resolve()
-  const onInterfaceSetChange = (): Promise<ViteDevServer> => {
-    const rebuild = runRebuild()
-    rebuildInFlight = rebuild.catch(() => {})
-    return rebuild
-  }
-
-  // Workbench is opted into solely by calling `unstable_defineApp` — its
-  // branded identity is the only signal. The workbench remote is the exception:
-  // it's the shell itself, not a dock app, so it never registers into the
-  // shared workbench registry.
-  let registration: Awaited<ReturnType<typeof startDevServerRegistration>> | undefined
-  try {
-    if (isWorkbenchApp(cliConfig?.app) && !isWorkbenchRemote) {
-      // CLI-domain wiring the registry doesn't own: the deprecated-id check and
-      // the studio-vs-app manifest extractor are injected here, keeping the
-      // workbench package free of CLI config/manifest conventions.
-      checkForDeprecatedAppId({cliConfig, output})
-      registration = await startDevServerRegistration({
-        appId: getAppId(cliConfig),
-        cliConfig,
-        extractManifest: options.isApp
-          ? ({workDir: wd}) => extractCoreAppManifest({workDir: wd})
-          : (params) => extractStudioManifest(params),
-        isApp: options.isApp,
-        onInterfaceSetChange,
-        output,
-        server,
-        workDir,
-      })
-    }
-  } catch (err) {
-    // Registration runs only after both servers are already up. If it throws
-    // (e.g. `deriveInterfaces` rejects), tear them down before rethrowing —
-    // otherwise the workbench lock and dev servers leak until the next run.
-    await Promise.allSettled([closeWorkbenchServer(), closeAppDevServer()])
-    throw err
-  }
-
-  if (workbenchAvailable) {
-    const workbenchUrl = `http://${toDisplayHost(workbenchHost)}:${workbenchPort}`
-    const addr = server.httpServer?.address()
-    const appPort = typeof addr === 'object' && addr ? addr.port : server.config.server.port
-    output.log(
-      `Workbench dev server started at ${styleText(['blue', 'underline'], workbenchUrl)} (app on port ${appPort})`,
-    )
-  }
-
-  // Single-flight: SIGINT followed by SIGTERM (each signal has its own `once`
-  // handler), or a signal racing the caller's own close(), must share one
-  // teardown instead of double-closing every server.
-  let closing: Promise<void> | undefined
-  const close = () => {
-    closing ??= (async () => {
-      closed = true
-      process.off('SIGINT', onSignal)
-      process.off('SIGTERM', onSignal)
-      await rebuildInFlight
-      await Promise.allSettled([registration?.close(), closeWorkbenchServer(), closeAppDevServer()])
-    })()
-    return closing
-  }
-
-  // Ensure the workbench lock file and registry entries are cleaned up on
-  // abrupt shutdown. The registry is self-healing (stale PIDs are pruned on
-  // next read), but eager cleanup avoids the detect-prune-retry cycle.
-  // Plain projects have no lock or registry entry, so they keep the default
-  // signal handling (and exit codes) they had before workbench existed.
-  //
-  // Trapping the signal disables Node's default exit, and a finished teardown
-  // doesn't guarantee an empty event loop (keep-alive sockets, an extraction
-  // worker mid-run) — without an explicit exit the process lingers, holding
-  // its ports, while the shell prompt returns. Re-raising after teardown
-  // restores the default termination (the `once` handler is gone by then),
-  // with conventional signal exit semantics.
-  const onSignal = (signal: NodeJS.Signals) => {
-    // Backstop for a teardown that never settles (a wedged socket or watcher):
-    // force the exit once the grace period elapses. Cleared on the normal path
-    // so the re-raise fires exactly once; `unref` keeps the timer from holding
-    // the process open by itself.
-    const graceTimer = setTimeout(() => process.kill(process.pid, signal), SHUTDOWN_GRACE_MS)
-    graceTimer.unref()
-    void close().finally(() => {
-      clearTimeout(graceTimer)
-      process.kill(process.pid, signal)
+  if (isWorkbenchApp(cliConfig?.app) && !isWorkbenchRemote) {
+    // Lazy so a non-workbench `sanity dev` never loads the package. `doImport`
+    // is path-based and doesn't apply to a bare specifier.
+    // eslint-disable-next-line no-restricted-syntax
+    const {startWorkbenchDev} = await import('@sanity/workbench-cli/dev')
+    return startWorkbenchDev({
+      appId: getAppId(cliConfig),
+      cacheDir: `${SANITY_CACHE_DIR}/vite`,
+      checkForDeprecatedAppId: () => checkForDeprecatedAppId({cliConfig, output}),
+      cliConfig,
+      extractManifest: isApp
+        ? ({workDir: wd}) => extractCoreAppManifest({workDir: wd})
+        : (params) => extractStudioManifest(params),
+      httpHost,
+      httpPort,
+      isApp,
+      output,
+      // Runtime template needs a concrete boolean; collapse an unset config to off.
+      reactStrictMode: resolveReactStrictMode(cliConfig) ?? false,
+      startAppServer,
+      workDir,
     })
   }
-  if (workbenchAvailable || registration) {
-    process.once('SIGINT', onSignal)
-    process.once('SIGTERM', onSignal)
-  }
 
-  return {close}
+  // Plain studio/app (incl. the workbench remote): one dev server announcing its
+  // own URL — no lock, registry, or signals.
+  const result = await startAppServer({announceUrl: true, cliConfig, httpPort})
+  return {close: result.started ? result.close : noop}
 }

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
@@ -119,7 +119,6 @@ describe('startAppDevServer', () => {
         cliConfig: workbenchCliConfig(),
         flags: {...DEV_FLAGS, 'load-in-dashboard': false},
         output,
-        workbenchAvailable: true,
       }),
     )
 
@@ -146,24 +145,24 @@ describe('startAppDevServer', () => {
     )
   })
 
-  test('logs "App dev server started" for workbench apps when workbench is not available', async () => {
+  test('logs "App dev server started" for workbench apps when asked to announce its URL', async () => {
     mockStartDevServer.mockResolvedValue(createMockDevServer({port: 3334}))
     const output = createMockOutput()
 
     await startAppDevServer(
-      createOptions({cliConfig: workbenchCliConfig(), output, workbenchAvailable: false}),
+      createOptions({announceUrl: true, cliConfig: workbenchCliConfig(), output}),
     )
 
     expect(output.log).toHaveBeenCalledWith('App dev server started on port 3334')
     expect(mockGetDashboardAppURL).not.toHaveBeenCalled()
   })
 
-  test('skips the port log line for workbench apps when workbench is available', async () => {
+  test('skips the port log line for workbench apps when the workbench announces instead', async () => {
     mockStartDevServer.mockResolvedValue(createMockDevServer({port: 3334}))
     const output = createMockOutput()
 
     await startAppDevServer(
-      createOptions({cliConfig: workbenchCliConfig(), output, workbenchAvailable: true}),
+      createOptions({announceUrl: false, cliConfig: workbenchCliConfig(), output}),
     )
 
     // 'Starting dev server' is still logged, but the port announcement is not

--- a/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
@@ -10,7 +10,7 @@ import {getDashboardAppURL} from './getDashboardAppUrl.js'
 import {getDevServerConfig} from './getDevServerConfig.js'
 
 export async function startAppDevServer(options: DevActionOptions): Promise<StartDevServerResult> {
-  const {cliConfig, flags, httpPort, output, workbenchAvailable, workDir} = options
+  const {announceUrl = true, cliConfig, flags, httpPort, output, workDir} = options
 
   const isWorkbenchApp = determineIsWorkbenchApp(cliConfig?.app)
 
@@ -48,10 +48,9 @@ export async function startAppDevServer(options: DevActionOptions): Promise<Star
     const {port} = server.config.server
 
     if (isWorkbenchApp) {
-      // Federated apps surface through the workbench, so the dashboard URL is
-      // meaningless for them. When the workbench runs, devAction announces its
-      // URL instead — only the package-unavailable fallback logs from here.
-      if (!workbenchAvailable) {
+      // Federated apps surface through the workbench, which announces the URL;
+      // only the package-unavailable fallback announces from here.
+      if (announceUrl) {
         output.log(`App dev server started on port ${port}`)
       }
     } else {

--- a/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
@@ -24,7 +24,7 @@ import {getDevServerConfig} from './getDevServerConfig.js'
 export async function startStudioDevServer(
   options: DevActionOptions,
 ): Promise<StartDevServerResult> {
-  const {cliConfig, flags, httpPort, output, workbenchAvailable, workDir} = options
+  const {announceUrl = true, cliConfig, flags, httpPort, output, workDir} = options
   const projectId = cliConfig?.api?.projectId
   let organizationId: string | undefined
 
@@ -157,7 +157,7 @@ export async function startStudioDevServer(
         `${appType} ` +
           `using ${styleText('cyan', `vite@${viteVersion}`)} ` +
           `ready in ${styleText('cyan', `${Math.ceil(startupDuration)}ms`)}` +
-          (workbenchAvailable ? '' : ` and running at ${styleText('cyan', url)}`),
+          (announceUrl ? ` and running at ${styleText('cyan', url)}` : ''),
       )
     }
 

--- a/packages/@sanity/cli/src/actions/dev/types.ts
+++ b/packages/@sanity/cli/src/actions/dev/types.ts
@@ -12,14 +12,15 @@ export interface DevActionOptions {
   output: Output
   workDir: string
 
+  /** Announce the server's own URL on startup; `false` when the workbench announces it instead (default `true`). */
+  announceUrl?: boolean
+
   /**
    * Port the app/studio dev server should bind. `devAction` sets it when a
    * running workbench has claimed the configured port; otherwise it stays
    * absent and the server resolves its port from flags/env/config.
    */
   httpPort?: number
-
-  workbenchAvailable?: boolean
 }
 
 /**

--- a/packages/@sanity/cli/test/integration/commands/dev.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/dev.test.ts
@@ -57,24 +57,6 @@ vi.mock('@sanity/cli-core/ux', async () => {
 vi.mock('../../../src/util/packageManager/upgradePackages.js')
 vi.mock('../../../src/util/packageManager/packageManagerChoice.js')
 
-// Prevent the workbench dev server from starting — it would shift ports (+1)
-// and suppress output messages that tests assert on.
-vi.mock('../../../src/actions/dev/workbench/startWorkbenchDevServer.js', () => ({
-  startWorkbenchDevServer: vi.fn().mockImplementation(async (options) => {
-    const {getSharedServerConfig} = await vi.importActual<
-      typeof import('../../../src/util/getSharedServerConfig.js')
-    >('../../../src/util/getSharedServerConfig.js')
-
-    const {httpHost, httpPort} = getSharedServerConfig({
-      cliConfig: options.cliConfig,
-      flags: {host: options.flags.host, port: options.flags.port},
-      workDir: options.workDir,
-    })
-
-    return {close: async () => {}, httpHost, workbenchAvailable: false, workbenchPort: httpPort}
-  }),
-}))
-
 vi.mock('@sanity/cli-core', async () => {
   const actual = await vi.importActual<typeof import('@sanity/cli-core')>('@sanity/cli-core')
   return {

--- a/packages/@sanity/workbench-cli/src/_exports/dev.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/dev.ts
@@ -1,23 +1,6 @@
-// Node-only dev entry: the dev-server registry the CLI drives and the workbench
-// host watches (singleton lock + PID-liveness), plus the interface model derived
-// from `unstable_defineApp`.
-export {canonicalizeWatchDir} from '../actions/dev/canonicalizeWatchDir.js'
-export {deriveInterfaces, type DevServerInterface} from '../actions/dev/deriveInterfaces.js'
-export {
-  createInterfacesTracker,
-  interfaceSetId,
-  trackInterfaceSet,
-} from '../actions/dev/interfaceSetId.js'
-export {
-  acquireWorkbenchLock,
-  type DevServerManifest,
-  getRegisteredServers,
-  readWorkbenchLock,
-  registerDevServer,
-  watchRegistry,
-} from '../actions/dev/registry.js'
-export {startDevServerRegistration} from '../actions/dev/startDevServerRegistration.js'
-export {
-  startWorkbenchDevServer,
-  type StartWorkbenchOptions,
-} from '../actions/dev/startWorkbenchDevServer.js'
+// Node-only dev entry: the workbench dev orchestration the CLI delegates to.
+// `startWorkbenchDev` starts the singleton workbench server, wires both it and
+// the injected app/studio server into the dev-server registry, and owns their
+// teardown. The registry, interface model, and orchestration are internal now,
+// reached only through this entry.
+export {startWorkbenchDev, type StartWorkbenchDevOptions} from '../actions/dev/startWorkbenchDev.js'

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/appServerSupervisor.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/appServerSupervisor.test.ts
@@ -1,0 +1,114 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {type AppServerResult, startAppServerSupervisor} from '../appServerSupervisor.js'
+import {workbenchCliConfig} from './devTestHelpers.js'
+
+const mockGetCliConfigUncached = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/cli-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
+  getCliConfigUncached: mockGetCliConfigUncached,
+}))
+
+function mockAppServer({port = 3334}: {port?: number} = {}): AppServerResult {
+  return {
+    close: vi.fn().mockResolvedValue(undefined),
+    server: {config: {server: {port}}} as never,
+    started: true,
+  }
+}
+
+async function startSupervisor(start: ReturnType<typeof vi.fn>) {
+  const result = await startAppServerSupervisor({
+    cliConfig: workbenchCliConfig(),
+    start,
+    workDir: '/tmp/sanity-project',
+  })
+  if (!result.started) throw new Error('expected the supervisor to start')
+  return result.supervisor
+}
+
+describe('startAppServerSupervisor', () => {
+  beforeEach(() => {
+    mockGetCliConfigUncached.mockResolvedValue(workbenchCliConfig())
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('passes through an expected early exit from the initial start', async () => {
+    const start = vi.fn().mockResolvedValue({reason: 'missing-organization-id', started: false})
+
+    const result = await startAppServerSupervisor({
+      cliConfig: workbenchCliConfig(),
+      start,
+      workDir: '/tmp/sanity-project',
+    })
+
+    expect(result).toEqual({reason: 'missing-organization-id', started: false})
+  })
+
+  test('rebuild closes the current server and starts a fresh one with the reloaded config', async () => {
+    const first = mockAppServer({port: 3334})
+    const second = mockAppServer({port: 3335})
+    const start = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second)
+    const freshConfig = workbenchCliConfig()
+    mockGetCliConfigUncached.mockResolvedValue(freshConfig)
+
+    const supervisor = await startSupervisor(start)
+
+    await expect(supervisor.rebuild()).resolves.toBe(second.server)
+    expect(first.close).toHaveBeenCalledTimes(1)
+    expect(start).toHaveBeenLastCalledWith(freshConfig)
+    // The live server re-points at the replacement.
+    expect(supervisor.server).toBe(second.server)
+  })
+
+  test('rebuild rejects when the restart reports an expected early exit', async () => {
+    const start = vi
+      .fn()
+      .mockResolvedValueOnce(mockAppServer())
+      .mockResolvedValueOnce({reason: 'missing-organization-id', started: false})
+
+    const supervisor = await startSupervisor(start)
+
+    await expect(supervisor.rebuild()).rejects.toThrow(
+      'Dev server did not restart after the view/service change',
+    )
+  })
+
+  test('refuses a rebuild once close has started shutdown', async () => {
+    const supervisor = await startSupervisor(vi.fn().mockResolvedValue(mockAppServer()))
+
+    await supervisor.close()
+
+    await expect(supervisor.rebuild()).rejects.toThrow('Dev server is shutting down')
+  })
+
+  test('close waits out an in-flight rebuild and closes the replacement', async () => {
+    const first = mockAppServer()
+    const second = mockAppServer()
+    let releaseStart!: () => void
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve
+    })
+    const start = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockImplementationOnce(async () => {
+        await startGate
+        return second
+      })
+
+    const supervisor = await startSupervisor(start)
+
+    const rebuild = supervisor.rebuild()
+    const closing = supervisor.close()
+    releaseStart()
+
+    await rebuild
+    await closing
+    expect(second.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDev.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDev.test.ts
@@ -1,0 +1,347 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {startWorkbenchDev, type StartWorkbenchDevOptions} from '../startWorkbenchDev.js'
+import {createMockOutput, workbenchCliConfig} from './devTestHelpers.js'
+
+const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
+const mockStartDevServerRegistration = vi.hoisted(() => vi.fn())
+const mockGetCliConfigUncached = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/cli-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
+  getCliConfigUncached: mockGetCliConfigUncached,
+}))
+vi.mock('../startWorkbenchDevServer.js', () => ({
+  startWorkbenchDevServer: mockStartWorkbenchDevServer,
+}))
+vi.mock('../startDevServerRegistration.js', () => ({
+  startDevServerRegistration: mockStartDevServerRegistration,
+}))
+
+/** A started app/studio dev server result, with a distinct close per call. */
+function mockAppServer({port = 3334}: {port?: number} = {}) {
+  return {
+    close: vi.fn().mockResolvedValue(undefined),
+    server: {config: {server: {port}}, httpServer: {address: () => ({port})}},
+    started: true as const,
+  }
+}
+
+const mockStartAppServer = vi.hoisted(() => vi.fn())
+const mockExtractManifest = vi.hoisted(() => vi.fn())
+const mockCheckForDeprecatedAppId = vi.hoisted(() => vi.fn())
+
+function run(overrides: Partial<StartWorkbenchDevOptions> = {}) {
+  return startWorkbenchDev({
+    appId: undefined,
+    cacheDir: '/tmp/sanity-project/.sanity/vite',
+    checkForDeprecatedAppId: mockCheckForDeprecatedAppId,
+    cliConfig: workbenchCliConfig(),
+    extractManifest: mockExtractManifest,
+    httpHost: 'localhost',
+    httpPort: 3333,
+    isApp: true,
+    output: createMockOutput(),
+    reactStrictMode: false,
+    startAppServer: mockStartAppServer,
+    workDir: '/tmp/sanity-project',
+    ...overrides,
+  })
+}
+
+/** Pull the rebuild hook the orchestrator handed to the registration. */
+function passedRebuild(): () => Promise<unknown> {
+  return mockStartDevServerRegistration.mock.calls[0][0].onInterfaceSetChange
+}
+
+/** The signal handler installed last. */
+function installedSignalHandler(): (signal: NodeJS.Signals) => void {
+  return process.listeners('SIGINT').at(-1) as (signal: NodeJS.Signals) => void
+}
+
+describe('startWorkbenchDev', () => {
+  beforeEach(() => {
+    mockStartWorkbenchDevServer.mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      httpHost: 'localhost',
+      workbenchAvailable: true,
+      workbenchPort: 3333,
+    })
+    mockStartDevServerRegistration.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
+    mockStartAppServer.mockResolvedValue(mockAppServer({port: 3334}))
+    mockGetCliConfigUncached.mockResolvedValue(workbenchCliConfig())
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('port + URL announcement', () => {
+    test('binds the app server to the next port and silences its URL when the workbench runs', async () => {
+      await run()
+
+      expect(mockStartAppServer).toHaveBeenCalledWith(
+        expect.objectContaining({announceUrl: false, httpPort: 3334}),
+      )
+    })
+
+    test('keeps the configured port and announces the URL when the workbench is unavailable', async () => {
+      mockStartWorkbenchDevServer.mockResolvedValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        httpHost: 'localhost',
+        workbenchAvailable: false,
+        workbenchPort: 3333,
+      })
+
+      await run()
+
+      expect(mockStartAppServer).toHaveBeenCalledWith(
+        expect.objectContaining({announceUrl: true, httpPort: 3333}),
+      )
+    })
+
+    test('logs the workbench URL with the app port when the workbench runs', async () => {
+      const output = createMockOutput()
+      await run({output})
+
+      expect(output.log).toHaveBeenCalledWith(expect.stringContaining('http://localhost:3333'))
+    })
+
+    test('shows the existing lock host in the URL, not the caller host', async () => {
+      mockStartWorkbenchDevServer.mockResolvedValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        httpHost: 'mydev.local',
+        workbenchAvailable: true,
+        workbenchPort: 3333,
+      })
+      const output = createMockOutput()
+
+      await run({output})
+
+      expect(output.log).toHaveBeenCalledWith(expect.stringContaining('mydev.local:3333'))
+    })
+
+    test('falls back to localhost for a non-routable bind address', async () => {
+      mockStartWorkbenchDevServer.mockResolvedValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        httpHost: '0.0.0.0',
+        workbenchAvailable: true,
+        workbenchPort: 3333,
+      })
+      const output = createMockOutput()
+
+      await run({output})
+
+      expect(output.log).toHaveBeenCalledWith(expect.stringContaining('http://localhost:3333'))
+    })
+  })
+
+  describe('registration', () => {
+    test('checks for the deprecated app id, then registers with the live server', async () => {
+      const server = mockAppServer({port: 3334})
+      mockStartAppServer.mockResolvedValue(server)
+
+      await run({appId: 'app-abc', isApp: true})
+
+      expect(mockCheckForDeprecatedAppId).toHaveBeenCalled()
+      expect(mockStartDevServerRegistration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: 'app-abc',
+          extractManifest: mockExtractManifest,
+          isApp: true,
+          server: server.server,
+        }),
+      )
+    })
+
+    test('tears down both servers and re-throws when registration fails', async () => {
+      const workbenchClose = vi.fn().mockResolvedValue(undefined)
+      const appClose = vi.fn().mockResolvedValue(undefined)
+      mockStartWorkbenchDevServer.mockResolvedValue({
+        close: workbenchClose,
+        httpHost: 'localhost',
+        workbenchAvailable: true,
+        workbenchPort: 3333,
+      })
+      mockStartAppServer.mockResolvedValue({...mockAppServer({port: 3334}), close: appClose})
+      const registrationError = new Error('deriveInterfaces failed')
+      mockStartDevServerRegistration.mockRejectedValue(registrationError)
+
+      const thrown = await run().catch((err) => err)
+
+      expect(thrown).toBe(registrationError)
+      expect(workbenchClose).toHaveBeenCalled()
+      expect(appClose).toHaveBeenCalled()
+    })
+
+    test('closes the registration on close', async () => {
+      const handle = {close: vi.fn().mockResolvedValue(undefined)}
+      mockStartDevServerRegistration.mockResolvedValue(handle)
+
+      const {close} = await run()
+      await close()
+
+      expect(handle.close).toHaveBeenCalled()
+    })
+
+    test('returns a workbench-only close and skips registration when the app server does not start', async () => {
+      const workbenchClose = vi.fn().mockResolvedValue(undefined)
+      mockStartWorkbenchDevServer.mockResolvedValue({
+        close: workbenchClose,
+        httpHost: 'localhost',
+        workbenchAvailable: false,
+        workbenchPort: 3333,
+      })
+      mockStartAppServer.mockResolvedValue({reason: 'missing-organization-id', started: false})
+
+      const {close} = await run()
+      await close()
+
+      expect(workbenchClose).toHaveBeenCalled()
+      expect(mockStartDevServerRegistration).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('rebuild', () => {
+    test('rebuilds the app server with a freshly-loaded config when the interface set changes', async () => {
+      const first = mockAppServer({port: 3334})
+      const second = mockAppServer({port: 3334})
+      mockStartAppServer.mockResolvedValueOnce(first).mockResolvedValueOnce(second)
+      const freshConfig = workbenchCliConfig()
+      mockGetCliConfigUncached.mockResolvedValue(freshConfig)
+
+      await run()
+      await passedRebuild()()
+
+      expect(first.close).toHaveBeenCalledTimes(1)
+      expect(mockStartAppServer).toHaveBeenCalledTimes(2)
+      expect(mockStartAppServer).toHaveBeenLastCalledWith(
+        expect.objectContaining({cliConfig: freshConfig}),
+      )
+    })
+
+    test('the rebuild hook resolves with the recreated server', async () => {
+      const second = mockAppServer({port: 3335})
+      mockStartAppServer
+        .mockResolvedValueOnce(mockAppServer({port: 3334}))
+        .mockResolvedValueOnce(second)
+
+      await run()
+
+      await expect(passedRebuild()()).resolves.toBe(second.server)
+    })
+
+    test('the rebuild hook rejects on an expected early exit, and close stays safe', async () => {
+      const first = mockAppServer({port: 3334})
+      mockStartAppServer
+        .mockResolvedValueOnce(first)
+        .mockResolvedValueOnce({reason: 'missing-organization-id', started: false})
+
+      const {close} = await run()
+
+      await expect(passedRebuild()()).rejects.toThrow(
+        'Dev server did not restart after the view/service change',
+      )
+      await expect(close()).resolves.toBeUndefined()
+      expect(first.close).toHaveBeenCalledTimes(1)
+    })
+
+    test('close() waits for an in-flight rebuild and closes the replacement server', async () => {
+      const first = mockAppServer({port: 3334})
+      const second = mockAppServer({port: 3334})
+      let releaseStart!: () => void
+      const startGate = new Promise<void>((resolve) => {
+        releaseStart = resolve
+      })
+      mockStartAppServer.mockResolvedValueOnce(first).mockImplementationOnce(async () => {
+        await startGate
+        return second
+      })
+
+      const {close} = await run()
+      const rebuild = passedRebuild()()
+      const closing = close()
+      releaseStart()
+
+      await rebuild
+      await closing
+      expect(second.close).toHaveBeenCalledTimes(1)
+    })
+
+    test('refuses a rebuild once shutdown has started', async () => {
+      const {close} = await run()
+      await close()
+
+      await expect(passedRebuild()()).rejects.toThrow('Dev server is shutting down')
+      // Only the initial startup reached the app server.
+      expect(mockStartAppServer).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('signals', () => {
+    test('close() is single-flight — a second call shares the same teardown', async () => {
+      const appClose = vi.fn().mockResolvedValue(undefined)
+      mockStartAppServer.mockResolvedValue({...mockAppServer({port: 3334}), close: appClose})
+
+      const {close} = await run()
+      await Promise.all([close(), close()])
+
+      expect(appClose).toHaveBeenCalledTimes(1)
+    })
+
+    test('registers signal handlers and removes them on close', async () => {
+      const sigintBefore = process.listenerCount('SIGINT')
+      const sigtermBefore = process.listenerCount('SIGTERM')
+
+      const {close} = await run()
+
+      expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
+      expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + 1)
+
+      await close()
+
+      expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
+      expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)
+    })
+
+    test('re-raises the signal once teardown settles so the default exit runs', async () => {
+      const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+      vi.useFakeTimers()
+      try {
+        const appClose = vi.fn().mockResolvedValue(undefined)
+        mockStartAppServer.mockResolvedValue({...mockAppServer({port: 3334}), close: appClose})
+
+        await run()
+        installedSignalHandler()('SIGINT')
+        await vi.runAllTimersAsync()
+
+        expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGINT')
+        expect(appClose.mock.invocationCallOrder[0]).toBeLessThan(
+          killSpy.mock.invocationCallOrder[0],
+        )
+      } finally {
+        vi.useRealTimers()
+        killSpy.mockRestore()
+      }
+    })
+
+    test('force-exits after the grace period when teardown hangs', async () => {
+      const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+      vi.useFakeTimers()
+      try {
+        const hangingClose = vi.fn(() => new Promise<void>(() => {}))
+        mockStartAppServer.mockResolvedValue({...mockAppServer({port: 3334}), close: hangingClose})
+
+        await run()
+        installedSignalHandler()('SIGTERM')
+        await vi.advanceTimersByTimeAsync(5000)
+
+        expect(hangingClose).toHaveBeenCalled()
+        expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM')
+      } finally {
+        vi.useRealTimers()
+        killSpy.mockRestore()
+      }
+    })
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/dev/appServerSupervisor.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/appServerSupervisor.ts
@@ -1,0 +1,94 @@
+import {type CliConfig, getCliConfigUncached} from '@sanity/cli-core'
+import {type ViteDevServer} from 'vite'
+
+/**
+ * Minimal shape the supervisor needs back from a started app/studio dev server.
+ * The not-started arm is reserved for expected early exits the server already
+ * reported (e.g. a missing organization id) — a failure to *boot* still throws.
+ */
+export type AppServerResult =
+  | {close: () => Promise<void>; server: ViteDevServer; started: true}
+  | {reason: string; started: false}
+
+/** Start the app/studio dev server for a given config (port + URL intent baked in by the caller). */
+export type StartAppServer = (cliConfig: CliConfig) => Promise<AppServerResult>
+
+const noop = async () => {}
+
+export interface AppServerSupervisor {
+  /** Stop the server once, waiting out any rebuild already in flight. */
+  close: () => Promise<void>
+  /** Tear down the running server and bring it back up with a freshly-loaded config. */
+  rebuild: () => Promise<ViteDevServer>
+  /** The currently-live dev server; re-points after a rebuild. */
+  readonly server: ViteDevServer
+}
+
+/**
+ * Own the app/studio dev server's lifecycle behind the dev-server registry seam.
+ *
+ * Adding or removing a view/service rebuilds the federation remote: its
+ * module-federation `exposes` map and codegen artifacts are computed once at
+ * server start, so a newly-declared interface has no expose until the server is
+ * recreated — `server.restart()` can't do it (it reuses the inline config).
+ * `rebuild` therefore tears the server down and starts a fresh one with a
+ * reloaded config; the registry watcher calls it when the interface set changes.
+ *
+ * Returns the not-started result verbatim when the initial boot is an expected
+ * early exit, so the caller can skip the rest of the orchestration.
+ */
+export async function startAppServerSupervisor(options: {
+  cliConfig: CliConfig
+  start: StartAppServer
+  workDir: string
+}): Promise<{reason: string; started: false} | {started: true; supervisor: AppServerSupervisor}> {
+  const {cliConfig, start, workDir} = options
+
+  const initial = await start(cliConfig)
+  if (!initial.started) return {reason: initial.reason, started: false}
+
+  // `closeCurrent` repoints at the replacement only once a rebuild succeeds, so a
+  // failed rebuild (old server already closed) leaves nothing for close() to re-close.
+  let server = initial.server
+  let closeCurrent = initial.close
+  let closed = false
+  // close() waits on this so a rebuild racing teardown can't orphan the replacement.
+  // Rejections are the watcher's (warn + retry); the tracked copy is swallowed.
+  let rebuildInFlight: Promise<unknown> = Promise.resolve()
+
+  const runRebuild = async (): Promise<ViteDevServer> => {
+    // Refuse once shutting down — a config save in the teardown window must not
+    // boot a replacement nobody owns.
+    if (closed) throw new Error('Dev server is shutting down')
+    const freshConfig = await getCliConfigUncached(workDir)
+    await closeCurrent()
+    closeCurrent = noop
+    const result = await start(freshConfig)
+    if (!result.started) {
+      // The server already reported why (e.g. organizationId was removed).
+      throw new Error('Dev server did not restart after the view/service change')
+    }
+    server = result.server
+    closeCurrent = result.close
+    return server
+  }
+
+  return {
+    started: true,
+    supervisor: {
+      async close() {
+        closed = true
+        await rebuildInFlight
+        await closeCurrent()
+      },
+      rebuild() {
+        const rebuild = runRebuild()
+        rebuildInFlight = rebuild.catch(() => {})
+        return rebuild
+      },
+      get server() {
+        return server
+      },
+    },
+  }
+}

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDev.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDev.ts
@@ -1,0 +1,176 @@
+import {styleText} from 'node:util'
+
+import {type CliConfig, type Output} from '@sanity/cli-core'
+
+import {type AppServerResult, startAppServerSupervisor} from './appServerSupervisor.js'
+import {type DevServerManifest} from './registry.js'
+import {startDevServerRegistration} from './startDevServerRegistration.js'
+import {startWorkbenchDevServer} from './startWorkbenchDevServer.js'
+
+/** How long teardown runs before re-raising the signal to force-exit — enough for
+ * Vite/watchers to close, short enough not to strand a backgrounded process. */
+const SHUTDOWN_GRACE_MS = 5000
+
+// Bind-only addresses ('0.0.0.0', '::') aren't routable in every browser (notably
+// Windows); the displayed URL falls back to localhost. The bind address is untouched.
+function toDisplayHost(host: string | undefined): string {
+  if (!host || host === '0.0.0.0' || host === '::' || host === '[::]') {
+    return 'localhost'
+  }
+  return host
+}
+
+export interface StartWorkbenchDevOptions {
+  /** Resolved app id for the registry entry (the CLI owns id resolution). */
+  appId: string | undefined
+  /** Directory for the workbench Vite server's dependency cache. */
+  cacheDir: string
+  /** CLI-domain `app.id`/`deployment.appId` deprecation check, run before registering. */
+  checkForDeprecatedAppId: () => void
+  cliConfig: CliConfig
+  /** Extract the project manifest to inline into the registry (studio-vs-app handled by the CLI). */
+  extractManifest: (params: {
+    configPath: string
+    workDir: string
+  }) => Promise<DevServerManifest['manifest']>
+  httpHost: string | undefined
+  httpPort: number
+  isApp: boolean
+  output: Output
+  reactStrictMode: boolean
+  /** Start the app/studio dev server — the CLI owns the server, this orchestrates it. */
+  startAppServer: (params: {
+    announceUrl: boolean
+    cliConfig: CliConfig
+    httpPort: number
+  }) => Promise<AppServerResult>
+  workDir: string
+}
+
+/**
+ * Orchestrate the dev servers a workbench project needs: a singleton workbench
+ * Vite server plus the app/studio dev server it renders, wired to the dev-server
+ * registry so view/service edits re-sync live.
+ *
+ * A running workbench claims the configured port, so the app server binds the
+ * next one. If the workbench can't start (package or port unavailable), the app
+ * server falls back to the configured port and announces its own URL, exactly as
+ * a plain `sanity dev` would.
+ */
+export async function startWorkbenchDev(
+  options: StartWorkbenchDevOptions,
+): Promise<{close: () => Promise<void>}> {
+  const {
+    appId,
+    cacheDir,
+    checkForDeprecatedAppId,
+    cliConfig,
+    extractManifest,
+    httpHost,
+    httpPort,
+    isApp,
+    output,
+    reactStrictMode,
+    startAppServer,
+    workDir,
+  } = options
+
+  // Unwound in reverse on any failure or on close(): the watcher stops before
+  // the app server, and the supervisor waits out an in-flight rebuild.
+  const closers: Array<() => Promise<void>> = []
+  const disposeAll = async () => {
+    for (const close of closers.splice(0).toReversed()) {
+      await close().catch(() => {})
+    }
+  }
+
+  const workbench = await startWorkbenchDevServer({
+    cacheDir,
+    cliConfig,
+    httpHost,
+    httpPort,
+    output,
+    reactStrictMode,
+    workDir,
+  })
+  closers.push(workbench.close)
+
+  // A running workbench owns the configured port; the app server takes the next.
+  // Without one it claims the configured port and announces its own URL.
+  const appPort = workbench.workbenchAvailable ? workbench.workbenchPort + 1 : httpPort
+  const announceUrl = !workbench.workbenchAvailable
+
+  let closing: Promise<void> | undefined
+  const close = () => {
+    closing ??= (async () => {
+      process.off('SIGINT', onSignal)
+      process.off('SIGTERM', onSignal)
+      await disposeAll()
+    })()
+    return closing
+  }
+
+  const supervised = await startAppServerSupervisor({
+    cliConfig,
+    start: (config) => startAppServer({announceUrl, cliConfig: config, httpPort: appPort}),
+    workDir,
+  }).catch(async (err) => {
+    await disposeAll()
+    throw err
+  })
+
+  if (!supervised.started) {
+    // The app server already reported why (e.g. missing organization id). Hand
+    // back a close that releases the workbench lock; nothing else came up.
+    return {close}
+  }
+  const {supervisor} = supervised
+  closers.push(supervisor.close)
+
+  try {
+    // The deprecated-id check and manifest extractor are CLI-domain, injected here.
+    checkForDeprecatedAppId()
+    const registration = await startDevServerRegistration({
+      appId,
+      cliConfig,
+      extractManifest,
+      isApp,
+      onInterfaceSetChange: () => supervisor.rebuild(),
+      output,
+      server: supervisor.server,
+      workDir,
+    })
+    closers.push(registration.close)
+  } catch (err) {
+    // Registration runs after both servers are up; a failure here would leak the
+    // workbench lock and dev servers without this teardown.
+    await disposeAll()
+    throw err
+  }
+
+  if (workbench.workbenchAvailable) {
+    const workbenchUrl = `http://${toDisplayHost(workbench.httpHost)}:${workbench.workbenchPort}`
+    const addr = supervisor.server.httpServer?.address()
+    const port = typeof addr === 'object' && addr ? addr.port : supervisor.server.config.server.port
+    output.log(
+      `Workbench dev server started at ${styleText(['blue', 'underline'], workbenchUrl)} (app on port ${port})`,
+    )
+  }
+
+  // Trapping the signal disables Node's default exit, and a finished teardown
+  // doesn't guarantee an empty event loop (keep-alive sockets, an extraction
+  // worker mid-run) — so re-raise after teardown to restore conventional signal
+  // exit semantics. A backstop timer force-exits if teardown wedges.
+  function onSignal(signal: NodeJS.Signals) {
+    const graceTimer = setTimeout(() => process.kill(process.pid, signal), SHUTDOWN_GRACE_MS)
+    graceTimer.unref()
+    void close().finally(() => {
+      clearTimeout(graceTimer)
+      process.kill(process.pid, signal)
+    })
+  }
+  process.once('SIGINT', onSignal)
+  process.once('SIGTERM', onSignal)
+
+  return {close}
+}


### PR DESCRIPTION
### Description

devAction had grown into a ~240-line orchestrator carrying the workbench lock, app-server supervision, registry wiring, and signal teardown — moving all of it into one `startWorkbenchDev` entry leaves devAction a small dispatcher that injects the CLI-domain pieces and lazy-loads the package, so a plain `sanity dev` never touches workbench-cli.

### What to review

The new `startWorkbenchDev` + `appServerSupervisor`, the slimmed devAction dispatcher, and `workbenchAvailable` → `announceUrl`. One behaviour delta: teardown is now a sequential reverse unwind (was a parallel `allSettled`), which keeps the watcher stopping before the app server closes.

### Testing

Orchestration tests moved to `startWorkbenchDev`/`appServerSupervisor`; devAction tests now cover the dispatch + injection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core `sanity dev` paths for workbench projects (ports, registry, rebuild-on-config-change, signal shutdown) with a deliberate teardown-order change; plain projects are largely unchanged aside from the `announceUrl` flag.
> 
> **Overview**
> **Moves workbench dev orchestration out of `devAction` into `@sanity/workbench-cli`.** `devAction` is now a thin dispatcher: plain studio/app runs still start a single server with `announceUrl: true`; workbench projects lazy-load `startWorkbenchDev` and pass injected CLI concerns (app id, deprecated-id check, manifest extraction, and a `startAppServer` callback). The workbench-remote env path stays a plain server with no orchestration.
> 
> **New workbench-cli surface:** `startWorkbenchDev` plus `appServerSupervisor` own the singleton workbench server, registry registration, interface-set rebuilds (reload config + restart app server), URL logging, and SIGINT/SIGTERM teardown. The public `@sanity/workbench-cli/dev` export is reduced to `startWorkbenchDev` only.
> 
> **API tweak:** `DevActionOptions` drops `workbenchAvailable` in favor of **`announceUrl`** so app/studio servers know whether to print their own URL or let the workbench announce it.
> 
> **Tests** follow the split: orchestration coverage lives in `startWorkbenchDev` / `appServerSupervisor`; `devAction` tests cover routing and injection. **Teardown order** is now a sequential reverse unwind of closers (was parallel `allSettled`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587338658fd3622d275b6f73032a370d3dbdca6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->