### PR TITLE
chore: add changeset for workbench dev runtime refactor

### DIFF
--- a/.changeset/workbench-cli-extraction.md
+++ b/.changeset/workbench-cli-extraction.md
@@ -1,0 +1,5 @@
+---
+'@sanity/workbench-cli': patch
+---
+
+refactor(workbench): move workbench related code into workbench-cli package


### PR DESCRIPTION
### Description

The refactor PRs that moved the workbench dev runtime into `@sanity/workbench-cli` merged before the auto-changeset bot treated `refactor` as releasable, so they landed without a changelog entry or release. This adds the missing patch changeset to cover them, because otherwise it may break the next release.

Doing it manually until a conclusion on https://github.com/sanity-io/cli/pull/1383 has been reached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changeset-only PR with no runtime or build logic changes.
> 
> **Overview**
> Adds a **missing changeset** so the earlier workbench dev-runtime refactor can ship in the next release. The file bumps **`@sanity/cli`** and **`@sanity/workbench-cli`** as **patch** and records that workbench-related code was moved into **`@sanity/workbench-cli`**.
> 
> There are **no application or package code changes** in this PR—only release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdef8bea3a46672b78f4cc1321f2f3f466d40abf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->