### PR TITLE
test(cli): stop users list error test from leaking an in-flight request

### DIFF
--- a/packages/@sanity/cli/src/commands/users/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/list.test.ts
@@ -115,16 +115,22 @@ describe('#list', () => {
   })
 
   test('displays an error if the API request fails', async () => {
-    // Wait for 50ms to ensure the Promise.all is called
-    setTimeout(
-      () => mockGetProjectCliClient.mockRejectedValue(new Error('Internal server error')),
-      50,
-    )
+    // Resolve the project lookup so the only failure originates from the awaited
+    // invitations request below. The previous version rejected getProjectById
+    // while the invitations request was still in flight, which left that request
+    // dangling: on slower runners (Windows CI) it settled after this test, then
+    // consumed the next test's matching mock. Failing an awaited request instead
+    // guarantees it is dispatched and consumed before the command settles.
+    mockGetProjectCliClient.mockResolvedValue({
+      projects: {
+        getById: vi.fn().mockResolvedValue({members: []}),
+      },
+    } as never)
 
     mockApi({
       apiVersion: PROJECTS_API_VERSION,
       uri: `/invitations/project/${testProjectId}`,
-    }).reply(200, [])
+    }).reply(500, {message: 'Internal server error'})
 
     const {error} = await testCommand(List, [], {mocks: defaultMocks})
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes the Windows CI test failures in [`test (windows-8core, …, 2, 4)`](https://github.com/sanity-io/cli/actions/runs/28019100200/job/82930651627) (and the matching Node 24/26 shard-2 jobs), where `packages/@sanity/cli/src/commands/users/__tests__/list.test.ts` reported `2 failed`:

- `displays an error if the API request fails` → `pending mocks: expected [ Array(1) ] to deeply equal []` (leftover `GET /invitations/project/test-project`)
- `sorts by role when --sort role is specified` → `expected -1 to be greater than -1` plus a leftover `GET /users/user1,user2,user3` mock

**Root cause:** the error test made `getProjectById` reject (via a `setTimeout` that swapped `getProjectCliClient` to a rejecting mock) while the sibling `getProjectInvites` request was still in flight inside `Promise.all`. When `Promise.all` short-circuits on the `getProjectById` rejection, the invitations request is left dangling. On slower runners (Windows CI) that request was dispatched *after* the test finished and `afterEach` ran `cleanAll()`, so:

1. The test's own `afterEach` saw the invitations mock still pending → first failure.
2. The leaked request then matched and consumed the *next* test's `/invitations/project/test-project` mock, so `sorts by role`'s own invitations request had no mock, threw, produced empty output (`adminIndex === -1`) and never reached the `/users/...` request → cascade failure.

This is exactly the leaked-running-command class of bug called out in `AGENTS.md` testing rule #8.

**Fix:** resolve the project lookup and instead fail the **awaited** invitations request (`reply(500)`). Because that request is part of the command's awaited work, it is always dispatched and consumed before the command settles — no dangling request, no cross-test mock theft. The error-handling assertion is unchanged (`getMembersForProject` still wraps the failure as `Error fetching members for <projectId>`).

### What to review

- `packages/@sanity/cli/src/commands/users/__tests__/list.test.ts` — the only changed file (the `displays an error if the API request fails` test).
- Confirm the test still asserts the wrapped error message and no longer relies on `setTimeout`/timing.

### Testing

The failure is timing-dependent and only manifests on slower (Windows) runners, so I reproduced it deterministically on Linux by temporarily wrapping `getGlobalCliClient` with a ~300ms delay (simulating Windows-slow client init) in a throwaway copy of the test:

- **Before fix (with simulated slowness):** reproduced both CI failures exactly — `pending mocks: expected [ Array(1) ] to deeply equal []` and `expected -1 to be greater than -1`.
- **After fix (slowness retained):** both tests pass.

Then, with the real change and no simulated delay:

- ✅ `vitest run …/users/__tests__/list.test.ts` — 8/8 passing, run 3× consecutively (stable; the error test dropped from ~3.3s to ~0.1s now that it no longer waits on a racy timer).
- ✅ `vitest run …/commands/users/` — 20/20 passing (`list` + `invite`).
- ✅ `pnpm check:types`
- ✅ `pnpm check:lint`
- ✅ `pnpm check:deps`

The repro file was deleted; only the test fix is committed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f92ce6b3-ba1d-4d14-80af-77d66408441e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f92ce6b3-ba1d-4d14-80af-77d66408441e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

