### PR TITLE
refactor(workbench): drop spec user-story/task refs from comments

### DIFF
--- a/packages/@sanity/cli/src/actions/dev/servers/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/getDevServerConfig.ts
@@ -51,7 +51,7 @@ export function getDevServerConfig({
   return {
     ...baseConfig,
     // The app's navigable entry. A branded app that omits `entry` has no app
-    // view (sanity-io/workbench spec 002-workbench-extension-api, US5): the runtime/federation skip the `./App` render path entirely.
+    // view: the runtime/federation skip the `./App` render path entirely.
     entry: app?.entry,
     // `devAction` passes an explicit port when a running workbench claimed the
     // configured one; otherwise the shared resolution stands.

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -53,7 +53,7 @@ describe('deriveInterfaces', () => {
     ])
   })
 
-  test('rejects a studio that declares entry (FR-026)', () => {
+  test('rejects a studio that declares entry', () => {
     const app = workbenchApp({entry: './src/App.tsx'})
     expect(() => deriveInterfaces(app, {isApp: false})).toThrow(
       'App views for studios are not implemented yet',

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -276,7 +276,7 @@ describe('startDevManifestWatcher', () => {
     const APP_CONFIG_PATH = '/tmp/sdk-app/sanity.cli.ts'
     const appManifest = {icon: '<svg/>', title: 'My App', version: '1'}
     // Interfaces ride alongside the manifest (not inside it) and re-sync on
-    // every config edit — FR-024.
+    // every config edit.
     const appInterfaces = [
       {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
     ]

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
@@ -184,7 +184,7 @@ describe('startDevServerRegistration', () => {
     await expect(register()).rejects.toThrow(error)
   })
 
-  // US5 — `entry` declares an SDK app's navigable `app` view.
+  // `entry` declares an SDK app's navigable `app` view.
   test('forwards an `app` interface derived from `entry` for an SDK app', async () => {
     await register({cliConfig: {app: workbenchApp({entry: './src/App.tsx'})} as any, isApp: true})
 
@@ -212,8 +212,8 @@ describe('startDevServerRegistration', () => {
     ).rejects.toThrow('App views for studios are not implemented yet')
   })
 
-  // FR-024 — adding/removing a view or service must rebuild the federation
-  // remote so the new interface gets an expose + artifact. The watcher drives it.
+  // Adding/removing a view or service must rebuild the federation remote so the
+  // new interface gets an expose + artifact. The watcher drives it.
   const feed = {entry_point: './src/Feed.tsx', interface_type: 'panel', name: 'feed'}
 
   test('rebuilds the remote when the interface set changes, then keeps quiet on a repeat', async () => {

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -10,7 +10,7 @@ export type DevServerInterface = NonNullable<DevServerManifest['interfaces']>[nu
  * its registry entry: `views` → panels, `services` → workers, `entry` → the
  * navigable `app` view (`entry_point` is the raw `src`, not a resolved URL).
  * `undefined` for a non-branded app; a studio that declares `entry` is rejected
- * (FR-026, studio app views are not implemented yet).
+ * (studio app views are not implemented yet).
  */
 export function deriveInterfaces(
   app: CliConfig['app'],

--- a/packages/@sanity/workbench-cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startDevManifestWatcher.ts
@@ -27,7 +27,7 @@ interface ManifestPatch<T> {
   /**
    * Workbench interfaces (views/services/app view) re-derived from the config
    * on each change, so editing `views`/`services`/`entry` in `sanity.cli.ts`
-   * re-syncs live like `title`/`icon` (FR-024). `undefined` only for
+   * re-syncs live like `title`/`icon`. `undefined` only for
    * non-branded configs — the registry patch is a shallow merge, so extractors
    * must re-derive rather than omit, or the registered set gets wiped.
    */

--- a/packages/@sanity/workbench-cli/src/actions/dev/startDevServerRegistration.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startDevServerRegistration.ts
@@ -23,6 +23,7 @@ interface DevServerRegistrationOptions {
   output: Output
   server: ViteDevServer
   workDir: string
+
   /**
    * Rebuild the app's federation remote when its interface set changes, awaited
    * *before* the registry patch — the patch reloads the workbench page, which must


### PR DESCRIPTION
### Description

The workbench spec (FR-/US- identifiers) lives in a separate repo, so those references carry no meaning in this codebase — this sweeps them out of the comments. Kept as a follow-up on top of the stack so the four reviewed PRs don't need another pass.

### What to review

Comment-only changes (plus one cosmetic test title); no behavior change.

### Testing

Existing tests unchanged and green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test titles only; no logic, APIs, or runtime paths are modified.
> 
> **Overview**
> Strips **workbench spec** traceability (`FR-024`, `FR-026`, `US5`, and related doc links) from comments in `@sanity/cli` and `@sanity/workbench-cli` dev-server code. The explanatory text is kept; only identifiers that point at a spec in another repo are removed.
> 
> Touches `getDevServerConfig`, `deriveInterfaces`, `startDevManifestWatcher`, `startDevServerRegistration`, and matching tests (including renaming one test from `rejects a studio that declares entry (FR-026)` to a plain title). A single blank line is added in `startDevServerRegistration` between fields—formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 638f2c69dd87c840776509305f8d545246a9e8d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->