### PR TITLE
feat: use OAuth for authenticating MCP in `sanity init` for more clients

### DIFF
--- a/.changeset/green-pears-doubt.md
+++ b/.changeset/green-pears-doubt.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": minor
+---
+
+OpenCode is now configured to use OAuth when initializing the Sanity MCP server

--- a/.changeset/green-pears-doubt.md
+++ b/.changeset/green-pears-doubt.md
@@ -2,4 +2,4 @@
 "@sanity/cli": minor
 ---
 
-OpenCode is now configured to use OAuth when initializing the Sanity MCP server
+OpenCode, VS Code, and VS Code Insiders are now configured to use OAuth when initializing the Sanity MCP server

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
@@ -90,6 +90,15 @@ describe('buildServerConfig', () => {
     })
   })
 
+  test('OpenCode config uses OAuth (no Authorization header)', () => {
+    const config = EDITOR_CONFIGS.OpenCode.buildServerConfig()
+
+    expect(config).toStrictEqual({
+      type: 'remote',
+      url: 'https://mcp.sanity.io',
+    })
+  })
+
   test('all editors except OAuth-only ones include auth credentials', () => {
     const editorsWithToken = [
       'Antigravity',
@@ -98,7 +107,6 @@ describe('buildServerConfig', () => {
       'Gemini CLI',
       'GitHub Copilot CLI',
       'MCPorter',
-      'OpenCode',
       'VS Code',
       'VS Code Insiders',
       'Zed',

--- a/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
+++ b/packages/@sanity/cli/src/actions/mcp/__tests__/editorConfigs.test.ts
@@ -61,11 +61,19 @@ describe('buildServerConfig', () => {
     })
   })
 
-  test('VS Code config includes Authorization header with token', () => {
-    const config = EDITOR_CONFIGS['VS Code'].buildServerConfig(testToken)
+  test('VS Code config uses OAuth (no Authorization header)', () => {
+    const config = EDITOR_CONFIGS['VS Code'].buildServerConfig()
 
     expect(config).toStrictEqual({
-      headers: {Authorization: `Bearer ${testToken}`},
+      type: 'http',
+      url: 'https://mcp.sanity.io',
+    })
+  })
+
+  test('VS Code Insiders config uses OAuth (no Authorization header)', () => {
+    const config = EDITOR_CONFIGS['VS Code Insiders'].buildServerConfig()
+
+    expect(config).toStrictEqual({
       type: 'http',
       url: 'https://mcp.sanity.io',
     })
@@ -107,8 +115,6 @@ describe('buildServerConfig', () => {
       'Gemini CLI',
       'GitHub Copilot CLI',
       'MCPorter',
-      'VS Code',
-      'VS Code Insiders',
       'Zed',
     ] as const
 

--- a/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
+++ b/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
@@ -281,12 +281,17 @@ function buildGitHubCopilotCliServerConfig(token: string): Record<string, unknow
   }
 }
 
-function buildOpenCodeServerConfig(token: string): Record<string, unknown> {
-  return {
-    headers: {Authorization: `Bearer ${token}`},
+function buildOpenCodeServerConfig(token?: string): Record<string, unknown> {
+  const config: Record<string, unknown> = {
     type: 'remote',
     url: MCP_SERVER_URL,
   }
+
+  if (token) {
+    config.headers = {Authorization: `Bearer ${token}`}
+  }
+
+  return config
 }
 
 function buildZedServerConfig(token: string): Record<string, unknown> {
@@ -379,6 +384,7 @@ export const EDITOR_CONFIGS = {
     buildServerConfig: buildOpenCodeServerConfig,
     configKey: 'mcp',
     detect: detectOpenCode,
+    oauthOnly: true,
     skillsCliAgent: 'opencode',
   },
   // Doc: https://code.visualstudio.com/docs/copilot/chat/mcp-servers

--- a/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
+++ b/packages/@sanity/cli/src/actions/mcp/editorConfigs.ts
@@ -395,6 +395,7 @@ export const EDITOR_CONFIGS = {
     ...EDITOR_DEFAULTS,
     configKey: 'servers',
     detect: detectVSCode,
+    oauthOnly: true,
     skillsCliAgent: 'github-copilot',
   },
   // Doc: https://code.visualstudio.com/docs/copilot/chat/mcp-servers
@@ -403,6 +404,7 @@ export const EDITOR_CONFIGS = {
     ...EDITOR_DEFAULTS,
     configKey: 'servers',
     detect: detectVSCodeInsiders,
+    oauthOnly: true,
     skillsCliAgent: 'github-copilot',
   },
   // Doc: https://zed.dev/docs/assistant/model-context-protocol

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -323,6 +323,7 @@ const editorTestCases: EditorTestCase[] = [
     detect: {cliCommands: ['opencode'], overridePlatform: 'darwin'},
     expectedConfigPath: '.config/opencode/opencode.json',
     name: 'OpenCode',
+    oauthOnly: true,
     platform: 'darwin',
   },
   {
@@ -659,8 +660,6 @@ describe.sequential('#mcp:configure', () => {
 
     mockCheckbox.mockResolvedValue(['Cursor', 'VS Code'])
 
-    mockMCPTokenCreation('multi-token-123')
-
     const {stdout} = await testCommand(ConfigureMcpCommand, [])
 
     expect(mockWriteFile).toHaveBeenCalledTimes(2)
@@ -672,7 +671,7 @@ describe.sequential('#mcp:configure', () => {
     )
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining(convertToSystemPath('Code/User/mcp.json')),
-      expect.stringContaining('multi-token-123'),
+      expect.not.stringContaining('multi-token-123'),
       'utf8',
     )
 
@@ -687,14 +686,12 @@ describe.sequential('#mcp:configure', () => {
       throw new Error('Not installed')
     }) as never)
 
-    mockMCPTokenCreation('test-token-ci')
-
     const {stdout} = await testCommand(ConfigureMcpCommand, [])
 
     expect(mockCheckbox).not.toHaveBeenCalled()
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining(convertToSystemPath('.config/opencode/opencode.json')),
-      expect.stringContaining('test-token-ci'),
+      expect.not.stringContaining('test-token-ci'),
       'utf8',
     )
     expect(stdout).toContain('MCP configured for OpenCode')
@@ -705,12 +702,11 @@ describe.sequential('#mcp:configure', () => {
   // -------------------------------------------------------------------------
 
   test('handles token creation error gracefully', async () => {
-    mockExeca.mockImplementation((async (command: string | URL) => {
-      if (command === 'opencode') return EXECA_SUCCESS
-      throw new Error('Not installed')
-    }) as never)
+    mockExistsSync.mockImplementation((path: PathLike) => {
+      return String(path).endsWith('.gemini/settings.json')
+    })
 
-    mockCheckbox.mockResolvedValue(['OpenCode'])
+    mockCheckbox.mockResolvedValue(['Gemini CLI'])
 
     mockCreateMCPToken.mockRejectedValueOnce(new Error('Not authenticated'))
 
@@ -728,8 +724,6 @@ describe.sequential('#mcp:configure', () => {
     }) as never)
 
     mockCheckbox.mockResolvedValue(['OpenCode'])
-
-    mockMCPTokenCreation('token-write-error')
 
     mockWriteFile.mockRejectedValue(new Error('Permission denied'))
 
@@ -787,8 +781,6 @@ describe.sequential('#mcp:configure', () => {
     )
 
     mockCheckbox.mockResolvedValue(['OpenCode'])
-
-    mockMCPTokenCreation('merge-token-123')
 
     await testCommand(ConfigureMcpCommand, [])
 

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -212,6 +212,7 @@ const editorTestCases: EditorTestCase[] = [
     },
     expectedConfigPath: 'Code/User/mcp.json',
     name: 'VS Code',
+    oauthOnly: true,
     platform: 'darwin',
   },
   {
@@ -222,6 +223,7 @@ const editorTestCases: EditorTestCase[] = [
     },
     expectedConfigPath: String.raw`AppData\Roaming\Code\User\mcp.json`,
     name: 'VS Code',
+    oauthOnly: true,
     platform: 'win32',
   },
   {
@@ -231,6 +233,7 @@ const editorTestCases: EditorTestCase[] = [
     },
     expectedConfigPath: 'Code - Insiders/User/mcp.json',
     name: 'VS Code Insiders',
+    oauthOnly: true,
     platform: 'darwin',
   },
   {
@@ -241,6 +244,7 @@ const editorTestCases: EditorTestCase[] = [
     },
     expectedConfigPath: String.raw`AppData\Roaming\Code - Insiders\User\mcp.json`,
     name: 'VS Code Insiders',
+    oauthOnly: true,
     platform: 'win32',
   },
   {

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -707,7 +707,8 @@ describe.sequential('#mcp:configure', () => {
 
   test('handles token creation error gracefully', async () => {
     mockExistsSync.mockImplementation((path: PathLike) => {
-      return String(path).endsWith('.gemini/settings.json')
+      const normalized = String(path).replaceAll('\\', '/')
+      return normalized.endsWith('/.gemini/settings.json')
     })
 
     mockCheckbox.mockResolvedValue(['Gemini CLI'])


### PR DESCRIPTION
Use OAuth (instead of generating a Bearer auth token) for a few more MCP clients who have now improved their MCP authentication flows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only MCP config behavior change for three editors; no server auth or data-path changes, with test coverage aligned to OAuth-only output.
> 
> **Overview**
> **OpenCode**, **VS Code**, and **VS Code Insiders** are now treated like other OAuth-native MCP clients during `sanity` MCP configuration: written configs point at `https://mcp.sanity.io` **without** embedding a Bearer token.
> 
> In `editorConfigs`, those three editors get `oauthOnly: true`. **OpenCode**’s `buildOpenCodeServerConfig` now omits `Authorization` headers when no token is passed (token remains optional for legacy paths). Tests were updated so configure flows for these editors no longer expect MCP token creation or tokens in written files; the token-creation failure case now uses **Gemini CLI** instead of OpenCode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34dfca9e937f2e44ef1da361c4c2def3eb7fff91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->