### PR TITLE
refactor(cli): move missing appid warning out of internal logic

### DIFF
--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -40,7 +40,7 @@ interface InternalBuildOptions {
   appId: string | undefined
   appTitle: string | undefined
   autoUpdatesEnabled: boolean
-  calledFromDeploy: boolean | undefined
+  checkAppId: () => void
   compareDependencyVersions: (
     packages: {name: string; version: string}[],
   ) => Promise<CompareDependencyVersionsResult>
@@ -80,7 +80,14 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     appId,
     appTitle: app?.title,
     autoUpdatesEnabled: options.autoUpdatesEnabled,
-    calledFromDeploy: options.calledFromDeploy,
+    checkAppId: () => {
+      // Warn if auto updates enabled but no appId configured.
+      // Skip when called from deploy, since deploy handles appId itself
+      // (prompts the user and tells them to add it to config).
+      if (!appId && !options.calledFromDeploy) {
+        warnAboutMissingAppId({appType: 'app', output})
+      }
+    },
     compareDependencyVersions: (packages) => compareDependencyVersions(packages, workDir, {appId}),
     determineBasePath: () => determineBasePath(cliConfig, 'app', output),
     entry: app?.entry,
@@ -151,11 +158,7 @@ async function internalBuildApp(options: InternalBuildOptions): Promise<void> {
     output.log(`${logSymbols.info} Building with auto-updates enabled`)
 
     // Warn if auto updates enabled but no appId configured.
-    // Skip when called from deploy, since deploy handles appId itself
-    // (prompts the user and tells them to add it to config).
-    if (!appId && !options.calledFromDeploy) {
-      warnAboutMissingAppId({appType: 'app', output})
-    }
+    options.checkAppId()
 
     // Check the versions
     const {mismatched, unresolvedPrerelease} =

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -99,7 +99,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
       // Warn if auto updates enabled but no appId configured.
       // Skip when called from deploy, since deploy handles appId itself
       // (prompts the user and tells them to add it to config).
-      if (!appId && !options.calledFromDeploy) {
+      if (!appId && !calledFromDeploy) {
         warnAboutMissingAppId({appType: 'studio', output, projectId: cliConfig?.api?.projectId})
       }
     },

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -44,7 +44,7 @@ import {type BuildOptions} from './types.js'
 interface InternalBuildOptions {
   appId: string | undefined
   autoUpdatesEnabled: boolean
-  calledFromDeploy: boolean | undefined
+  checkAppId: () => void
   compareDependencyVersions: (
     packages: {name: string; version: string}[],
   ) => Promise<CompareDependencyVersionsResult>
@@ -54,7 +54,6 @@ interface InternalBuildOptions {
   minify: boolean
   outDir: string | undefined
   output: Output
-  projectId: string | undefined
   reactCompiler: CliConfig['reactCompiler']
   schemaExtraction: CliConfig['schemaExtraction']
   services: DefineAppInput['services']
@@ -96,7 +95,14 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
   await internalBuildStudio({
     appId,
     autoUpdatesEnabled: options.autoUpdatesEnabled,
-    calledFromDeploy,
+    checkAppId: () => {
+      // Warn if auto updates enabled but no appId configured.
+      // Skip when called from deploy, since deploy handles appId itself
+      // (prompts the user and tells them to add it to config).
+      if (!appId && !options.calledFromDeploy) {
+        warnAboutMissingAppId({appType: 'studio', output, projectId: cliConfig?.api?.projectId})
+      }
+    },
     compareDependencyVersions: (packages) => compareDependencyVersions(packages, workDir, {appId}),
     determineBasePath: () => determineBasePath(cliConfig, 'studio', output),
     isApp: determineIsApp(cliConfig),
@@ -104,7 +110,6 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     minify: Boolean(flags.minify),
     outDir,
     output,
-    projectId: cliConfig?.api?.projectId,
     reactCompiler: cliConfig.reactCompiler,
     schemaExtraction: cliConfig.schemaExtraction,
     services: workbench?.services,
@@ -133,7 +138,6 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
     minify,
     outDir,
     output,
-    projectId,
     reactCompiler,
     schemaExtraction,
     services,
@@ -172,12 +176,8 @@ async function internalBuildStudio(options: InternalBuildOptions): Promise<void>
 
     output.log(`${logSymbols.info} Building with auto-updates enabled`)
 
-    // Warn if auto updates enabled but no appId configured.
-    // Skip when called from deploy, since deploy handles appId itself
-    // (prompts the user and tells them to add it to config).
-    if (!appId && !options.calledFromDeploy) {
-      warnAboutMissingAppId({appType: 'studio', output, projectId})
-    }
+    // Warn if auto updates enabled but no appId configured
+    options.checkAppId()
 
     const installedVisionVersion = await getLocalPackageVersion('@sanity/vision', workDir)
     const cleanVisionVersion = installedVisionVersion


### PR DESCRIPTION
### Description

Another dependency refactor. Since the blueprints deployment won't use this logic, we can keep it in the cli package instead.

### Testing

No logic changes here, just moving the dependency chain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with the same warning conditions preserved at the public build wrappers; no auth, data, or deploy behavior changes beyond call-site organization.
> 
> **Overview**
> Refactors **auto-updates missing `appId` warnings** so they no longer live inside `internalBuildApp` / `internalBuildStudio`.
> 
> `InternalBuildOptions` drops **`calledFromDeploy`** (and studio drops **`projectId`** used only for that warning). In their place, callers pass **`checkAppId`**, which `buildApp` and `buildStudio` implement with the same rules as before: warn via `warnAboutMissingAppId` when auto-updates are on and there is no `appId`, unless **`calledFromDeploy`** is set on the outer build options. The internal path only invokes **`options.checkAppId()`** when auto-updates are enabled.
> 
> Behavior is intended to be unchanged; the split keeps deploy-specific skip logic and warning helpers at the CLI entry layer rather than in shared internal build code (e.g. for paths like blueprints that won’t use this warning chain).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ded37b9cf3b943fa199f691d331955e61b04dd19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->