### PR TITLE
fix(workbench): drop @sanity/federation from federated-studio

### DIFF
--- a/fixtures/federated-studio/package.json
+++ b/fixtures/federated-studio/package.json
@@ -12,7 +12,6 @@
     "build:fixture": "sanity build"
   },
   "dependencies": {
-    "@sanity/federation": "0.1.0-alpha.10",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "sanity": "workbench",

--- a/fixtures/federated-studio/sanity.cli.ts
+++ b/fixtures/federated-studio/sanity.cli.ts
@@ -1,5 +1,4 @@
-import {unstable_defineApp} from '@sanity/federation'
-import {defineCliConfig} from 'sanity/cli'
+import {defineCliConfig, unstable_defineApp} from 'sanity/cli'
 
 export default defineCliConfig({
   api: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,9 +270,6 @@ importers:
 
   fixtures/federated-studio:
     dependencies:
-      '@sanity/federation':
-        specifier: 0.1.0-alpha.10
-        version: 0.1.0-alpha.10(typescript@5.9.3)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       react:
         specifier: ^19.2.5
         version: 19.2.7
@@ -4534,12 +4531,6 @@ packages:
     resolution: {integrity: sha512-qu/I3EZIjj36lBQ2FLhBJSPqYZF2t2UO7/jtfYJQ0Qi5LBqVrtlVFOZ/niNg8gu4FUFoOuKTOxXY+V76xw/19Q==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
-
-  '@sanity/federation@0.1.0-alpha.10':
-    resolution: {integrity: sha512-4bs2OKoIAitDM0kyDsCJL+prdUrhTFYaZIvQ+CgoVGCsHTOEVTNymC9EdpYdL5jjvsui91A8pptGTNaNhQZtYw==}
-    engines: {node: '>=20.19.1 <22 || >=22.12'}
-    peerDependencies:
-      vite: ^7.0.0 || ^8.0.0
 
   '@sanity/functions@1.3.1':
     resolution: {integrity: sha512-k/DOh7PTPFYrE9ryAagWETpgt0yhqc4gN5Eti3k1nwndFEpveg9z+I1s4NI7viWt8QCYpWpeW9ixSDZeTdczdA==}
@@ -12262,22 +12253,6 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/vite@1.16.0(typescript@5.9.3)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@module-federation/dts-plugin': 2.5.0(typescript@5.9.3)
-      '@module-federation/runtime': 2.5.0
-      '@module-federation/sdk': 2.5.0
-      es-module-lexer: 2.1.0
-      estree-walker: 3.0.3
-      pathe: 2.0.3
-      vite: 8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - node-fetch
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-
   '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -13324,19 +13299,6 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
-
-  '@sanity/federation@0.1.0-alpha.10(typescript@5.9.3)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@module-federation/runtime': 2.5.1
-      '@module-federation/vite': 1.16.0(typescript@5.9.3)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      vite: 8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - bufferutil
-      - node-fetch
-      - typescript
-      - utf-8-validate
-      - vue-tsc
 
   '@sanity/functions@1.3.1': {}
 


### PR DESCRIPTION
### Description

The `federated-studio` fixture pulled in `@sanity/federation` solely for `unstable_defineApp`. After the workbench refactor that helper is re-exported from `sanity/cli` (the same import the `init` scaffolding now generates), so the fixture can source it from there.

Dropping the dep also stops the fixture from pinning an older `@module-federation/vite` transitively — clearing the path for the Renovate bump in #1365 to leave a single resolved version in the lockfile.

### What to review

`fixtures/federated-studio/sanity.cli.ts` now imports `unstable_defineApp` from `sanity/cli`; `@sanity/federation` is removed from the fixture's `package.json` and the lockfile.

### Testing

Exercised by the existing `build.studio` integration test and the `dev.workbench` e2e test, both of which run against this fixture. Fixture typechecks clean against the new import.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Fixture-only dependency and import path change with no production runtime logic changes.
> 
> **Overview**
> The **federated-studio** fixture no longer depends on **`@sanity/federation`**. It now imports **`unstable_defineApp`** alongside **`defineCliConfig`** from **`sanity/cli`**, matching current init scaffolding after the workbench refactor.
> 
> Removing the package also drops transitive **`@module-federation/vite`** resolution from this fixture’s lockfile slice, avoiding a duplicate pinned version alongside broader dependency bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f366dbdccd5c296f5f93f710b017153c7962518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->