### PR TITLE
fix(workbench): claim lock when developing workbench remote

### DIFF
--- a/.changeset/workbench-mf-vite-remoteentry.md
+++ b/.changeset/workbench-mf-vite-remoteentry.md
@@ -1,0 +1,5 @@
+---
+'@sanity/workbench-cli': patch
+---
+
+Bump `@module-federation/vite` to the [module-federation/vite#854](https://github.com/module-federation/vite/pull/854) preview, which fixes `findRemoteEntryFile` so a federated build's `mf-manifest.json` advertises the container (the chunk exporting `init`) as `remoteEntry` instead of a same-named `./App` expose. Resolves the `#RUNTIME-002` host failure under Vite 8 / rolldown.

--- a/.changeset/workbench-remote-dev-coordinator.md
+++ b/.changeset/workbench-remote-dev-coordinator.md
@@ -1,0 +1,6 @@
+---
+'@sanity/workbench-cli': patch
+'@sanity/cli': patch
+---
+
+The workbench remote dev server now claims the workbench lock and bridges the registry so app `sanity dev`s register into it instead of starting their own, and announces a clickable URL.

--- a/packages/@sanity/cli/src/actions/dev/__tests__/devAction.unit.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/devAction.unit.test.ts
@@ -126,18 +126,15 @@ describe('devAction', () => {
   })
 
   describe('workbench remote', () => {
-    // The remote is the shell that renders other workbench apps, so it can't
-    // render itself — an internal env var runs it as a plain standalone server.
-    test('runs as a plain dev server with no workbench orchestration', async () => {
+    // devAction no longer special-cases the remote: every workbench app routes to
+    // startWorkbenchDev, which runs the remote (it can't render itself) as a plain
+    // server internally.
+    test('still routes to startWorkbenchDev with the remote flag set', async () => {
       vi.stubEnv('SANITY_INTERNAL_IS_WORKBENCH_REMOTE', 'true')
-      mockStartAppDevServer.mockResolvedValue(mockServer({port: 3333}))
 
       await devAction(createBaseDevOptions({cliConfig: workbenchCliConfig(), isApp: true}))
 
-      expect(mockStartWorkbenchDev).not.toHaveBeenCalled()
-      expect(mockStartAppDevServer).toHaveBeenCalledWith(
-        expect.objectContaining({announceUrl: true}),
-      )
+      expect(mockStartWorkbenchDev).toHaveBeenCalled()
     })
   })
 })

--- a/packages/@sanity/cli/src/actions/dev/devAction.ts
+++ b/packages/@sanity/cli/src/actions/dev/devAction.ts
@@ -27,11 +27,6 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     workDir,
   })
 
-  // The workbench remote renders other workbench apps, so it can't render
-  // itself — this internal flag runs it as a plain, standalone dev server.
-  const isWorkbenchRemote =
-    isWorkbenchApp(cliConfig?.app) && process.env.SANITY_INTERNAL_IS_WORKBENCH_REMOTE === 'true'
-
   // The app/studio server, parameterized per call; `announceUrl` is false when
   // the workbench announces the URL on its behalf.
   const startAppServer = (params: {announceUrl: boolean; cliConfig: CliConfig; httpPort: number}) =>
@@ -42,7 +37,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
       httpPort: params.httpPort,
     })
 
-  if (isWorkbenchApp(cliConfig?.app) && !isWorkbenchRemote) {
+  if (isWorkbenchApp(cliConfig?.app)) {
     // Lazy so a non-workbench `sanity dev` never loads the package. `doImport`
     // is path-based and doesn't apply to a bare specifier.
     // eslint-disable-next-line no-restricted-syntax
@@ -66,8 +61,7 @@ export async function devAction(options: DevActionOptions): Promise<{close: () =
     })
   }
 
-  // Plain studio/app (incl. the workbench remote): one dev server announcing its
-  // own URL — no lock, registry, or signals.
+  // Plain non-workbench studio/app: one dev server announcing its own URL.
   const result = await startAppServer({announceUrl: true, cliConfig, httpPort})
   return {close: result.started ? result.close : noop}
 }

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
@@ -153,7 +153,8 @@ describe('startAppDevServer', () => {
       createOptions({announceUrl: true, cliConfig: workbenchCliConfig(), output}),
     )
 
-    expect(output.log).toHaveBeenCalledWith('App dev server started on port 3334')
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('App dev server started at'))
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('http://localhost:3334'))
     expect(mockGetDashboardAppURL).not.toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
@@ -9,6 +9,15 @@ import {type DevActionOptions, type StartDevServerResult} from '../types.js'
 import {getDashboardAppURL} from './getDashboardAppUrl.js'
 import {getDevServerConfig} from './getDevServerConfig.js'
 
+// Bind-only addresses ('0.0.0.0', '::') aren't routable in every browser; the
+// displayed URL falls back to localhost. The bind address itself is untouched.
+function toDisplayHost(host: string | undefined): string {
+  if (!host || host === '0.0.0.0' || host === '::' || host === '[::]') {
+    return 'localhost'
+  }
+  return host
+}
+
 export async function startAppDevServer(options: DevActionOptions): Promise<StartDevServerResult> {
   const {announceUrl = true, cliConfig, flags, httpPort, output, workDir} = options
 
@@ -47,13 +56,12 @@ export async function startAppDevServer(options: DevActionOptions): Promise<Star
 
     const {port} = server.config.server
 
-    if (isWorkbenchApp) {
-      // Federated apps surface through the workbench, which announces the URL;
-      // only the package-unavailable fallback announces from here.
-      if (announceUrl) {
-        output.log(`App dev server started on port ${port}`)
-      }
-    } else {
+    // Federated apps surface through the workbench, which announces the URL;
+    // only the package-unavailable fallback announces from here.
+    if (isWorkbenchApp && announceUrl) {
+      const url = `http://${toDisplayHost(config.httpHost)}:${port}`
+      output.log(`App dev server started at ${styleText(['blue', 'underline'], url)}`)
+    } else if (!isWorkbenchApp) {
       const httpHost = config.httpHost || 'localhost'
 
       const dashboardAppUrl = await getDashboardAppURL({

--- a/packages/@sanity/workbench-cli/package.json
+++ b/packages/@sanity/workbench-cli/package.json
@@ -57,7 +57,7 @@
     "watch": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ --watch src"
   },
   "dependencies": {
-    "@module-federation/vite": "1.16.0",
+    "@module-federation/vite": "https://pkg.pr.new/@module-federation/vite@952ec00",
     "@sanity/cli-core": "workspace:^",
     "@vitejs/plugin-react": "catalog:",
     "vite": "catalog:",

--- a/packages/@sanity/workbench-cli/src/_exports/dev.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/dev.ts
@@ -1,6 +1,1 @@
-// Node-only dev entry: the workbench dev orchestration the CLI delegates to.
-// `startWorkbenchDev` starts the singleton workbench server, wires both it and
-// the injected app/studio server into the dev-server registry, and owns their
-// teardown. The registry, interface model, and orchestration are internal now,
-// reached only through this entry.
 export {startWorkbenchDev, type StartWorkbenchDevOptions} from '../actions/dev/startWorkbenchDev.js'

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/appServerSupervisor.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/appServerSupervisor.test.ts
@@ -1,6 +1,10 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {type AppServerResult, startAppServerSupervisor} from '../appServerSupervisor.js'
+import {
+  type AppServerResult,
+  type StartAppServer,
+  startAppServerSupervisor,
+} from '../appServerSupervisor.js'
 import {workbenchCliConfig} from './devTestHelpers.js'
 
 const mockGetCliConfigUncached = vi.hoisted(() => vi.fn())
@@ -10,7 +14,10 @@ vi.mock('@sanity/cli-core', async (importOriginal) => ({
   getCliConfigUncached: mockGetCliConfigUncached,
 }))
 
-function mockAppServer({port = 3334}: {port?: number} = {}): AppServerResult {
+function mockAppServer({port = 3334}: {port?: number} = {}): Extract<
+  AppServerResult,
+  {started: true}
+> {
   return {
     close: vi.fn().mockResolvedValue(undefined),
     server: {config: {server: {port}}} as never,
@@ -18,7 +25,7 @@ function mockAppServer({port = 3334}: {port?: number} = {}): AppServerResult {
   }
 }
 
-async function startSupervisor(start: ReturnType<typeof vi.fn>) {
+async function startSupervisor(start: StartAppServer) {
   const result = await startAppServerSupervisor({
     cliConfig: workbenchCliConfig(),
     start,

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDev.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDev.ts
@@ -5,7 +5,10 @@ import {type CliConfig, type Output} from '@sanity/cli-core'
 import {type AppServerResult, startAppServerSupervisor} from './appServerSupervisor.js'
 import {type DevServerManifest} from './registry.js'
 import {startDevServerRegistration} from './startDevServerRegistration.js'
-import {startWorkbenchDevServer} from './startWorkbenchDevServer.js'
+import {
+  startWorkbenchDevServer,
+  startWorkbenchRemoteCoordinator,
+} from './startWorkbenchDevServer.js'
 
 /** How long teardown runs before re-raising the signal to force-exit — enough for
  * Vite/watchers to close, short enough not to strand a backgrounded process. */
@@ -74,6 +77,26 @@ export async function startWorkbenchDev(
     startAppServer,
     workDir,
   } = options
+
+  // The remote can't render itself, so it runs as a plain app server (not the
+  // shell) that still claims the lock and bridges the registry, so app
+  // `sanity dev`s register into it.
+  if (process.env.SANITY_INTERNAL_IS_WORKBENCH_REMOTE === 'true') {
+    const remote = await startAppServer({announceUrl: true, cliConfig, httpPort})
+    if (!remote.started) return {close: async () => {}}
+
+    const addr = remote.server.httpServer?.address()
+    const port =
+      (typeof addr === 'object' && addr ? addr.port : remote.server.config.server.port) ?? httpPort
+    const coordinator = startWorkbenchRemoteCoordinator({httpHost, port, server: remote.server})
+
+    return {
+      close: async () => {
+        await coordinator.close()
+        await remote.close()
+      },
+    }
+  }
 
   // Unwound in reverse on any failure or on close(): the watcher stops before
   // the app server, and the supervisor waits out an in-flight rebuild.

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -6,7 +6,7 @@ import {
   subdebug,
 } from '@sanity/cli-core'
 import viteReact from '@vitejs/plugin-react'
-import {createServer, type InlineConfig, type Plugin} from 'vite'
+import {createServer, type InlineConfig, type Plugin, type ViteDevServer} from 'vite'
 import {z} from 'zod/mini'
 
 import {createInterfacesTracker} from './interfaceSetId.js'
@@ -34,6 +34,65 @@ const toApplicationsPayload = (servers: DevServerManifest[]) => ({
     type,
   })),
 })
+
+/**
+ * Bridge the dev-server registry into a workbench Vite server's HMR channel so
+ * the page tracks apps as they come and go. A changed interface set means a
+ * rebuilt remote — full-reload to drop the stale remote-entry; otherwise
+ * rebroadcast for a soft reconcile. Returns a detach fn.
+ */
+function attachViteDevServerBridge(server: ViteDevServer): () => void {
+  server.ws.on('sanity:workbench:get-local-applications', (_, client) => {
+    client.send(
+      'sanity:workbench:local-applications',
+      toApplicationsPayload(getRegisteredServers()),
+    )
+  })
+
+  const setTracker = createInterfacesTracker()
+  const registryWatcher = watchRegistry((servers) => {
+    if (setTracker.hasChanged(servers)) {
+      server.ws.send({type: 'full-reload'})
+      return
+    }
+    server.ws.send('sanity:workbench:local-applications', toApplicationsPayload(servers))
+  })
+
+  return () => registryWatcher.close()
+}
+
+/**
+ * Make the workbench remote act as the machine's workbench: claim the singleton
+ * lock so app `sanity dev`s register into it instead of each starting their own,
+ * and bridge the registry so the remote shows the local apps. No-op lock if one
+ * is already held.
+ */
+export function startWorkbenchRemoteCoordinator(options: {
+  httpHost: string | undefined
+  port: number
+  server: ViteDevServer
+}): {close: () => Promise<void>} {
+  const {httpHost, port, server} = options
+
+  const lock = acquireWorkbenchLock({host: httpHost || 'localhost', port})
+  if (!lock) {
+    const existing = readWorkbenchLock()
+    devDebug(
+      'Workbench lock already held by pid %d on port %d; bridging the registry without claiming it',
+      existing?.pid,
+      existing?.port,
+    )
+  }
+
+  const detachBridge = attachViteDevServerBridge(server)
+
+  return {
+    close: async () => {
+      detachBridge()
+      lock?.release()
+    },
+  }
+}
 
 interface WorkbenchDevServerResult {
   close: () => Promise<void>
@@ -244,29 +303,12 @@ async function createWorkbenchViteServer(
     devDebug('Warming workbench remote at %s', remoteUrl)
   }
 
-  server.ws.on('sanity:workbench:get-local-applications', (_, client) => {
-    client.send(
-      'sanity:workbench:local-applications',
-      toApplicationsPayload(getRegisteredServers()),
-    )
-  })
-
-  // A changed interface set means the remote was rebuilt with new exposes —
-  // full-reload so the page drops the stale remote-entry; otherwise rebroadcast
-  // the app list for a soft reconcile.
-  const setTracker = createInterfacesTracker()
-  const registryWatcher = watchRegistry((servers) => {
-    if (setTracker.hasChanged(servers)) {
-      server.ws.send({type: 'full-reload'})
-      return
-    }
-    server.ws.send('sanity:workbench:local-applications', toApplicationsPayload(servers))
-  })
+  const detachBridge = attachViteDevServerBridge(server)
 
   return {
     actualPort,
     close: async () => {
-      registryWatcher.close()
+      detachBridge()
       await server.close()
     },
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1241,8 +1241,8 @@ importers:
   packages/@sanity/workbench-cli:
     dependencies:
       '@module-federation/vite':
-        specifier: 1.16.0
-        version: 1.16.0(typescript@5.9.3)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: https://pkg.pr.new/@module-federation/vite@952ec00
+        version: https://pkg.pr.new/@module-federation/vite@952ec00(typescript@5.9.3)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sanity/cli-core':
         specifier: workspace:^
         version: link:../cli-core
@@ -3242,8 +3242,8 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@module-federation/dts-plugin@2.5.0':
-    resolution: {integrity: sha512-q7KDhJ5tn2HrUV7uMuh/L3TaaztUosE+4LAb90sxx0pPPqWRwlpBpxu1REubv5BWXmU1K/Ozn14u6jRbjLVaGA==}
+  '@module-federation/dts-plugin@2.6.0':
+    resolution: {integrity: sha512-0dMjLhU+2HNPyX5Txu6JqA2CAYxVLRv3c/bpRk58aNVwhDO/jqp66IdFztdMZ1XiHqOW9jB3pkOSuIpcl/yXpQ==}
     peerDependencies:
       typescript: ^4.9.0 || ^5.0.0
       vue-tsc: '>=1.0.24'
@@ -3251,48 +3251,33 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/error-codes@2.5.0':
-    resolution: {integrity: sha512-sq05/8Gp3csy1nr2/f76K3vLy0/xRqVtP71ibGy8BiLg7h1UxWN7G4EwAKSrPZ4FnsERGeFlIszg5Z+MqlwhFg==}
+  '@module-federation/error-codes@2.6.0':
+    resolution: {integrity: sha512-J9opjWJJZ1JI/9EvNZF8Ps1VMHS9EsH/i0UjCkQQxFVYZxSDBX1CFunvc7awac4cY//LqJUfqBbfoQPhCfKKKw==}
 
-  '@module-federation/error-codes@2.5.1':
-    resolution: {integrity: sha512-3KIR8XbEW0Y+Fn8IAnxzDWMvXQWiS40Z1TE/Fft9aTeXP9dDAM7AiVhjTh5yF2csAwHSt/1LJVZbiCmS13mE8A==}
+  '@module-federation/managers@2.6.0':
+    resolution: {integrity: sha512-7Y4Ri6Lh10dCHoEJvNGFmK2Gg1JKy7oJ1TEZhuU3n3mgIpZ519fDNRvU4+tiO9C49p1xyK+mQ8ewxth83waKUA==}
 
-  '@module-federation/managers@2.5.0':
-    resolution: {integrity: sha512-9b5mU/7OYbKrYUJmhZ1kkfeJCZqR7qX6/FWp+oOfZMzUynN7Rb41dwoUs3TdnOKzbZ3CCwtZ2WsR4pF9ZNvuJA==}
+  '@module-federation/runtime-core@2.6.0':
+    resolution: {integrity: sha512-9sL7Yj3H3COZI9JpK/J4hmJUBkIJdmowkj6phHuFiy5Hm5bHiE5U+9WBbR9KqTdyNhAVSL9FeprBW5/Io6i59A==}
 
-  '@module-federation/runtime-core@2.5.0':
-    resolution: {integrity: sha512-STmhQ3c6/hunba2FMP6GrHazXU/8GuN7Gk4dOkWNRpnqYIoD8Wx4MNl76j3HdCzBESC7uSMXTniksVaM1+xxyA==}
+  '@module-federation/runtime@2.6.0':
+    resolution: {integrity: sha512-Y8KgL70RDxD8cCtGWGlGkt+TSDleIjdGmS27gnllibQAIgG/vHhPD11r8kd92x44k4dqtMIntzreOphGICl92g==}
 
-  '@module-federation/runtime-core@2.5.1':
-    resolution: {integrity: sha512-UMuMsWHXeMrm8Isl8YD6/s1jmTVau3SQhp9RO4Ln+eD2lrjM4hQSwOX2xPtfT1C1I4/E6hgyZQV1K1Q/3Zpr0Q==}
-
-  '@module-federation/runtime@2.5.0':
-    resolution: {integrity: sha512-dOc7pFEf8aruHBk5hoJLnvwkCa5ELT78q3o9dqcdaa/TT74X5z0FT0BsaGaRBPcse/iP6czK3fWd7RLv5ZKP5g==}
-
-  '@module-federation/runtime@2.5.1':
-    resolution: {integrity: sha512-Tf33FIpnQMn8FjIUAQMtSTYQgGibfh5vEvJihFO3q/hG9LiWwLMErZvOz/+wcPsE81gzHjYPxQgMKGSP3BuG8g==}
-
-  '@module-federation/sdk@2.5.0':
-    resolution: {integrity: sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==}
+  '@module-federation/sdk@2.6.0':
+    resolution: {integrity: sha512-Z3HT1uDciMrvz2at3sw6TJbAK9Fl7RmoC/8iqO35HDtQMQJ1qSsMIAjnsiCpAC0D4nAm6PIqgSqPWRO/WYgo0Q==}
     peerDependencies:
       node-fetch: ^2.7.0 || ^3.3.2
     peerDependenciesMeta:
       node-fetch:
         optional: true
 
-  '@module-federation/sdk@2.5.1':
-    resolution: {integrity: sha512-FDhCx81ZCxX1oT/fyt/bW+gpPt287GR156E/Thv1yhb9XyNHGNkqe8zqJOipOMfb07E22OMzSzOulCBvAOgn3g==}
-    peerDependencies:
-      node-fetch: ^2.7.0 || ^3.3.2
-    peerDependenciesMeta:
-      node-fetch:
-        optional: true
+  '@module-federation/third-party-dts-extractor@2.6.0':
+    resolution: {integrity: sha512-rEC1YRC3gTafoOcFm1Htz6cAwHRoWEMQNCm1LXR1HiuayJzUkViVpK/1Pp37UZfytOyQ0qIaP6Ag81PdGvDbmw==}
 
-  '@module-federation/third-party-dts-extractor@2.5.0':
-    resolution: {integrity: sha512-5di43LGk2ies86Cj8QyzYr540Ijc+nyPqYziyFotL6Pparnu+uf3b3ERfEyQfBmEcyGk1MpitQIO2J3bd9BcNw==}
-
-  '@module-federation/vite@1.16.0':
-    resolution: {integrity: sha512-xgEcAj00A+1fGNLOg88FbJJjyLGqQQMM4qvTEGgw1bkVT1l8Bv2hqhjfk0UNs86EPPYfBbZxC2dR2rLxIljMQw==}
+  '@module-federation/vite@https://pkg.pr.new/@module-federation/vite@952ec00':
+    resolution: {integrity: sha512-CYW7XZyI/wYbhIWVQPuu64q9NYdiA7vpD381dbcJo029qv9HU3iAm5XnAVpEA3camXTvNckd2wUL1HbL6Ys4Bg==, tarball: https://pkg.pr.new/@module-federation/vite@952ec00}
+    version: 1.16.10
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
@@ -9260,10 +9245,6 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.24.7:
-    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -9617,18 +9598,6 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -12169,82 +12138,60 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@module-federation/dts-plugin@2.5.0(typescript@5.9.3)':
+  '@module-federation/dts-plugin@2.6.0(typescript@5.9.3)':
     dependencies:
-      '@module-federation/error-codes': 2.5.0
-      '@module-federation/managers': 2.5.0
-      '@module-federation/sdk': 2.5.0
-      '@module-federation/third-party-dts-extractor': 2.5.0
+      '@module-federation/error-codes': 2.6.0
+      '@module-federation/managers': 2.6.0
+      '@module-federation/sdk': 2.6.0
+      '@module-federation/third-party-dts-extractor': 2.6.0
       adm-zip: 0.5.10
       ansi-colors: 4.1.3
-      isomorphic-ws: 5.0.0(ws@8.18.0)
+      isomorphic-ws: 5.0.0(ws@8.21.0)
       node-schedule: 2.1.1
       typescript: 5.9.3
-      undici: 7.24.7
-      ws: 8.18.0
+      undici: 7.28.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/error-codes@2.5.0': {}
+  '@module-federation/error-codes@2.6.0': {}
 
-  '@module-federation/error-codes@2.5.1': {}
-
-  '@module-federation/managers@2.5.0':
+  '@module-federation/managers@2.6.0':
     dependencies:
-      '@module-federation/sdk': 2.5.0
+      '@module-federation/sdk': 2.6.0
       find-pkg: 2.0.0
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/runtime-core@2.5.0':
+  '@module-federation/runtime-core@2.6.0':
     dependencies:
-      '@module-federation/error-codes': 2.5.0
-      '@module-federation/sdk': 2.5.0
+      '@module-federation/error-codes': 2.6.0
+      '@module-federation/sdk': 2.6.0
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/runtime-core@2.5.1':
+  '@module-federation/runtime@2.6.0':
     dependencies:
-      '@module-federation/error-codes': 2.5.1
-      '@module-federation/sdk': 2.5.1
+      '@module-federation/error-codes': 2.6.0
+      '@module-federation/runtime-core': 2.6.0
+      '@module-federation/sdk': 2.6.0
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/runtime@2.5.0':
-    dependencies:
-      '@module-federation/error-codes': 2.5.0
-      '@module-federation/runtime-core': 2.5.0
-      '@module-federation/sdk': 2.5.0
-    transitivePeerDependencies:
-      - node-fetch
+  '@module-federation/sdk@2.6.0': {}
 
-  '@module-federation/runtime@2.5.1':
-    dependencies:
-      '@module-federation/error-codes': 2.5.1
-      '@module-federation/runtime-core': 2.5.1
-      '@module-federation/sdk': 2.5.1
-    transitivePeerDependencies:
-      - node-fetch
-
-  '@module-federation/sdk@2.5.0': {}
-
-  '@module-federation/sdk@2.5.1': {}
-
-  '@module-federation/third-party-dts-extractor@2.5.0':
+  '@module-federation/third-party-dts-extractor@2.6.0':
     dependencies:
       find-pkg: 2.0.0
       resolve: 1.22.8
 
-  '@module-federation/vite@1.16.0(typescript@5.9.3)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@module-federation/vite@https://pkg.pr.new/@module-federation/vite@952ec00(typescript@5.9.3)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@module-federation/dts-plugin': 2.5.0(typescript@5.9.3)
-      '@module-federation/runtime': 2.5.0
-      '@module-federation/sdk': 2.5.0
-      es-module-lexer: 2.1.0
-      estree-walker: 3.0.3
-      pathe: 2.0.3
+      '@module-federation/dts-plugin': 2.6.0(typescript@5.9.3)
+      '@module-federation/runtime': 2.6.0
+      '@module-federation/sdk': 2.6.0
       vite: 8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - bufferutil
@@ -13833,7 +13780,7 @@ snapshots:
 
   '@sanity/workbench@0.1.0-alpha.22(@sanity/sdk@2.14.1(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.1))(react@19.2.7)(xstate@5.32.1)':
     dependencies:
-      '@module-federation/runtime': 2.5.1
+      '@module-federation/runtime': 2.6.0
       '@sanity/message-protocol': 0.23.0
       '@sanity/sdk': 2.14.1(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.1)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
@@ -16516,9 +16463,9 @@ snapshots:
       - canvas
       - supports-color
 
-  isomorphic-ws@5.0.0(ws@8.18.0):
+  isomorphic-ws@5.0.0(ws@8.21.0):
     dependencies:
-      ws: 8.18.0
+      ws: 8.21.0
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -18910,8 +18857,6 @@ snapshots:
 
   undici@6.27.0: {}
 
-  undici@7.24.7: {}
-
   undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -19272,8 +19217,6 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
-
-  ws@8.18.0: {}
 
   ws@8.21.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,6 +97,9 @@ minimumReleaseAgeExclude:
   - 'vite'
   - '@vitejs/*'
   - 'vitest'
+  # Pinned to the module-federation/vite#854 pkg.pr.new preview for the
+  # #RUNTIME-002 fix; its MF runtime deps are newer than the release-age window.
+  - '@module-federation/*'
   - '@vitest/*'
   # Bump for jiti with ts path support, can remove after ~May 9th
   - 'jiti@2.7.0'


### PR DESCRIPTION
### Description

The workbench remote runs as a plain `sanity dev` (it can't render itself), so it never claimed the workbench lock or the dev-server registry. Two fallouts:

- It announced a bare `App dev server started on port 5173` — no clickable URL.
- Running `sanity dev` for dev apps saw no running workbench, so each started its own shell instead of registering into the remote.

Now the workbench remote claims the lock and bridges the registry, and the plain app server prints a clickable URL. Apps discover the remote and register into it.

I've used that opportunity to move even more code into the workbench-cli package.

### Testing

Verified against sanity-io/workbench#262: the remote claims `workbench.lock` and prints a clickable URL, and a `favorites` dev run reports `Workbench dev server started at http://localhost:5173 (app on port 5174)`. No automated coverage for the multi-process dev orchestration yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-process workbench dev orchestration (lock, registry, HMR bridge); scope is dev-only but incorrect behavior could still break local federation workflows.
> 
> **Overview**
> Workbench remote `sanity dev` no longer bypasses workbench orchestration in **`devAction`**—every workbench app goes through **`startWorkbenchDev`**, which handles the remote internally.
> 
> When **`SANITY_INTERNAL_IS_WORKBENCH_REMOTE`** is set, **`startWorkbenchDev`** starts a plain app/studio server and attaches **`startWorkbenchRemoteCoordinator`**, which **claims the workbench lock** (when free) and **bridges the dev-server registry** into the Vite HMR channel via shared **`attachViteDevServerBridge`** logic (extracted from the full workbench shell path). Other app **`sanity dev`** runs can discover the remote and register instead of each spawning its own shell.
> 
> **`startAppDevServer`** now prints a **styled, clickable `http://…` URL** for workbench apps that announce their own URL, using **`toDisplayHost`** so bind addresses like `0.0.0.0` show as `localhost`. Tests and a changeset cover the routing and logging updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936949a02eb52505df9064ff19b7f8418d169efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->