### PR TITLE
fix(workbench): upgrade @module-federation/vite to 1.16.11

### DIFF
--- a/.changeset/workbench-mf-vite-release.md
+++ b/.changeset/workbench-mf-vite-release.md
@@ -1,0 +1,5 @@
+---
+'@sanity/workbench-cli': patch
+---
+
+Upgrade `@module-federation/vite` to 1.16.11, replacing the temporary preview build. The release fixes federated remote-entry resolution under Vite 8.

--- a/packages/@sanity/workbench-cli/package.json
+++ b/packages/@sanity/workbench-cli/package.json
@@ -57,7 +57,7 @@
     "watch": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ --watch src"
   },
   "dependencies": {
-    "@module-federation/vite": "https://pkg.pr.new/@module-federation/vite@952ec00",
+    "@module-federation/vite": "1.16.11",
     "@sanity/cli-core": "workspace:^",
     "@vitejs/plugin-react": "catalog:",
     "vite": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1241,8 +1241,8 @@ importers:
   packages/@sanity/workbench-cli:
     dependencies:
       '@module-federation/vite':
-        specifier: https://pkg.pr.new/@module-federation/vite@952ec00
-        version: https://pkg.pr.new/@module-federation/vite@952ec00(typescript@5.9.3)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: 1.16.11
+        version: 1.16.11(typescript@5.9.3)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sanity/cli-core':
         specifier: workspace:^
         version: link:../cli-core
@@ -3274,9 +3274,8 @@ packages:
   '@module-federation/third-party-dts-extractor@2.6.0':
     resolution: {integrity: sha512-rEC1YRC3gTafoOcFm1Htz6cAwHRoWEMQNCm1LXR1HiuayJzUkViVpK/1Pp37UZfytOyQ0qIaP6Ag81PdGvDbmw==}
 
-  '@module-federation/vite@https://pkg.pr.new/@module-federation/vite@952ec00':
-    resolution: {integrity: sha512-CYW7XZyI/wYbhIWVQPuu64q9NYdiA7vpD381dbcJo029qv9HU3iAm5XnAVpEA3camXTvNckd2wUL1HbL6Ys4Bg==, tarball: https://pkg.pr.new/@module-federation/vite@952ec00}
-    version: 1.16.10
+  '@module-federation/vite@1.16.11':
+    resolution: {integrity: sha512-tmVBSdHDDQvGPYPZgp7Hpi980reReObP1yyai3kxWeQZ8CL6zAFIgz3wb97o20J/lJjxM6DDzs31da3RXtvdxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -12187,7 +12186,7 @@ snapshots:
       find-pkg: 2.0.0
       resolve: 1.22.8
 
-  '@module-federation/vite@https://pkg.pr.new/@module-federation/vite@952ec00(typescript@5.9.3)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@module-federation/vite@1.16.11(typescript@5.9.3)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@module-federation/dts-plugin': 2.6.0(typescript@5.9.3)
       '@module-federation/runtime': 2.6.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,9 +97,14 @@ minimumReleaseAgeExclude:
   - 'vite'
   - '@vitejs/*'
   - 'vitest'
-  # Pinned to the module-federation/vite#854 pkg.pr.new preview for the
-  # #RUNTIME-002 fix; its MF runtime deps are newer than the release-age window.
-  - '@module-federation/*'
+  - '@module-federation/vite@1.16.11'
+  - '@module-federation/dts-plugin@2.6.0'
+  - '@module-federation/error-codes@2.6.0'
+  - '@module-federation/managers@2.6.0'
+  - '@module-federation/runtime@2.6.0'
+  - '@module-federation/runtime-core@2.6.0'
+  - '@module-federation/sdk@2.6.0'
+  - '@module-federation/third-party-dts-extractor@2.6.0'
   - '@vitest/*'
   # Bump for jiti with ts path support, can remove after ~May 9th
   - 'jiti@2.7.0'


### PR DESCRIPTION
### Description

`@module-federation/vite` was pinned to a `pkg.pr.new` preview while the federated remote-entry fix was unreleased. 1.16.11 ships that fix, so this swaps the preview for the released version.

The `2.6.0` MF deps it pulls were published two days ago, so they're added to `minimumReleaseAgeExclude` — pinned to exact versions rather than a `@module-federation/*` glob, so min-age protection stays on for every other package and future version. They can be removed once they pass the release-age window.

### What to review

- `packages/@sanity/workbench-cli/package.json` — preview URL → `1.16.11`
- `pnpm-workspace.yaml` — strict per-version min-age excludes for `1.16.11` and its fresh `2.6.0` dependency closure

### Testing

Covered by the existing unit / integration / e2e suites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change in the experimental workbench CLI; no application logic changes, with behavior covered by existing test suites.
> 
> **Overview**
> **`@sanity/workbench-cli`** stops depending on a **`pkg.pr.new`** preview of **`@module-federation/vite`** and pins the released **`1.16.11`** build, which includes the fix for federated remote-entry resolution on **Vite 8** (the reason the preview was used).
> 
> **`pnpm-workspace.yaml`** drops the blanket **`@module-federation/*`** minimum-release-age exception and replaces it with exact-version excludes for **`@module-federation/vite@1.16.11`** and its fresh **`2.6.0`** transitive MF packages, so other **`@module-federation`** versions still honor the release-age window. The lockfile and a patch **changeset** for **`@sanity/workbench-cli`** complete the swap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a75ea9b087c768ebdec0a2ee2ad8131158267b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->