### PR TITLE
fix(deps): pin vite to 8.1.0 to avoid broken 8.1.1 studio builds

### DIFF
--- a/.changeset/pin-vite-8-1-0.md
+++ b/.changeset/pin-vite-8-1-0.md
@@ -1,0 +1,8 @@
+---
+"@sanity/cli": patch
+"@sanity/cli-build": patch
+"@sanity/cli-core": patch
+"@sanity/workbench-cli": patch
+---
+
+fix(deps): pin vite to 8.1.0 to avoid broken 8.1.1 studio builds

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ catalogs:
       specifier: ^5.9.3
       version: 5.9.3
     vite:
-      specifier: ^8.1.0
+      specifier: 8.1.0
       version: 8.1.0
     vite-node:
       specifier: ^6.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -102,8 +102,6 @@ minimumReleaseAgeExclude:
   - 'vite'
   - '@vitejs/*'
   - 'vitest'
-  # Transitive dependency of vite, published in lockstep with vite. Kept exempt
-  # so future vite bumps aren't blocked by a freshly published postcss release.
   - 'postcss'
   - '@module-federation/vite@1.16.11'
   - '@module-federation/dts-plugin@2.6.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,10 +34,11 @@ catalog:
   # Build & Development Tools
   babel-plugin-react-compiler: ^1.0.0
   typescript: ^5.9.3
-  # Pinned to 8.1.0: vite 8.1.1 bundles rolldown 1.1.3, which crashes studio
-  # builds with "RolldownError: WebAssembly.Memory.grow(): Maximum memory size
-  # exceeded". See https://github.com/sanity-io/cli/pull/1405. Unpin once fixed
-  # upstream.
+  # Pinned to 8.1.0: vite 8.1.1 breaks studio builds, failing import analysis
+  # with "Worker error: Failed to parse source for import analysis because the
+  # content contains invalid JS syntax. If you are using JSX, make sure to name
+  # the file with the .jsx or .tsx extension." See
+  # https://github.com/sanity-io/cli/pull/1405. Unpin once fixed upstream.
   vite: 8.1.0
   vite-node: ^6.0.0
   '@vitejs/plugin-react': ^6.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,11 @@ catalog:
   # Build & Development Tools
   babel-plugin-react-compiler: ^1.0.0
   typescript: ^5.9.3
-  vite: ^8.1.0
+  # Pinned to 8.1.0: vite 8.1.1 bundles rolldown 1.1.3, which crashes studio
+  # builds with "RolldownError: WebAssembly.Memory.grow(): Maximum memory size
+  # exceeded". See https://github.com/sanity-io/cli/pull/1405. Unpin once fixed
+  # upstream.
+  vite: 8.1.0
   vite-node: ^6.0.0
   '@vitejs/plugin-react': ^6.0.3
   tsx: ^4.22.4
@@ -97,6 +101,9 @@ minimumReleaseAgeExclude:
   - 'vite'
   - '@vitejs/*'
   - 'vitest'
+  # Transitive dependency of vite, published in lockstep with vite. Kept exempt
+  # so future vite bumps aren't blocked by a freshly published postcss release.
+  - 'postcss'
   - '@module-federation/vite@1.16.11'
   - '@module-federation/dts-plugin@2.6.0'
   - '@module-federation/error-codes@2.6.0'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Pins `vite` to `8.1.0` in the pnpm catalog and keeps `postcss` in `minimumReleaseAgeExclude`.

`vite@8.1.1` breaks studio builds. Any command that bundles the studio (build, deploy, graphql/schema extraction) fails during import analysis with:

```
Worker error: Failed to parse source for import analysis because the content contains
invalid JS syntax. If you are using JSX, make sure to name the file with the .jsx or
.tsx extension.
```

**Root cause (upstream):** this is an upstream regression in `es-module-lexer`, tracked in https://github.com/guybedford/es-module-lexer/issues/214. `vite@8.1.1` pulls in the affected version, so the fix has to land upstream before we can unpin.

**Proof this is necessary:** the Renovate bump to `vite@^8.1.1` (#1405) is red — unit tests pass, but **every** integration-test shard fails on both Ubuntu and Windows (Node 22/24/26) with the error above. See run [28449254719](https://github.com/sanity-io/cli/actions/runs/28449254719).

`postcss` is kept in the release-age exemptions on purpose: `vite@8.1.1+` depends on `postcss@^8.5.16`, which is newer than the 3-day `minimumReleaseAge` window, so without the exemption the install fails with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`. Keeping it means the next vite bump (once the upstream fix ships) won't be blocked by a freshly published postcss.

### What to review

- `pnpm-workspace.yaml` — catalog `vite` pinned `^8.1.0` → `8.1.0` (with a comment explaining why + link to #1405), and `postcss` added to `minimumReleaseAgeExclude`.
- `pnpm-lock.yaml` — only the catalog specifier changes; resolved versions are unchanged from `main` (`vite@8.1.0`, `postcss@8.5.15`, `rolldown@1.1.2`).
- `.changeset/pin-vite-8-1-0.md` — patch bump for the packages that ship `vite` as a runtime dependency (`@sanity/cli`, `@sanity/cli-build`, `@sanity/cli-core`, `@sanity/workbench-cli`), so the tightened constraint is published. The auto-changeset workflow only detects changes under `packages/`, so a catalog-only change needs a manual changeset.

### Testing

- Ran a studio-build integration suite locally with the pin (`test/integration/actions/build/buildStaticFiles.test.ts`): 10/10 pass.
- `pnpm check:types`, `pnpm check:lint`, `pnpm check:deps`, `pnpm check:format` all pass.
- `npx changeset status` confirms the patch bumps resolve correctly.
- The pin restores `main`'s resolved `vite@8.1.0`, so the rest is validated by CI.

Unpin once the upstream `es-module-lexer` regression is fixed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba9e5f07-d216-46f7-b59c-0b22068fa54d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba9e5f07-d216-46f7-b59c-0b22068fa54d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

