### PR TITLE
perf(cli-build): skip redundant initial render in sanity dev watcher

### DIFF
--- a/.changeset/pr-1388.md
+++ b/.changeset/pr-1388.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': patch
+---
+
+perf(cli-build): skip redundant initial render in sanity dev watcher

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/writeSanityRuntime.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/writeSanityRuntime.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi} from 'vitest'
+
+const mockWatch = vi.hoisted(() => vi.fn())
+const mockRenderDocument = vi.hoisted(() => vi.fn())
+
+vi.mock('chokidar', () => ({watch: mockWatch}))
+vi.mock('../renderDocument.js', () => ({renderDocument: mockRenderDocument}))
+
+const {writeSanityRuntime} = await import('../writeSanityRuntime.js')
+const {getPossibleDocumentComponentLocations} =
+  await import('../getPossibleDocumentComponentLocations.js')
+
+describe('writeSanityRuntime watch mode', () => {
+  // A chainable stand-in for the chokidar FSWatcher: `.on()` returns the watcher
+  // so `chokidarWatch(...).on('all', cb)` resolves to it.
+  const fakeWatcher = {on: vi.fn().mockReturnThis()}
+  let cwd: string
+
+  beforeAll(async () => {
+    cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'sanity-runtime-'))
+  })
+
+  afterAll(async () => {
+    await fs.rm(cwd, {force: true, recursive: true})
+  })
+
+  beforeEach(() => {
+    mockWatch.mockReturnValue(fakeWatcher)
+    mockRenderDocument.mockResolvedValue('<html><head></head><body></body></html>')
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('passes ignoreInitial so the initial scan does not double-render', async () => {
+    const {watcher} = await writeSanityRuntime({
+      cwd,
+      isApp: true,
+      reactStrictMode: false,
+      watch: true,
+    })
+
+    expect(mockWatch).toHaveBeenCalledWith(getPossibleDocumentComponentLocations(cwd), {
+      ignoreInitial: true,
+    })
+    expect(watcher).toBe(fakeWatcher)
+  })
+
+  test('creates no watcher when watch is disabled', async () => {
+    const {watcher} = await writeSanityRuntime({
+      cwd,
+      isApp: true,
+      reactStrictMode: false,
+      watch: false,
+    })
+
+    expect(mockWatch).not.toHaveBeenCalled()
+    expect(watcher).toBeUndefined()
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
+++ b/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
@@ -67,8 +67,10 @@ export async function writeSanityRuntime(options: RuntimeOptions): Promise<{
   let watcher: FSWatcher | undefined
 
   if (watch) {
-    watcher = chokidarWatch(getPossibleDocumentComponentLocations(cwd)).on('all', () =>
-      renderAndWriteDocument(),
+    // Skip the initial scan; the explicit renderAndWriteDocument() below handles first generation.
+    watcher = chokidarWatch(getPossibleDocumentComponentLocations(cwd), {ignoreInitial: true}).on(
+      'all',
+      () => renderAndWriteDocument(),
     )
   }
 


### PR DESCRIPTION
### Description

The dev runtime document watcher relied on chokidar's defaults, where `ignoreInitial` is `false`. When a project ships a custom `_document.{js,tsx}`, chokidar emits an initial `add` on startup, firing `renderAndWriteDocument()` — on top of the explicit first render a few lines below. Net: one wasted `index.html` render at `sanity dev` startup, only when a custom `_document` exists.

Passing `{ignoreInitial: true}` drops the duplicate; the explicit render already handles first generation. No self-trigger or render loop existed — runtime writes (`app.js`, `index.html`) land in `.sanity/runtime/`, outside the watched `_document` paths.

Dev-only, low impact. Resolves SDK-1769. Came up during https://github.com/sanity-io/cli/pull/907

### What to review

- [writeSanityRuntime.ts](https://github.com/sanity-io/cli/blob/worktree-sdk-1769/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts#L69-L75) — confirm the explicit `renderAndWriteDocument()` still covers first generation now that the initial scan is skipped.

### Testing

Added unit tests for both watcher branches: watch mode passes `ignoreInitial: true`, and no watcher is created when watch is disabled. chokidar and `renderDocument` are mocked to keep the test off real fs/timing and worker threads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only cli-build watcher tuning with tests; no change to production build or auth/data paths.
> 
> **Overview**
> **`sanity dev`** no longer runs **`index.html`** generation twice at startup when a custom **`_document`** file is present.
> 
> The chokidar watcher for document components now uses **`ignoreInitial: true`**, so the initial filesystem scan does not fire **`renderAndWriteDocument()`**. The existing explicit call after the watcher is set up still performs the first render.
> 
> Unit tests cover watch mode (**`ignoreInitial: true`**) and the path where **`watch`** is disabled (no watcher).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f51164e63388acf6ed2ab64831b20cee34dbd214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->