### PR TITLE
test(chore): Revert unit test warning suppression

### DIFF
--- a/packages/@sanity/cli-core/src/__tests__/SanityCommand.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/SanityCommand.test.ts
@@ -1,6 +1,4 @@
-import {resolve} from 'node:path'
-
-import {Command, Config, Flags} from '@oclif/core'
+import {Command, Flags} from '@oclif/core'
 import {afterEach, beforeEach, describe, expect, Mock, test, vi} from 'vitest'
 
 const {SanityCommand} = await import('../SanityCommand.js')
@@ -27,21 +25,6 @@ function createMockedRunCommand<T extends typeof Command>(mocks: {
           return trimmed
         },
       }),
-    }
-    // Use OCLIF_TEST_ROOT, set in vitest configs in this repo, as a fallback root directory for OCLIF.
-    // Without this, unit tests yield warnings in console output (not catastrophic, but annoying).
-    public static override run<T extends Command>(...args: Parameters<typeof Command.run>) {
-      const [argv, opts] = args
-      const testRoot = process.env.OCLIF_TEST_ROOT
-        ? resolve(process.cwd(), process.env.OCLIF_TEST_ROOT)
-        : undefined
-      if (typeof opts === 'string' || opts instanceof Config) {
-        return super.run(argv, opts) as Promise<ReturnType<T['run']>>
-      }
-      return super.run(argv, {
-        ...opts,
-        root: opts?.root ?? testRoot ?? process.cwd(),
-      }) as Promise<ReturnType<T['run']>>
     }
     public async getCliConfig() {
       return (mocks.cliConfig || vi.fn(() => ({api: {}})))()

--- a/packages/@sanity/cli-core/vitest.config.ts
+++ b/packages/@sanity/cli-core/vitest.config.ts
@@ -20,6 +20,5 @@ export default defineConfig({
     exclude: ['**/node_modules/**', '**/dist/**'],
     globals: false,
     name: '@sanity/cli-core/unit',
-    testTimeout: 10_000,
   },
 })

--- a/packages/@sanity/cli/test/mockSanityCommand.ts
+++ b/packages/@sanity/cli/test/mockSanityCommand.ts
@@ -1,6 +1,4 @@
-import {resolve} from 'node:path'
-
-import {Command, Config} from '@oclif/core'
+import {Command} from '@oclif/core'
 import {type Output, type SanityCommandInterface} from '@sanity/cli-core'
 import {vi} from 'vitest'
 
@@ -30,21 +28,6 @@ export function createMockSanityCommand() {
         error: mocks.SanityCmdOutputError,
         log: mocks.SanityCmdOutputLog,
         warn: mocks.SanityCmdOutputWarn,
-      }
-      // Use OCLIF_TEST_ROOT, set in vitest configs in this repo, as a fallback root directory for OCLIF.
-      // Without this, unit tests yield warnings in console output (not catastrophic, but annoying).
-      public static override run<T extends Command>(...args: Parameters<typeof Command.run>) {
-        const [argv, opts] = args
-        const testRoot = process.env.OCLIF_TEST_ROOT
-          ? resolve(process.cwd(), process.env.OCLIF_TEST_ROOT)
-          : undefined
-        if (typeof opts === 'string' || opts instanceof Config) {
-          return super.run(argv, opts) as Promise<ReturnType<T['run']>>
-        }
-        return super.run(argv, {
-          ...opts,
-          root: opts?.root ?? testRoot ?? process.cwd(),
-        }) as Promise<ReturnType<T['run']>>
       }
       public exit(code?: number) {
         return mocks.OclifCmdExit(code)

--- a/packages/@sanity/cli/vitest.config.ts
+++ b/packages/@sanity/cli/vitest.config.ts
@@ -16,6 +16,5 @@ export default defineConfig({
     name: '@sanity/cli/unit',
     setupFiles: ['test/setup.ts'],
     snapshotSerializers: ['test/snapshotSerializer.ts'],
-    testTimeout: 10_000,
   },
 })


### PR DESCRIPTION
### Description

Since introducing overriding OCLIF static `run` into `main`, the unit tests on slower CI machines regularly time out. Going to attempt to run CI on this branch multiple times and see if stability changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness and Vitest config only; no production CLI behavior changes in this diff.
> 
> **Overview**
> Rolls back test-only workarounds that customized OCLIF **`Command.run`** so unit tests passed a **`root`** derived from **`OCLIF_TEST_ROOT`**, which had been added to quiet OCLIF warnings in test output.
> 
> Those overrides are removed from **`SanityCommand.test.ts`** and **`mockSanityCommand.ts`**, along with related **`node:path`** / **`Config`** imports. **`testTimeout: 10_000`** is also dropped from **`@sanity/cli-core`** and **`@sanity/cli`** Vitest configs so default timeouts apply again.
> 
> **`OCLIF_TEST_ROOT`** is still set in Vitest env but is no longer read by these helpers after this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23591657fa190284b99685742bfc6effe9be87bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->