### PR TITLE
feat(cli-build): preconnect and gate modulepreload of the CDN sanity module

### DIFF
--- a/.changeset/cli-build-safari-gated-module-preload.md
+++ b/.changeset/cli-build-safari-gated-module-preload.md
@@ -1,0 +1,7 @@
+---
+'@sanity/cli-build': minor
+---
+
+feat(cli-build): preconnect and modulepreload the CDN `sanity` module for auto-update studios
+
+Re-introduces the resource hints reverted in #1400. `preconnect` only warms a socket, so it runs unconditionally and is safe in every engine. `modulepreload` follows the CDN's cross-origin redirect, which triggers a WebKit CORS bug that blanks the studio, so it is gated behind a positive allowlist: it runs only for engines confirmed to handle the redirect (desktop and Android Chromium and Gecko). Any unrecognised or WebKit engine - including all iOS browsers - falls back to the plain import-map load, costing a missed download rather than risking a blank studio.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ All commands are run from the root of the repo.
 - Be sure to typecheck, lint, build, depcheck and run tests when you are done.
 - Testing coverage should be maximized. Prefer running tests with coverage and the goal is to achieve maximum testing coverage for any new code added.
 - When creating pull requests, always follow the template in `.github/PULL_REQUEST_TEMPLATE.md`. Do not use your own format.
+- Releasable changes need a changeset, normally auto-generated from the PR's "Notes for release" section (empty uses the PR title; `N/A` skips it). See CONTRIBUTING.md "Automatic Changesets"; a hand-authored `.changeset/` file also works and takes precedence.
 
 # Testing Rules
 

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
@@ -129,10 +129,40 @@ describe('addTimestampedImportMapScriptToHtml', () => {
 
 const fixedTimestamp = 1_700_000_000_000
 
-function createRuntimeDom(html: string) {
+// A current desktop Chrome UA: a known-safe engine on the modulepreload
+// allowlist, so it gets the modulepreload as well as the preconnect.
+const chromeUserAgent =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+
+// Desktop Safari and iOS Safari: WebKit engines that blank the studio when the
+// modulepreload follows the CDN's cross-origin redirect, so the modulepreload
+// must be withheld from both (the safe preconnect still runs).
+const desktopSafariUserAgent =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15'
+const iosSafariUserAgent =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1'
+
+// An iOS UA carrying a `Chrome` token (an in-app webview or spoof): WebKit
+// under the hood, so it must be withheld. The allowlist's engine token would
+// match it — the iOS device-name exclusion is the only thing keeping the
+// modulepreload off, which proves that guard is load-bearing, not dead code.
+const iosChromeTokenUserAgent =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile/15E148 Safari/604.1'
+
+// An unrecognised engine matching neither the device-name nor the allowlist:
+// default-deny must withhold the modulepreload rather than risk bricking it.
+const unknownEngineUserAgent = 'SomeFutureBrowser/1.0'
+
+function createRuntimeDom(html: string, userAgent: string = chromeUserAgent): JSDOM {
   return new JSDOM(html, {
     beforeParse(window) {
       window.Date.now = () => fixedTimestamp
+      // The injected script branches on navigator.userAgent to gate the hints,
+      // so the UA the in-page script sees must be stubbed before it runs.
+      Object.defineProperty(window.navigator, 'userAgent', {
+        configurable: true,
+        get: () => userAgent,
+      })
     },
     runScripts: 'dangerously',
     url: 'https://example.test/',
@@ -187,5 +217,112 @@ describe('tests the runtime TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT', () => {
       'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000/index.css',
       'https://example.com/styles/external.css',
     ])
+  })
+
+  describe.each([
+    ['desktop Chrome', chromeUserAgent],
+    ['desktop Safari', desktopSafariUserAgent],
+    ['iOS Safari', iosSafariUserAgent],
+    ['an iOS webview with a Chrome token', iosChromeTokenUserAgent],
+    ['an unrecognised engine', unknownEngineUserAgent],
+  ])('preconnect is safe in every engine (%s)', (_label, userAgent) => {
+    test('warms the CDN connection with a crossorigin preconnect', () => {
+      const importMap = {
+        imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
+      }
+      const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+      const dom = createRuntimeDom(result, userAgent)
+
+      const preconnectLinks = dom.window.document.querySelectorAll('link[rel="preconnect"]')
+      expect(preconnectLinks).toHaveLength(1)
+      expect(preconnectLinks[0].getAttribute('href')).toBe('https://sanity-cdn.com')
+      expect(preconnectLinks[0].getAttribute('crossorigin')).toBe('anonymous')
+    })
+  })
+
+  test('modulepreloads sanity with a timestamp matching the importmap entry (no double fetch)', () => {
+    const importMap = {
+      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
+    }
+    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+    const dom = createRuntimeDom(result, chromeUserAgent)
+
+    const preloadLinks = dom.window.document.querySelectorAll('link[rel="modulepreload"]')
+    expect(preloadLinks).toHaveLength(1)
+    const preloadHref = preloadLinks[0].getAttribute('href')
+    expect(preloadHref).toBe(
+      'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000',
+    )
+    expect(preloadLinks[0].getAttribute('crossorigin')).toBe('anonymous')
+
+    const importMapEl = dom.window.document.querySelector('script[type="importmap"]')
+    const runtimeImportMap = JSON.parse(importMapEl?.textContent || '{}') as {
+      imports?: Record<string, string>
+    }
+    // The preload href must equal what the importmap resolves `sanity` to,
+    // otherwise the browser fetches the largest chunk twice.
+    expect(preloadHref).toBe(runtimeImportMap.imports?.sanity)
+  })
+
+  test('emits no hints when sanity resolves to a non-CDN host', () => {
+    const importMap = {imports: {sanity: 'https://example.com/modules/sanity/index.js'}}
+    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+    const dom = createRuntimeDom(result, chromeUserAgent)
+
+    expect(dom.window.document.querySelectorAll('link[rel="preconnect"]')).toHaveLength(0)
+    expect(dom.window.document.querySelectorAll('link[rel="modulepreload"]')).toHaveLength(0)
+  })
+
+  test('emits no hints when no import resolves to a sanity-cdn host', () => {
+    const importMap = {
+      imports: {external: 'https://example.com/modules/external/index.js'},
+    }
+    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+    const dom = createRuntimeDom(result, chromeUserAgent)
+
+    expect(dom.window.document.querySelectorAll('link[rel="preconnect"]')).toHaveLength(0)
+    expect(dom.window.document.querySelectorAll('link[rel="modulepreload"]')).toHaveLength(0)
+  })
+
+  describe.each([
+    ['desktop Safari', desktopSafariUserAgent],
+    ['iOS Safari', iosSafariUserAgent],
+    ['an iOS webview with a Chrome token (device guard wins)', iosChromeTokenUserAgent],
+    ['an unrecognised engine', unknownEngineUserAgent],
+  ])('modulepreload is withheld outside the allowlist (%s)', (_label, gatedUserAgent) => {
+    const importMap = {
+      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
+    }
+    const cssUrls = [
+      'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890/index.css',
+    ]
+
+    test('withholds the modulepreload while keeping the safe preconnect', () => {
+      const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+      const dom = createRuntimeDom(result, gatedUserAgent)
+
+      expect(dom.window.document.querySelectorAll('link[rel="modulepreload"]')).toHaveLength(0)
+      expect(dom.window.document.querySelectorAll('link[rel="preconnect"]')).toHaveLength(1)
+    })
+
+    test('still rewrites the import map and emits stylesheet links (graceful fallback)', () => {
+      const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap, cssUrls)
+      const dom = createRuntimeDom(result, gatedUserAgent)
+
+      const importMapEl = dom.window.document.querySelector('script[type="importmap"]')
+      const runtimeImportMap = JSON.parse(importMapEl?.textContent || '{}') as {
+        imports?: Record<string, string>
+      }
+      expect(runtimeImportMap.imports?.sanity).toBe(
+        'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000',
+      )
+
+      const stylesheetLinks = [
+        ...dom.window.document.querySelectorAll('link[rel="stylesheet"]'),
+      ].map((link) => link.getAttribute('href'))
+      expect(stylesheetLinks).toEqual([
+        'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000/index.css',
+      ])
+    })
   })
 })

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/addTimestampImportMapScriptToHtml.ts
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/addTimestampImportMapScriptToHtml.ts
@@ -22,10 +22,22 @@ const TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT = `<script>
   importMapEl.type = 'importmap';
   const newTimestamp = \`/t\${Math.floor(Date.now() / 1000)}\`;
 
+  function isSanityCdnHost(hostname) {
+    return /^sanity-cdn\\.[a-zA-Z]+$/.test(hostname);
+  }
+
+  function isSanityCdnUrl(urlStr) {
+    try {
+      return isSanityCdnHost(new URL(urlStr).hostname);
+    } catch {
+      return false;
+    }
+  }
+
   function replaceTimestamp(urlStr) {
     try {
       const url = new URL(urlStr);
-      if (/^sanity-cdn\\.[a-zA-Z]+$/.test(url.hostname)) {
+      if (isSanityCdnHost(url.hostname)) {
         url.pathname = url.pathname.replace(/\\/t\\d+/, newTimestamp);
       }
       return url.toString();
@@ -48,6 +60,55 @@ const TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT = `<script>
     linkEl.rel = 'stylesheet';
     linkEl.href = replaceTimestamp(cssUrl);
     document.head.appendChild(linkEl);
+  }
+
+  // The CDN serves the \`sanity\` module via a cross-origin 302
+  // (sanity-cdn.com -> modules.sanity-cdn.com). WebKit mishandles a
+  // \`modulepreload\` that follows a cross-origin redirect: it forces the CORS
+  // credentials flag true even for \`crossorigin="anonymous"\`, then rejects the
+  // redirect because the CDN sends no \`Access-Control-Allow-Credentials\`,
+  // which blanks the studio. (This is why these hints were reverted; see
+  // PR #1400.)
+  //
+  // \`preconnect\` only warms a socket; it never follows the redirect or fetches
+  // the module, so it is safe in every engine and runs unconditionally.
+  const firstCdnImport = Object.values(imports).find(isSanityCdnUrl);
+
+  if (firstCdnImport) {
+    const preconnectEl = document.createElement('link');
+    preconnectEl.rel = 'preconnect';
+    preconnectEl.href = new URL(firstCdnImport).origin;
+    // Module fetches are CORS; without crossorigin the warmed socket is not reused.
+    preconnectEl.crossOrigin = 'anonymous';
+    document.head.appendChild(preconnectEl);
+  }
+
+  // \`modulepreload\` is the hint that follows the redirect and can blank the
+  // studio in WebKit, so it is gated behind a positive allowlist: it runs only
+  // for engines confirmed to handle the cross-origin redirect, i.e. Chromium or
+  // Gecko. Every Chromium variant (Edge, Opera, Samsung Internet, ...) carries
+  // the \`Chrome\` token, so matching \`Chrom(e|ium)|Firefox\` covers them without
+  // enumerating brands. The iOS device-name exclusion is the hard guard for the
+  // brick-prone platform: every iOS browser is WebKit regardless of brand, and
+  // iOS in-app webviews carry messy UAs, so nothing on an iOS device is ever
+  // treated as safe. Anything unrecognised falls through to no preload, costing
+  // a missed download rather than bricking the studio.
+  const userAgent = typeof navigator === 'undefined' ? '' : navigator.userAgent || '';
+  const isKnownSafeEngine =
+    !/\\b(iPad|iPhone|iPod)\\b/.test(userAgent) && /Chrom(e|ium)|Firefox/.test(userAgent);
+
+  // The href reuses replaceTimestamp so it matches the importmap entry exactly;
+  // a stale timestamp here would double-fetch the largest chunk.
+  const sanityModuleUrl = imports['sanity'];
+  if (isKnownSafeEngine && typeof sanityModuleUrl === 'string' && isSanityCdnUrl(sanityModuleUrl)) {
+    const preloadEl = document.createElement('link');
+    preloadEl.rel = 'modulepreload';
+    preloadEl.href = replaceTimestamp(sanityModuleUrl);
+    // Must match the preconnect's credentials mode, otherwise the browser
+    // treats them as separate connections and the warmed cross-origin socket
+    // is not reused for this fetch.
+    preloadEl.crossOrigin = 'anonymous';
+    document.head.appendChild(preloadEl);
   }
 </script>`
 


### PR DESCRIPTION
### Description

Re-introduces the `preconnect` + `modulepreload` resource hints for the CDN `sanity` module in the auto-update studio HTML, originally added in #1276 and reverted in #1400. This time the risky hint is gated so it cannot break Safari.

#1276 was reverted because it blanked auto-update studios in Safari. The studio loads the `sanity` module from `sanity-cdn.com`, which responds with a cross-origin redirect to the bucket that actually holds the bytes (`modules.sanity-cdn.com`). That redirect is the auto-update mechanism: it resolves a version range to a specific pinned build. When a `modulepreload` follows a cross-origin redirect, WebKit (Safari) forces the request into credentialed CORS mode even though the hint is `crossorigin="anonymous"` - a WebKit bug. The bytes are served straight from storage with `Access-Control-Allow-Origin: *` and no credentials header, so the credentialed check fails, the preload errors, and the studio renders blank. Chromium and Firefox follow the same redirect correctly, which is why #1276 passed review and only Safari broke.

This PR re-lands the hints with the unsafe one gated behind a browser allowlist (default-deny):

- `preconnect` only opens a connection; it never follows the redirect or downloads the module, so it is safe everywhere and runs unconditionally.
- `modulepreload` is emitted only for engines confirmed to handle the cross-origin redirect (Chromium or Gecko, with all iOS devices excluded). Any other or unrecognised engine falls back to the normal import-map load - a missed download, never a blank studio. A denylist was rejected on purpose: a missed Safari user-agent would fail dangerous, whereas default-deny fails safe.

Why this is not fixed in the server layer instead: the proper fix has to change what the module origin serves, and that is infrastructure work owned outside the CLI, not a code change here. The module bytes come from a storage/CDN bucket that our API gateway never sees, so we cannot patch the response headers there. A real fix is one of: serve the module bytes from the same origin as the redirect (so there is no cross-origin hop and the bug never triggers), or front the bucket with an edge that returns a specific `Access-Control-Allow-Origin` plus `Access-Control-Allow-Credentials: true` (the storage bucket alone cannot send either). Both are larger, riskier changes than this CLI gate, and they extend the optimization to Safari rather than block it. This PR recovers the win now for the browsers that can already use it, safely; the infra fix can follow.

### What to review

- `packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/addTimestampImportMapScriptToHtml.ts` - the injected runtime script. Focus on the gating predicate `isKnownSafeEngine` (`!/\b(iPad|iPhone|iPod)\b/.test(ua) && /Chrom(e|ium)|Firefox/.test(ua)`): `preconnect` runs unconditionally, `modulepreload` only when it passes.
- The `modulepreload` href reuses `replaceTimestamp(...)` so it matches the import-map entry exactly; a mismatched timestamp would download the largest chunk twice. Both hints use `crossorigin="anonymous"` so the warmed connection is reused for the module fetch.
- Affected flow: auto-update studio builds only. Non-CDN import maps emit no hints.

### Testing

Unit tests in `__tests__/addTimestampImportMapScriptToHtml.test.ts` run the injected script in JSDOM with a stubbed `navigator.userAgent`:

- `preconnect` is emitted with `crossorigin="anonymous"` across every engine (desktop Chrome, desktop Safari, iOS Safari, iOS webview with a `Chrome` token, unrecognised engine).
- `modulepreload` is emitted only for the allowlisted engine, with a timestamp equal to the import-map entry (guards against the double download).
- `modulepreload` is withheld for desktop Safari, iOS Safari, an iOS user-agent carrying a `Chrome` token (proving the iOS guard is load-bearing), and an unrecognised engine, while the safe `preconnect` and the import-map and stylesheet rewrites still happen.
- No hints when `sanity` resolves to a non-CDN host, or when no import is a `sanity-cdn` host.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production HTML for auto-update studios and browser-specific loading behavior; gating is default-deny so WebKit should not regress, but UA heuristics could misclassify edge clients (missed preload only).
> 
> **Overview**
> Re-lands **CDN resource hints** in the auto-update studio HTML injector (`addTimestampImportMapScriptToHtml.ts`), after they were removed in #1400 because **`modulepreload` blanked WebKit** when following the CDN’s cross-origin redirect.
> 
> For import maps that resolve to **`sanity-cdn` hosts**, the runtime script now always injects **`link rel="preconnect"`** (with `crossorigin="anonymous"`) to warm the CDN connection. It injects **`link rel="modulepreload"`** for the `sanity` entry **only** when `navigator.userAgent` passes a **default-deny allowlist**: not an iOS device (`iPad|iPhone|iPod`) and Chromium or Firefox. Safari, iOS (including Chrome-branded UAs), and unknown engines still get the import map and preconnect but **no modulepreload**, avoiding the WebKit CORS/redirect bug at the cost of a possible extra fetch. Hints are skipped when nothing points at a sanity-cdn host; the preload URL reuses the same timestamp rewrite as the import map to avoid double-downloading the main chunk.
> 
> **Tests** exercise the injected script in JSDOM with stubbed `userAgent`, covering preconnect everywhere, preload only on allowlisted UAs, graceful fallback when preload is withheld, and no hints for non-CDN maps. **AGENTS.md** documents automatic changesets; a **minor changeset** is included for `@sanity/cli-build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc94fe311934a386f3e6f5d433c11b048a9d4c7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->