### PR TITLE
chore(build): ignore changes to *.md and *.test.ts files for build tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!**/*.test.ts"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**", ".sanity/**", "lib/**", "fixtures/**"]
     },
     "@sanity/cli-test#build": {
@@ -22,6 +23,7 @@
     },
     "build:types": {
       "dependsOn": ["^build", "^build:types", "build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!**/*.test.ts"],
       "outputs": ["dist/**/*.d.ts"]
     },
     "lint": {},


### PR DESCRIPTION
### Description

When iterating on tests locally, I found it annoying that, locally, changing only test code would force a re-run of the package I was working in, as well as its types. Spent some time reading about [turbo and its `inputs`](https://turborepo.dev/docs/reference/configuration#inputs) and found a way to ignore certain files, like markdown and tests, from being considered as cache inputs. This significantly speeds up my local test iteration loop. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects Turbo cache fingerprinting for build tasks; no runtime or publish artifact logic changes, with a small chance of stale cache if a test-only change somehow required a rebuild.
> 
> **Overview**
> Turbo **`build`** and **`build:types`** now declare explicit **`inputs`** so changes to **`*.md`** and **`*.test.ts`** no longer invalidate those task caches.
> 
> That keeps local runs from rebuilding a package and regenerating types when you only edit docs or tests, while **`@sanity/cli-test#build`** still uses its existing input set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee4a3438f527dc3e5bc444e3f269699232576f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->