### PR TITLE
test(cli-build): convert copyDir test to a unit test

### DIFF
--- a/packages/@sanity/cli-build/src/util/__tests__/copyDir.test.ts
+++ b/packages/@sanity/cli-build/src/util/__tests__/copyDir.test.ts
@@ -1,5 +1,6 @@
 import {constants as fsConstants} from 'node:fs'
 import fs from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
@@ -19,6 +20,8 @@ const mkdir = vi.mocked(fs.mkdir)
 const readdir = vi.mocked(fs.readdir)
 const stat = vi.mocked(fs.stat)
 const copyFile = vi.mocked(fs.copyFile)
+
+const tmpdir = os.tmpdir()
 
 function fileStat() {
   return {isDirectory: () => false, isFile: () => true} as Awaited<ReturnType<typeof fs.stat>>
@@ -66,8 +69,8 @@ describe('#skipIfExistsError', () => {
 
 describe('#copyDir', () => {
   test('creates destination directory when it does not exist', async () => {
-    const src = '/src'
-    const dest = '/nested/dest'
+    const src = path.join(tmpdir, 'src')
+    const dest = path.join(tmpdir, 'nested/dest')
 
     readdir.mockResolvedValue(['file.txt'] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
     stat.mockResolvedValue(fileStat())
@@ -82,8 +85,8 @@ describe('#copyDir', () => {
   })
 
   test('copies files from source to destination', async () => {
-    const src = '/src'
-    const dest = '/dest'
+    const src = path.join(tmpdir, 'src')
+    const dest = path.join(tmpdir, 'dest')
 
     readdir.mockResolvedValue(['a.txt', 'b.txt'] as unknown as Awaited<
       ReturnType<typeof fs.readdir>
@@ -98,8 +101,8 @@ describe('#copyDir', () => {
   })
 
   test('recursively copies subdirectories', async () => {
-    const src = '/src'
-    const dest = '/dest'
+    const src = path.join(tmpdir, 'src')
+    const dest = path.join(tmpdir, 'dest')
     const subSrc = path.join(src, 'sub')
     const deeperSrc = path.join(subSrc, 'deeper')
 
@@ -136,8 +139,8 @@ describe('#copyDir', () => {
   })
 
   test('returns silently when source directory does not exist', async () => {
-    const src = '/missing'
-    const dest = '/dest'
+    const src = path.join(tmpdir, 'missing')
+    const dest = path.join(tmpdir, 'dest')
 
     readdir.mockRejectedValue(fsError('ENOENT'))
 
@@ -150,8 +153,8 @@ describe('#copyDir', () => {
   })
 
   test('overwrites existing files when skipExisting is not set', async () => {
-    const src = '/src'
-    const dest = '/dest'
+    const src = path.join(tmpdir, 'src')
+    const dest = path.join(tmpdir, 'dest')
 
     readdir.mockResolvedValue(['file.txt'] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
     stat.mockResolvedValue(fileStat())
@@ -169,8 +172,8 @@ describe('#copyDir', () => {
   })
 
   test('does not overwrite existing files when skipExisting is true', async () => {
-    const src = '/src'
-    const dest = '/dest'
+    const src = path.join(tmpdir, 'src')
+    const dest = path.join(tmpdir, 'dest')
 
     readdir.mockResolvedValue(['existing.txt', 'fresh.txt'] as unknown as Awaited<
       ReturnType<typeof fs.readdir>
@@ -199,8 +202,8 @@ describe('#copyDir', () => {
   })
 
   test('rethrows non-EEXIST errors when skipExisting is true', async () => {
-    const src = '/src'
-    const dest = '/dest'
+    const src = path.join(tmpdir, 'src')
+    const dest = path.join(tmpdir, 'dest')
 
     readdir.mockResolvedValue(['file.txt'] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
     stat.mockResolvedValue(fileStat())
@@ -212,7 +215,7 @@ describe('#copyDir', () => {
   test('skips entries where srcFile resolves to destDir', async () => {
     // When the destination directory is nested inside the source directory,
     // copyDir should skip the destination to avoid infinite recursion.
-    const src = '/src'
+    const src = path.join(tmpdir, 'src')
     const dest = path.join(src, 'dest')
 
     readdir.mockResolvedValue(['file.txt', 'dest'] as unknown as Awaited<
@@ -235,8 +238,8 @@ describe('#copyDir', () => {
   })
 
   test('rejects when source is not a directory', async () => {
-    const src = '/src'
-    const dest = '/dest'
+    const src = path.join(tmpdir, 'src')
+    const dest = path.join(tmpdir, 'dest')
 
     // Source is a file, not a directory — readdir throws ENOTDIR, which is not
     // caught by tryReadDir and therefore propagates.
@@ -246,8 +249,8 @@ describe('#copyDir', () => {
   })
 
   test('rejects when destination cannot be created', async () => {
-    const src = '/src'
-    const dest = '/dest'
+    const src = path.join(tmpdir, 'src')
+    const dest = path.join(tmpdir, 'dest')
 
     mkdir.mockRejectedValue(fsError('ENOTDIR'))
 

--- a/packages/@sanity/cli-build/src/util/__tests__/copyDir.test.ts
+++ b/packages/@sanity/cli-build/src/util/__tests__/copyDir.test.ts
@@ -1,19 +1,49 @@
+import {constants as fsConstants} from 'node:fs'
 import fs from 'node:fs/promises'
-import os from 'node:os'
 import path from 'node:path'
 
-import {afterEach, beforeEach, describe, expect, test} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {copyDir, skipIfExistsError} from '../copyDir'
 
-let workDir: string
+vi.mock('node:fs/promises', () => ({
+  default: {
+    mkdir: vi.fn(),
+    readdir: vi.fn(),
+    stat: vi.fn(),
+    copyFile: vi.fn(),
+  },
+}))
 
-beforeEach(async () => {
-  workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'copydir-test-'))
+const mkdir = vi.mocked(fs.mkdir)
+const readdir = vi.mocked(fs.readdir)
+const stat = vi.mocked(fs.stat)
+const copyFile = vi.mocked(fs.copyFile)
+
+function fileStat() {
+  return {isDirectory: () => false, isFile: () => true} as Awaited<ReturnType<typeof fs.stat>>
+}
+
+function dirStat() {
+  return {isDirectory: () => true, isFile: () => false} as Awaited<ReturnType<typeof fs.stat>>
+}
+
+function fsError(code: string): Error & {code: string} {
+  const err = new Error(code) as Error & {code: string}
+  err.code = code
+  return err
+}
+
+beforeEach(() => {
+  // Safe defaults: mkdir/copyFile succeed, source dirs are empty, all entries are files.
+  mkdir.mockResolvedValue(undefined)
+  readdir.mockResolvedValue([])
+  stat.mockResolvedValue(fileStat())
+  copyFile.mockResolvedValue(undefined)
 })
 
-afterEach(async () => {
-  await fs.rm(workDir, {force: true, recursive: true})
+afterEach(() => {
+  vi.clearAllMocks()
 })
 
 describe('#skipIfExistsError', () => {
@@ -36,134 +66,181 @@ describe('#skipIfExistsError', () => {
 
 describe('#copyDir', () => {
   test('creates destination directory when it does not exist', async () => {
-    const src = path.join(workDir, 'src')
-    const dest = path.join(workDir, 'nested', 'dest')
+    const src = '/src'
+    const dest = '/nested/dest'
 
-    await fs.mkdir(src, {recursive: true})
-    await fs.writeFile(path.join(src, 'file.txt'), 'hello')
+    readdir.mockResolvedValue(['file.txt'] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+    stat.mockResolvedValue(fileStat())
 
     await copyDir(src, dest)
 
-    const destStat = await fs.stat(dest)
-    expect(destStat.isDirectory()).toBe(true)
-    expect(await fs.readFile(path.join(dest, 'file.txt'), 'utf8')).toBe('hello')
+    expect(mkdir).toHaveBeenCalledWith(dest, {recursive: true})
+    expect(copyFile).toHaveBeenCalledWith(path.resolve(src, 'file.txt'), path.resolve(dest, 'file.txt'))
   })
 
   test('copies files from source to destination', async () => {
-    const src = path.join(workDir, 'src')
-    const dest = path.join(workDir, 'dest')
+    const src = '/src'
+    const dest = '/dest'
 
-    await fs.mkdir(src, {recursive: true})
-    await fs.writeFile(path.join(src, 'a.txt'), 'A')
-    await fs.writeFile(path.join(src, 'b.txt'), 'B')
+    readdir.mockResolvedValue(['a.txt', 'b.txt'] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+    stat.mockResolvedValue(fileStat())
 
     await copyDir(src, dest)
 
-    expect(await fs.readFile(path.join(dest, 'a.txt'), 'utf8')).toBe('A')
-    expect(await fs.readFile(path.join(dest, 'b.txt'), 'utf8')).toBe('B')
+    expect(copyFile).toHaveBeenCalledTimes(2)
+    expect(copyFile).toHaveBeenCalledWith(path.resolve(src, 'a.txt'), path.resolve(dest, 'a.txt'))
+    expect(copyFile).toHaveBeenCalledWith(path.resolve(src, 'b.txt'), path.resolve(dest, 'b.txt'))
   })
 
   test('recursively copies subdirectories', async () => {
-    const src = path.join(workDir, 'src')
-    const dest = path.join(workDir, 'dest')
+    const src = '/src'
+    const dest = '/dest'
+    const subSrc = path.join(src, 'sub')
+    const deeperSrc = path.join(subSrc, 'deeper')
 
-    await fs.mkdir(path.join(src, 'sub', 'deeper'), {recursive: true})
-    await fs.writeFile(path.join(src, 'top.txt'), 'top')
-    await fs.writeFile(path.join(src, 'sub', 'mid.txt'), 'mid')
-    await fs.writeFile(path.join(src, 'sub', 'deeper', 'bottom.txt'), 'bottom')
+    readdir.mockImplementation(async (dir) => {
+      if (dir === src) return ['top.txt', 'sub'] as never
+      if (dir === subSrc) return ['mid.txt', 'deeper'] as never
+      if (dir === deeperSrc) return ['bottom.txt'] as never
+      return [] as never
+    })
+
+    stat.mockImplementation(async (p) => {
+      if (p === subSrc || p === deeperSrc) return dirStat()
+      return fileStat()
+    })
 
     await copyDir(src, dest)
 
-    expect(await fs.readFile(path.join(dest, 'top.txt'), 'utf8')).toBe('top')
-    expect(await fs.readFile(path.join(dest, 'sub', 'mid.txt'), 'utf8')).toBe('mid')
-    expect(await fs.readFile(path.join(dest, 'sub', 'deeper', 'bottom.txt'), 'utf8')).toBe('bottom')
+    // Destination directory and every nested destination directory are created.
+    expect(mkdir).toHaveBeenCalledWith(dest, {recursive: true})
+    expect(mkdir).toHaveBeenCalledWith(path.join(dest, 'sub'), {recursive: true})
+    expect(mkdir).toHaveBeenCalledWith(path.join(dest, 'sub', 'deeper'), {recursive: true})
+
+    // Every file in the tree is copied.
+    expect(copyFile).toHaveBeenCalledWith(path.join(src, 'top.txt'), path.join(dest, 'top.txt'))
+    expect(copyFile).toHaveBeenCalledWith(
+      path.join(subSrc, 'mid.txt'),
+      path.join(dest, 'sub', 'mid.txt'),
+    )
+    expect(copyFile).toHaveBeenCalledWith(
+      path.join(deeperSrc, 'bottom.txt'),
+      path.join(dest, 'sub', 'deeper', 'bottom.txt'),
+    )
+    expect(copyFile).toHaveBeenCalledTimes(3)
   })
 
   test('returns silently when source directory does not exist', async () => {
-    const src = path.join(workDir, 'missing')
-    const dest = path.join(workDir, 'dest')
+    const src = '/missing'
+    const dest = '/dest'
+
+    readdir.mockRejectedValue(fsError('ENOENT'))
 
     await expect(copyDir(src, dest)).resolves.toBeUndefined()
 
-    // Destination is still created
-    const destStat = await fs.stat(dest)
-    expect(destStat.isDirectory()).toBe(true)
-
-    const entries = await fs.readdir(dest)
-    expect(entries).toEqual([])
+    // Destination is still created.
+    expect(mkdir).toHaveBeenCalledWith(dest, {recursive: true})
+    // No files are copied.
+    expect(copyFile).not.toHaveBeenCalled()
   })
 
   test('overwrites existing files when skipExisting is not set', async () => {
-    const src = path.join(workDir, 'src')
-    const dest = path.join(workDir, 'dest')
+    const src = '/src'
+    const dest = '/dest'
 
-    await fs.mkdir(src, {recursive: true})
-    await fs.mkdir(dest, {recursive: true})
-    await fs.writeFile(path.join(src, 'file.txt'), 'new')
-    await fs.writeFile(path.join(dest, 'file.txt'), 'old')
+    readdir.mockResolvedValue(['file.txt'] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+    stat.mockResolvedValue(fileStat())
 
     await copyDir(src, dest)
 
-    expect(await fs.readFile(path.join(dest, 'file.txt'), 'utf8')).toBe('new')
+    // copyFile is called without the COPYFILE_EXCL flag, so existing files are overwritten.
+    expect(copyFile).toHaveBeenCalledWith(path.resolve(src, 'file.txt'), path.resolve(dest, 'file.txt'))
+    expect(copyFile).toHaveBeenCalledTimes(1)
+    // Sanity check: no flag argument was passed.
+    expect(copyFile.mock.calls[0]).toHaveLength(2)
   })
 
   test('does not overwrite existing files when skipExisting is true', async () => {
-    const src = path.join(workDir, 'src')
-    const dest = path.join(workDir, 'dest')
+    const src = '/src'
+    const dest = '/dest'
 
-    await fs.mkdir(src, {recursive: true})
-    await fs.mkdir(dest, {recursive: true})
-    await fs.writeFile(path.join(src, 'existing.txt'), 'new')
-    await fs.writeFile(path.join(src, 'fresh.txt'), 'fresh')
-    await fs.writeFile(path.join(dest, 'existing.txt'), 'old')
+    readdir.mockResolvedValue([
+      'existing.txt',
+      'fresh.txt',
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+    stat.mockResolvedValue(fileStat())
+
+    // Simulate the destination file already existing for the first entry.
+    copyFile.mockImplementationOnce(async () => {
+      throw fsError('EEXIST')
+    })
 
     await copyDir(src, dest, true)
 
-    // Existing file is preserved
-    expect(await fs.readFile(path.join(dest, 'existing.txt'), 'utf8')).toBe('old')
-    // New file is copied
-    expect(await fs.readFile(path.join(dest, 'fresh.txt'), 'utf8')).toBe('fresh')
+    // copyFile is invoked with the COPYFILE_EXCL flag for both entries.
+    expect(copyFile).toHaveBeenCalledWith(
+      path.resolve(src, 'existing.txt'),
+      path.resolve(dest, 'existing.txt'),
+      fsConstants.COPYFILE_EXCL,
+    )
+    expect(copyFile).toHaveBeenCalledWith(
+      path.resolve(src, 'fresh.txt'),
+      path.resolve(dest, 'fresh.txt'),
+      fsConstants.COPYFILE_EXCL,
+    )
+    expect(copyFile).toHaveBeenCalledTimes(2)
+  })
+
+  test('rethrows non-EEXIST errors when skipExisting is true', async () => {
+    const src = '/src'
+    const dest = '/dest'
+
+    readdir.mockResolvedValue(['file.txt'] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+    stat.mockResolvedValue(fileStat())
+    copyFile.mockRejectedValueOnce(fsError('EACCES'))
+
+    await expect(copyDir(src, dest, true)).rejects.toMatchObject({code: 'EACCES'})
   })
 
   test('skips entries where srcFile resolves to destDir', async () => {
     // When the destination directory is nested inside the source directory,
     // copyDir should skip the destination to avoid infinite recursion.
-    const src = path.join(workDir, 'src')
+    const src = '/src'
     const dest = path.join(src, 'dest')
 
-    await fs.mkdir(src, {recursive: true})
-    await fs.mkdir(dest, {recursive: true})
-    await fs.writeFile(path.join(src, 'file.txt'), 'content')
+    readdir.mockResolvedValue(['file.txt', 'dest'] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+    stat.mockResolvedValue(fileStat())
 
     await copyDir(src, dest)
 
-    expect(await fs.readFile(path.join(dest, 'file.txt'), 'utf8')).toBe('content')
-    // The dest should not contain a nested copy of itself
-    const nestedDest = path.join(dest, 'dest')
-    await expect(fs.stat(nestedDest)).rejects.toMatchObject({code: 'ENOENT'})
+    // Only the non-dest entry is copied.
+    expect(copyFile).toHaveBeenCalledTimes(1)
+    expect(copyFile).toHaveBeenCalledWith(path.resolve(src, 'file.txt'), path.resolve(dest, 'file.txt'))
+    // stat is never called for the dest entry because the `srcFile === destDir`
+    // check short-circuits the loop body first.
+    expect(stat).toHaveBeenCalledTimes(1)
+    expect(stat).toHaveBeenCalledWith(path.resolve(src, 'file.txt'))
   })
 
   test('rejects when source is not a directory', async () => {
-    const src = path.join(workDir, 'src')
-    const dest = path.join(workDir, 'dest')
+    const src = '/src'
+    const dest = '/dest'
 
-    // Source is a file, not a directory — readdir will throw ENOTDIR.
-    await fs.writeFile(src, 'not-a-dir')
+    // Source is a file, not a directory — readdir throws ENOTDIR, which is not
+    // caught by tryReadDir and therefore propagates.
+    readdir.mockRejectedValue(fsError('ENOTDIR'))
 
     await expect(copyDir(src, dest)).rejects.toMatchObject({code: 'ENOTDIR'})
   })
 
   test('rejects when destination cannot be created', async () => {
-    const src = path.join(workDir, 'src')
-    const dest = path.join(workDir, 'dest')
+    const src = '/src'
+    const dest = '/dest'
 
-    await fs.mkdir(src, {recursive: true})
-    await fs.writeFile(path.join(src, 'file.txt'), 'data')
+    mkdir.mockRejectedValue(fsError('ENOTDIR'))
 
-    // Pre-create dest as a regular file so the initial mkdir(dest, {recursive: true})
-    // fails because the path exists but is not a directory.
-    await fs.writeFile(dest, 'not-a-dir')
-
-    await expect(copyDir(src, dest)).rejects.toThrow()
+    await expect(copyDir(src, dest)).rejects.toMatchObject({code: 'ENOTDIR'})
+    // The failure happens before readdir is attempted.
+    expect(readdir).not.toHaveBeenCalled()
   })
 })

--- a/packages/@sanity/cli-build/src/util/__tests__/copyDir.test.ts
+++ b/packages/@sanity/cli-build/src/util/__tests__/copyDir.test.ts
@@ -8,10 +8,10 @@ import {copyDir, skipIfExistsError} from '../copyDir'
 
 vi.mock('node:fs/promises', () => ({
   default: {
+    copyFile: vi.fn(),
     mkdir: vi.fn(),
     readdir: vi.fn(),
     stat: vi.fn(),
-    copyFile: vi.fn(),
   },
 }))
 
@@ -75,14 +75,19 @@ describe('#copyDir', () => {
     await copyDir(src, dest)
 
     expect(mkdir).toHaveBeenCalledWith(dest, {recursive: true})
-    expect(copyFile).toHaveBeenCalledWith(path.resolve(src, 'file.txt'), path.resolve(dest, 'file.txt'))
+    expect(copyFile).toHaveBeenCalledWith(
+      path.resolve(src, 'file.txt'),
+      path.resolve(dest, 'file.txt'),
+    )
   })
 
   test('copies files from source to destination', async () => {
     const src = '/src'
     const dest = '/dest'
 
-    readdir.mockResolvedValue(['a.txt', 'b.txt'] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+    readdir.mockResolvedValue(['a.txt', 'b.txt'] as unknown as Awaited<
+      ReturnType<typeof fs.readdir>
+    >)
     stat.mockResolvedValue(fileStat())
 
     await copyDir(src, dest)
@@ -154,7 +159,10 @@ describe('#copyDir', () => {
     await copyDir(src, dest)
 
     // copyFile is called without the COPYFILE_EXCL flag, so existing files are overwritten.
-    expect(copyFile).toHaveBeenCalledWith(path.resolve(src, 'file.txt'), path.resolve(dest, 'file.txt'))
+    expect(copyFile).toHaveBeenCalledWith(
+      path.resolve(src, 'file.txt'),
+      path.resolve(dest, 'file.txt'),
+    )
     expect(copyFile).toHaveBeenCalledTimes(1)
     // Sanity check: no flag argument was passed.
     expect(copyFile.mock.calls[0]).toHaveLength(2)
@@ -164,10 +172,9 @@ describe('#copyDir', () => {
     const src = '/src'
     const dest = '/dest'
 
-    readdir.mockResolvedValue([
-      'existing.txt',
-      'fresh.txt',
-    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+    readdir.mockResolvedValue(['existing.txt', 'fresh.txt'] as unknown as Awaited<
+      ReturnType<typeof fs.readdir>
+    >)
     stat.mockResolvedValue(fileStat())
 
     // Simulate the destination file already existing for the first entry.
@@ -208,14 +215,19 @@ describe('#copyDir', () => {
     const src = '/src'
     const dest = path.join(src, 'dest')
 
-    readdir.mockResolvedValue(['file.txt', 'dest'] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+    readdir.mockResolvedValue(['file.txt', 'dest'] as unknown as Awaited<
+      ReturnType<typeof fs.readdir>
+    >)
     stat.mockResolvedValue(fileStat())
 
     await copyDir(src, dest)
 
     // Only the non-dest entry is copied.
     expect(copyFile).toHaveBeenCalledTimes(1)
-    expect(copyFile).toHaveBeenCalledWith(path.resolve(src, 'file.txt'), path.resolve(dest, 'file.txt'))
+    expect(copyFile).toHaveBeenCalledWith(
+      path.resolve(src, 'file.txt'),
+      path.resolve(dest, 'file.txt'),
+    )
     // stat is never called for the dest entry because the `srcFile === destDir`
     // check short-circuits the loop body first.
     expect(stat).toHaveBeenCalledTimes(1)

--- a/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
@@ -5,8 +5,8 @@ import path from 'node:path'
 import {type Output} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {resolveLatestVersions} from '../../../../src/util/resolveLatestVersions.js'
 import {bootstrapLocalTemplate} from '../../../../src/actions/init/bootstrapLocalTemplate.js'
+import {resolveLatestVersions} from '../../../../src/util/resolveLatestVersions.js'
 
 vi.mock('../../../../src/util/resolveLatestVersions.js', () => ({
   resolveLatestVersions: vi.fn().mockImplementation(async (deps: Record<string, string>) => {

--- a/packages/@sanity/cli/test/integration/actions/schema/getExtractOptions.test.ts
+++ b/packages/@sanity/cli/test/integration/actions/schema/getExtractOptions.test.ts
@@ -4,8 +4,8 @@ import {join, resolve} from 'node:path'
 
 import {describe, expect, test} from 'vitest'
 
-import {type ExtractSchemaCommand} from '../../../../src/commands/schemas/extract.js'
 import {getExtractOptions} from '../../../../src/actions/schema/getExtractOptions.js'
+import {type ExtractSchemaCommand} from '../../../../src/commands/schemas/extract.js'
 
 describe('getExtractOptions', () => {
   const mockProjectRoot = {

--- a/packages/@sanity/cli/test/integration/hooks/prerun/setupTelemetry.test.ts
+++ b/packages/@sanity/cli/test/integration/hooks/prerun/setupTelemetry.test.ts
@@ -19,11 +19,11 @@ import {cleanAll, pendingMocks} from 'nock'
 import {glob} from 'tinyglobby'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {getCommandAndConfig} from '../../../helpers/getCommandAndConfig.js'
+import {setupTelemetry} from '../../../../src/hooks/prerun/setupTelemetry.js'
 import {TELEMETRY_API_VERSION} from '../../../../src/services/telemetry.js'
 import {flushTelemetryFiles} from '../../../../src/util/telemetry/flushTelemetryFiles.js'
 import {readNDJSON} from '../../../../src/util/telemetry/readNDJSON.js'
-import {setupTelemetry} from '../../../../src/hooks/prerun/setupTelemetry.js'
+import {getCommandAndConfig} from '../../../helpers/getCommandAndConfig.js'
 
 // Mock external dependencies
 vi.mock('node:os', () => ({tmpdir: vi.fn()}))


### PR DESCRIPTION
### Description

Mock the `node:fs/promises` imports to verify the copyDir logic without actually writing files.

> [!NOTE]
> This was implemented by Claude Opus and reviewed manually.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modified; risk is limited to test fidelity if mocks diverge from real fs behavior.
> 
> **Overview**
> **`copyDir` tests** are rewritten from temp-directory integration tests to **mocked `node:fs/promises` unit tests**, asserting `mkdir`, `readdir`, `stat`, and `copyFile` behavior (including recursion, `skipExisting` / `COPYFILE_EXCL`, ENOENT handling, and dest-inside-src skipping) without touching the real filesystem. A new case verifies that **non-`EEXIST` errors propagate** when `skipExisting` is true.
> 
> Three CLI integration test files only **reorder imports** (implementation import before type/helper import); no test logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec4a1cda31224073bb767746e1490b94c4ef20f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->