### PR TITLE
ci: generate changesets for PRs using `refactor` prefix

### DIFF
--- a/.github/scripts/generate-changeset.mjs
+++ b/.github/scripts/generate-changeset.mjs
@@ -56,7 +56,7 @@ function determineBump(type, breaking, body) {
   if (breaking) return 'major'
   if (body.split('\n').some((l) => l.startsWith('BREAKING CHANGE:'))) return 'major'
   if (type === 'feat') return 'minor'
-  if (['fix', 'perf', 'revert'].includes(type)) return 'patch'
+  if (['fix', 'perf', 'refactor', 'revert'].includes(type)) return 'patch'
   return null
 }
 


### PR DESCRIPTION
### Description

`refactor` PRs ship code changes but the auto-changeset bot produced nothing for them, so refactors landed with no changelog entry and no release. This can be dangerous, when the refactoring happens across monorepo-packages.

https://sanity-io.slack.com/archives/C08QMPTJPJQ/p1782374510524409

This maps `refactor` to a patch bump alongside `fix`/`perf`/`revert` in `determineBump`, so refactors get a changeset like any other shipped change.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line CI release automation tweak with no runtime or security impact; only affects when auto-changesets are written for refactor-titled PRs after merge to main.
> 
> **Overview**
> **Auto-changeset** PRs titled with conventional **`refactor:`** commits now get a **patch** bump and an auto-generated changeset, same as **`fix`**, **`perf`**, and **`revert`**.
> 
> The change is a single addition to the patch-type list in **`determineBump`** in **`.github/scripts/generate-changeset.mjs`**. Refactor PRs that touch public packages previously returned **`null`** from **`determineBump`**, so the bot skipped them with no changelog entry or release bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6164d851af7f53dc245c58beafc44ab7f506a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->