### PR TITLE
test(chore): eliminate OCLIF root package.json warnings when running unit tests

### DIFF
--- a/packages/@sanity/cli/test/mockSanityCommand.ts
+++ b/packages/@sanity/cli/test/mockSanityCommand.ts
@@ -1,4 +1,6 @@
-import {Command} from '@oclif/core'
+import {resolve} from 'node:path'
+
+import {Command, Config} from '@oclif/core'
 import {type Output, SanityCommandInterface} from '@sanity/cli-core'
 import {vi} from 'vitest'
 
@@ -28,6 +30,21 @@ export function createMockSanityCommand() {
         error: mocks.SanityCmdOutputError,
         log: mocks.SanityCmdOutputLog,
         warn: mocks.SanityCmdOutputWarn,
+      }
+      // Use OCLIF_TEST_ROOT, set in vitest configs in this repo, as a fallback root directory for OCLIF.
+      // Without this, unit tests yield warnings in console output (not catastrophic, but annoying).
+      public static override run<T extends Command>(...args: Parameters<typeof Command.run>) {
+        const [argv, opts] = args
+        const testRoot = process.env.OCLIF_TEST_ROOT
+          ? resolve(process.cwd(), process.env.OCLIF_TEST_ROOT)
+          : undefined
+        if (typeof opts === 'string' || opts instanceof Config) {
+          return super.run(argv, opts) as Promise<ReturnType<T['run']>>
+        }
+        return super.run(argv, {
+          ...opts,
+          root: opts?.root ?? testRoot ?? process.cwd(),
+        }) as Promise<ReturnType<T['run']>>
       }
       public exit(code?: number) {
         return mocks.OclifCmdExit(code)


### PR DESCRIPTION
### Description

Before this PR, when you'd run unit tests, you'd see the following warnings in your terminal:

```console
(node:7728) Error Plugin: @oclif/core: could not find package.json with {
  name: '@oclif/plugin-plugins',
  root: '/Users/filmaj/src/cli/node_modules/.pnpm/@oclif+core@4.11.7/node_modules/@oclif/core',
  type: 'dev'
}
module: @oclif/core@4.11.7
plugin: @oclif/core
root: /Users/filmaj/src/cli/node_modules/.pnpm/@oclif+core@4.11.7/node_modules/@oclif/core
See more details with DEBUG=*
(Use `node --trace-warnings ...` to show where the warning was created)
(node:7728) Error Plugin: @oclif/core: could not find package.json with {
  name: '@oclif/plugin-plugins',
  root: '/Users/filmaj/src/cli/node_modules/.pnpm/@oclif+core@4.11.7/node_modules/@oclif/core',
  type: 'dev'
}
module: @oclif/core@4.11.7
plugin: @oclif/core
root: /Users/filmaj/src/cli/node_modules/.pnpm/@oclif+core@4.11.7/node_modules/@oclif/core
See more details with DEBUG=*
(node:7728) Error Plugin: @oclif/core: could not find package.json with {
  name: '@oclif/plugin-plugins',
  root: '/Users/filmaj/src/cli/node_modules/.pnpm/@oclif+core@4.11.7/node_modules/@oclif/core',
  type: 'dev'
}
module: @oclif/core@4.11.7
plugin: @oclif/core
root: /Users/filmaj/src/cli/node_modules/.pnpm/@oclif+core@4.11.7/node_modules/@oclif/core
See more details with DEBUG=*
 ✓  @sanity/cli/unit  src/commands/schemas/__tests__/extract.test.ts (3 tests) 59ms
```

That was due to the mock `SanityCommand` class leveraged by unit tests being unable to find the root of the project due to the mocking. This PR addresses this by overriding the `run` command in the mock class to help OCLIF find the root location. It leverages the `OCLIF_TEST_ROOT` environment variable, set in various vitest configs in this project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock behavior with no production CLI impact.
> 
> **Overview**
> Overrides **`Command.run`** on the shared **`MockedSanityCommand`** test double so OCLIF gets an explicit CLI **`root`** instead of resolving from the mocked command context (which pointed at **`@oclif/core`** inside **`node_modules`** and triggered “could not find package.json” plugin warnings).
> 
> When **`run`** is invoked with an options object, it sets **`root`** to **`opts.root`**, else **`resolve(cwd, OCLIF_TEST_ROOT)`** when that env var is set (already provided by vitest configs), else **`process.cwd()`**. The **`Config`/string overload** path is unchanged and still delegates to **`super.run`** as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 912acba56296e5d95219223862f1a6bb0ff5561d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->