### PR TITLE
fix: update Zed MCP settings object format

### DIFF
--- a/.changeset/shiny-baboons-unite.md
+++ b/.changeset/shiny-baboons-unite.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+Updated how the Sanity MCP server is registered to match the new Zed settings format

--- a/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
+++ b/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
@@ -286,8 +286,8 @@ function buildOpenCodeServerConfig(token: string): Record<string, unknown> {
 
 function buildZedServerConfig(token: string): Record<string, unknown> {
   return {
+    enabled: true,
     headers: {Authorization: `Bearer ${token}`},
-    settings: {},
     url: MCP_SERVER_URL,
   }
 }


### PR DESCRIPTION
Came up as part of AIGRO-5121, noticed that Zed has changed their MCP config structure, removing `settings`

Related to AIGRO-5121

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-object shape change for Zed MCP registration only; no auth, data, or shared runtime logic changes.
> 
> **Overview**
> Updates **`buildZedServerConfig`** so the Sanity CLI writes Zed **`context_servers`** entries in the format Zed now expects.
> 
> Each registered server block now includes **`enabled: true`** and no longer includes an empty **`settings`** object, which Zed removed from its MCP configuration schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd263c2b1be7b4e2854560af1ee09b696093ebcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->