### PR TITLE
refactor: move compareDependencyVersions out of internal build logic

### DIFF
--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -25,7 +25,10 @@ import {resolveWorkbenchApp} from '@sanity/workbench-cli/build'
 import {parse as semverParse} from 'semver'
 
 import {getAppId} from '../../util/appId.js'
-import {compareDependencyVersions} from '../../util/compareDependencyVersions.js'
+import {
+  compareDependencyVersions,
+  CompareDependencyVersionsResult,
+} from '../../util/compareDependencyVersions.js'
 import {formatModuleSizes, sortModulesBySize} from '../../util/moduleFormatUtils.js'
 import {warnAboutMissingAppId} from '../../util/warnAboutMissingAppId.js'
 import {buildStaticFiles} from './buildStaticFiles.js'
@@ -38,6 +41,9 @@ interface InternalBuildOptions {
   appTitle: string | undefined
   autoUpdatesEnabled: boolean
   calledFromDeploy: boolean | undefined
+  compareDependencyVersions: (
+    packages: {name: string; version: string}[],
+  ) => Promise<CompareDependencyVersionsResult>
   determineBasePath: () => string
   entry: string | undefined
   isWorkbenchApp: boolean
@@ -68,11 +74,14 @@ export async function buildApp(options: BuildOptions): Promise<void> {
   // legacy `app` config object — resolve the workbench capability to read them.
   const workbench = resolveWorkbenchApp(cliConfig)
 
+  const appId = getAppId(cliConfig)
+
   await internalBuildApp({
-    appId: getAppId(cliConfig),
+    appId,
     appTitle: app?.title,
     autoUpdatesEnabled: options.autoUpdatesEnabled,
     calledFromDeploy: options.calledFromDeploy,
+    compareDependencyVersions: (packages) => compareDependencyVersions(packages, workDir, {appId}),
     determineBasePath: () => determineBasePath(cliConfig, 'app', output),
     entry: app?.entry,
     isWorkbenchApp: !!workbench,
@@ -149,11 +158,8 @@ async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
     }
 
     // Check the versions
-    const {mismatched, unresolvedPrerelease} = await compareDependencyVersions(
-      autoUpdatedPackages,
-      workDir,
-      {appId},
-    )
+    const {mismatched, unresolvedPrerelease} =
+      await options.compareDependencyVersions(autoUpdatedPackages)
 
     if (unresolvedPrerelease.length > 0) {
       await handlePrereleaseVersions({output, unattendedMode, unresolvedPrerelease})

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -27,7 +27,10 @@ import {resolveWorkbenchApp} from '@sanity/workbench-cli/build'
 import {parse as semverParse} from 'semver'
 
 import {getAppId} from '../../util/appId.js'
-import {compareDependencyVersions} from '../../util/compareDependencyVersions.js'
+import {
+  compareDependencyVersions,
+  CompareDependencyVersionsResult,
+} from '../../util/compareDependencyVersions.js'
 import {determineIsApp} from '../../util/determineIsApp.js'
 import {formatModuleSizes, sortModulesBySize} from '../../util/moduleFormatUtils.js'
 import {getPackageManagerChoice} from '../../util/packageManager/packageManagerChoice.js'
@@ -42,6 +45,9 @@ interface InternalBuildOptions {
   appId: string | undefined
   autoUpdatesEnabled: boolean
   calledFromDeploy: boolean | undefined
+  compareDependencyVersions: (
+    packages: {name: string; version: string}[],
+  ) => Promise<CompareDependencyVersionsResult>
   determineBasePath: () => string
   isApp: boolean
   isWorkbenchApp: boolean
@@ -73,6 +79,8 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
   // the workbench capability so it's gated on the brand, like the app build.
   const workbench = resolveWorkbenchApp(cliConfig)
 
+  const appId = getAppId(cliConfig)
+
   const upgradePkgs = async (options: {
     packages: [name: string, version: string][]
   }): Promise<void> => {
@@ -86,9 +94,10 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
   }
 
   await internalBuildStudio({
-    appId: getAppId(cliConfig),
+    appId,
     autoUpdatesEnabled: options.autoUpdatesEnabled,
     calledFromDeploy,
+    compareDependencyVersions: (packages) => compareDependencyVersions(packages, workDir, {appId}),
     determineBasePath: () => determineBasePath(cliConfig, 'studio', output),
     isApp: determineIsApp(cliConfig),
     isWorkbenchApp: !!workbench,
@@ -186,11 +195,8 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     autoUpdatesCssUrls = getAutoUpdatesCssUrls(sanityDependencies, {appId})
 
     // Check the versions
-    const {mismatched, unresolvedPrerelease} = await compareDependencyVersions(
-      sanityDependencies,
-      workDir,
-      {appId},
-    )
+    const {mismatched, unresolvedPrerelease} =
+      await options.compareDependencyVersions(sanityDependencies)
 
     if (unresolvedPrerelease.length > 0) {
       await handlePrereleaseVersions({output, unattendedMode, unresolvedPrerelease})

--- a/packages/@sanity/cli/src/util/compareDependencyVersions.ts
+++ b/packages/@sanity/cli/src/util/compareDependencyVersions.ts
@@ -20,7 +20,7 @@ export interface UnresolvedPrerelease {
   version: string
 }
 
-interface CompareDependencyVersionsResult {
+export interface CompareDependencyVersionsResult {
   mismatched: Array<CompareDependencyVersions>
   unresolvedPrerelease: Array<UnresolvedPrerelease>
 }


### PR DESCRIPTION
### Description

In order to avoid moving compareDependencyVersions into the cli-build package and then exporting it to cli for the dev server and to make it easier to mock the logic from tests in the cli package, I've moved the call out of the internal logic into the cli package logic.

Note that we will eventually have to duplicate the return type into cli-build here as part of the options properties. The only alternative is to push this util into cli-core but that would then make mocking difficult again so I went with this option.

### Testing

No functionality changes here just adjusting the dependency chain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only wiring with no change to comparison logic or build output; risk is limited to a mistaken callback binding, which existing unit tests already mock.
> 
> **Overview**
> **Dependency version checks** for auto-updates are no longer invoked directly inside `internalBuildApp` and `internalBuildStudio`. Both internal builders now take a **`compareDependencyVersions` callback** on their options; the public `buildApp` and `buildStudio` entry points supply the real implementation bound to `workDir` and `appId`.
> 
> `CompareDependencyVersionsResult` is **exported** from `compareDependencyVersions.ts` so the injected callback can be typed on `InternalBuildOptions`. Behavior of the version check is unchanged—only **where the call is wired** and **how tests can substitute** the logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b2147a44e310b210432f431b63618cd1b3d6f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->