### PR TITLE
feat(init): promote page-builder template to production

### DIFF
--- a/.changeset/pr-1353.md
+++ b/.changeset/pr-1353.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(init): promote page-builder template to production

--- a/packages/@sanity/cli/src/actions/init/__tests__/scaffoldTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/scaffoldTemplate.test.ts
@@ -1,15 +1,10 @@
 import {describe, expect, test} from 'vitest'
 
-import {getTemplateChoices} from '../scaffoldTemplate.js'
+import {templateChoices} from '../scaffoldTemplate.js'
 
-describe('getTemplateChoices', () => {
-  test('includes the page-builder template in non-production environments', () => {
-    const values = getTemplateChoices('staging').map((choice) => choice.value)
+describe('templateChoices', () => {
+  test('offers the page-builder template', () => {
+    const values = templateChoices.map((choice) => choice.value)
     expect(values).toContain('page-builder')
-  })
-
-  test('excludes the page-builder template in production', () => {
-    const values = getTemplateChoices('production').map((choice) => choice.value)
-    expect(values).not.toContain('page-builder')
   })
 })

--- a/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/scaffoldTemplate.ts
@@ -4,7 +4,6 @@ import {type TelemetryTrace} from '@sanity/telemetry'
 
 import {promptForTypeScript} from '../../prompts/init/promptForTypescript.js'
 import {type InitStepResult} from '../../telemetry/init.telemetry.js'
-import {getSanityEnv} from '../../util/getSanityEnv.js'
 import {installDeclaredPackages} from '../../util/packageManager/installPackages.js'
 import {type PackageManager} from '../../util/packageManager/packageManagerChoice.js'
 import {bootstrapTemplate} from './bootstrapTemplate.js'
@@ -26,22 +25,13 @@ interface TemplateChoice {
   value: string
 }
 
-const baseTemplateChoices: TemplateChoice[] = [
+export const templateChoices: TemplateChoice[] = [
   {name: 'Clean project with no predefined schema types', value: 'clean'},
   {name: 'Blog (schema)', value: 'blog'},
   {name: 'E-commerce (Shopify)', value: 'shopify'},
   {name: 'Movie project (schema + sample data)', value: 'moviedb'},
-]
-
-const stagingTemplateChoices: TemplateChoice[] = [
   {name: 'Page Builder (presets)', value: 'page-builder'},
 ]
-
-export function getTemplateChoices(env: string): TemplateChoice[] {
-  return env === 'production'
-    ? baseTemplateChoices
-    : [...baseTemplateChoices, ...stagingTemplateChoices]
-}
 
 async function promptForTemplate(params: {
   template?: string
@@ -53,7 +43,7 @@ async function promptForTemplate(params: {
   }
 
   return select({
-    choices: getTemplateChoices(getSanityEnv()),
+    choices: templateChoices,
     message: 'Select project template',
   })
 }

--- a/packages/@sanity/cli/src/actions/init/templates/pageBuilder.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/pageBuilder.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 const pageBuilderTemplate: ProjectTemplate = {
   configTemplate,
   dependencies: {
-    '@sanity/presets': '^0.5.0',
+    '@sanity/presets': '^1.0.0',
   },
 }
 


### PR DESCRIPTION
### Description

The Page Builder template was added behind a staging-only gate that kept it out of the interactive `sanity init` menu in production. The gate existed solely to hide the template until its dependency, `@sanity/presets`, was ready. `@sanity/presets` v1 is now released.

This PR promotes the Page Builder template to production. It removes the staging-only gate, collapses the environment-branching machinery (`baseTemplateChoices`, `stagingTemplateChoices`, `getTemplateChoices`) into a single flat `templateChoices` list, and bumps the template's `@sanity/presets` dependency to `^1.0.0`.

### What to review

- The gate only ever affected the interactive menu. `sanity init --template page-builder` already worked in production, so this surfaces the existing option rather than enabling new behaviour.
- `@sanity/presets` is bumped from `^0.5.0` to `^1.0.0` in `pageBuilder.ts`.

### Testing

- Updated the unit test to assert `templateChoices` offers `page-builder`.
- Existing e2e (`init.studio.shared.ts`) already initialises the `page-builder` template against a production dataset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI init menu and template dependency version only; `--template page-builder` already worked in production, so behavior change is surfacing the menu option.
> 
> **Overview**
> Makes **Page Builder** a first-class option in the interactive `sanity init` template picker by removing the production/staging split that hid it outside non-production environments.
> 
> **`scaffoldTemplate.ts`** now exports one flat `templateChoices` array (including page-builder) and uses it directly in the prompt—`getTemplateChoices`, `getSanityEnv`, and separate base/staging lists are gone. **`pageBuilder.ts`** bumps `@sanity/presets` from `^0.5.0` to `^1.0.0`. Tests now assert page-builder is always offered; the production-exclusion case is removed. Changeset records a **minor** bump for `@sanity/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0ffe60eea3f98fec15136bd85a3d3e229f94e5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->