### PR TITLE
refactor(deploy): restructure core app deploy and extract shared deploy checks

### DIFF
--- a/.changeset/refactor-core-app-deploy.md
+++ b/.changeset/refactor-core-app-deploy.md
@@ -1,0 +1,5 @@
+---
+"@sanity/workbench-cli": patch
+---
+
+refactor(deploy): restructure core app deploy and extract shared deploy checks

--- a/.changeset/refactor-core-app-deploy.md
+++ b/.changeset/refactor-core-app-deploy.md
@@ -1,4 +1,5 @@
 ---
+"@sanity/cli": patch
 "@sanity/workbench-cli": patch
 ---
 

--- a/packages/@sanity/cli/src/actions/build/__tests__/shouldAutoUpdate.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/shouldAutoUpdate.test.ts
@@ -1,7 +1,7 @@
 import {type Output} from '@sanity/cli-core'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {shouldAutoUpdate} from '../shouldAutoUpdate'
+import {resolveAutoUpdates, shouldAutoUpdate} from '../shouldAutoUpdate'
 import {type BuildFlags} from '../types'
 
 describe('shouldAutoUpdate', () => {
@@ -234,5 +234,57 @@ describe('shouldAutoUpdate', () => {
       )
       expect(mockOutput.warn).toHaveBeenCalledTimes(1)
     })
+  })
+})
+
+describe('resolveAutoUpdates', () => {
+  it('returns disabled with no issue when nothing is configured', () => {
+    expect(resolveAutoUpdates({cliConfig: {}, flags: {} as BuildFlags})).toEqual({
+      enabled: false,
+      issue: null,
+    })
+  })
+
+  it('reads deployment.autoUpdates without an issue', () => {
+    expect(
+      resolveAutoUpdates({cliConfig: {deployment: {autoUpdates: true}}, flags: {} as BuildFlags}),
+    ).toEqual({enabled: true, issue: null})
+    expect(
+      resolveAutoUpdates({cliConfig: {deployment: {autoUpdates: false}}, flags: {} as BuildFlags}),
+    ).toEqual({enabled: false, issue: null})
+  })
+
+  it('reports the deprecated top-level config', () => {
+    expect(resolveAutoUpdates({cliConfig: {autoUpdates: true}, flags: {} as BuildFlags})).toEqual({
+      enabled: true,
+      issue: {type: 'deprecated-config'},
+    })
+  })
+
+  it('reports a conflict when both configs are present, preferring the new value', () => {
+    expect(
+      resolveAutoUpdates({
+        cliConfig: {autoUpdates: true, deployment: {autoUpdates: false}},
+        flags: {} as BuildFlags,
+      }),
+    ).toEqual({enabled: false, issue: {type: 'conflicting-config'}})
+  })
+
+  it('reports the deprecated flag and takes its value', () => {
+    expect(
+      resolveAutoUpdates({cliConfig: {}, flags: {'auto-updates': true} as BuildFlags}),
+    ).toEqual({enabled: true, issue: {flag: '--auto-updates', type: 'deprecated-flag'}})
+    expect(
+      resolveAutoUpdates({cliConfig: {}, flags: {'auto-updates': false} as BuildFlags}),
+    ).toEqual({enabled: false, issue: {flag: '--no-auto-updates', type: 'deprecated-flag'}})
+  })
+
+  it('lets the flag take precedence over config, masking config issues', () => {
+    expect(
+      resolveAutoUpdates({
+        cliConfig: {autoUpdates: true, deployment: {autoUpdates: true}},
+        flags: {'auto-updates': false} as BuildFlags,
+      }),
+    ).toEqual({enabled: false, issue: {flag: '--no-auto-updates', type: 'deprecated-flag'}})
   })
 })

--- a/packages/@sanity/cli/src/actions/build/shouldAutoUpdate.ts
+++ b/packages/@sanity/cli/src/actions/build/shouldAutoUpdate.ts
@@ -9,23 +9,39 @@ import {type BuildFlags} from './types.js'
 interface AutoUpdateSources {
   cliConfig: CliConfig
   flags: BuildFlags | DeployFlags | DevFlags
-  output: Output
 }
 
 /**
- * Compares parameters from various sources to determine whether or not to auto-update.
- * @remarks Throws an error if both the old and new auto update config are used; throws a warning if the old config is used, or if the auto updates flags are used.
+ * The single auto-update configuration problem to surface, if any.
+ * Flag usage takes precedence over config problems: when the deprecated flag
+ * is passed, config is not consulted, so config issues are not reported.
+ */
+type AutoUpdateIssue =
+  | {flag: '--auto-updates' | '--no-auto-updates'; type: 'deprecated-flag'}
+  | {type: 'conflicting-config'}
+  | {type: 'deprecated-config'}
+
+export interface AutoUpdateSettings {
+  enabled: boolean
+  issue: AutoUpdateIssue | null
+}
+
+/**
+ * Owns the auto-update rules: flag-over-config precedence, the deprecated
+ * top-level `autoUpdates` config, and the old/new config conflict.
+ * Returns plain facts so each surface (deploy warnings, dry-run checks)
+ * decides its own presentation.
+ *
  * @internal
  */
-export function shouldAutoUpdate({cliConfig, flags, output}: AutoUpdateSources): boolean {
-  // Auto updates in flags is deprecated; throw a warning if used
+export function resolveAutoUpdates({cliConfig, flags}: AutoUpdateSources): AutoUpdateSettings {
+  // Flags always take precedence over config
   if ('auto-updates' in flags) {
-    const flagUsed = flags['auto-updates'] ? '--auto-updates' : '--no-auto-updates'
-    output.warn(
-      `The ${flagUsed} flag is deprecated for deploy and build commands. Set the autoUpdates option in the deployment section of sanity.cli.ts or sanity.cli.js instead.`,
-    )
-    // Flags always take precedence over config
-    return Boolean(flags['auto-updates'])
+    const enabled = Boolean(flags['auto-updates'])
+    return {
+      enabled,
+      issue: {flag: enabled ? '--auto-updates' : '--no-auto-updates', type: 'deprecated-flag'},
+    }
   }
 
   const hasOldConfig = cliConfig && 'autoUpdates' in cliConfig
@@ -36,30 +52,86 @@ export function shouldAutoUpdate({cliConfig, flags, output}: AutoUpdateSources):
     cliConfig.deployment &&
     'autoUpdates' in cliConfig.deployment
 
-  if (hasOldConfig && hasNewConfig) {
-    output.error(
-      'Found both `autoUpdates` (deprecated) and `deployment.autoUpdates` in sanity.cli.js/.ts. Please remove the deprecated top level `autoUpdates` config.',
-      {
-        exit: 1,
-      },
-    )
-  }
-
-  if (hasOldConfig) {
-    output.warn('The autoUpdates config has moved to deployment.autoUpdates.')
-    output.warn(`Please update sanity.cli.ts or sanity.cli.js and make the following change:
-  ${styleText('red', `-  autoUpdates: ${cliConfig.autoUpdates},`)}
-  ${styleText('green', `+  deployment: {autoUpdates: ${cliConfig.autoUpdates}}`)}
-`)
-  }
-
   if (hasNewConfig) {
-    return Boolean(cliConfig?.deployment?.autoUpdates)
+    return {
+      enabled: Boolean(cliConfig?.deployment?.autoUpdates),
+      issue: hasOldConfig ? {type: 'conflicting-config'} : null,
+    }
   }
 
   if (hasOldConfig) {
-    return Boolean(cliConfig?.autoUpdates)
+    return {enabled: Boolean(cliConfig?.autoUpdates), issue: {type: 'deprecated-config'}}
   }
 
-  return false
+  return {enabled: false, issue: null}
+}
+
+/**
+ * The user-facing message for an auto-update configuration problem.
+ * Shared by every surface that reports the issue (deploy warnings, dry-run
+ * checks) so the wording has one home.
+ *
+ * @internal
+ */
+export function getAutoUpdateIssueMessage(issue: AutoUpdateIssue): string {
+  switch (issue.type) {
+    case 'conflicting-config': {
+      return 'Found both `autoUpdates` (deprecated) and `deployment.autoUpdates` in sanity.cli.js/.ts. Please remove the deprecated top level `autoUpdates` config.'
+    }
+    case 'deprecated-config': {
+      return 'The autoUpdates config has moved to deployment.autoUpdates.'
+    }
+    case 'deprecated-flag': {
+      return `The ${issue.flag} flag is deprecated for deploy and build commands. Set the autoUpdates option in the deployment section of sanity.cli.ts or sanity.cli.js instead.`
+    }
+  }
+}
+
+/**
+ * The styled before/after edit that migrates the deprecated top-level
+ * `autoUpdates` to `deployment.autoUpdates`. Lives here so every surface that
+ * reports the deprecated config (deploy warnings, dry-run checks) shows the
+ * same migration hint.
+ *
+ * @internal
+ */
+export function getAutoUpdateMigrationHint(currentValue: unknown): string {
+  return `Please update sanity.cli.ts or sanity.cli.js and make the following change:
+  ${styleText('red', `-  autoUpdates: ${currentValue},`)}
+  ${styleText('green', `+  deployment: {autoUpdates: ${currentValue}}`)}
+`
+}
+
+/**
+ * Resolves the auto-update setting and prints any configuration problem.
+ * @remarks Throws an error if both the old and new auto update config are used; throws a warning if the old config is used, or if the auto updates flags are used.
+ * @internal
+ */
+export function shouldAutoUpdate({
+  cliConfig,
+  flags,
+  output,
+}: AutoUpdateSources & {output: Output}): boolean {
+  const {enabled, issue} = resolveAutoUpdates({cliConfig, flags})
+
+  switch (issue?.type) {
+    case 'conflicting-config': {
+      output.error(getAutoUpdateIssueMessage(issue), {exit: 1})
+      break
+    }
+    case 'deprecated-config': {
+      output.warn(getAutoUpdateIssueMessage(issue))
+      output.warn(getAutoUpdateMigrationHint(cliConfig.autoUpdates))
+      break
+    }
+    case 'deprecated-flag': {
+      output.warn(getAutoUpdateIssueMessage(issue))
+      break
+    }
+    default: {
+      break
+    }
+  }
+
+  return enabled
 }

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -40,19 +40,19 @@ beforeEach(() => vi.clearAllMocks())
 describe('createFailFastReporter', () => {
   test('a fail exits with its exit code', () => {
     const output = mockOutput()
-    createFailFastReporter(output).report({exitCode: 2, message: 'boom', name: 'x', status: 'fail'})
+    createFailFastReporter(output).report({exitCode: 2, message: 'boom', status: 'fail'})
     expect(output.error).toHaveBeenCalledWith('boom', {exit: 2})
   })
 
   test('a fail without an exit code defaults to 1', () => {
     const output = mockOutput()
-    createFailFastReporter(output).report({message: 'boom', name: 'x', status: 'fail'})
+    createFailFastReporter(output).report({message: 'boom', status: 'fail'})
     expect(output.error).toHaveBeenCalledWith('boom', {exit: 1})
   })
 
   test('a warn prints and does not exit', () => {
     const output = mockOutput()
-    createFailFastReporter(output).report({message: 'heads up', name: 'x', status: 'warn'})
+    createFailFastReporter(output).report({message: 'heads up', status: 'warn'})
     expect(output.warn).toHaveBeenCalledWith('heads up')
     expect(output.error).not.toHaveBeenCalled()
   })
@@ -60,8 +60,8 @@ describe('createFailFastReporter', () => {
   test('pass and skip are silent', () => {
     const output = mockOutput()
     const reporter = createFailFastReporter(output)
-    reporter.report({message: 'good', name: 'x', status: 'pass'})
-    reporter.report({message: 'skipped', name: 'y', status: 'skip'})
+    reporter.report({message: 'good', status: 'pass'})
+    reporter.report({message: 'skipped', status: 'skip'})
     expect(output.error).not.toHaveBeenCalled()
     expect(output.warn).not.toHaveBeenCalled()
   })
@@ -70,8 +70,8 @@ describe('createFailFastReporter', () => {
 describe('createCollectingReporter', () => {
   test('collects every reported check on results', () => {
     const reporter = createCollectingReporter()
-    reporter.report({message: 'ok', name: 'a', status: 'pass'})
-    reporter.report({message: 'bad', name: 'b', status: 'fail'})
+    reporter.report({message: 'ok', status: 'pass'})
+    reporter.report({message: 'bad', status: 'fail'})
     expect(reporter.results).toHaveLength(2)
   })
 })
@@ -90,7 +90,7 @@ describe('runStep', () => {
       throw new Error('nope')
     })
     expect(result).toBeNull()
-    expect(reporter.results[0]).toMatchObject({name: 'boom', status: 'fail'})
+    expect(reporter.results[0]).toMatchObject({status: 'fail'})
     expect(reporter.results[0]?.message).toContain('nope')
   })
 
@@ -109,44 +109,25 @@ describe('runStep', () => {
 })
 
 describe('checkAppTarget', () => {
-  test('found → pass check, existing app and target', async () => {
+  test('found → pass check for the existing application', async () => {
     const app = application({appHost: 'app-host', id: 'core-1', title: 'My App', type: 'coreApp'})
     mockResolveApp.mockResolvedValue({application: app, type: 'found'})
     const reporter = createCollectingReporter()
 
-    const {existingApp, target} = await checkAppTarget(reporter, {
-      appId: 'core-1',
-      organizationId: 'org-1',
-    })
+    await checkAppTarget(reporter, {appId: 'core-1', organizationId: 'org-1'})
 
-    expect(existingApp).toBe(app)
-    expect(target).toEqual({
-      appId: 'core-1',
-      exists: true,
-      host: 'app-host',
-      isExternal: false,
-      type: 'coreApp',
-    })
+    expect(reporter.results[0]).toMatchObject({status: 'pass'})
     expect(reporter.results[0]?.message).toContain('Deploys to existing application "My App"')
   })
 
-  test('would-create → pass check, no existing app', async () => {
+  test('would-create → pass check', async () => {
     mockResolveApp.mockResolvedValue({type: 'would-create'})
     const reporter = createCollectingReporter()
 
-    const {existingApp, target} = await checkAppTarget(reporter, {
-      appId: undefined,
-      organizationId: 'org-1',
-    })
+    await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
 
-    expect(existingApp).toBeNull()
-    expect(target).toEqual({
-      appId: null,
-      exists: false,
-      host: null,
-      isExternal: false,
-      type: 'coreApp',
-    })
+    expect(reporter.results[0]).toMatchObject({status: 'pass'})
+    expect(reporter.results[0]?.message).toContain('Would create a new application deployment')
   })
 
   test('needs-input → fail check (would prompt)', async () => {
@@ -156,10 +137,9 @@ describe('checkAppTarget', () => {
     })
     const reporter = createCollectingReporter()
 
-    const {target} = await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
+    await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
 
-    expect(target).toBeNull()
-    expect(reporter.results[0]).toMatchObject({name: 'target', status: 'fail'})
+    expect(reporter.results[0]).toMatchObject({status: 'fail'})
     expect(reporter.results[0]?.message).toContain('2 existing applications found')
   })
 
@@ -171,9 +151,8 @@ describe('checkAppTarget', () => {
     })
     const reporter = createCollectingReporter()
 
-    const {target} = await checkAppTarget(reporter, {appId: 'nope', organizationId: 'org-1'})
+    await checkAppTarget(reporter, {appId: 'nope', organizationId: 'org-1'})
 
-    expect(target).toBeNull()
     expect(reporter.results[0]?.status).toBe('fail')
   })
 
@@ -181,9 +160,9 @@ describe('checkAppTarget', () => {
     mockResolveApp.mockRejectedValue(Object.assign(new Error('forbidden'), {statusCode: 403}))
     const reporter = createCollectingReporter()
 
-    const {target} = await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
+    await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
 
-    expect(target).toBeNull()
+    expect(reporter.results[0]?.status).toBe('fail')
     expect(reporter.results[0]?.message).toContain('don’t have permission')
   })
 })
@@ -198,9 +177,7 @@ describe('checkAutoUpdates', () => {
     })
 
     expect(enabled).toBe(false)
-    expect(reporter.results).toEqual([
-      expect.objectContaining({name: 'auto-updates', status: 'fail'}),
-    ])
+    expect(reporter.results).toEqual([expect.objectContaining({status: 'fail'})])
   })
 
   test('the deprecated top-level config warns and includes the migration edit', () => {
@@ -213,9 +190,7 @@ describe('checkAutoUpdates', () => {
 
     expect(enabled).toBe(true)
     expect(reporter.results).toHaveLength(2)
-    expect(reporter.results.every((c) => c.name === 'auto-updates' && c.status === 'warn')).toBe(
-      true,
-    )
+    expect(reporter.results.every((c) => c.status === 'warn')).toBe(true)
     expect(reporter.results[0]?.message).toContain('autoUpdates config has moved')
     expect(reporter.results[1]?.message).toContain('Please update sanity.cli.ts')
     expect(reporter.results[1]?.message).toContain('deployment: {autoUpdates: true}')
@@ -226,9 +201,7 @@ describe('checkAutoUpdates', () => {
 
     checkAutoUpdates(reporter, {cliConfig: {}, flags: {'auto-updates': true} as DeployFlags})
 
-    expect(reporter.results).toEqual([
-      expect.objectContaining({name: 'auto-updates', status: 'warn'}),
-    ])
+    expect(reporter.results).toEqual([expect.objectContaining({status: 'warn'})])
   })
 
   test('a clean config records no check', () => {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -154,6 +154,7 @@ describe('checkAppTarget', () => {
     await checkAppTarget(reporter, {appId: 'nope', organizationId: 'org-1'})
 
     expect(reporter.results[0]?.status).toBe('fail')
+    expect(reporter.results[0]?.solution).toContain('deployment.appId')
   })
 
   test('a 403 becomes a permissions fail check', async () => {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -1,7 +1,14 @@
+import {type Output} from '@sanity/cli-core'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {type UserApplication} from '../../../services/userApplications.js'
-import {checkAppTarget, checkAutoUpdates, createAggregatingChecks} from '../deployChecks.js'
+import {
+  checkAppTarget,
+  checkAutoUpdates,
+  createCollectingReporter,
+  createFailFastReporter,
+  runStep,
+} from '../deployChecks.js'
 import {resolveAppDeployTarget} from '../resolveDeployTarget.js'
 import {type DeployFlags} from '../types.js'
 
@@ -10,6 +17,8 @@ vi.mock('../resolveDeployTarget.js', () => ({
 }))
 
 const mockResolveApp = vi.mocked(resolveAppDeployTarget)
+
+const mockOutput = () => ({error: vi.fn(), warn: vi.fn()}) as unknown as Output
 
 function application(overrides: Partial<UserApplication> = {}): UserApplication {
   return {
@@ -28,29 +37,74 @@ function application(overrides: Partial<UserApplication> = {}): UserApplication 
 
 beforeEach(() => vi.clearAllMocks())
 
-describe('createAggregatingChecks', () => {
-  test('records checks without exiting', () => {
-    const checks = createAggregatingChecks()
-    checks.add({message: 'ok', name: 'a', status: 'pass'})
-    checks.add({message: 'bad', name: 'b', status: 'fail'})
-    expect(checks.all()).toHaveLength(2)
+describe('createFailFastReporter', () => {
+  test('a fail exits with its exit code', () => {
+    const output = mockOutput()
+    createFailFastReporter(output).report({exitCode: 2, message: 'boom', name: 'x', status: 'fail'})
+    expect(output.error).toHaveBeenCalledWith('boom', {exit: 2})
   })
 
-  test('a thrown step becomes a fail check', async () => {
-    const checks = createAggregatingChecks()
-    const result = await checks.run('boom', async () => {
+  test('a fail without an exit code defaults to 1', () => {
+    const output = mockOutput()
+    createFailFastReporter(output).report({message: 'boom', name: 'x', status: 'fail'})
+    expect(output.error).toHaveBeenCalledWith('boom', {exit: 1})
+  })
+
+  test('a warn prints and does not exit', () => {
+    const output = mockOutput()
+    createFailFastReporter(output).report({message: 'heads up', name: 'x', status: 'warn'})
+    expect(output.warn).toHaveBeenCalledWith('heads up')
+    expect(output.error).not.toHaveBeenCalled()
+  })
+
+  test('pass and skip are silent', () => {
+    const output = mockOutput()
+    const reporter = createFailFastReporter(output)
+    reporter.report({message: 'good', name: 'x', status: 'pass'})
+    reporter.report({message: 'skipped', name: 'y', status: 'skip'})
+    expect(output.error).not.toHaveBeenCalled()
+    expect(output.warn).not.toHaveBeenCalled()
+  })
+})
+
+describe('createCollectingReporter', () => {
+  test('collects every reported check on results', () => {
+    const reporter = createCollectingReporter()
+    reporter.report({message: 'ok', name: 'a', status: 'pass'})
+    reporter.report({message: 'bad', name: 'b', status: 'fail'})
+    expect(reporter.results).toHaveLength(2)
+  })
+})
+
+describe('runStep', () => {
+  test('returns the value when the work succeeds', async () => {
+    const reporter = createCollectingReporter()
+    const result = await runStep(reporter, 'ok', async () => 42)
+    expect(result).toBe(42)
+    expect(reporter.results).toHaveLength(0)
+  })
+
+  test('a throw becomes a fail check and returns null', async () => {
+    const reporter = createCollectingReporter()
+    const result = await runStep(reporter, 'boom', async () => {
       throw new Error('nope')
     })
     expect(result).toBeNull()
-    expect(checks.all()[0]).toMatchObject({name: 'boom', status: 'fail'})
-    expect(checks.all()[0]?.message).toContain('nope')
+    expect(reporter.results[0]).toMatchObject({name: 'boom', status: 'fail'})
+    expect(reporter.results[0]?.message).toContain('nope')
   })
 
-  test('run returns the value when the step succeeds', async () => {
-    const checks = createAggregatingChecks()
-    const result = await checks.run('ok', async () => 42)
-    expect(result).toBe(42)
-    expect(checks.all()).toHaveLength(0)
+  test('uses a custom formatError for the fail message', async () => {
+    const reporter = createCollectingReporter()
+    await runStep(
+      reporter,
+      'boom',
+      async () => {
+        throw new Error('raw')
+      },
+      () => 'friendly',
+    )
+    expect(reporter.results[0]?.message).toBe('friendly')
   })
 })
 
@@ -58,9 +112,9 @@ describe('checkAppTarget', () => {
   test('found → pass check, existing app and target', async () => {
     const app = application({appHost: 'app-host', id: 'core-1', title: 'My App', type: 'coreApp'})
     mockResolveApp.mockResolvedValue({application: app, type: 'found'})
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const {existingApp, target} = await checkAppTarget(checks, {
+    const {existingApp, target} = await checkAppTarget(reporter, {
       appId: 'core-1',
       organizationId: 'org-1',
     })
@@ -73,14 +127,14 @@ describe('checkAppTarget', () => {
       isExternal: false,
       type: 'coreApp',
     })
-    expect(checks.all()[0]?.message).toContain('Deploys to existing application "My App"')
+    expect(reporter.results[0]?.message).toContain('Deploys to existing application "My App"')
   })
 
   test('would-create → pass check, no existing app', async () => {
     mockResolveApp.mockResolvedValue({type: 'would-create'})
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const {existingApp, target} = await checkAppTarget(checks, {
+    const {existingApp, target} = await checkAppTarget(reporter, {
       appId: undefined,
       organizationId: 'org-1',
     })
@@ -100,13 +154,13 @@ describe('checkAppTarget', () => {
       existing: [application(), application()],
       type: 'needs-input',
     })
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const {target} = await checkAppTarget(checks, {appId: undefined, organizationId: 'org-1'})
+    const {target} = await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
 
     expect(target).toBeNull()
-    expect(checks.all()[0]).toMatchObject({name: 'target', status: 'fail'})
-    expect(checks.all()[0]?.message).toContain('2 existing applications found')
+    expect(reporter.results[0]).toMatchObject({name: 'target', status: 'fail'})
+    expect(reporter.results[0]?.message).toContain('2 existing applications found')
   })
 
   test('invalid → fail check', async () => {
@@ -115,71 +169,76 @@ describe('checkAppTarget', () => {
       reason: 'app-not-found',
       type: 'invalid',
     })
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const {target} = await checkAppTarget(checks, {appId: 'nope', organizationId: 'org-1'})
+    const {target} = await checkAppTarget(reporter, {appId: 'nope', organizationId: 'org-1'})
 
     expect(target).toBeNull()
-    expect(checks.all()[0]?.status).toBe('fail')
+    expect(reporter.results[0]?.status).toBe('fail')
   })
 
   test('a 403 becomes a permissions fail check', async () => {
     mockResolveApp.mockRejectedValue(Object.assign(new Error('forbidden'), {statusCode: 403}))
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const {target} = await checkAppTarget(checks, {appId: undefined, organizationId: 'org-1'})
+    const {target} = await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
 
     expect(target).toBeNull()
-    expect(checks.all()[0]?.message).toContain('don’t have permission')
+    expect(reporter.results[0]?.message).toContain('don’t have permission')
   })
 })
 
 describe('checkAutoUpdates', () => {
   test('a config conflict is a fail check', () => {
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const enabled = checkAutoUpdates(checks, {
+    const enabled = checkAutoUpdates(reporter, {
       cliConfig: {autoUpdates: true, deployment: {autoUpdates: false}},
       flags: {} as DeployFlags,
     })
 
     expect(enabled).toBe(false)
-    expect(checks.all()).toEqual([expect.objectContaining({name: 'auto-updates', status: 'fail'})])
+    expect(reporter.results).toEqual([
+      expect.objectContaining({name: 'auto-updates', status: 'fail'}),
+    ])
   })
 
   test('the deprecated top-level config warns and includes the migration edit', () => {
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const enabled = checkAutoUpdates(checks, {
+    const enabled = checkAutoUpdates(reporter, {
       cliConfig: {autoUpdates: true},
       flags: {} as DeployFlags,
     })
 
     expect(enabled).toBe(true)
-    const all = checks.all()
-    expect(all).toHaveLength(2)
-    expect(all.every((c) => c.name === 'auto-updates' && c.status === 'warn')).toBe(true)
-    expect(all[0]?.message).toContain('autoUpdates config has moved')
-    expect(all[1]?.message).toContain('Please update sanity.cli.ts')
-    expect(all[1]?.message).toContain('deployment: {autoUpdates: true}')
+    expect(reporter.results).toHaveLength(2)
+    expect(reporter.results.every((c) => c.name === 'auto-updates' && c.status === 'warn')).toBe(
+      true,
+    )
+    expect(reporter.results[0]?.message).toContain('autoUpdates config has moved')
+    expect(reporter.results[1]?.message).toContain('Please update sanity.cli.ts')
+    expect(reporter.results[1]?.message).toContain('deployment: {autoUpdates: true}')
   })
 
   test('a deprecated flag warns', () => {
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    checkAutoUpdates(checks, {cliConfig: {}, flags: {'auto-updates': true} as DeployFlags})
+    checkAutoUpdates(reporter, {cliConfig: {}, flags: {'auto-updates': true} as DeployFlags})
 
-    expect(checks.all()).toEqual([expect.objectContaining({name: 'auto-updates', status: 'warn'})])
+    expect(reporter.results).toEqual([
+      expect.objectContaining({name: 'auto-updates', status: 'warn'}),
+    ])
   })
 
   test('a clean config records no check', () => {
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    checkAutoUpdates(checks, {
+    checkAutoUpdates(reporter, {
       cliConfig: {deployment: {autoUpdates: true}},
       flags: {} as DeployFlags,
     })
 
-    expect(checks.all()).toHaveLength(0)
+    expect(reporter.results).toHaveLength(0)
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -1,0 +1,185 @@
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {type UserApplication} from '../../../services/userApplications.js'
+import {checkAppTarget, checkAutoUpdates, createAggregatingChecks} from '../deployChecks.js'
+import {resolveAppDeployTarget} from '../resolveDeployTarget.js'
+import {type DeployFlags} from '../types.js'
+
+vi.mock('../resolveDeployTarget.js', () => ({
+  resolveAppDeployTarget: vi.fn(),
+}))
+
+const mockResolveApp = vi.mocked(resolveAppDeployTarget)
+
+function application(overrides: Partial<UserApplication> = {}): UserApplication {
+  return {
+    appHost: 'my-studio',
+    createdAt: '2024-01-01T00:00:00Z',
+    id: 'app-1',
+    organizationId: null,
+    projectId: 'project-1',
+    title: null,
+    type: 'studio',
+    updatedAt: '2024-01-01T00:00:00Z',
+    urlType: 'internal',
+    ...overrides,
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('createAggregatingChecks', () => {
+  test('records checks without exiting', () => {
+    const checks = createAggregatingChecks()
+    checks.add({message: 'ok', name: 'a', status: 'pass'})
+    checks.add({message: 'bad', name: 'b', status: 'fail'})
+    expect(checks.all()).toHaveLength(2)
+  })
+
+  test('a thrown step becomes a fail check', async () => {
+    const checks = createAggregatingChecks()
+    const result = await checks.run('boom', async () => {
+      throw new Error('nope')
+    })
+    expect(result).toBeNull()
+    expect(checks.all()[0]).toMatchObject({name: 'boom', status: 'fail'})
+    expect(checks.all()[0]?.message).toContain('nope')
+  })
+
+  test('run returns the value when the step succeeds', async () => {
+    const checks = createAggregatingChecks()
+    const result = await checks.run('ok', async () => 42)
+    expect(result).toBe(42)
+    expect(checks.all()).toHaveLength(0)
+  })
+})
+
+describe('checkAppTarget', () => {
+  test('found → pass check, existing app and target', async () => {
+    const app = application({appHost: 'app-host', id: 'core-1', title: 'My App', type: 'coreApp'})
+    mockResolveApp.mockResolvedValue({application: app, type: 'found'})
+    const checks = createAggregatingChecks()
+
+    const {existingApp, target} = await checkAppTarget(checks, {
+      appId: 'core-1',
+      organizationId: 'org-1',
+    })
+
+    expect(existingApp).toBe(app)
+    expect(target).toEqual({
+      appId: 'core-1',
+      exists: true,
+      host: 'app-host',
+      isExternal: false,
+      type: 'coreApp',
+    })
+    expect(checks.all()[0]?.message).toContain('Deploys to existing application "My App"')
+  })
+
+  test('would-create → pass check, no existing app', async () => {
+    mockResolveApp.mockResolvedValue({type: 'would-create'})
+    const checks = createAggregatingChecks()
+
+    const {existingApp, target} = await checkAppTarget(checks, {
+      appId: undefined,
+      organizationId: 'org-1',
+    })
+
+    expect(existingApp).toBeNull()
+    expect(target).toEqual({
+      appId: null,
+      exists: false,
+      host: null,
+      isExternal: false,
+      type: 'coreApp',
+    })
+  })
+
+  test('needs-input → fail check (would prompt)', async () => {
+    mockResolveApp.mockResolvedValue({
+      existing: [application(), application()],
+      type: 'needs-input',
+    })
+    const checks = createAggregatingChecks()
+
+    const {target} = await checkAppTarget(checks, {appId: undefined, organizationId: 'org-1'})
+
+    expect(target).toBeNull()
+    expect(checks.all()[0]).toMatchObject({name: 'target', status: 'fail'})
+    expect(checks.all()[0]?.message).toContain('2 existing applications found')
+  })
+
+  test('invalid → fail check', async () => {
+    mockResolveApp.mockResolvedValue({
+      message: 'Cannot find app with app ID nope',
+      reason: 'app-not-found',
+      type: 'invalid',
+    })
+    const checks = createAggregatingChecks()
+
+    const {target} = await checkAppTarget(checks, {appId: 'nope', organizationId: 'org-1'})
+
+    expect(target).toBeNull()
+    expect(checks.all()[0]?.status).toBe('fail')
+  })
+
+  test('a 403 becomes a permissions fail check', async () => {
+    mockResolveApp.mockRejectedValue(Object.assign(new Error('forbidden'), {statusCode: 403}))
+    const checks = createAggregatingChecks()
+
+    const {target} = await checkAppTarget(checks, {appId: undefined, organizationId: 'org-1'})
+
+    expect(target).toBeNull()
+    expect(checks.all()[0]?.message).toContain('don’t have permission')
+  })
+})
+
+describe('checkAutoUpdates', () => {
+  test('a config conflict is a fail check', () => {
+    const checks = createAggregatingChecks()
+
+    const enabled = checkAutoUpdates(checks, {
+      cliConfig: {autoUpdates: true, deployment: {autoUpdates: false}},
+      flags: {} as DeployFlags,
+    })
+
+    expect(enabled).toBe(false)
+    expect(checks.all()).toEqual([expect.objectContaining({name: 'auto-updates', status: 'fail'})])
+  })
+
+  test('the deprecated top-level config warns and includes the migration edit', () => {
+    const checks = createAggregatingChecks()
+
+    const enabled = checkAutoUpdates(checks, {
+      cliConfig: {autoUpdates: true},
+      flags: {} as DeployFlags,
+    })
+
+    expect(enabled).toBe(true)
+    const all = checks.all()
+    expect(all).toHaveLength(2)
+    expect(all.every((c) => c.name === 'auto-updates' && c.status === 'warn')).toBe(true)
+    expect(all[0]?.message).toContain('autoUpdates config has moved')
+    expect(all[1]?.message).toContain('Please update sanity.cli.ts')
+    expect(all[1]?.message).toContain('deployment: {autoUpdates: true}')
+  })
+
+  test('a deprecated flag warns', () => {
+    const checks = createAggregatingChecks()
+
+    checkAutoUpdates(checks, {cliConfig: {}, flags: {'auto-updates': true} as DeployFlags})
+
+    expect(checks.all()).toEqual([expect.objectContaining({name: 'auto-updates', status: 'warn'})])
+  })
+
+  test('a clean config records no check', () => {
+    const checks = createAggregatingChecks()
+
+    checkAutoUpdates(checks, {
+      cliConfig: {deployment: {autoUpdates: true}},
+      flags: {} as DeployFlags,
+    })
+
+    expect(checks.all()).toHaveLength(0)
+  })
+})

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/resolveDeployTarget.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/resolveDeployTarget.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, test} from 'vitest'
+
+import {resolveAppDeployTarget} from '../resolveDeployTarget.js'
+
+// The verdicts that hit the API (found / would-create / needs-input) are
+// exercised end-to-end by the deploy integration tests; this covers the guard
+// that short-circuits before any lookup.
+
+describe('resolveAppDeployTarget', () => {
+  test('no appId and no organizationId → blocked', async () => {
+    const result = await resolveAppDeployTarget({appId: undefined, organizationId: undefined})
+
+    expect(result).toEqual({message: 'app.organizationId is missing', type: 'blocked'})
+  })
+})

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -3,58 +3,48 @@ import {styleText} from 'node:util'
 import {createGzip} from 'node:zlib'
 
 import {CLIError} from '@oclif/core/errors'
-import {exitCodes, getLocalPackageVersion} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {getWorkbench} from '@sanity/workbench-cli/deploy'
 import {pack} from 'tar-fs'
 
-import {createDeployment, updateUserApplication} from '../../services/userApplications.js'
+import {
+  createDeployment,
+  updateUserApplication,
+  type UserApplication,
+} from '../../services/userApplications.js'
 import {getAppId} from '../../util/appId.js'
-import {NO_ORGANIZATION_ID} from '../../util/errorMessages.js'
+import {EXTERNAL_APP_NOT_SUPPORTED, NO_ORGANIZATION_ID} from '../../util/errorMessages.js'
 import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {buildApp} from '../build/buildApp.js'
-import {shouldAutoUpdate} from '../build/shouldAutoUpdate.js'
-import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
+import {extractCoreAppManifest, resolveTitleUpdate} from '../manifest/extractCoreAppManifest.js'
 import {type CoreAppManifest} from '../manifest/types.js'
-import {checkDir} from './checkDir.js'
 import {createUserApplicationForApp} from './createUserApplicationForApp.js'
+import {
+  checkAutoUpdates,
+  checkBuild,
+  checkPackageVersion,
+  createFailFastChecks,
+  type DeployChecks,
+  verifyOutputDir,
+} from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
 import {findUserApplicationForApp} from './findUserApplicationForApp.js'
 import {type DeployAppOptions} from './types.js'
-import {buildViewDeploymentPayload} from './viewDeployment.js'
+
+type Workbench = ReturnType<typeof getWorkbench>
 
 /**
- * Deploy a Sanity application.
+ * Builds and deploys a Sanity application.
  *
  * @internal
  */
-export async function deployApp(options: DeployAppOptions) {
-  const {cliConfig, flags, output, projectRoot, sourceDir} = options
+export async function deployApp(options: DeployAppOptions): Promise<void> {
+  const {cliConfig, output} = options
   const workbench = getWorkbench(cliConfig)
 
-  const workDir = projectRoot.directory
-
-  const organizationId = cliConfig.app?.organizationId
-  const appId = getAppId(cliConfig)
-  const isAutoUpdating = shouldAutoUpdate({cliConfig, flags, output})
-  const installedSdkVersion = await getLocalPackageVersion('@sanity/sdk-react', workDir)
-
-  if (!installedSdkVersion) {
-    output.error(`Failed to find installed @sanity/sdk-react version`, {exit: 1})
-    return
-  }
-
-  if (!organizationId) {
-    output.error(NO_ORGANIZATION_ID, {exit: 1})
-    return
-  }
-
-  if (flags.external) {
-    output.error('Deploying an app to an external host is not supported.', {exit: 1})
-  }
-
-  // Fail before any prompts or API calls when the app declares nothing to
-  // expose.
+  // A federated app with no entry, view or service would ship a remote with
+  // nothing to load — fail before any prompts or API calls.
   if (workbench) {
     try {
       workbench.assertDeployable()
@@ -64,29 +54,69 @@ export async function deployApp(options: DeployAppOptions) {
     }
   }
 
-  let spin = spinner('Verifying local content...')
-
   try {
-    let userApplication = await findUserApplicationForApp({
-      cliConfig,
-      organizationId,
-      output,
-    })
-
-    deployDebug(`User application found`, userApplication)
-
-    if (!userApplication) {
-      deployDebug(`No user application found. Creating a new one`)
-
-      userApplication = await createUserApplicationForApp(organizationId)
-      deployDebug(`User application created`, userApplication)
+    const checks = createFailFastChecks(output)
+    await createAppDeployment(options, checks, workbench)
+  } catch (error) {
+    // Don't throw a generic error when the user cancels a prompt
+    if (error.name === 'ExitPromptError') {
+      output.error('Deployment cancelled by user', {exit: 1})
+      return
     }
+    if (error instanceof CLIError) {
+      const {message, ...errorOptions} = error
+      output.error(message, {...errorOptions, exit: 1})
+      return
+    }
+    deployDebug('Error deploying application', error)
+    output.error(`Error deploying application: ${error}`, {exit: 1})
+  }
+}
 
-    // Always build the project, unless --no-build is passed
-    const shouldBuild = flags.build
-    if (shouldBuild) {
-      deployDebug(`Building app`)
-      await buildApp({
+interface AppDeployment {
+  application: UserApplication | null
+  isAutoUpdating: boolean
+  manifest: CoreAppManifest | undefined
+  version: string | null
+}
+
+/**
+ * Validates the deploy, syncs the title from the manifest, and ships the build.
+ * Steps report through `checks`; a real deploy fails fast on the first problem.
+ */
+async function createAppDeployment(
+  options: DeployAppOptions,
+  checks: DeployChecks,
+  workbench: Workbench,
+): Promise<AppDeployment> {
+  const {cliConfig, flags, output, projectRoot, sourceDir} = options
+  const workDir = projectRoot.directory
+  const organizationId = cliConfig.app?.organizationId
+
+  const isAutoUpdating = checkAutoUpdates(checks, {cliConfig, flags})
+
+  const version = await checkPackageVersion(checks, {
+    moduleName: '@sanity/sdk-react',
+    name: 'sdk-version',
+    workDir,
+  })
+
+  checks.add(
+    organizationId
+      ? {message: `Organization: ${organizationId}`, name: 'organization-id', status: 'pass'}
+      : {message: NO_ORGANIZATION_ID, name: 'organization-id', status: 'fail'},
+  )
+
+  let application: UserApplication | null = null
+  if (flags.external) {
+    checks.add({message: EXTERNAL_APP_NOT_SUPPORTED, name: 'target', status: 'fail'})
+  } else {
+    application = await resolveAppApplication(options)
+  }
+
+  await checkBuild(checks, {
+    build: () =>
+      buildApp({
         autoUpdatesEnabled: isAutoUpdating,
         calledFromDeploy: true,
         cliConfig,
@@ -94,111 +124,102 @@ export async function deployApp(options: DeployAppOptions) {
         outDir: sourceDir,
         output,
         workDir,
-      })
-    }
+      }),
+    skipReason: flags.build
+      ? undefined
+      : 'Build skipped (--no-build) — validating existing output directory',
+    successMessage: 'App built',
+  })
 
-    // Ensure that the directory exists, is a directory and seems to have valid content
-    spin = spin.start()
+  await verifyOutputDir({isWorkbenchApp: workbench !== null, output, sourceDir})
+
+  // Manifests aren't strictly essential, so a failure warns and continues
+  let manifest: CoreAppManifest | undefined
+  try {
+    manifest = await extractCoreAppManifest({workDir})
+  } catch (err) {
+    deployDebug('Error extracting app manifest', err)
+    checks.add({
+      message: `Error extracting app manifest: ${getErrorMessage(err)}`,
+      name: 'app-manifest',
+      status: 'warn',
+    })
+  }
+
+  // Sync the application title from the manifest when it has changed
+  const titleUpdate = application ? resolveTitleUpdate(manifest, application) : null
+  if (application && titleUpdate) {
+    deployDebug('Updating application title from manifest', titleUpdate)
+    output.log(
+      titleUpdate.from
+        ? `Updating title from "${titleUpdate.from}" to "${titleUpdate.to}"`
+        : `Setting application title to "${titleUpdate.to}"`,
+    )
+    const spin = spinner('Updating application title').start()
     try {
-      await (workbench ? workbench.checkBuiltOutput(sourceDir) : checkDir(sourceDir))
+      application = await updateUserApplication({
+        applicationId: application.id,
+        appType: 'coreApp',
+        body: {title: titleUpdate.to},
+      })
       spin.succeed()
     } catch (err) {
       spin.fail()
-      deployDebug('Error checking directory', err)
-      output.error(getErrorMessage(err), {exit: 1})
-      return
-    }
-
-    // Create a tarball of the given directory
-    const parentDir = dirname(sourceDir)
-    const base = basename(sourceDir)
-    const tarball = pack(parentDir, {entries: [base]}).pipe(createGzip())
-    let manifest: CoreAppManifest | undefined
-    try {
-      manifest = await extractCoreAppManifest({workDir})
-    } catch (err) {
-      deployDebug('Error extracting app manifest', err)
       const message = getErrorMessage(err)
-      // manifests aren't strictly essential, so continue deploy
-      output.warn(`Error extracting app manifest: ${message}`)
+      deployDebug('Error updating application title', {message})
+      output.warn(`Error updating application title: ${message}`)
     }
+  }
 
-    // Sync app title from manifest when it has changed (Brett user-applications)
-    if (manifest?.title !== undefined && manifest.title !== userApplication.title) {
-      deployDebug('Updating application title from manifest', {
-        from: userApplication.title,
-        to: manifest.title,
-      })
-      const existing = userApplication.title
-      output.log(
-        existing
-          ? `Updating title from "${existing}" to "${manifest.title}"`
-          : `Setting application title to "${manifest.title}"`,
-      )
-      spin = spinner(`Updating application title`).start()
-      try {
-        userApplication = await updateUserApplication({
-          applicationId: userApplication.id,
-          appType: 'coreApp',
-          body: {title: manifest.title},
-        })
-        spin.succeed()
-      } catch (err) {
-        spin.fail()
-        const message = getErrorMessage(err)
-        deployDebug('Error updating application title', {message})
-        output.warn(`Error updating application title: ${message}`)
-      }
-    }
+  if (!application || !version) return {application, isAutoUpdating, manifest, version}
 
-    // Register the app's declared views with the application service. That
-    // service doesn't exist yet, so validate the payload and log it (no store);
-    // a malformed view declaration fails the deploy before we ship the bundle.
-    // `views` lives on the branded `unstable_defineApp` result, not the legacy
-    // `app` config object.
-    const declaredViews = workbench?.views ?? []
-    if (declaredViews.length > 0) {
-      try {
-        const payload = buildViewDeploymentPayload({
-          applicationId: userApplication.id,
-          views: declaredViews,
-        })
+  const parentDir = dirname(sourceDir)
+  const base = basename(sourceDir)
+  const tarball = pack(parentDir, {entries: [base]}).pipe(createGzip())
+
+  // Register the app's declared views with the application service. The payload
+  // is validated and logged (the storing service doesn't exist yet); a malformed
+  // view declaration fails the deploy before we ship the bundle.
+  if (workbench) {
+    try {
+      const payload = workbench.buildViewDeploymentPayload(application.id)
+      if (payload.views.length > 0) {
         output.log(
           `Validated ${payload.views.length} view(s) for the application service (not yet persisted):`,
         )
         output.log(JSON.stringify(payload, null, 2))
         deployDebug('View deployment payload', payload)
-      } catch (err) {
-        const message = getErrorMessage(err)
-        output.error(`Invalid view declaration: ${message}`, {exit: 1})
-        return
       }
+    } catch (err) {
+      output.error(`Invalid view declaration: ${getErrorMessage(err)}`, {exit: 1})
+      return {application, isAutoUpdating, manifest, version}
     }
+  }
 
-    spin = spinner('Deploying...').start()
+  const spin = spinner('Deploying...').start()
+  try {
     await createDeployment({
-      applicationId: userApplication.id,
+      applicationId: application.id,
       isApp: true,
       isAutoUpdating,
       manifest,
       tarball,
-      version: installedSdkVersion,
+      version,
     })
+  } catch (error) {
+    spin.clear()
+    throw error
+  }
+  spin.succeed()
 
-    spin.succeed()
+  output.log(`\n🚀 ${styleText('bold', 'Success!')} Application deployed`)
 
-    // And let the user know we're done
-    output.log(`\n🚀 ${styleText('bold', 'Success!')} Application deployed`)
-
-    if (!appId) {
-      output.log(`\n════ ${styleText('bold', 'Next step:')} ════`)
-      output.log(
-        styleText(
-          'bold',
-          '\nAdd the deployment.appId to your sanity.cli.js or sanity.cli.ts file:',
-        ),
-      )
-      output.log(`
+  if (!getAppId(cliConfig)) {
+    output.log(`\n════ ${styleText('bold', 'Next step:')} ════`)
+    output.log(
+      styleText('bold', '\nAdd the deployment.appId to your sanity.cli.js or sanity.cli.ts file:'),
+    )
+    output.log(`
 ${styleText(
   'dim',
   `app: {
@@ -208,25 +229,26 @@ ${styleText(
 ${styleText(
   ['bold', 'green'],
   `deployment: {
-  appId: '${userApplication.id}',
+  appId: '${application.id}',
 }\n`,
 )}`)
-    }
-  } catch (error) {
-    spin.clear()
-    // Don't throw generic error if user cancels
-    if (error.name === 'ExitPromptError') {
-      output.error('Deployment cancelled by user', {exit: 1})
-      return
-    }
-    // If the error is a CLIError, we can just output the message & error options (if any), while ensuring we exit
-    if (error instanceof CLIError) {
-      const {message, ...errorOptions} = error
-      output.error(message, {...errorOptions, exit: 1})
-      return
-    }
-
-    deployDebug('Error deploying application', error)
-    output.error(`Error deploying application: ${error}`, {exit: 1})
   }
+
+  return {application, isAutoUpdating, manifest, version}
+}
+
+/** Resolves the app's target application, creating one when none exists. */
+async function resolveAppApplication(options: DeployAppOptions): Promise<UserApplication | null> {
+  const {cliConfig, output} = options
+  const organizationId = cliConfig.app?.organizationId ?? ''
+  let application = await findUserApplicationForApp({cliConfig, organizationId, output})
+  deployDebug('User application found', application)
+
+  if (!application) {
+    deployDebug('No user application found. Creating a new one')
+    application = await createUserApplicationForApp(organizationId)
+    deployDebug('User application created', application)
+  }
+
+  return application
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -225,9 +225,14 @@ ${styleText(
 
 /** Resolves the app's target application, creating one when none exists. */
 async function resolveAppApplication(options: DeployAppOptions): Promise<UserApplication | null> {
-  const {cliConfig, output} = options
+  const {cliConfig, flags, output} = options
   const organizationId = cliConfig.app?.organizationId ?? ''
-  let application = await findUserApplicationForApp({cliConfig, organizationId, output})
+  let application = await findUserApplicationForApp({
+    cliConfig,
+    organizationId,
+    output,
+    unattended: !!flags.yes,
+  })
   deployDebug('User application found', application)
 
   if (!application) {

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -101,19 +101,18 @@ async function createAppDeployment(
 
   const version = await checkPackageVersion(reporter, {
     moduleName: '@sanity/sdk-react',
-    name: 'sdk-version',
     workDir,
   })
 
   reporter.report(
     organizationId
-      ? {message: `Organization: ${organizationId}`, name: 'organization-id', status: 'pass'}
-      : {message: NO_ORGANIZATION_ID, name: 'organization-id', status: 'fail'},
+      ? {message: `Organization: ${organizationId}`, status: 'pass'}
+      : {message: NO_ORGANIZATION_ID, status: 'fail'},
   )
 
   let application: UserApplication | null = null
   if (flags.external) {
-    reporter.report({message: EXTERNAL_APP_NOT_SUPPORTED, name: 'target', status: 'fail'})
+    reporter.report({message: EXTERNAL_APP_NOT_SUPPORTED, status: 'fail'})
   } else {
     application = await resolveAppApplication(options)
   }
@@ -145,7 +144,6 @@ async function createAppDeployment(
     deployDebug('Error extracting app manifest', err)
     reporter.report({
       message: `Error extracting app manifest: ${getErrorMessage(err)}`,
-      name: 'app-manifest',
       status: 'warn',
     })
   }

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -184,25 +184,6 @@ async function createAppDeployment(
   const base = basename(sourceDir)
   const tarball = pack(parentDir, {entries: [base]}).pipe(createGzip())
 
-  // Register the app's declared views with the application service. The payload
-  // is validated and logged (the storing service doesn't exist yet); a malformed
-  // view declaration fails the deploy before we ship the bundle.
-  if (workbench) {
-    try {
-      const payload = workbench.buildViewDeploymentPayload(application.id)
-      if (payload.views.length > 0) {
-        output.log(
-          `Validated ${payload.views.length} view(s) for the application service (not yet persisted):`,
-        )
-        output.log(JSON.stringify(payload, null, 2))
-        deployDebug('View deployment payload', payload)
-      }
-    } catch (err) {
-      output.error(`Invalid view declaration: ${getErrorMessage(err)}`, {exit: 1})
-      return {application, isAutoUpdating, manifest, version}
-    }
-  }
-
   const spin = spinner('Deploying...').start()
   try {
     await createDeployment({

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -24,8 +24,8 @@ import {
   checkAutoUpdates,
   checkBuild,
   checkPackageVersion,
-  createFailFastChecks,
-  type DeployChecks,
+  type CheckReporter,
+  createFailFastReporter,
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
@@ -55,8 +55,8 @@ export async function deployApp(options: DeployAppOptions): Promise<void> {
   }
 
   try {
-    const checks = createFailFastChecks(output)
-    await createAppDeployment(options, checks, workbench)
+    const reporter = createFailFastReporter(output)
+    await createAppDeployment(options, reporter, workbench)
   } catch (error) {
     // Don't throw a generic error when the user cancels a prompt
     if (error.name === 'ExitPromptError') {
@@ -82,26 +82,30 @@ interface AppDeployment {
 
 /**
  * Validates the deploy, syncs the title from the manifest, and ships the build.
- * Steps report through `checks`; a real deploy fails fast on the first problem.
+ *
+ * Every step reports through `reporter`. In a real deploy a failed check exits
+ * immediately, so reaching any later step means the earlier ones passed. A dry
+ * run collects the failures instead and returns before shipping (the guard
+ * below), so the steps read as one straight sequence in both modes.
  */
 async function createAppDeployment(
   options: DeployAppOptions,
-  checks: DeployChecks,
+  reporter: CheckReporter,
   workbench: Workbench,
 ): Promise<AppDeployment> {
   const {cliConfig, flags, output, projectRoot, sourceDir} = options
   const workDir = projectRoot.directory
   const organizationId = cliConfig.app?.organizationId
 
-  const isAutoUpdating = checkAutoUpdates(checks, {cliConfig, flags})
+  const isAutoUpdating = checkAutoUpdates(reporter, {cliConfig, flags})
 
-  const version = await checkPackageVersion(checks, {
+  const version = await checkPackageVersion(reporter, {
     moduleName: '@sanity/sdk-react',
     name: 'sdk-version',
     workDir,
   })
 
-  checks.add(
+  reporter.report(
     organizationId
       ? {message: `Organization: ${organizationId}`, name: 'organization-id', status: 'pass'}
       : {message: NO_ORGANIZATION_ID, name: 'organization-id', status: 'fail'},
@@ -109,12 +113,12 @@ async function createAppDeployment(
 
   let application: UserApplication | null = null
   if (flags.external) {
-    checks.add({message: EXTERNAL_APP_NOT_SUPPORTED, name: 'target', status: 'fail'})
+    reporter.report({message: EXTERNAL_APP_NOT_SUPPORTED, name: 'target', status: 'fail'})
   } else {
     application = await resolveAppApplication(options)
   }
 
-  await checkBuild(checks, {
+  await checkBuild(reporter, {
     build: () =>
       buildApp({
         autoUpdatesEnabled: isAutoUpdating,
@@ -131,7 +135,7 @@ async function createAppDeployment(
     successMessage: 'App built',
   })
 
-  await verifyOutputDir({isWorkbenchApp: workbench !== null, output, sourceDir})
+  await verifyOutputDir({isWorkbenchApp: workbench !== null, reporter, sourceDir})
 
   // Manifests aren't strictly essential, so a failure warns and continues
   let manifest: CoreAppManifest | undefined
@@ -139,7 +143,7 @@ async function createAppDeployment(
     manifest = await extractCoreAppManifest({workDir})
   } catch (err) {
     deployDebug('Error extracting app manifest', err)
-    checks.add({
+    reporter.report({
       message: `Error extracting app manifest: ${getErrorMessage(err)}`,
       name: 'app-manifest',
       status: 'warn',
@@ -171,6 +175,9 @@ async function createAppDeployment(
     }
   }
 
+  // A real deploy has already exited if anything failed; landing here without a
+  // resolved application or version means a dry run collected problems — stop
+  // before shipping.
   if (!application || !version) return {application, isAutoUpdating, manifest, version}
 
   const parentDir = dirname(sourceDir)

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -2,7 +2,6 @@ import {type CliConfig, getLocalPackageVersion, type Output} from '@sanity/cli-c
 import {spinner} from '@sanity/cli-core/ux'
 import {checkBuiltOutput} from '@sanity/workbench-cli/deploy'
 
-import {type UserApplication} from '../../services/userApplications.js'
 import {APP_ID_NOT_FOUND_IN_ORGANIZATION} from '../../util/errorMessages.js'
 import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {
@@ -17,11 +16,8 @@ import {type DeployFlags} from './types.js'
 
 type DeployCheckStatus = 'fail' | 'pass' | 'skip' | 'warn'
 
-interface DeployCheck {
+export interface DeployCheck {
   message: string
-
-  /** Stable identifier for machine consumers; the message carries the details */
-  name: string
   status: DeployCheckStatus
 
   /** Exit code a real deploy uses when this check fails; defaults to 1 */
@@ -63,7 +59,8 @@ export function createCollectingReporter(): CheckReporter & {results: DeployChec
 /**
  * Runs a fallible step and turns a throw into a `fail` check. In a real deploy
  * that fail exits (aborting the run); in a dry run it's recorded and `null`
- * comes back so the caller can skip the rest of the step.
+ * comes back so the caller can skip the rest of the step. `name` labels the
+ * step in debug logs.
  */
 export async function runStep<T>(
   reporter: CheckReporter,
@@ -75,20 +72,20 @@ export async function runStep<T>(
     return await work()
   } catch (err) {
     deployDebug(`${name} step failed`, err)
-    reporter.report({message: formatError(err), name, status: 'fail'})
+    reporter.report({message: formatError(err), status: 'fail'})
     return null
   }
 }
 
 export async function checkPackageVersion(
   reporter: CheckReporter,
-  {moduleName, name, workDir}: {moduleName: string; name: string; workDir: string},
+  {moduleName, workDir}: {moduleName: string; workDir: string},
 ): Promise<string | null> {
   const version = await getLocalPackageVersion(moduleName, workDir)
   reporter.report(
     version
-      ? {message: `Using ${moduleName} ${version}`, name, status: 'pass'}
-      : {message: `Failed to find installed ${moduleName} version`, name, status: 'fail'},
+      ? {message: `Using ${moduleName} ${version}`, status: 'pass'}
+      : {message: `Failed to find installed ${moduleName} version`, status: 'fail'},
   )
   return version
 }
@@ -102,7 +99,6 @@ export function checkAutoUpdates(
   if (issue) {
     reporter.report({
       message: getAutoUpdateIssueMessage(issue),
-      name: 'auto-updates',
       // A config conflict makes a real deploy refuse to run; deprecations only warn
       status: issue.type === 'conflicting-config' ? 'fail' : 'warn',
     })
@@ -112,7 +108,6 @@ export function checkAutoUpdates(
     if (issue.type === 'deprecated-config') {
       reporter.report({
         message: getAutoUpdateMigrationHint(cliConfig.autoUpdates),
-        name: 'auto-updates',
         status: 'warn',
       })
     }
@@ -130,7 +125,7 @@ export async function checkBuild(
   }: {build: () => Promise<void>; skipReason: string | undefined; successMessage: string},
 ): Promise<void> {
   if (skipReason) {
-    reporter.report({message: skipReason, name: 'build', status: 'skip'})
+    reporter.report({message: skipReason, status: 'skip'})
     return
   }
 
@@ -139,7 +134,7 @@ export async function checkBuild(
     'build',
     async () => {
       await build()
-      reporter.report({message: successMessage, name: 'build', status: 'pass'})
+      reporter.report({message: successMessage, status: 'pass'})
     },
     (err) => `Build failed: ${getErrorMessage(err)}`,
   )
@@ -166,32 +161,20 @@ export async function verifyOutputDir({
   } catch (err) {
     spin.fail()
     deployDebug('Error checking directory', err)
-    reporter.report({message: getErrorMessage(err), name: 'output-dir', status: 'fail'})
+    reporter.report({message: getErrorMessage(err), status: 'fail'})
   }
 }
 
-interface DeployTarget {
-  /** User application id when the deploy targets an existing application */
-  appId: string | null
-  /** Whether the target application already exists (false means deploy would create it) */
-  exists: boolean
-  /** Studio hostname or external URL */
-  host: string | null
-  /** A studio deployed to a host outside sanity.studio; always false for apps */
-  isExternal: boolean
-  type: 'coreApp' | 'studio'
-}
-
 /**
- * Maps the read-only app deploy-target verdict to a check and a target
- * descriptor. The rules live in resolveDeployTarget; a real deploy consumes the
- * same verdicts through findUserApplicationForApp.
+ * Reports the read-only app deploy-target verdict. The rules live in
+ * resolveDeployTarget; a real deploy consumes the same verdicts through
+ * findUserApplication.
  */
 export async function checkAppTarget(
   reporter: CheckReporter,
   {appId, organizationId}: {appId: string | undefined; organizationId: string | undefined},
-): Promise<{existingApp: UserApplication | null; target: DeployTarget | null}> {
-  const result = await runStep(
+): Promise<void> {
+  await runStep(
     reporter,
     'target',
     async () => {
@@ -201,61 +184,32 @@ export async function checkAppTarget(
         case 'blocked': {
           reporter.report({
             message: `Deploy target not resolved — ${resolution.message}`,
-            name: 'target',
             status: 'skip',
           })
-          return {existingApp: null, target: null}
+          return
         }
         case 'found': {
           const {application} = resolution
           reporter.report({
             message: `Deploys to existing application "${application.title ?? application.appHost}"`,
-            name: 'target',
             status: 'pass',
           })
-          return {
-            existingApp: application,
-            target: {
-              appId: application.id,
-              exists: true,
-              host: application.appHost,
-              isExternal: false,
-              type: 'coreApp' as const,
-            },
-          }
+          return
         }
         case 'invalid': {
-          reporter.report({
-            message: APP_ID_NOT_FOUND_IN_ORGANIZATION,
-            name: 'target',
-            status: 'fail',
-          })
-          return {existingApp: null, target: null}
+          reporter.report({message: APP_ID_NOT_FOUND_IN_ORGANIZATION, status: 'fail'})
+          return
         }
         case 'needs-input': {
           reporter.report({
             message: `No appId configured and ${resolution.existing.length} existing ${resolution.existing.length === 1 ? 'application' : 'applications'} found — deploy would prompt. Add deployment.appId to sanity.cli.ts.`,
-            name: 'target',
             status: 'fail',
           })
-          return {existingApp: null, target: null}
+          return
         }
         case 'would-create': {
-          reporter.report({
-            message: 'Would create a new application deployment',
-            name: 'target',
-            status: 'pass',
-          })
-          return {
-            existingApp: null,
-            target: {
-              appId: null,
-              exists: false,
-              host: null,
-              isExternal: false,
-              type: 'coreApp' as const,
-            },
-          }
+          reporter.report({message: 'Would create a new application deployment', status: 'pass'})
+          return
         }
       }
     },
@@ -264,6 +218,4 @@ export async function checkAppTarget(
         ? `You don’t have permission to view applications for the configured organization ID ("${organizationId}"). Verify the organization ID, or ask your organization’s admin for access.`
         : `Failed to resolve deploy target: ${getErrorMessage(err)}`,
   )
-
-  return result ?? {existingApp: null, target: null}
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -22,6 +22,8 @@ export interface DeployCheck {
 
   /** Exit code a real deploy uses when this check fails; defaults to 1 */
   exitCode?: number
+  /** Actionable fix, shown under a failing or warning check */
+  solution?: string
 }
 
 /**
@@ -67,12 +69,13 @@ export async function runStep<T>(
   name: string,
   work: () => Promise<T>,
   formatError: (err: unknown) => string = getErrorMessage,
+  solution?: string,
 ): Promise<T | null> {
   try {
     return await work()
   } catch (err) {
     deployDebug(`${name} step failed`, err)
-    reporter.report({message: formatError(err), status: 'fail'})
+    reporter.report({message: formatError(err), solution, status: 'fail'})
     return null
   }
 }
@@ -85,7 +88,11 @@ export async function checkPackageVersion(
   reporter.report(
     version
       ? {message: `Using ${moduleName} ${version}`, status: 'pass'}
-      : {message: `Failed to find installed ${moduleName} version`, status: 'fail'},
+      : {
+          message: `Failed to find installed ${moduleName} version`,
+          solution: `Install ${moduleName} in this project`,
+          status: 'fail',
+        },
   )
   return version
 }
@@ -137,6 +144,7 @@ export async function checkBuild(
       reporter.report({message: successMessage, status: 'pass'})
     },
     (err) => `Build failed: ${getErrorMessage(err)}`,
+    'Fix the build error above, then retry',
   )
 }
 
@@ -161,7 +169,11 @@ export async function verifyOutputDir({
   } catch (err) {
     spin.fail()
     deployDebug('Error checking directory', err)
-    reporter.report({message: getErrorMessage(err), status: 'fail'})
+    reporter.report({
+      message: getErrorMessage(err),
+      solution: 'Run the build first, or check the output directory',
+      status: 'fail',
+    })
   }
 }
 
@@ -197,12 +209,17 @@ export async function checkAppTarget(
           return
         }
         case 'invalid': {
-          reporter.report({message: APP_ID_NOT_FOUND_IN_ORGANIZATION, status: 'fail'})
+          reporter.report({
+            message: APP_ID_NOT_FOUND_IN_ORGANIZATION,
+            solution: 'Check `deployment.appId` matches an app in your organization',
+            status: 'fail',
+          })
           return
         }
         case 'needs-input': {
           reporter.report({
-            message: `No appId configured and ${resolution.existing.length} existing ${resolution.existing.length === 1 ? 'application' : 'applications'} found — deploy would prompt. Add deployment.appId to sanity.cli.ts.`,
+            message: `No \`deployment.appId\` configured and ${resolution.existing.length} existing ${resolution.existing.length === 1 ? 'application' : 'applications'} found — a real deploy would prompt`,
+            solution: 'Add `deployment.appId` to sanity.cli.ts',
             status: 'fail',
           })
           return

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -29,75 +29,63 @@ interface DeployCheck {
 }
 
 /**
- * The mode seam for a deploy step sequence: steps report through this interface
- * and the adapter decides what a failure means, so one sequence can back more
- * than one deploy mode.
+ * Where deploy steps send their check outcomes — and the only place the deploy
+ * mode lives. A real deploy fails fast: a `fail` prints and exits immediately,
+ * which aborts the sequence. A dry run collects every outcome and never exits.
+ * Steps just call `report`; they never know which mode is running.
  */
-export interface DeployChecks {
-  add(check: DeployCheck): void
-  all(): DeployCheck[]
-  run<T>(
-    name: string,
-    fn: () => Promise<T>,
-    formatError?: (err: unknown) => string,
-  ): Promise<T | null>
+export interface CheckReporter {
+  report(check: DeployCheck): void
 }
 
-/**
- * Real deploys fail fast: a fail check exits immediately, warn checks print,
- * and `run` lets errors propagate to the command's own error handling.
- */
-export function createFailFastChecks(output: Output): DeployChecks {
+export function createFailFastReporter(output: Output): CheckReporter {
   return {
-    add(check) {
+    report(check) {
       if (check.status === 'fail') {
         output.error(check.message, {exit: check.exitCode ?? 1})
       } else if (check.status === 'warn') {
         output.warn(check.message)
       }
     },
-    all() {
-      return []
+  }
+}
+
+export function createCollectingReporter(): CheckReporter & {results: DeployCheck[]} {
+  const results: DeployCheck[] = []
+  return {
+    report(check) {
+      results.push(check)
     },
-    run(name, fn) {
-      return fn()
-    },
+    results,
   }
 }
 
 /**
- * Aggregating checks: a fail or warn check is recorded, never exits, and a
- * throw inside `run` becomes a fail check — so one broken step never aborts
- * the rest, and every problem is reported in one pass.
+ * Runs a fallible step and turns a throw into a `fail` check. In a real deploy
+ * that fail exits (aborting the run); in a dry run it's recorded and `null`
+ * comes back so the caller can skip the rest of the step.
  */
-export function createAggregatingChecks(): DeployChecks {
-  const checks: DeployCheck[] = []
-
-  return {
-    add(check) {
-      checks.push(check)
-    },
-    all() {
-      return checks
-    },
-    async run(name, fn, formatError = getErrorMessage) {
-      try {
-        return await fn()
-      } catch (err) {
-        deployDebug(`${name} check failed`, err)
-        checks.push({message: formatError(err), name, status: 'fail'})
-        return null
-      }
-    },
+export async function runStep<T>(
+  reporter: CheckReporter,
+  name: string,
+  work: () => Promise<T>,
+  formatError: (err: unknown) => string = getErrorMessage,
+): Promise<T | null> {
+  try {
+    return await work()
+  } catch (err) {
+    deployDebug(`${name} step failed`, err)
+    reporter.report({message: formatError(err), name, status: 'fail'})
+    return null
   }
 }
 
 export async function checkPackageVersion(
-  checks: DeployChecks,
+  reporter: CheckReporter,
   {moduleName, name, workDir}: {moduleName: string; name: string; workDir: string},
 ): Promise<string | null> {
   const version = await getLocalPackageVersion(moduleName, workDir)
-  checks.add(
+  reporter.report(
     version
       ? {message: `Using ${moduleName} ${version}`, name, status: 'pass'}
       : {message: `Failed to find installed ${moduleName} version`, name, status: 'fail'},
@@ -106,13 +94,13 @@ export async function checkPackageVersion(
 }
 
 export function checkAutoUpdates(
-  checks: DeployChecks,
+  reporter: CheckReporter,
   {cliConfig, flags}: {cliConfig: CliConfig; flags: DeployFlags},
 ): boolean {
   const {enabled, issue} = resolveAutoUpdates({cliConfig, flags})
 
   if (issue) {
-    checks.add({
+    reporter.report({
       message: getAutoUpdateIssueMessage(issue),
       name: 'auto-updates',
       // A config conflict makes a real deploy refuse to run; deprecations only warn
@@ -122,7 +110,7 @@ export function checkAutoUpdates(
     // The deprecated top-level config also gets the styled migration edit, the
     // same second warning the build/dev path prints through shouldAutoUpdate.
     if (issue.type === 'deprecated-config') {
-      checks.add({
+      reporter.report({
         message: getAutoUpdateMigrationHint(cliConfig.autoUpdates),
         name: 'auto-updates',
         status: 'warn',
@@ -134,7 +122,7 @@ export function checkAutoUpdates(
 }
 
 export async function checkBuild(
-  checks: DeployChecks,
+  reporter: CheckReporter,
   {
     build,
     skipReason,
@@ -142,15 +130,16 @@ export async function checkBuild(
   }: {build: () => Promise<void>; skipReason: string | undefined; successMessage: string},
 ): Promise<void> {
   if (skipReason) {
-    checks.add({message: skipReason, name: 'build', status: 'skip'})
+    reporter.report({message: skipReason, name: 'build', status: 'skip'})
     return
   }
 
-  await checks.run(
+  await runStep(
+    reporter,
     'build',
     async () => {
       await build()
-      checks.add({message: successMessage, name: 'build', status: 'pass'})
+      reporter.report({message: successMessage, name: 'build', status: 'pass'})
     },
     (err) => `Build failed: ${getErrorMessage(err)}`,
   )
@@ -162,22 +151,22 @@ export async function checkBuild(
  */
 export async function verifyOutputDir({
   isWorkbenchApp,
-  output,
+  reporter,
   sourceDir,
 }: {
   isWorkbenchApp: boolean
-  output: Output
+  reporter: CheckReporter
   sourceDir: string
 }): Promise<void> {
   const spin = spinner('Verifying local content...').start()
+  const verifyBuild = isWorkbenchApp ? checkBuiltOutput : checkDir
   try {
-    const verifyBuild = isWorkbenchApp ? checkBuiltOutput : checkDir
     await verifyBuild(sourceDir)
     spin.succeed()
   } catch (err) {
     spin.fail()
     deployDebug('Error checking directory', err)
-    output.error(getErrorMessage(err), {exit: 1})
+    reporter.report({message: getErrorMessage(err), name: 'output-dir', status: 'fail'})
   }
 }
 
@@ -199,17 +188,18 @@ interface DeployTarget {
  * same verdicts through findUserApplicationForApp.
  */
 export async function checkAppTarget(
-  checks: DeployChecks,
+  reporter: CheckReporter,
   {appId, organizationId}: {appId: string | undefined; organizationId: string | undefined},
 ): Promise<{existingApp: UserApplication | null; target: DeployTarget | null}> {
-  const result = await checks.run(
+  const result = await runStep(
+    reporter,
     'target',
     async () => {
       const resolution = await resolveAppDeployTarget({appId, organizationId})
 
       switch (resolution.type) {
         case 'blocked': {
-          checks.add({
+          reporter.report({
             message: `Deploy target not resolved — ${resolution.message}`,
             name: 'target',
             status: 'skip',
@@ -218,7 +208,7 @@ export async function checkAppTarget(
         }
         case 'found': {
           const {application} = resolution
-          checks.add({
+          reporter.report({
             message: `Deploys to existing application "${application.title ?? application.appHost}"`,
             name: 'target',
             status: 'pass',
@@ -235,11 +225,15 @@ export async function checkAppTarget(
           }
         }
         case 'invalid': {
-          checks.add({message: APP_ID_NOT_FOUND_IN_ORGANIZATION, name: 'target', status: 'fail'})
+          reporter.report({
+            message: APP_ID_NOT_FOUND_IN_ORGANIZATION,
+            name: 'target',
+            status: 'fail',
+          })
           return {existingApp: null, target: null}
         }
         case 'needs-input': {
-          checks.add({
+          reporter.report({
             message: `No appId configured and ${resolution.existing.length} existing ${resolution.existing.length === 1 ? 'application' : 'applications'} found — deploy would prompt. Add deployment.appId to sanity.cli.ts.`,
             name: 'target',
             status: 'fail',
@@ -247,7 +241,7 @@ export async function checkAppTarget(
           return {existingApp: null, target: null}
         }
         case 'would-create': {
-          checks.add({
+          reporter.report({
             message: 'Would create a new application deployment',
             name: 'target',
             status: 'pass',

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -1,0 +1,275 @@
+import {type CliConfig, getLocalPackageVersion, type Output} from '@sanity/cli-core'
+import {spinner} from '@sanity/cli-core/ux'
+import {checkBuiltOutput} from '@sanity/workbench-cli/deploy'
+
+import {type UserApplication} from '../../services/userApplications.js'
+import {APP_ID_NOT_FOUND_IN_ORGANIZATION} from '../../util/errorMessages.js'
+import {getErrorMessage} from '../../util/getErrorMessage.js'
+import {
+  getAutoUpdateIssueMessage,
+  getAutoUpdateMigrationHint,
+  resolveAutoUpdates,
+} from '../build/shouldAutoUpdate.js'
+import {checkDir} from './checkDir.js'
+import {deployDebug} from './deployDebug.js'
+import {resolveAppDeployTarget} from './resolveDeployTarget.js'
+import {type DeployFlags} from './types.js'
+
+type DeployCheckStatus = 'fail' | 'pass' | 'skip' | 'warn'
+
+interface DeployCheck {
+  message: string
+
+  /** Stable identifier for machine consumers; the message carries the details */
+  name: string
+  status: DeployCheckStatus
+
+  /** Exit code a real deploy uses when this check fails; defaults to 1 */
+  exitCode?: number
+}
+
+/**
+ * The mode seam for a deploy step sequence: steps report through this interface
+ * and the adapter decides what a failure means, so one sequence can back more
+ * than one deploy mode.
+ */
+export interface DeployChecks {
+  add(check: DeployCheck): void
+  all(): DeployCheck[]
+  run<T>(
+    name: string,
+    fn: () => Promise<T>,
+    formatError?: (err: unknown) => string,
+  ): Promise<T | null>
+}
+
+/**
+ * Real deploys fail fast: a fail check exits immediately, warn checks print,
+ * and `run` lets errors propagate to the command's own error handling.
+ */
+export function createFailFastChecks(output: Output): DeployChecks {
+  return {
+    add(check) {
+      if (check.status === 'fail') {
+        output.error(check.message, {exit: check.exitCode ?? 1})
+      } else if (check.status === 'warn') {
+        output.warn(check.message)
+      }
+    },
+    all() {
+      return []
+    },
+    run(name, fn) {
+      return fn()
+    },
+  }
+}
+
+/**
+ * Aggregating checks: a fail or warn check is recorded, never exits, and a
+ * throw inside `run` becomes a fail check — so one broken step never aborts
+ * the rest, and every problem is reported in one pass.
+ */
+export function createAggregatingChecks(): DeployChecks {
+  const checks: DeployCheck[] = []
+
+  return {
+    add(check) {
+      checks.push(check)
+    },
+    all() {
+      return checks
+    },
+    async run(name, fn, formatError = getErrorMessage) {
+      try {
+        return await fn()
+      } catch (err) {
+        deployDebug(`${name} check failed`, err)
+        checks.push({message: formatError(err), name, status: 'fail'})
+        return null
+      }
+    },
+  }
+}
+
+export async function checkPackageVersion(
+  checks: DeployChecks,
+  {moduleName, name, workDir}: {moduleName: string; name: string; workDir: string},
+): Promise<string | null> {
+  const version = await getLocalPackageVersion(moduleName, workDir)
+  checks.add(
+    version
+      ? {message: `Using ${moduleName} ${version}`, name, status: 'pass'}
+      : {message: `Failed to find installed ${moduleName} version`, name, status: 'fail'},
+  )
+  return version
+}
+
+export function checkAutoUpdates(
+  checks: DeployChecks,
+  {cliConfig, flags}: {cliConfig: CliConfig; flags: DeployFlags},
+): boolean {
+  const {enabled, issue} = resolveAutoUpdates({cliConfig, flags})
+
+  if (issue) {
+    checks.add({
+      message: getAutoUpdateIssueMessage(issue),
+      name: 'auto-updates',
+      // A config conflict makes a real deploy refuse to run; deprecations only warn
+      status: issue.type === 'conflicting-config' ? 'fail' : 'warn',
+    })
+
+    // The deprecated top-level config also gets the styled migration edit, the
+    // same second warning the build/dev path prints through shouldAutoUpdate.
+    if (issue.type === 'deprecated-config') {
+      checks.add({
+        message: getAutoUpdateMigrationHint(cliConfig.autoUpdates),
+        name: 'auto-updates',
+        status: 'warn',
+      })
+    }
+  }
+
+  return enabled
+}
+
+export async function checkBuild(
+  checks: DeployChecks,
+  {
+    build,
+    skipReason,
+    successMessage,
+  }: {build: () => Promise<void>; skipReason: string | undefined; successMessage: string},
+): Promise<void> {
+  if (skipReason) {
+    checks.add({message: skipReason, name: 'build', status: 'skip'})
+    return
+  }
+
+  await checks.run(
+    'build',
+    async () => {
+      await build()
+      checks.add({message: successMessage, name: 'build', status: 'pass'})
+    },
+    (err) => `Build failed: ${getErrorMessage(err)}`,
+  )
+}
+
+/**
+ * The deploy directory must exist and hold the right build output: a federation
+ * remote for a workbench app, an `index.html` SPA otherwise.
+ */
+export async function verifyOutputDir({
+  isWorkbenchApp,
+  output,
+  sourceDir,
+}: {
+  isWorkbenchApp: boolean
+  output: Output
+  sourceDir: string
+}): Promise<void> {
+  const spin = spinner('Verifying local content...').start()
+  try {
+    const verifyBuild = isWorkbenchApp ? checkBuiltOutput : checkDir
+    await verifyBuild(sourceDir)
+    spin.succeed()
+  } catch (err) {
+    spin.fail()
+    deployDebug('Error checking directory', err)
+    output.error(getErrorMessage(err), {exit: 1})
+  }
+}
+
+interface DeployTarget {
+  /** User application id when the deploy targets an existing application */
+  appId: string | null
+  /** Whether the target application already exists (false means deploy would create it) */
+  exists: boolean
+  /** Studio hostname or external URL */
+  host: string | null
+  /** A studio deployed to a host outside sanity.studio; always false for apps */
+  isExternal: boolean
+  type: 'coreApp' | 'studio'
+}
+
+/**
+ * Maps the read-only app deploy-target verdict to a check and a target
+ * descriptor. The rules live in resolveDeployTarget; a real deploy consumes the
+ * same verdicts through findUserApplicationForApp.
+ */
+export async function checkAppTarget(
+  checks: DeployChecks,
+  {appId, organizationId}: {appId: string | undefined; organizationId: string | undefined},
+): Promise<{existingApp: UserApplication | null; target: DeployTarget | null}> {
+  const result = await checks.run(
+    'target',
+    async () => {
+      const resolution = await resolveAppDeployTarget({appId, organizationId})
+
+      switch (resolution.type) {
+        case 'blocked': {
+          checks.add({
+            message: `Deploy target not resolved — ${resolution.message}`,
+            name: 'target',
+            status: 'skip',
+          })
+          return {existingApp: null, target: null}
+        }
+        case 'found': {
+          const {application} = resolution
+          checks.add({
+            message: `Deploys to existing application "${application.title ?? application.appHost}"`,
+            name: 'target',
+            status: 'pass',
+          })
+          return {
+            existingApp: application,
+            target: {
+              appId: application.id,
+              exists: true,
+              host: application.appHost,
+              isExternal: false,
+              type: 'coreApp' as const,
+            },
+          }
+        }
+        case 'invalid': {
+          checks.add({message: APP_ID_NOT_FOUND_IN_ORGANIZATION, name: 'target', status: 'fail'})
+          return {existingApp: null, target: null}
+        }
+        case 'needs-input': {
+          checks.add({
+            message: `No appId configured and ${resolution.existing.length} existing ${resolution.existing.length === 1 ? 'application' : 'applications'} found — deploy would prompt. Add deployment.appId to sanity.cli.ts.`,
+            name: 'target',
+            status: 'fail',
+          })
+          return {existingApp: null, target: null}
+        }
+        case 'would-create': {
+          checks.add({
+            message: 'Would create a new application deployment',
+            name: 'target',
+            status: 'pass',
+          })
+          return {
+            existingApp: null,
+            target: {
+              appId: null,
+              exists: false,
+              host: null,
+              isExternal: false,
+              type: 'coreApp' as const,
+            },
+          }
+        }
+      }
+    },
+    (err) =>
+      (err as {statusCode?: number})?.statusCode === 403
+        ? `You don’t have permission to view applications for the configured organization ID ("${organizationId}"). Verify the organization ID, or ask your organization’s admin for access.`
+        : `Failed to resolve deploy target: ${getErrorMessage(err)}`,
+  )
+
+  return result ?? {existingApp: null, target: null}
+}

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -6,7 +6,7 @@ import {CLIError} from '@oclif/core/errors'
 import {formatSchemaValidation, SchemaExtractionError} from '@sanity/cli-build/_internal/extract'
 import {exitCodes, getLocalPackageVersion, type Output} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
-import {getWorkbench} from '@sanity/workbench-cli/deploy'
+import {checkBuiltOutput, getWorkbench} from '@sanity/workbench-cli/deploy'
 import {type StudioManifest} from 'sanity'
 import {pack} from 'tar-fs'
 
@@ -150,7 +150,7 @@ export async function deployStudio(options: DeployAppOptions) {
       // Ensure that the directory exists, is a directory and seems to have valid content
       spin = spin.start()
       try {
-        await (workbench ? workbench.checkBuiltOutput(sourceDir) : checkDir(sourceDir))
+        await (workbench ? checkBuiltOutput(sourceDir) : checkDir(sourceDir))
         spin.succeed()
       } catch (err) {
         spin.fail()

--- a/packages/@sanity/cli/src/actions/deploy/findUserApplicationForApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/findUserApplicationForApp.ts
@@ -3,7 +3,7 @@
  * that turns the resolveAppDeployTarget verdicts into prompts and exits.
  */
 
-import {type CliConfig, type Output} from '@sanity/cli-core'
+import {type CliConfig, exitCodes, type Output} from '@sanity/cli-core'
 import {select, Separator, spinner} from '@sanity/cli-core/ux'
 
 import {type UserApplication} from '../../services/userApplications.js'
@@ -16,12 +16,14 @@ interface FindUserApplicationForAppOptions {
   cliConfig: CliConfig
   organizationId: string
   output: Output
+
+  unattended?: boolean
 }
 
 export async function findUserApplicationForApp(
   options: FindUserApplicationForAppOptions,
 ): Promise<UserApplication | null> {
-  const {cliConfig, organizationId, output} = options
+  const {cliConfig, organizationId, output, unattended = false} = options
 
   const spin = spinner('Checking application info...').start()
 
@@ -54,11 +56,27 @@ export async function findUserApplicationForApp(
       }
       case 'needs-input': {
         spin.info('No application ID configured')
+        // Nobody to prompt in unattended mode — a real deploy would hang otherwise
+        if (unattended) {
+          output.error(
+            'No `deployment.appId` configured. Set it in sanity.cli.ts to deploy without prompting.',
+            {exit: exitCodes.USAGE_ERROR},
+          )
+          return null
+        }
         return promptForExistingApp(resolution.existing)
       }
       // No appId configured and no existing applications — the deploy creates one
       case 'would-create': {
         spin.info('No application ID configured')
+        // Creating one needs an interactive title prompt, which unattended can't answer
+        if (unattended) {
+          output.error(
+            'No application to deploy to. Run `sanity deploy` interactively once to create one.',
+            {exit: exitCodes.USAGE_ERROR},
+          )
+          return null
+        }
         return null
       }
     }

--- a/packages/@sanity/cli/src/actions/deploy/findUserApplicationForApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/findUserApplicationForApp.ts
@@ -1,17 +1,16 @@
 /**
- * Helper functions to find a user application for a Sanity application.
+ * Finds the user application an app deploy targets — the interactive adapter
+ * that turns the resolveAppDeployTarget verdicts into prompts and exits.
  */
 
 import {type CliConfig, type Output} from '@sanity/cli-core'
 import {select, Separator, spinner} from '@sanity/cli-core/ux'
 
-import {
-  getUserApplication,
-  getUserApplications,
-  type UserApplication,
-} from '../../services/userApplications.js'
+import {type UserApplication} from '../../services/userApplications.js'
 import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
+import {APP_ID_NOT_FOUND_IN_ORGANIZATION} from '../../util/errorMessages.js'
 import {deployDebug} from './deployDebug.js'
+import {resolveAppDeployTarget} from './resolveDeployTarget.js'
 
 interface FindUserApplicationForAppOptions {
   cliConfig: CliConfig
@@ -19,9 +18,6 @@ interface FindUserApplicationForAppOptions {
   output: Output
 }
 
-/**
- * Find a user application for a Sanity application.
- */
 export async function findUserApplicationForApp(
   options: FindUserApplicationForAppOptions,
 ): Promise<UserApplication | null> {
@@ -32,77 +28,40 @@ export async function findUserApplicationForApp(
   try {
     checkForDeprecatedAppId({cliConfig, output})
 
-    deployDebug('Checking for a user application as specified in the local app config')
-    const userApplication = await findUserApplication(options)
+    deployDebug('Resolving the deploy target from the local app config')
+    const resolution = await resolveAppDeployTarget({appId: getAppId(cliConfig), organizationId})
+    deployDebug('Resolved app deploy target', resolution)
 
-    if (userApplication) {
-      deployDebug('Found a user application as configured')
-      spin.succeed()
-      return userApplication
-    }
-
-    const appId = getAppId(cliConfig)
-
-    // If there's an appId in the application config but there's no userApplication,
-    // then the provided application ID doesn’t exist in the org
-    if (appId) {
-      spin.clear()
-      output.error(
-        'The `appId` provided in your configuration’s `deployment` object cannot be found in your organization',
-        {
+    switch (resolution.type) {
+      // The deploy validates organizationId before resolving, so this shouldn't happen
+      case 'blocked': {
+        spin.clear()
+        output.error(resolution.message, {exit: 1})
+        return null
+      }
+      case 'found': {
+        spin.succeed()
+        return resolution.application
+      }
+      // The provided application ID doesn't exist in the org
+      case 'invalid': {
+        spin.clear()
+        output.error(APP_ID_NOT_FOUND_IN_ORGANIZATION, {
           exit: 1,
           suggestions: ['Verify the appId in your configuration matches an existing application'],
-        },
-      )
-      return null
+        })
+        return null
+      }
+      case 'needs-input': {
+        spin.info('No application ID configured')
+        return promptForExistingApp(resolution.existing)
+      }
+      // No appId configured and no existing applications — the deploy creates one
+      case 'would-create': {
+        spin.info('No application ID configured')
+        return null
+      }
     }
-
-    // Done checking local application info
-    // Update the spinner text to indicate the next operation
-    spin.text = 'No application ID configured; checking for existing applications...'
-
-    // Get a list of existing applications to select from.
-    // This will fail if the org ID is malformed or the user doesn’t have access to the org ID
-    const userApplications = await getUserApplications({
-      appType: 'coreApp',
-      organizationId,
-    })
-
-    // If no applications are found, return null
-    if (!userApplications?.length) {
-      spin.info('No application ID configured')
-      return null
-    }
-
-    // No app ID configured, done checking for existing applications;
-    // retain this spinner text for clarity
-    spin.info('No application ID configured')
-
-    // Enumerate the available applications
-    const choices = userApplications.map((app) => ({
-      name: app.title ?? app.appHost,
-      value: app.appHost,
-    }))
-
-    // Ask the user to select an existing app or create a new one
-    const selected = await select({
-      choices: [
-        {name: 'New application deployment', value: 'NEW_APP'},
-        new Separator(' ════ Existing applications: ════ '),
-        ...choices,
-      ],
-      loop: false,
-      message:
-        'Would you like to create a new application deployment, or deploy to an existing one?',
-      pageSize: 10,
-    })
-
-    // If the user wants to create a new deployed application, return null
-    if (selected === 'NEW_APP') {
-      return null
-    }
-
-    return userApplications.find((app) => app.appHost === selected)!
   } catch (error) {
     // User can't access applications for the org
     if (error?.statusCode === 403) {
@@ -132,16 +91,23 @@ export async function findUserApplicationForApp(
   }
 }
 
-function findUserApplication(
-  options: FindUserApplicationForAppOptions,
-): Promise<UserApplication | null> | null {
-  const {cliConfig} = options
+async function promptForExistingApp(existing: UserApplication[]): Promise<UserApplication | null> {
+  const choices = existing.map((app) => ({name: app.title ?? app.appHost, value: app.appHost}))
 
-  const appId = getAppId(cliConfig)
+  const selected = await select({
+    choices: [
+      {name: 'New application deployment', value: 'NEW_APP'},
+      new Separator(' ════ Existing applications: ════ '),
+      ...choices,
+    ],
+    loop: false,
+    message: 'Would you like to create a new application deployment, or deploy to an existing one?',
+    pageSize: 10,
+  })
 
-  if (!appId) {
+  if (selected === 'NEW_APP') {
     return null
   }
 
-  return getUserApplication({appId, isSdkApp: true})
+  return existing.find((app) => app.appHost === selected)!
 }

--- a/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
+++ b/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
@@ -1,0 +1,61 @@
+import {
+  getUserApplication,
+  getUserApplications,
+  type UserApplication,
+} from '../../services/userApplications.js'
+
+/**
+ * The read-only outcome of resolving where a deploy would go.
+ *
+ * - `found` — the deploy targets this existing user application
+ * - `would-create` — nothing registered yet; a deploy would create it without prompting
+ * - `needs-input` — config doesn't determine a target; a deploy would prompt
+ *   (`existing` lists the applications a prompt would offer)
+ * - `invalid` — the configured target can never resolve (bad host, unknown appId)
+ * - `blocked` — resolution requires config that's missing (projectId/organizationId)
+ *
+ * Transport errors (network, permissions) throw — they're not verdicts.
+ */
+type CommonDeployTargetResolution =
+  | {application: UserApplication; type: 'found'}
+  | {existing: UserApplication[]; type: 'needs-input'}
+  | {message: string; reason: 'app-not-found' | 'invalid-host'; type: 'invalid'}
+  | {message: string; type: 'blocked'}
+
+export type AppDeployTargetResolution = CommonDeployTargetResolution | {type: 'would-create'}
+
+/**
+ * Owns the app deploy-target rules: appId lookup, falling back to listing the
+ * organization's applications.
+ *
+ * @internal
+ */
+export async function resolveAppDeployTarget(options: {
+  appId: string | undefined
+  organizationId: string | undefined
+}): Promise<AppDeployTargetResolution> {
+  const {appId, organizationId} = options
+
+  if (appId) {
+    const application = await getUserApplication({appId, isSdkApp: true})
+    if (application) {
+      return {application, type: 'found'}
+    }
+    return {
+      message: `Cannot find app with app ID ${appId}`,
+      reason: 'app-not-found',
+      type: 'invalid',
+    }
+  }
+
+  if (!organizationId) {
+    return {message: 'app.organizationId is missing', type: 'blocked'}
+  }
+
+  const existing = await getUserApplications({appType: 'coreApp', organizationId})
+  if (existing?.length) {
+    return {existing, type: 'needs-input'}
+  }
+
+  return {type: 'would-create'}
+}

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -3,7 +3,8 @@ import {readFile} from 'node:fs/promises'
 import {getCliConfigUncached} from '@sanity/cli-core'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {extractCoreAppManifest} from '../extractCoreAppManifest.js'
+import {extractCoreAppManifest, resolveTitleUpdate} from '../extractCoreAppManifest.js'
+import {type CoreAppManifest} from '../types.js'
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
@@ -131,5 +132,35 @@ describe('extractCoreAppManifest', () => {
     await expect(extractCoreAppManifest({workDir: '/project'})).rejects.toThrow(
       /Could not read icon file at "missing.svg"/,
     )
+  })
+})
+
+const manifestWithTitle = (title: string | undefined) => ({title}) as CoreAppManifest
+
+describe('resolveTitleUpdate', () => {
+  test('no update when the manifest has no title', () => {
+    expect(resolveTitleUpdate(manifestWithTitle(undefined), {title: 'Current'})).toBeNull()
+  })
+
+  test('no update when the manifest is missing entirely', () => {
+    expect(resolveTitleUpdate(undefined, {title: 'Current'})).toBeNull()
+  })
+
+  test('no update when the titles already match', () => {
+    expect(resolveTitleUpdate(manifestWithTitle('Same'), {title: 'Same'})).toBeNull()
+  })
+
+  test('renames when the manifest title differs', () => {
+    expect(resolveTitleUpdate(manifestWithTitle('New'), {title: 'Old'})).toEqual({
+      from: 'Old',
+      to: 'New',
+    })
+  })
+
+  test('sets the title when the application has none', () => {
+    expect(resolveTitleUpdate(manifestWithTitle('New'), {title: null})).toEqual({
+      from: null,
+      to: 'New',
+    })
   })
 })

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -12,6 +12,22 @@ interface ExtractCoreAppManifestOptions {
   workDir: string
 }
 
+/**
+ * The title change a deploy would sync from the manifest to the user
+ * application, or null when the titles already match (or none is set).
+ *
+ * @internal
+ */
+export function resolveTitleUpdate(
+  manifest: CoreAppManifest | undefined,
+  application: {title: string | null},
+): {from: string | null; to: string} | null {
+  if (manifest?.title === undefined || manifest.title === application.title) {
+    return null
+  }
+  return {from: application.title, to: manifest.title}
+}
+
 const sanitizeIconPath = new URL('sanitizeIcon.js', import.meta.url).href
 
 /**

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -103,27 +103,33 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
         relativeOutput = `./${relativeOutput}`
       }
 
-      const isEmpty = await dirIsEmptyOrNonExistent(sourceDir)
-      // Prompt to delete the directory if it's not empty
-      const shouldProceed =
-        isEmpty ||
-        (await confirm({
-          default: false,
-          message: `"${relativeOutput}" is not empty, do you want to proceed?`,
-        }))
+      // Unattended runs (--yes or a non-interactive terminal) skip the overwrite prompt
+      if (!this.isUnattended()) {
+        const isEmpty = await dirIsEmptyOrNonExistent(sourceDir)
+        const shouldProceed =
+          isEmpty ||
+          (await confirm({
+            default: false,
+            message: `"${relativeOutput}" is not empty, do you want to proceed?`,
+          }))
 
-      if (!shouldProceed) {
-        this.output.error('Cancelled.', {exit: 1})
+        if (!shouldProceed) {
+          this.output.error('Cancelled.', {exit: 1})
+        }
       }
 
       this.output.log(`Building to ${relativeOutput}\n`)
     }
 
+    // An unattended run (--yes or a non-interactive terminal) deploys without any
+    // prompts downstream (application resolution, the build).
+    const deployFlags = this.isUnattended() ? {...flags, yes: true} : flags
+
     if (isApp) {
       deployDebug('Deploying app')
       await deployApp({
         cliConfig,
-        flags,
+        flags: deployFlags,
         output: this.output,
         projectRoot,
         sourceDir,
@@ -132,7 +138,7 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
       deployDebug('Deploying studio')
       await deployStudio({
         cliConfig,
-        flags,
+        flags: deployFlags,
         output: this.output,
         projectRoot,
         sourceDir,

--- a/packages/@sanity/cli/src/util/errorMessages.ts
+++ b/packages/@sanity/cli/src/util/errorMessages.ts
@@ -1,3 +1,5 @@
 export const NO_PROJECT_ID = `sanity.cli.ts does not contain a project identifier ("api.projectId"), which is required for the Sanity CLI to communicate with the Sanity API`
 export const NO_ORGANIZATION_ID = `sanity.cli.ts does not contain an organization identifier ("app.organizationId"), which is required for the Sanity CLI to communicate with the Sanity API`
 export const NO_MEDIA_LIBRARY_ASPECTS_PATH = `sanity.cli.ts does not contain a media library aspects path ("mediaLibrary.aspectsPath"), which is required for the Sanity CLI to manage aspects.`
+export const EXTERNAL_APP_NOT_SUPPORTED = `Deploying an app to an external host is not supported.`
+export const APP_ID_NOT_FOUND_IN_ORGANIZATION = `The \`appId\` provided in your configuration’s \`deployment\` object cannot be found in your organization`

--- a/packages/@sanity/cli/test/integration/commands/build.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/build.studio.test.ts
@@ -2,10 +2,8 @@ import {readdir, readFile, writeFile} from 'node:fs/promises'
 import {platform} from 'node:os'
 import {join} from 'node:path'
 
-import {type CliConfig} from '@sanity/cli-core'
 import {testCommand, testFixture} from '@sanity/cli-test'
-import {unstable_defineApp} from '@sanity/workbench-cli'
-import {getWorkbench} from '@sanity/workbench-cli/deploy'
+import {checkBuiltOutput} from '@sanity/workbench-cli/deploy'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {BuildCommand} from '../../../src/commands/build.js'
@@ -127,23 +125,15 @@ describe('#build studio', {timeout: (platform() === 'win32' ? 120 : 60) * 1000},
       const assetFiles = await readdir(join(cwd, 'dist', 'assets'))
       expect(assetFiles.some((f) => /^remote-entry-.+\.js$/.test(f))).toBe(true)
 
-      // The build output must satisfy the deploy gate: `sanity deploy` runs the
-      // workbench `checkBuiltOutput` (not the static-SPA check) and ships only if
-      // it finds the federation manifest. Asserting it against the real dist here
-      // closes the build→deploy seam that deploy.studio.test.ts can't — it mocks
-      // the build away.
-      const workbench = getWorkbench({
-        app: unstable_defineApp({
-          name: 'federated-studio',
-          organizationId: 'oSyH1iET5',
-          title: 'Federated Studio',
-        }),
-      } as CliConfig)
-      expect(workbench).not.toBeNull()
-      await expect(workbench!.checkBuiltOutput(join(cwd, 'dist'))).resolves.toBeUndefined()
+      // The build output must satisfy the deploy gate: `sanity deploy` runs
+      // `checkBuiltOutput` (not the static-SPA check) and ships only if it finds
+      // the federation manifest. Asserting it against the real dist here closes
+      // the build→deploy seam that deploy.studio.test.ts can't — it mocks the
+      // build away.
+      await expect(checkBuiltOutput(join(cwd, 'dist'))).resolves.toBeUndefined()
       // And the gate actually gates — a directory without the federation manifest
       // is rejected, so the pass above isn't `checkBuiltOutput` silently no-opping.
-      await expect(workbench!.checkBuiltOutput(cwd)).rejects.toThrow(/mf-manifest|federation/i)
+      await expect(checkBuiltOutput(cwd)).rejects.toThrow(/mf-manifest|federation/i)
     },
   )
 

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -32,27 +32,25 @@ vi.mock('../../../src/actions/deploy/checkDir.js', () => ({
 
 // `getWorkbench`/`assertDeployable` stay real — pure config the no-interfaces
 // test exercises; only the fs-touching `checkBuiltOutput` is stubbed.
-vi.mock('@sanity/workbench-cli/deploy', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@sanity/workbench-cli/deploy')>()),
+vi.mock(import('@sanity/workbench-cli/deploy'), async (importOriginal) => ({
+  ...(await importOriginal()),
   checkBuiltOutput: mockCheckBuiltOutput,
 }))
 
-vi.mock('../../../src/actions/manifest/extractCoreAppManifest.js', async (importOriginal) => ({
-  ...(await importOriginal<
-    typeof import('../../../src/actions/manifest/extractCoreAppManifest.js')
-  >()),
-  extractCoreAppManifest: vi.fn(),
-}))
+vi.mock(
+  import('../../../src/actions/manifest/extractCoreAppManifest.js'),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    extractCoreAppManifest: vi.fn(),
+  }),
+)
 
-vi.mock('@sanity/cli-core/ux', async () => {
-  const actual = await vi.importActual<typeof import('@sanity/cli-core/ux')>('@sanity/cli-core/ux')
-  return {
-    ...actual,
-    confirm: vi.fn(),
-    input: vi.fn(),
-    select: vi.fn(),
-  }
-})
+vi.mock(import('@sanity/cli-core/ux'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  confirm: vi.fn(),
+  input: vi.fn(),
+  select: vi.fn(),
+}))
 
 vi.mock('../../../src/util/dirIsEmptyOrNonExistent.js', () => ({
   dirIsEmptyOrNonExistent: vi.fn(() => true),
@@ -86,6 +84,9 @@ const defaultMocks = {
       appId,
     },
   },
+  // Deploy treats a non-interactive terminal as unattended; these tests exercise
+  // the interactive flows, so mark them interactive.
+  isInteractive: true,
 }
 
 describe('#deploy app', () => {
@@ -483,6 +484,7 @@ describe('#deploy app', () => {
             organizationId,
           },
         },
+        isInteractive: true,
       },
     })
 
@@ -500,6 +502,58 @@ describe('#deploy app', () => {
     // Verify the spinner is stopped before returning - a running spinner
     // blocks the subsequent input() prompt, causing the CLI to hang
     expect(stderr).toContain('No application ID configured')
+  })
+
+  test('--yes errors instead of prompting to pick an existing application', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    // Existing apps but no configured appId → needs-input; unattended can't pick one.
+    mockApi({
+      apiVersion: USER_APPLICATIONS_API_VERSION,
+      query: {appType: 'coreApp', organizationId},
+      uri: `/user-applications`,
+    }).reply(200, [
+      {
+        appHost: 'existing-host',
+        createdAt: '2024-01-01T00:00:00Z',
+        id: 'existing-app-id',
+        organizationId,
+        projectId: null,
+        title: 'Existing App',
+        type: 'coreApp',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'internal',
+      },
+    ])
+
+    const {error} = await testCommand(DeployCommand, ['--yes'], {
+      config: {root: cwd},
+      mocks: {cliConfig: {app: {organizationId}}},
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect(mockSelect).not.toHaveBeenCalled()
+  })
+
+  test('--yes errors instead of prompting for a new application title', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    // No existing apps and no appId → would-create; unattended can't prompt for a title.
+    mockApi({
+      apiVersion: USER_APPLICATIONS_API_VERSION,
+      query: {appType: 'coreApp', organizationId},
+      uri: `/user-applications`,
+    }).reply(200, [])
+
+    const {error} = await testCommand(DeployCommand, ['--yes'], {
+      config: {root: cwd},
+      mocks: {cliConfig: {app: {organizationId}}},
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect(mockInput).not.toHaveBeenCalled()
   })
 
   test('should skip build when --no-build flag is used', async () => {
@@ -866,6 +920,7 @@ describe('#deploy app', () => {
             organizationId,
           },
         },
+        isInteractive: true,
       },
     })
 
@@ -909,6 +964,7 @@ describe('#deploy app', () => {
             organizationId,
           },
         },
+        isInteractive: true,
       },
     })
 
@@ -975,6 +1031,7 @@ describe('#deploy app', () => {
             organizationId,
           },
         },
+        isInteractive: true,
       },
     })
 
@@ -1066,6 +1123,7 @@ describe('#deploy app', () => {
             organizationId,
           },
         },
+        isInteractive: true,
       },
     })
 
@@ -1220,6 +1278,7 @@ describe('#deploy app', () => {
             organizationId,
           },
         },
+        isInteractive: true,
       },
     })
 

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -30,19 +30,17 @@ vi.mock('../../../src/actions/deploy/checkDir.js', () => ({
   checkDir: vi.fn(),
 }))
 
-// `assertDeployable` stays real — it's pure config validation the no-interfaces
+// `getWorkbench`/`assertDeployable` stay real — pure config the no-interfaces
 // test exercises; only the fs-touching `checkBuiltOutput` is stubbed.
-vi.mock('@sanity/workbench-cli/deploy', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@sanity/workbench-cli/deploy')>()
-  return {
-    getWorkbench: (config: Parameters<typeof actual.getWorkbench>[0]) => {
-      const workbench = actual.getWorkbench(config)
-      return workbench && {...workbench, checkBuiltOutput: mockCheckBuiltOutput}
-    },
-  }
-})
+vi.mock('@sanity/workbench-cli/deploy', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/workbench-cli/deploy')>()),
+  checkBuiltOutput: mockCheckBuiltOutput,
+}))
 
-vi.mock('../../../src/actions/manifest/extractCoreAppManifest.js', () => ({
+vi.mock('../../../src/actions/manifest/extractCoreAppManifest.js', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('../../../src/actions/manifest/extractCoreAppManifest.js')
+  >()),
   extractCoreAppManifest: vi.fn(),
 }))
 

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.external.test.ts
@@ -287,6 +287,7 @@ describe('#deploy studio (external)', () => {
             projectId,
           },
         },
+        isInteractive: true,
       },
     })
 
@@ -361,6 +362,7 @@ describe('#deploy studio (external)', () => {
             projectId,
           },
         },
+        isInteractive: true,
       },
     })
 

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -469,6 +469,7 @@ describe('#deploy studio', () => {
             projectId,
           },
         },
+        isInteractive: true,
       },
     })
 
@@ -567,6 +568,7 @@ describe('#deploy studio', () => {
             projectId,
           },
         },
+        isInteractive: true,
       },
     })
 
@@ -668,6 +670,7 @@ describe('#deploy studio', () => {
             projectId,
           },
         },
+        isInteractive: true,
       },
     })
 
@@ -729,6 +732,7 @@ describe('#deploy studio', () => {
             projectId,
           },
         },
+        isInteractive: true,
       },
     })
 
@@ -1034,6 +1038,7 @@ describe('#deploy studio', () => {
             projectId,
           },
         },
+        isInteractive: true,
       },
     })
 

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -21,16 +21,11 @@ vi.mock('../../../src/actions/deploy/checkDir.js', () => ({
   checkDir: vi.fn(),
 }))
 
-// Only the fs-touching `checkBuiltOutput` is stubbed; `assertDeployable` stays real.
-vi.mock('@sanity/workbench-cli/deploy', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@sanity/workbench-cli/deploy')>()
-  return {
-    getWorkbench: (config: Parameters<typeof actual.getWorkbench>[0]) => {
-      const workbench = actual.getWorkbench(config)
-      return workbench && {...workbench, checkBuiltOutput: mockCheckBuiltOutput}
-    },
-  }
-})
+// Only the fs-touching `checkBuiltOutput` is stubbed; `getWorkbench` stays real.
+vi.mock('@sanity/workbench-cli/deploy', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/workbench-cli/deploy')>()),
+  checkBuiltOutput: mockCheckBuiltOutput,
+}))
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()

--- a/packages/@sanity/workbench-cli/src/_exports/deploy.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/deploy.ts
@@ -1,4 +1,6 @@
-// Node-only deploy entry: the workbench-app accessor with the deploy-time guards
-// (`assertDeployable`, `checkBuiltOutput`) the deploy command runs before
-// shipping. Built on the same shared resolver as the build accessor.
+// Node-only deploy entry. `getWorkbench` is the workbench-app accessor with the
+// deploy-time guards that need the app's declarations (`assertDeployable`,
+// `buildViewDeploymentPayload`); `checkBuiltOutput` validates a federation build
+// on disk and needs no app, so it stands alone.
+export {checkBuiltOutput} from '../actions/deploy/checkBuiltOutput.js'
 export {getWorkbench} from '../actions/deploy/getWorkbench.js'

--- a/packages/@sanity/workbench-cli/src/_exports/deploy.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/deploy.ts
@@ -1,6 +1,2 @@
-// Node-only deploy entry. `getWorkbench` is the workbench-app accessor with the
-// deploy-time guards that need the app's declarations (`assertDeployable`,
-// `buildViewDeploymentPayload`); `checkBuiltOutput` validates a federation build
-// on disk and needs no app, so it stands alone.
 export {checkBuiltOutput} from '../actions/deploy/checkBuiltOutput.js'
 export {getWorkbench} from '../actions/deploy/getWorkbench.js'

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/checkBuiltOutput.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/checkBuiltOutput.test.ts
@@ -1,0 +1,87 @@
+import {stat} from 'node:fs/promises'
+import {join} from 'node:path'
+
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {checkBuiltOutput} from '../checkBuiltOutput.js'
+
+vi.mock('node:fs/promises', () => ({
+  stat: vi.fn(),
+}))
+
+const mockStat = vi.mocked(stat)
+
+const enoent = () => {
+  const error = new Error('ENOENT') as NodeJS.ErrnoException
+  error.code = 'ENOENT'
+  return error
+}
+
+const mockSourceDirExists = () => {
+  mockStat.mockResolvedValueOnce({isDirectory: () => true} as never)
+}
+
+describe('checkBuiltOutput', () => {
+  const testDir = '/test/directory'
+  const manifestPath = join(testDir, 'mf-manifest.json')
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('passes when the directory contains mf-manifest.json', async () => {
+    mockSourceDirExists()
+    mockStat.mockResolvedValueOnce({} as never)
+
+    await expect(checkBuiltOutput(testDir)).resolves.toBeUndefined()
+
+    expect(mockStat).toHaveBeenCalledTimes(2)
+    expect(mockStat).toHaveBeenNthCalledWith(1, testDir)
+    expect(mockStat).toHaveBeenNthCalledWith(2, manifestPath)
+    // never checks for index.html — that contract belongs to the non-workbench checkDir
+    expect(mockStat).not.toHaveBeenCalledWith(join(testDir, 'index.html'))
+  })
+
+  test('throws when the directory does not exist', async () => {
+    mockStat.mockRejectedValueOnce(enoent())
+
+    await expect(checkBuiltOutput(testDir)).rejects.toThrow(`Directory "${testDir}" does not exist`)
+
+    expect(mockStat).toHaveBeenCalledTimes(1)
+  })
+
+  test('throws when the path exists but is not a directory', async () => {
+    mockStat.mockResolvedValueOnce({isDirectory: () => false} as never)
+
+    await expect(checkBuiltOutput(testDir)).rejects.toThrow(`"${testDir}" is not a directory`)
+
+    expect(mockStat).toHaveBeenCalledTimes(1)
+  })
+
+  test('re-throws non-ENOENT errors when checking the directory', async () => {
+    const permissionError = new Error('Permission denied') as NodeJS.ErrnoException
+    permissionError.code = 'EACCES'
+    mockStat.mockRejectedValueOnce(permissionError)
+
+    await expect(checkBuiltOutput(testDir)).rejects.toThrow('Permission denied')
+  })
+
+  test('throws when mf-manifest.json does not exist', async () => {
+    mockSourceDirExists()
+    mockStat.mockRejectedValueOnce(enoent())
+
+    await expect(checkBuiltOutput(testDir)).rejects.toThrow(`"${manifestPath}" does not exist`)
+
+    expect(mockStat).toHaveBeenNthCalledWith(2, manifestPath)
+  })
+
+  test('re-throws non-ENOENT errors when checking the manifest', async () => {
+    mockSourceDirExists()
+
+    const permissionError = new Error('Permission denied') as NodeJS.ErrnoException
+    permissionError.code = 'EACCES'
+    mockStat.mockRejectedValueOnce(permissionError)
+
+    await expect(checkBuiltOutput(testDir)).rejects.toThrow('Permission denied')
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/getWorkbench.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/getWorkbench.test.ts
@@ -1,27 +1,8 @@
-import {stat} from 'node:fs/promises'
-import {join} from 'node:path'
-
 import {type CliConfig} from '@sanity/cli-core'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {describe, expect, test} from 'vitest'
 
 import {type DefineAppInput, unstable_defineApp} from '../../../defineApp.js'
 import {getWorkbench} from '../getWorkbench.js'
-
-vi.mock('node:fs/promises', () => ({
-  stat: vi.fn(),
-}))
-
-const mockStat = vi.mocked(stat)
-
-const enoent = () => {
-  const error = new Error('ENOENT') as NodeJS.ErrnoException
-  error.code = 'ENOENT'
-  return error
-}
-
-const mockSourceDirExists = () => {
-  mockStat.mockResolvedValueOnce({isDirectory: () => true} as never)
-}
 
 // Resolve a capability from a real branded app — the only way to a non-null
 // result, so every test exercises the actual `unstable_defineApp` brand rather
@@ -86,82 +67,5 @@ describe('assertDeployable', () => {
         services: [{name: 'services/sync', src: './src/sync.ts', type: 'worker'}],
       }).assertDeployable(),
     ).not.toThrow()
-  })
-})
-
-describe('checkBuiltOutput', () => {
-  const testDir = '/test/directory'
-  const manifestPath = join(testDir, 'mf-manifest.json')
-
-  afterEach(() => {
-    vi.clearAllMocks()
-  })
-
-  test('passes when the directory contains mf-manifest.json', async () => {
-    mockSourceDirExists()
-    mockStat.mockResolvedValueOnce({} as never)
-
-    await expect(
-      workbench({entry: './src/App.tsx'}).checkBuiltOutput(testDir),
-    ).resolves.toBeUndefined()
-
-    expect(mockStat).toHaveBeenCalledTimes(2)
-    expect(mockStat).toHaveBeenNthCalledWith(1, testDir)
-    expect(mockStat).toHaveBeenNthCalledWith(2, manifestPath)
-    // never checks for index.html — that contract belongs to the non-workbench checkDir
-    expect(mockStat).not.toHaveBeenCalledWith(join(testDir, 'index.html'))
-  })
-
-  test('throws when the directory does not exist', async () => {
-    mockStat.mockRejectedValueOnce(enoent())
-
-    await expect(workbench({entry: './src/App.tsx'}).checkBuiltOutput(testDir)).rejects.toThrow(
-      `Directory "${testDir}" does not exist`,
-    )
-
-    expect(mockStat).toHaveBeenCalledTimes(1)
-  })
-
-  test('throws when the path exists but is not a directory', async () => {
-    mockStat.mockResolvedValueOnce({isDirectory: () => false} as never)
-
-    await expect(workbench({entry: './src/App.tsx'}).checkBuiltOutput(testDir)).rejects.toThrow(
-      `"${testDir}" is not a directory`,
-    )
-
-    expect(mockStat).toHaveBeenCalledTimes(1)
-  })
-
-  test('re-throws non-ENOENT errors when checking the directory', async () => {
-    const permissionError = new Error('Permission denied') as NodeJS.ErrnoException
-    permissionError.code = 'EACCES'
-    mockStat.mockRejectedValueOnce(permissionError)
-
-    await expect(workbench({entry: './src/App.tsx'}).checkBuiltOutput(testDir)).rejects.toThrow(
-      'Permission denied',
-    )
-  })
-
-  test('throws when mf-manifest.json does not exist', async () => {
-    mockSourceDirExists()
-    mockStat.mockRejectedValueOnce(enoent())
-
-    await expect(workbench({entry: './src/App.tsx'}).checkBuiltOutput(testDir)).rejects.toThrow(
-      `"${manifestPath}" does not exist`,
-    )
-
-    expect(mockStat).toHaveBeenNthCalledWith(2, manifestPath)
-  })
-
-  test('re-throws non-ENOENT errors when checking the manifest', async () => {
-    mockSourceDirExists()
-
-    const permissionError = new Error('Permission denied') as NodeJS.ErrnoException
-    permissionError.code = 'EACCES'
-    mockStat.mockRejectedValueOnce(permissionError)
-
-    await expect(workbench({entry: './src/App.tsx'}).checkBuiltOutput(testDir)).rejects.toThrow(
-      'Permission denied',
-    )
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/deploy/checkBuiltOutput.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/checkBuiltOutput.ts
@@ -1,0 +1,31 @@
+import {stat} from 'node:fs/promises'
+import {join} from 'node:path'
+
+/**
+ * Throws unless `sourceDir` is a directory holding a federation build.
+ * Workbench builds emit a module-federation remote instead of a static SPA,
+ * so the usual `index.html` contract doesn't apply — `mf-manifest.json` is the
+ * marker that `sanity build` produced a federation build.
+ */
+export async function checkBuiltOutput(sourceDir: string): Promise<void> {
+  try {
+    const stats = await stat(sourceDir)
+    if (!stats.isDirectory()) {
+      throw new Error(`"${sourceDir}" is not a directory`)
+    }
+  } catch (err) {
+    throw err.code === 'ENOENT' ? new Error(`Directory "${sourceDir}" does not exist`) : err
+  }
+
+  const manifestPath = join(sourceDir, 'mf-manifest.json')
+  try {
+    await stat(manifestPath)
+  } catch (err) {
+    throw err.code === 'ENOENT'
+      ? new Error(
+          `"${manifestPath}" does not exist. ` +
+            'The deploy directory must contain a federation build created with "sanity build".',
+        )
+      : err
+  }
+}

--- a/packages/@sanity/workbench-cli/src/actions/deploy/getWorkbench.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/getWorkbench.ts
@@ -1,16 +1,12 @@
 // The deploy command's view of a workbench app: the resolved interfaces plus
-// the two deploy-time guards. `sanity deploy` calls `getWorkbench(config)` once
-// and either gets `null` (plain project — normal deploy) or an object it asks
-// to validate the app and its build output before shipping.
-//
-// Node-only (the build-output guard touches the filesystem).
-
-import {stat} from 'node:fs/promises'
-import {join} from 'node:path'
+// the deploy-time guards that need the app's declarations. `sanity deploy` calls
+// `getWorkbench(config)` once and either gets `null` (plain project — normal
+// deploy) or an object it asks to validate the app before shipping.
 
 import {type CliConfig} from '@sanity/cli-core'
 
 import {type ResolvedWorkbenchApp, resolveWorkbenchApp} from '../../resolveWorkbenchApp.js'
+import {buildViewDeploymentPayload, type ViewDeploymentPayload} from './viewDeployment.js'
 
 interface DeployableWorkbenchApp extends ResolvedWorkbenchApp {
   /**
@@ -20,12 +16,10 @@ interface DeployableWorkbenchApp extends ResolvedWorkbenchApp {
    */
   assertDeployable(): void
   /**
-   * Throws unless `sourceDir` is a directory holding a federation build.
-   * Workbench builds emit a module-federation remote instead of a static SPA,
-   * so the usual `index.html` contract doesn't apply — `mf-manifest.json` is the
-   * marker that `sanity build` produced a federation build.
+   * Validates the app's declared views into the application-service payload.
+   * Throws when a view declaration is malformed.
    */
-  checkBuiltOutput(sourceDir: string): Promise<void>
+  buildViewDeploymentPayload(applicationId: string): ViewDeploymentPayload
 }
 
 export function getWorkbench(
@@ -48,27 +42,8 @@ export function getWorkbench(
       }
     },
 
-    async checkBuiltOutput(sourceDir) {
-      try {
-        const stats = await stat(sourceDir)
-        if (!stats.isDirectory()) {
-          throw new Error(`"${sourceDir}" is not a directory`)
-        }
-      } catch (err) {
-        throw err.code === 'ENOENT' ? new Error(`Directory "${sourceDir}" does not exist`) : err
-      }
-
-      const manifestPath = join(sourceDir, 'mf-manifest.json')
-      try {
-        await stat(manifestPath)
-      } catch (err) {
-        throw err.code === 'ENOENT'
-          ? new Error(
-              `"${manifestPath}" does not exist. ` +
-                'The deploy directory must contain a federation build created with "sanity build".',
-            )
-          : err
-      }
+    buildViewDeploymentPayload(applicationId) {
+      return buildViewDeploymentPayload({applicationId, views})
     },
   }
 }

--- a/packages/@sanity/workbench-cli/src/actions/deploy/viewDeployment.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/viewDeployment.ts
@@ -22,10 +22,10 @@ const viewDeploymentPayloadSchema = z.object({
   views: z.array(viewRecordSchema),
 })
 
-type ViewDeploymentPayload = z.infer<typeof viewDeploymentPayloadSchema>
+export type ViewDeploymentPayload = z.infer<typeof viewDeploymentPayloadSchema>
 
 /**
- * Validate an app's declared views into the application-service payload.
+ * Validates an app's declared views into the application-service payload.
  * Throws (via Zod) when a view declaration is malformed.
  */
 export function buildViewDeploymentPayload(input: {


### PR DESCRIPTION
### Description

> [!NOTE]
> Lays the foundation for the `--dry-run` flag for the `deploy` command. I've created another stacked PR that applies the same [refactoring for studios](https://github.com/sanity-io/cli/pull/1407), to keep this one smaller and easier to review.

The deploy command had grown into one long function mixing validation, prompting, building, schema upload, packaging and reporting — hard to follow and impossible to reuse for a read-only check.

This is the first of two PRs that restructure it. It covers the **core app** deploy and lands the shared scaffolding the studio refactor (follow-up) builds on.

`deployApp` now runs through a single `createAppDeployment` that validates, prepares and ships the deployment, reporting through a small checks seam. The reusable pieces live in their own modules so the studio path can adopt them next: the checks seam and step helpers, read-only deploy-target resolution, and one home for the auto-update rules. Workbench-specific view validation moves out of the CLI into `@sanity/workbench-cli`.

The checks seam mirrors the `sanity doctor` command: each step reports a pass/warn/fail outcome to a reporter, and the mode decides what a failure means — a real deploy stops at the first one, a dry run collects them all.

Behavior-preserving, with one deliberate exception: `assertDeployable` runs before the other checks now, so its "nothing to deploy" error keeps its `USAGE_ERROR` exit code. For an app that's both non-deployable and missing config (sdk-react/org id), that error now surfaces first.

### What to review

- `createAppDeployment` against the old `deployApp`: prompts, spinners, error messages and exit codes should be unchanged.
- The shared modules (`deployChecks`, `resolveDeployTarget`), and that the studio deploy still works on its existing code.

### Testing

The integration deploy tests pass unchanged. New unit tests cover the checks seam, app target resolution, and the auto-update check mapping.

## 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core app deploy path and user-application resolution/API flow; behavior is intended to be preserved but ordering changes (e.g. `assertDeployable` first) and new unattended errors need careful review.
> 
> **Overview**
> Refactors **core app** `sanity deploy` into a linear `createAppDeployment` flow where validation, build, output checks, manifest/title sync, and upload each report through a shared **checks seam** (`CheckReporter`: fail-fast for real deploys, collecting for future dry-run).
> 
> Adds reusable deploy plumbing: `deployChecks` (package version, auto-updates, build, output dir, app target), read-only `resolveAppDeployTarget`, and pure auto-update resolution in `shouldAutoUpdate` (`resolveAutoUpdates` + shared messages). `findUserApplicationForApp` now maps those verdicts to prompts and supports **unattended** deploy via `flags.yes` (errors instead of select/title prompts). The deploy command propagates unattended mode from `--yes` or a non-interactive terminal and skips the non-empty output-dir confirm when unattended.
> 
> **Workbench:** `checkBuiltOutput` is a standalone export from `@sanity/workbench-cli/deploy`; `getWorkbench` keeps `assertDeployable` and gains `buildViewDeploymentPayload` while the CLI **removes** inline view-payload logging from app deploy. Studio deploy only switches to the exported `checkBuiltOutput`. Manifest title sync uses new `resolveTitleUpdate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb42bf23cb0f0252dc23b0f0544044805d9e9a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

