### PR TITLE
refactor(deploy): read the deploy checks as a single reporter seam

### DIFF
--- a/.changeset/deploy-checks-reporter.md
+++ b/.changeset/deploy-checks-reporter.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+refactor(deploy): collapse the deploy checks seam into a single reporter

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -1,7 +1,14 @@
+import {type Output} from '@sanity/cli-core'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {type UserApplication} from '../../../services/userApplications.js'
-import {checkAppTarget, checkAutoUpdates, createAggregatingChecks} from '../deployChecks.js'
+import {
+  checkAppTarget,
+  checkAutoUpdates,
+  createCollectingReporter,
+  createFailFastReporter,
+  runStep,
+} from '../deployChecks.js'
 import {resolveAppDeployTarget} from '../resolveDeployTarget.js'
 import {type DeployFlags} from '../types.js'
 
@@ -10,6 +17,8 @@ vi.mock('../resolveDeployTarget.js', () => ({
 }))
 
 const mockResolveApp = vi.mocked(resolveAppDeployTarget)
+
+const mockOutput = () => ({error: vi.fn(), warn: vi.fn()}) as unknown as Output
 
 function application(overrides: Partial<UserApplication> = {}): UserApplication {
   return {
@@ -28,29 +37,74 @@ function application(overrides: Partial<UserApplication> = {}): UserApplication 
 
 beforeEach(() => vi.clearAllMocks())
 
-describe('createAggregatingChecks', () => {
-  test('records checks without exiting', () => {
-    const checks = createAggregatingChecks()
-    checks.add({message: 'ok', name: 'a', status: 'pass'})
-    checks.add({message: 'bad', name: 'b', status: 'fail'})
-    expect(checks.all()).toHaveLength(2)
+describe('createFailFastReporter', () => {
+  test('a fail exits with its exit code', () => {
+    const output = mockOutput()
+    createFailFastReporter(output).report({exitCode: 2, message: 'boom', name: 'x', status: 'fail'})
+    expect(output.error).toHaveBeenCalledWith('boom', {exit: 2})
   })
 
-  test('a thrown step becomes a fail check', async () => {
-    const checks = createAggregatingChecks()
-    const result = await checks.run('boom', async () => {
+  test('a fail without an exit code defaults to 1', () => {
+    const output = mockOutput()
+    createFailFastReporter(output).report({message: 'boom', name: 'x', status: 'fail'})
+    expect(output.error).toHaveBeenCalledWith('boom', {exit: 1})
+  })
+
+  test('a warn prints and does not exit', () => {
+    const output = mockOutput()
+    createFailFastReporter(output).report({message: 'heads up', name: 'x', status: 'warn'})
+    expect(output.warn).toHaveBeenCalledWith('heads up')
+    expect(output.error).not.toHaveBeenCalled()
+  })
+
+  test('pass and skip are silent', () => {
+    const output = mockOutput()
+    const reporter = createFailFastReporter(output)
+    reporter.report({message: 'good', name: 'x', status: 'pass'})
+    reporter.report({message: 'skipped', name: 'y', status: 'skip'})
+    expect(output.error).not.toHaveBeenCalled()
+    expect(output.warn).not.toHaveBeenCalled()
+  })
+})
+
+describe('createCollectingReporter', () => {
+  test('collects every reported check on results', () => {
+    const reporter = createCollectingReporter()
+    reporter.report({message: 'ok', name: 'a', status: 'pass'})
+    reporter.report({message: 'bad', name: 'b', status: 'fail'})
+    expect(reporter.results).toHaveLength(2)
+  })
+})
+
+describe('runStep', () => {
+  test('returns the value when the work succeeds', async () => {
+    const reporter = createCollectingReporter()
+    const result = await runStep(reporter, 'ok', async () => 42)
+    expect(result).toBe(42)
+    expect(reporter.results).toHaveLength(0)
+  })
+
+  test('a throw becomes a fail check and returns null', async () => {
+    const reporter = createCollectingReporter()
+    const result = await runStep(reporter, 'boom', async () => {
       throw new Error('nope')
     })
     expect(result).toBeNull()
-    expect(checks.all()[0]).toMatchObject({name: 'boom', status: 'fail'})
-    expect(checks.all()[0]?.message).toContain('nope')
+    expect(reporter.results[0]).toMatchObject({name: 'boom', status: 'fail'})
+    expect(reporter.results[0]?.message).toContain('nope')
   })
 
-  test('run returns the value when the step succeeds', async () => {
-    const checks = createAggregatingChecks()
-    const result = await checks.run('ok', async () => 42)
-    expect(result).toBe(42)
-    expect(checks.all()).toHaveLength(0)
+  test('uses a custom formatError for the fail message', async () => {
+    const reporter = createCollectingReporter()
+    await runStep(
+      reporter,
+      'boom',
+      async () => {
+        throw new Error('raw')
+      },
+      () => 'friendly',
+    )
+    expect(reporter.results[0]?.message).toBe('friendly')
   })
 })
 
@@ -58,9 +112,9 @@ describe('checkAppTarget', () => {
   test('found → pass check, existing app and target', async () => {
     const app = application({appHost: 'app-host', id: 'core-1', title: 'My App', type: 'coreApp'})
     mockResolveApp.mockResolvedValue({application: app, type: 'found'})
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const {existingApp, target} = await checkAppTarget(checks, {
+    const {existingApp, target} = await checkAppTarget(reporter, {
       appId: 'core-1',
       organizationId: 'org-1',
     })
@@ -73,14 +127,14 @@ describe('checkAppTarget', () => {
       isExternal: false,
       type: 'coreApp',
     })
-    expect(checks.all()[0]?.message).toContain('Deploys to existing application "My App"')
+    expect(reporter.results[0]?.message).toContain('Deploys to existing application "My App"')
   })
 
   test('would-create → pass check, no existing app', async () => {
     mockResolveApp.mockResolvedValue({type: 'would-create'})
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const {existingApp, target} = await checkAppTarget(checks, {
+    const {existingApp, target} = await checkAppTarget(reporter, {
       appId: undefined,
       organizationId: 'org-1',
     })
@@ -100,13 +154,13 @@ describe('checkAppTarget', () => {
       existing: [application(), application()],
       type: 'needs-input',
     })
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const {target} = await checkAppTarget(checks, {appId: undefined, organizationId: 'org-1'})
+    const {target} = await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
 
     expect(target).toBeNull()
-    expect(checks.all()[0]).toMatchObject({name: 'target', status: 'fail'})
-    expect(checks.all()[0]?.message).toContain('2 existing applications found')
+    expect(reporter.results[0]).toMatchObject({name: 'target', status: 'fail'})
+    expect(reporter.results[0]?.message).toContain('2 existing applications found')
   })
 
   test('invalid → fail check', async () => {
@@ -115,71 +169,76 @@ describe('checkAppTarget', () => {
       reason: 'app-not-found',
       type: 'invalid',
     })
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const {target} = await checkAppTarget(checks, {appId: 'nope', organizationId: 'org-1'})
+    const {target} = await checkAppTarget(reporter, {appId: 'nope', organizationId: 'org-1'})
 
     expect(target).toBeNull()
-    expect(checks.all()[0]?.status).toBe('fail')
+    expect(reporter.results[0]?.status).toBe('fail')
   })
 
   test('a 403 becomes a permissions fail check', async () => {
     mockResolveApp.mockRejectedValue(Object.assign(new Error('forbidden'), {statusCode: 403}))
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const {target} = await checkAppTarget(checks, {appId: undefined, organizationId: 'org-1'})
+    const {target} = await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
 
     expect(target).toBeNull()
-    expect(checks.all()[0]?.message).toContain('don’t have permission')
+    expect(reporter.results[0]?.message).toContain('don’t have permission')
   })
 })
 
 describe('checkAutoUpdates', () => {
   test('a config conflict is a fail check', () => {
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const enabled = checkAutoUpdates(checks, {
+    const enabled = checkAutoUpdates(reporter, {
       cliConfig: {autoUpdates: true, deployment: {autoUpdates: false}},
       flags: {} as DeployFlags,
     })
 
     expect(enabled).toBe(false)
-    expect(checks.all()).toEqual([expect.objectContaining({name: 'auto-updates', status: 'fail'})])
+    expect(reporter.results).toEqual([
+      expect.objectContaining({name: 'auto-updates', status: 'fail'}),
+    ])
   })
 
   test('the deprecated top-level config warns and includes the migration edit', () => {
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    const enabled = checkAutoUpdates(checks, {
+    const enabled = checkAutoUpdates(reporter, {
       cliConfig: {autoUpdates: true},
       flags: {} as DeployFlags,
     })
 
     expect(enabled).toBe(true)
-    const all = checks.all()
-    expect(all).toHaveLength(2)
-    expect(all.every((c) => c.name === 'auto-updates' && c.status === 'warn')).toBe(true)
-    expect(all[0]?.message).toContain('autoUpdates config has moved')
-    expect(all[1]?.message).toContain('Please update sanity.cli.ts')
-    expect(all[1]?.message).toContain('deployment: {autoUpdates: true}')
+    expect(reporter.results).toHaveLength(2)
+    expect(reporter.results.every((c) => c.name === 'auto-updates' && c.status === 'warn')).toBe(
+      true,
+    )
+    expect(reporter.results[0]?.message).toContain('autoUpdates config has moved')
+    expect(reporter.results[1]?.message).toContain('Please update sanity.cli.ts')
+    expect(reporter.results[1]?.message).toContain('deployment: {autoUpdates: true}')
   })
 
   test('a deprecated flag warns', () => {
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    checkAutoUpdates(checks, {cliConfig: {}, flags: {'auto-updates': true} as DeployFlags})
+    checkAutoUpdates(reporter, {cliConfig: {}, flags: {'auto-updates': true} as DeployFlags})
 
-    expect(checks.all()).toEqual([expect.objectContaining({name: 'auto-updates', status: 'warn'})])
+    expect(reporter.results).toEqual([
+      expect.objectContaining({name: 'auto-updates', status: 'warn'}),
+    ])
   })
 
   test('a clean config records no check', () => {
-    const checks = createAggregatingChecks()
+    const reporter = createCollectingReporter()
 
-    checkAutoUpdates(checks, {
+    checkAutoUpdates(reporter, {
       cliConfig: {deployment: {autoUpdates: true}},
       flags: {} as DeployFlags,
     })
 
-    expect(checks.all()).toHaveLength(0)
+    expect(reporter.results).toHaveLength(0)
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -24,8 +24,8 @@ import {
   checkAutoUpdates,
   checkBuild,
   checkPackageVersion,
-  createFailFastChecks,
-  type DeployChecks,
+  type CheckReporter,
+  createFailFastReporter,
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
@@ -55,8 +55,8 @@ export async function deployApp(options: DeployAppOptions): Promise<void> {
   }
 
   try {
-    const checks = createFailFastChecks(output)
-    await createAppDeployment(options, checks, workbench)
+    const reporter = createFailFastReporter(output)
+    await createAppDeployment(options, reporter, workbench)
   } catch (error) {
     // Don't throw a generic error when the user cancels a prompt
     if (error.name === 'ExitPromptError') {
@@ -82,26 +82,30 @@ interface AppDeployment {
 
 /**
  * Validates the deploy, syncs the title from the manifest, and ships the build.
- * Steps report through `checks`; a real deploy fails fast on the first problem.
+ *
+ * Every step reports through `reporter`. In a real deploy a failed check exits
+ * immediately, so reaching any later step means the earlier ones passed. A dry
+ * run collects the failures instead and returns before shipping (the guard
+ * below), so the steps read as one straight sequence in both modes.
  */
 async function createAppDeployment(
   options: DeployAppOptions,
-  checks: DeployChecks,
+  reporter: CheckReporter,
   workbench: Workbench,
 ): Promise<AppDeployment> {
   const {cliConfig, flags, output, projectRoot, sourceDir} = options
   const workDir = projectRoot.directory
   const organizationId = cliConfig.app?.organizationId
 
-  const isAutoUpdating = checkAutoUpdates(checks, {cliConfig, flags})
+  const isAutoUpdating = checkAutoUpdates(reporter, {cliConfig, flags})
 
-  const version = await checkPackageVersion(checks, {
+  const version = await checkPackageVersion(reporter, {
     moduleName: '@sanity/sdk-react',
     name: 'sdk-version',
     workDir,
   })
 
-  checks.add(
+  reporter.report(
     organizationId
       ? {message: `Organization: ${organizationId}`, name: 'organization-id', status: 'pass'}
       : {message: NO_ORGANIZATION_ID, name: 'organization-id', status: 'fail'},
@@ -109,12 +113,12 @@ async function createAppDeployment(
 
   let application: UserApplication | null = null
   if (flags.external) {
-    checks.add({message: EXTERNAL_APP_NOT_SUPPORTED, name: 'target', status: 'fail'})
+    reporter.report({message: EXTERNAL_APP_NOT_SUPPORTED, name: 'target', status: 'fail'})
   } else {
     application = await resolveAppApplication(options)
   }
 
-  await checkBuild(checks, {
+  await checkBuild(reporter, {
     build: () =>
       buildApp({
         autoUpdatesEnabled: isAutoUpdating,
@@ -131,7 +135,7 @@ async function createAppDeployment(
     successMessage: 'App built',
   })
 
-  await verifyOutputDir({isWorkbenchApp: workbench !== null, output, sourceDir})
+  await verifyOutputDir({isWorkbenchApp: workbench !== null, reporter, sourceDir})
 
   // Manifests aren't strictly essential, so a failure warns and continues
   let manifest: CoreAppManifest | undefined
@@ -139,7 +143,7 @@ async function createAppDeployment(
     manifest = await extractCoreAppManifest({workDir})
   } catch (err) {
     deployDebug('Error extracting app manifest', err)
-    checks.add({
+    reporter.report({
       message: `Error extracting app manifest: ${getErrorMessage(err)}`,
       name: 'app-manifest',
       status: 'warn',
@@ -171,6 +175,9 @@ async function createAppDeployment(
     }
   }
 
+  // A real deploy has already exited if anything failed; landing here without a
+  // resolved application or version means a dry run collected problems — stop
+  // before shipping.
   if (!application || !version) return {application, isAutoUpdating, manifest, version}
 
   const parentDir = dirname(sourceDir)

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -29,75 +29,63 @@ interface DeployCheck {
 }
 
 /**
- * The mode seam for a deploy step sequence: steps report through this interface
- * and the adapter decides what a failure means, so one sequence can back more
- * than one deploy mode.
+ * Where deploy steps send their check outcomes — and the only place the deploy
+ * mode lives. A real deploy fails fast: a `fail` prints and exits immediately,
+ * which aborts the sequence. A dry run collects every outcome and never exits.
+ * Steps just call `report`; they never know which mode is running.
  */
-export interface DeployChecks {
-  add(check: DeployCheck): void
-  all(): DeployCheck[]
-  run<T>(
-    name: string,
-    fn: () => Promise<T>,
-    formatError?: (err: unknown) => string,
-  ): Promise<T | null>
+export interface CheckReporter {
+  report(check: DeployCheck): void
 }
 
-/**
- * Real deploys fail fast: a fail check exits immediately, warn checks print,
- * and `run` lets errors propagate to the command's own error handling.
- */
-export function createFailFastChecks(output: Output): DeployChecks {
+export function createFailFastReporter(output: Output): CheckReporter {
   return {
-    add(check) {
+    report(check) {
       if (check.status === 'fail') {
         output.error(check.message, {exit: check.exitCode ?? 1})
       } else if (check.status === 'warn') {
         output.warn(check.message)
       }
     },
-    all() {
-      return []
+  }
+}
+
+export function createCollectingReporter(): CheckReporter & {results: DeployCheck[]} {
+  const results: DeployCheck[] = []
+  return {
+    report(check) {
+      results.push(check)
     },
-    run(name, fn) {
-      return fn()
-    },
+    results,
   }
 }
 
 /**
- * Aggregating checks: a fail or warn check is recorded, never exits, and a
- * throw inside `run` becomes a fail check — so one broken step never aborts
- * the rest, and every problem is reported in one pass.
+ * Runs a fallible step and turns a throw into a `fail` check. In a real deploy
+ * that fail exits (aborting the run); in a dry run it's recorded and `null`
+ * comes back so the caller can skip the rest of the step.
  */
-export function createAggregatingChecks(): DeployChecks {
-  const checks: DeployCheck[] = []
-
-  return {
-    add(check) {
-      checks.push(check)
-    },
-    all() {
-      return checks
-    },
-    async run(name, fn, formatError = getErrorMessage) {
-      try {
-        return await fn()
-      } catch (err) {
-        deployDebug(`${name} check failed`, err)
-        checks.push({message: formatError(err), name, status: 'fail'})
-        return null
-      }
-    },
+export async function runStep<T>(
+  reporter: CheckReporter,
+  name: string,
+  work: () => Promise<T>,
+  formatError: (err: unknown) => string = getErrorMessage,
+): Promise<T | null> {
+  try {
+    return await work()
+  } catch (err) {
+    deployDebug(`${name} step failed`, err)
+    reporter.report({message: formatError(err), name, status: 'fail'})
+    return null
   }
 }
 
 export async function checkPackageVersion(
-  checks: DeployChecks,
+  reporter: CheckReporter,
   {moduleName, name, workDir}: {moduleName: string; name: string; workDir: string},
 ): Promise<string | null> {
   const version = await getLocalPackageVersion(moduleName, workDir)
-  checks.add(
+  reporter.report(
     version
       ? {message: `Using ${moduleName} ${version}`, name, status: 'pass'}
       : {message: `Failed to find installed ${moduleName} version`, name, status: 'fail'},
@@ -106,13 +94,13 @@ export async function checkPackageVersion(
 }
 
 export function checkAutoUpdates(
-  checks: DeployChecks,
+  reporter: CheckReporter,
   {cliConfig, flags}: {cliConfig: CliConfig; flags: DeployFlags},
 ): boolean {
   const {enabled, issue} = resolveAutoUpdates({cliConfig, flags})
 
   if (issue) {
-    checks.add({
+    reporter.report({
       message: getAutoUpdateIssueMessage(issue),
       name: 'auto-updates',
       // A config conflict makes a real deploy refuse to run; deprecations only warn
@@ -122,7 +110,7 @@ export function checkAutoUpdates(
     // The deprecated top-level config also gets the styled migration edit, the
     // same second warning the build/dev path prints through shouldAutoUpdate.
     if (issue.type === 'deprecated-config') {
-      checks.add({
+      reporter.report({
         message: getAutoUpdateMigrationHint(cliConfig.autoUpdates),
         name: 'auto-updates',
         status: 'warn',
@@ -134,7 +122,7 @@ export function checkAutoUpdates(
 }
 
 export async function checkBuild(
-  checks: DeployChecks,
+  reporter: CheckReporter,
   {
     build,
     skipReason,
@@ -142,15 +130,16 @@ export async function checkBuild(
   }: {build: () => Promise<void>; skipReason: string | undefined; successMessage: string},
 ): Promise<void> {
   if (skipReason) {
-    checks.add({message: skipReason, name: 'build', status: 'skip'})
+    reporter.report({message: skipReason, name: 'build', status: 'skip'})
     return
   }
 
-  await checks.run(
+  await runStep(
+    reporter,
     'build',
     async () => {
       await build()
-      checks.add({message: successMessage, name: 'build', status: 'pass'})
+      reporter.report({message: successMessage, name: 'build', status: 'pass'})
     },
     (err) => `Build failed: ${getErrorMessage(err)}`,
   )
@@ -162,22 +151,22 @@ export async function checkBuild(
  */
 export async function verifyOutputDir({
   isWorkbenchApp,
-  output,
+  reporter,
   sourceDir,
 }: {
   isWorkbenchApp: boolean
-  output: Output
+  reporter: CheckReporter
   sourceDir: string
 }): Promise<void> {
   const spin = spinner('Verifying local content...').start()
+  const verifyBuild = isWorkbenchApp ? checkBuiltOutput : checkDir
   try {
-    const verifyBuild = isWorkbenchApp ? checkBuiltOutput : checkDir
     await verifyBuild(sourceDir)
     spin.succeed()
   } catch (err) {
     spin.fail()
     deployDebug('Error checking directory', err)
-    output.error(getErrorMessage(err), {exit: 1})
+    reporter.report({message: getErrorMessage(err), name: 'output-dir', status: 'fail'})
   }
 }
 
@@ -199,17 +188,18 @@ interface DeployTarget {
  * same verdicts through findUserApplicationForApp.
  */
 export async function checkAppTarget(
-  checks: DeployChecks,
+  reporter: CheckReporter,
   {appId, organizationId}: {appId: string | undefined; organizationId: string | undefined},
 ): Promise<{existingApp: UserApplication | null; target: DeployTarget | null}> {
-  const result = await checks.run(
+  const result = await runStep(
+    reporter,
     'target',
     async () => {
       const resolution = await resolveAppDeployTarget({appId, organizationId})
 
       switch (resolution.type) {
         case 'blocked': {
-          checks.add({
+          reporter.report({
             message: `Deploy target not resolved — ${resolution.message}`,
             name: 'target',
             status: 'skip',
@@ -218,7 +208,7 @@ export async function checkAppTarget(
         }
         case 'found': {
           const {application} = resolution
-          checks.add({
+          reporter.report({
             message: `Deploys to existing application "${application.title ?? application.appHost}"`,
             name: 'target',
             status: 'pass',
@@ -235,11 +225,15 @@ export async function checkAppTarget(
           }
         }
         case 'invalid': {
-          checks.add({message: APP_ID_NOT_FOUND_IN_ORGANIZATION, name: 'target', status: 'fail'})
+          reporter.report({
+            message: APP_ID_NOT_FOUND_IN_ORGANIZATION,
+            name: 'target',
+            status: 'fail',
+          })
           return {existingApp: null, target: null}
         }
         case 'needs-input': {
-          checks.add({
+          reporter.report({
             message: `No appId configured and ${resolution.existing.length} existing ${resolution.existing.length === 1 ? 'application' : 'applications'} found — deploy would prompt. Add deployment.appId to sanity.cli.ts.`,
             name: 'target',
             status: 'fail',
@@ -247,7 +241,7 @@ export async function checkAppTarget(
           return {existingApp: null, target: null}
         }
         case 'would-create': {
-          checks.add({
+          reporter.report({
             message: 'Would create a new application deployment',
             name: 'target',
             status: 'pass',


### PR DESCRIPTION
### Description

> [!NOTE]
> Stacked on #1406. A readability refactor of the deploy checks — no new behavior beyond a more specific build-failure message.

The `DeployChecks` seam was hard to follow: one interface with three methods (`add`/`all`/`run`) that each behaved differently per mode, two of them no-ops or pass-throughs in the fail-fast mode that actually runs today (`all()` returned `[]`, `run` was identity). A reader of the real deploy path kept tripping over machinery meant for the not-yet-built dry run.

The two modes really differ in one thing: what happens to a reported check. So the seam collapses to a single `CheckReporter { report }`. A real deploy fails fast (`createFailFastReporter` — a fail prints and exits); a dry run collects (`createCollectingReporter`). The error-to-fail conversion lives in one shared `runStep`. `verifyOutputDir` now reports through the reporter like every other check, and `createAppDeployment` documents the one-sequence-two-modes control flow.

This mirrors the shape of `sanity doctor`'s `runDoctorChecks` (checks produce results; a runner decides) as its fail-fast sibling. I looked at sharing a common core, but the execution models are opposite — doctor collects every independent check, deploy aborts on the first failure of a dependent sequence — so a shared abstraction would be a shallow seam serving two masters. Same vocabulary, no shared code.

One small behavior change: a build failure now surfaces as `Build failed: <err>` (the `formatError` that was dead on the real-deploy path) instead of the generic `Error deploying application: <err>`.

### What to review

- `CheckReporter`, the two reporters, and `runStep` in `deployChecks.ts`.
- `createAppDeployment` reads as a straight sequence; the ship guard marks the dry-run boundary.

### Testing

Unit tests cover both reporters, `runStep`, and the check mappings. Integration deploy tests pass unchanged.
