### PR TITLE
feat(deploy): add a --dry-run flag to the deploy command

### DIFF
--- a/.changeset/deploy-dry-run.md
+++ b/.changeset/deploy-dry-run.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": minor
+---
+
+feat(deploy): add a `--dry-run` flag that reports whether a studio or app can be deployed, and the files a deploy would upload, without uploading or creating anything

--- a/packages/@sanity/cli-e2e/__tests__/deploy.test.ts
+++ b/packages/@sanity/cli-e2e/__tests__/deploy.test.ts
@@ -38,8 +38,8 @@ describe.skipIf(isRegistryMode)('sanity deploy --dry-run', {timeout: 180_000}, (
     const {stdout} = await runCli({args: ['deploy', '--dry-run'], cwd})
 
     expectDeploymentSummary(stdout)
-    // The missing studio hostname is surfaced with its fix
-    expect(stdout).toContain('→ Set `studioHost`')
+    // The missing studio hostname is surfaced with its fix on the same line
+    expect(stdout).toContain('No studio hostname configured: Set `studioHost`')
     expect(stdout).not.toContain('Success! Studio deployed')
   })
 

--- a/packages/@sanity/cli-e2e/__tests__/deploy.test.ts
+++ b/packages/@sanity/cli-e2e/__tests__/deploy.test.ts
@@ -1,0 +1,48 @@
+import {testFixture} from '@sanity/cli-test'
+import {describe, expect, test} from 'vitest'
+
+import {runCli} from '../helpers/runCli.js'
+
+// `--dry-run` isn't on the published `latest` CLI yet, so skip against the registry.
+const isRegistryMode = process.env.E2E_REGISTRY_MODE === 'true'
+
+/**
+ * Asserts the shared shape of a `--dry-run` report: the header, at least one
+ * built file, and the studio/app entrypoint. Each file renders as
+ * `  <path> (<size> MB)`; the summary line ends with `):`, so it's excluded.
+ *
+ * The bare fixtures aren't configured with a deploy target, so the plan may
+ * report "cannot be deployed" and exit non-zero — that's fine here. All we
+ * verify is that a dry run builds, renders the plan, and never deploys.
+ */
+function expectDeploymentSummary(stdout: string): void {
+  expect(stdout).toContain('Dry run — no changes made.')
+
+  const fileLines = stdout.split('\n').filter((line) => /\(\d+\.\d+ MB\)$/.test(line))
+  expect(fileLines.length).toBeGreaterThan(0)
+  expect(stdout).toContain('index.html')
+}
+
+// `deploy --dry-run` is safe to run against real infrastructure: it builds
+// locally and resolves the deploy target read-only, but never uploads, creates,
+// or prompts — so it always exits 0 and just prints the plan. These prove the
+// flag end-to-end for both deploy kinds.
+describe.skipIf(isRegistryMode)('sanity deploy --dry-run', {timeout: 180_000}, () => {
+  test('reports a studio deploy plan without deploying', async () => {
+    const cwd = await testFixture('basic-studio')
+
+    const {stdout} = await runCli({args: ['deploy', '--dry-run'], cwd})
+
+    expectDeploymentSummary(stdout)
+    expect(stdout).not.toContain('Success! Studio deployed')
+  })
+
+  test('reports a core app deploy plan without deploying', async () => {
+    const cwd = await testFixture('basic-app')
+
+    const {stdout} = await runCli({args: ['deploy', '--dry-run'], cwd})
+
+    expectDeploymentSummary(stdout)
+    expect(stdout).not.toContain('Success! Application deployed')
+  })
+})

--- a/packages/@sanity/cli-e2e/__tests__/deploy.test.ts
+++ b/packages/@sanity/cli-e2e/__tests__/deploy.test.ts
@@ -7,24 +7,18 @@ import {runCli} from '../helpers/runCli.js'
 const isRegistryMode = process.env.E2E_REGISTRY_MODE === 'true'
 
 /**
- * Asserts the shared shape of a `--dry-run` report: the header, at least one
- * built file, and the studio/app entrypoint. Each file renders as
- * `  <path> (<size> MB)`; the summary line ends with `):`, so it's excluded.
- *
- * The bare fixtures have no deploy target configured, so the plan reports a
- * blocking problem — which lets us verify problems and their fixes surface
- * end-to-end. A dry run still builds, renders the plan, and never deploys.
+ * Asserts the shared shape of a blocked `--dry-run` report: the header, the
+ * "can't be deployed" verdict, and its problems. The bare fixtures have no
+ * deploy target configured, so the plan is blocked — which lets us verify
+ * problems and their fixes surface end-to-end. A blocked deploy uploads nothing,
+ * so it lists no files. A dry run still builds, renders the plan, and never deploys.
  */
 function expectDeploymentSummary(stdout: string): void {
   expect(stdout).toContain('Dry run — no changes made.')
 
-  const fileLines = stdout.split('\n').filter((line) => /\(\d+\.\d+ MB\)$/.test(line))
-  expect(fileLines.length).toBeGreaterThan(0)
-  expect(stdout).toContain('index.html')
-
-  // No deploy target → a blocking problem in the report
   expect(stdout).toContain("can't be deployed")
   expect(stdout).toContain('Problems to fix:')
+  expect(stdout).not.toContain('Files to deploy')
 }
 
 // `deploy --dry-run` is safe against real infrastructure: it builds locally and

--- a/packages/@sanity/cli-e2e/__tests__/deploy.test.ts
+++ b/packages/@sanity/cli-e2e/__tests__/deploy.test.ts
@@ -11,9 +11,9 @@ const isRegistryMode = process.env.E2E_REGISTRY_MODE === 'true'
  * built file, and the studio/app entrypoint. Each file renders as
  * `  <path> (<size> MB)`; the summary line ends with `):`, so it's excluded.
  *
- * The bare fixtures aren't configured with a deploy target, so the plan may
- * report "cannot be deployed" and exit non-zero — that's fine here. All we
- * verify is that a dry run builds, renders the plan, and never deploys.
+ * The bare fixtures have no deploy target configured, so the plan reports a
+ * blocking problem — which lets us verify problems and their fixes surface
+ * end-to-end. A dry run still builds, renders the plan, and never deploys.
  */
 function expectDeploymentSummary(stdout: string): void {
   expect(stdout).toContain('Dry run — no changes made.')
@@ -21,12 +21,16 @@ function expectDeploymentSummary(stdout: string): void {
   const fileLines = stdout.split('\n').filter((line) => /\(\d+\.\d+ MB\)$/.test(line))
   expect(fileLines.length).toBeGreaterThan(0)
   expect(stdout).toContain('index.html')
+
+  // No deploy target → a blocking problem in the report
+  expect(stdout).toContain("can't be deployed")
+  expect(stdout).toContain('Problems to fix:')
 }
 
-// `deploy --dry-run` is safe to run against real infrastructure: it builds
-// locally and resolves the deploy target read-only, but never uploads, creates,
-// or prompts — so it always exits 0 and just prints the plan. These prove the
-// flag end-to-end for both deploy kinds.
+// `deploy --dry-run` is safe against real infrastructure: it builds locally and
+// resolves the deploy target read-only, never uploading, creating, or prompting.
+// The bare fixtures have no deploy target, so each run also exercises the
+// "can't deploy" report — its problems, fixes, and warnings.
 describe.skipIf(isRegistryMode)('sanity deploy --dry-run', {timeout: 180_000}, () => {
   test('reports a studio deploy plan without deploying', async () => {
     const cwd = await testFixture('basic-studio')
@@ -34,6 +38,8 @@ describe.skipIf(isRegistryMode)('sanity deploy --dry-run', {timeout: 180_000}, (
     const {stdout} = await runCli({args: ['deploy', '--dry-run'], cwd})
 
     expectDeploymentSummary(stdout)
+    // The missing studio hostname is surfaced with its fix
+    expect(stdout).toContain('→ Set `studioHost`')
     expect(stdout).not.toContain('Success! Studio deployed')
   })
 
@@ -44,5 +50,18 @@ describe.skipIf(isRegistryMode)('sanity deploy --dry-run', {timeout: 180_000}, (
 
     expectDeploymentSummary(stdout)
     expect(stdout).not.toContain('Success! Application deployed')
+  })
+
+  test('surfaces warnings in the report', async () => {
+    const cwd = await testFixture('basic-studio')
+
+    // The deprecated --auto-updates flag is reported as a warning
+    const {stdout} = await runCli({
+      args: ['deploy', '--dry-run', '--no-build', '--auto-updates'],
+      cwd,
+    })
+
+    expect(stdout).toContain('Warnings:')
+    expect(stdout).toContain('--auto-updates flag is deprecated')
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -1,8 +1,9 @@
-import {type Output} from '@sanity/cli-core'
+import {type CliConfig, type Output} from '@sanity/cli-core'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {type UserApplication} from '../../../services/userApplications.js'
 import {
+  checkAppId,
   checkAppTarget,
   checkAutoUpdates,
   checkStudioTarget,
@@ -318,6 +319,39 @@ describe('checkAutoUpdates', () => {
       cliConfig: {deployment: {autoUpdates: true}},
       flags: {} as DeployFlags,
     })
+
+    expect(reporter.results).toHaveLength(0)
+  })
+})
+
+describe('checkAppId', () => {
+  test('both app.id and deployment.appId set is a fail check with a fix', () => {
+    const reporter = createCollectingReporter()
+
+    checkAppId(reporter, {cliConfig: {app: {id: 'old'}, deployment: {appId: 'new'}} as CliConfig})
+
+    expect(reporter.results).toEqual([
+      {
+        message: 'Both `app.id` (deprecated) and `deployment.appId` are set',
+        solution: 'Remove `app.id` from sanity.cli.ts',
+        status: 'fail',
+      },
+    ])
+  })
+
+  test('the deprecated app.id alone warns', () => {
+    const reporter = createCollectingReporter()
+
+    checkAppId(reporter, {cliConfig: {app: {id: 'old'}} as CliConfig})
+
+    expect(reporter.results).toEqual([expect.objectContaining({status: 'warn'})])
+    expect(reporter.results[0]?.message).toContain('deprecated')
+  })
+
+  test('deployment.appId alone records no check', () => {
+    const reporter = createCollectingReporter()
+
+    checkAppId(reporter, {cliConfig: {deployment: {appId: 'new'}} as CliConfig})
 
     expect(reporter.results).toHaveLength(0)
   })

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -1,4 +1,4 @@
-import {type CliConfig, type Output} from '@sanity/cli-core'
+import {type CliConfig, exitCodes, type Output} from '@sanity/cli-core'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {type UserApplication} from '../../../services/userApplications.js'
@@ -170,17 +170,21 @@ describe('checkStudioTarget', () => {
     )
   })
 
-  test('needs-input → fail check (unattended cannot prompt)', async () => {
+  test('needs-input → fail check with a pure problem and its fix', async () => {
     mockResolveStudio.mockResolvedValue({existing: [], type: 'needs-input'})
     const reporter = createCollectingReporter()
 
     await checkStudioTarget(reporter, studioArgs)
 
-    expect(reporter.results[0]).toMatchObject({status: 'fail'})
-    expect(reporter.results[0]?.message).toContain('Cannot prompt for studio hostname')
+    expect(reporter.results[0]).toMatchObject({
+      exitCode: exitCodes.USAGE_ERROR,
+      message: 'No studio hostname configured',
+      solution: 'Set `studioHost` in sanity.cli.ts, or pass a hostname with --url',
+      status: 'fail',
+    })
   })
 
-  test('invalid → fail check with the resolution message', async () => {
+  test('invalid app-not-found → fail check exits 1, like a real deploy', async () => {
     mockResolveStudio.mockResolvedValue({
       message: 'Cannot find app with app ID nope',
       reason: 'app-not-found',
@@ -191,7 +195,24 @@ describe('checkStudioTarget', () => {
     await checkStudioTarget(reporter, {...studioArgs, appId: 'nope'})
 
     expect(reporter.results[0]).toMatchObject({
+      exitCode: 1,
       message: 'Cannot find app with app ID nope',
+      status: 'fail',
+    })
+  })
+
+  test('invalid host → fail check exits USAGE_ERROR, like a real deploy', async () => {
+    mockResolveStudio.mockResolvedValue({
+      message: 'Invalid studio hostname',
+      reason: 'invalid-host',
+      type: 'invalid',
+    })
+    const reporter = createCollectingReporter()
+
+    await checkStudioTarget(reporter, {...studioArgs, urlFlag: 'bad host'})
+
+    expect(reporter.results[0]).toMatchObject({
+      exitCode: exitCodes.USAGE_ERROR,
       status: 'fail',
     })
   })
@@ -246,7 +267,7 @@ describe('checkAppTarget', () => {
 
     await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
 
-    expect(reporter.results[0]).toMatchObject({status: 'fail'})
+    expect(reporter.results[0]).toMatchObject({exitCode: exitCodes.USAGE_ERROR, status: 'fail'})
     expect(reporter.results[0]?.message).toContain('2 existing applications found')
   })
 

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -248,14 +248,15 @@ describe('checkAppTarget', () => {
     expect(reporter.results[0]?.message).toContain('Deploys to existing application "My App"')
   })
 
-  test('would-create → pass check', async () => {
+  test('would-create → fail check (creating one needs an interactive prompt)', async () => {
     mockResolveApp.mockResolvedValue({type: 'would-create'})
     const reporter = createCollectingReporter()
 
     await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
 
-    expect(reporter.results[0]).toMatchObject({status: 'pass'})
-    expect(reporter.results[0]?.message).toContain('Would create a new application deployment')
+    expect(reporter.results[0]).toMatchObject({exitCode: exitCodes.USAGE_ERROR, status: 'fail'})
+    expect(reporter.results[0]?.message).toContain('No application to deploy to')
+    expect(reporter.results[0]?.solution).toContain('interactively once')
   })
 
   test('needs-input → fail check (would prompt)', async () => {
@@ -268,7 +269,7 @@ describe('checkAppTarget', () => {
     await checkAppTarget(reporter, {appId: undefined, organizationId: 'org-1'})
 
     expect(reporter.results[0]).toMatchObject({exitCode: exitCodes.USAGE_ERROR, status: 'fail'})
-    expect(reporter.results[0]?.message).toContain('2 existing applications found')
+    expect(reporter.results[0]?.message).toContain('2 existing applications to choose from')
   })
 
   test('invalid → fail check', async () => {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
@@ -30,6 +30,22 @@ describe('runDeploy dry run', () => {
     expect(output.error).toHaveBeenCalledWith('Deploy blocked by failing checks.', {exit: 2})
   })
 
+  test('a blocked plan lists no files, even when listFiles would return some', async () => {
+    const output = mockOutput()
+    const listFiles = vi.fn(async () => [{path: 'dist/index.html', size: 10}])
+    const spec: DeploySpec = {
+      listFiles,
+      run: async (_options, reporter) =>
+        reporter.report({exitCode: 2, message: 'boom', status: 'fail'}),
+      type: 'studio',
+    }
+
+    await runDeploy(dryRunOptions(output), spec)
+
+    expect(listFiles).not.toHaveBeenCalled()
+    expect(output.log).not.toHaveBeenCalledWith(expect.stringContaining('Files to deploy'))
+  })
+
   test('a deployable dry run renders the plan without erroring', async () => {
     const output = mockOutput()
     const spec: DeploySpec = {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
@@ -1,0 +1,46 @@
+import {type Output} from '@sanity/cli-core'
+import {describe, expect, test, vi} from 'vitest'
+
+import {type DeploySpec, runDeploy} from '../deployRunner.js'
+import {type DeployAppOptions} from '../types.js'
+
+const mockOutput = () => ({error: vi.fn(), log: vi.fn(), warn: vi.fn()}) as unknown as Output
+
+const dryRunOptions = (output: Output): DeployAppOptions =>
+  ({
+    cliConfig: {},
+    flags: {'dry-run': true},
+    output,
+    projectRoot: {directory: '/root', path: '/root/sanity.cli.ts'},
+    sourceDir: '/root/dist',
+  }) as unknown as DeployAppOptions
+
+describe('runDeploy dry run', () => {
+  test('exits with the first failing check exit code, like a real deploy', async () => {
+    const output = mockOutput()
+    const spec: DeploySpec = {
+      listFiles: async () => [],
+      run: async (_options, reporter) =>
+        reporter.report({exitCode: 2, message: 'boom', status: 'fail'}),
+      type: 'studio',
+    }
+
+    await runDeploy(dryRunOptions(output), spec)
+
+    expect(output.error).toHaveBeenCalledWith('Deploy blocked by failing checks.', {exit: 2})
+  })
+
+  test('a deployable dry run renders the plan without erroring', async () => {
+    const output = mockOutput()
+    const spec: DeploySpec = {
+      listFiles: async () => [{path: 'dist/index.html', size: 10}],
+      run: async (_options, reporter) => reporter.report({message: 'Project: p1', status: 'pass'}),
+      type: 'studio',
+    }
+
+    await runDeploy(dryRunOptions(output), spec)
+
+    expect(output.error).not.toHaveBeenCalled()
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('This studio can be deployed.'))
+  })
+})

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -1,9 +1,9 @@
-import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
-import {tmpdir} from 'node:os'
+import {type Dirent, type Stats} from 'node:fs'
+import {readdir, stat} from 'node:fs/promises'
 import {join} from 'node:path'
 
 import {type Output} from '@sanity/cli-core'
-import {afterEach, beforeEach, describe, expect, test} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {type DeployCheck} from '../deployChecks.js'
 import {
@@ -13,23 +13,34 @@ import {
   renderDeploymentPlan,
 } from '../deploymentPlan.js'
 
+vi.mock(import('node:fs/promises'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  readdir: vi.fn(),
+  stat: vi.fn(),
+}))
+
+const mockReaddir = vi.mocked(readdir)
+const mockStat = vi.mocked(stat)
+
+// Minimal Dirent stand-in: listDeploymentFiles only reads `name` and `isDirectory()`.
+const dirent = (name: string, isDirectory: boolean): Dirent =>
+  ({isDirectory: () => isDirectory, name}) as Dirent
+
 describe('listDeploymentFiles', () => {
-  let dir: string
-
-  beforeEach(async () => {
-    dir = await mkdtemp(join(tmpdir(), 'deploy-plan-'))
-  })
-
-  afterEach(async () => {
-    await rm(dir, {force: true, recursive: true})
-  })
+  beforeEach(() => vi.clearAllMocks())
 
   test('lists nested files as sorted paths with sizes, relative to fromDir', async () => {
-    await mkdir(join(dir, 'dist', 'assets'), {recursive: true})
-    await writeFile(join(dir, 'dist', 'index.html'), 'x')
-    await writeFile(join(dir, 'dist', 'assets', 'app.js'), 'xyz')
+    mockReaddir.mockImplementation((async (dir: string) => {
+      if (dir.endsWith(join('dist', 'assets'))) return [dirent('app.js', false)]
+      if (dir.endsWith('dist')) return [dirent('index.html', false), dirent('assets', true)]
+      return []
+    }) as unknown as typeof readdir)
+    mockStat.mockImplementation(
+      (async (file: string) =>
+        ({size: file.endsWith('app.js') ? 3 : 1}) as Stats) as unknown as typeof stat,
+    )
 
-    const files = await listDeploymentFiles(join(dir, 'dist'), dir)
+    const files = await listDeploymentFiles(join('/root', 'dist'), '/root')
 
     expect(files).toEqual([
       {path: 'dist/assets/app.js', size: 3},
@@ -38,7 +49,8 @@ describe('listDeploymentFiles', () => {
   })
 
   test('returns an empty list when the directory is missing', async () => {
-    expect(await listDeploymentFiles(join(dir, 'missing'), dir)).toEqual([])
+    mockReaddir.mockRejectedValue(new Error('ENOENT'))
+    expect(await listDeploymentFiles(join('/root', 'missing'), '/root')).toEqual([])
   })
 })
 
@@ -85,7 +97,8 @@ describe('renderDeploymentPlan', () => {
     expect(text).toContain("This studio can't be deployed.")
     expect(text).toContain('Problems to fix:')
     expect(text).toContain('No project ID configured: Add `api.projectId`')
-    expect(text).toContain('Files to deploy (0.00 MB):')
+    // No files to list, so the section is omitted rather than shown as "0.00 MB"
+    expect(text).not.toContain('Files to deploy')
   })
 
   test('surfaces warnings in their own section', () => {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -1,0 +1,89 @@
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {type Output} from '@sanity/cli-core'
+import {afterEach, beforeEach, describe, expect, test} from 'vitest'
+
+import {type DeployCheck} from '../deployChecks.js'
+import {
+  type DeploymentFile,
+  type DeploymentPlan,
+  listDeploymentFiles,
+  renderDeploymentPlan,
+} from '../deploymentPlan.js'
+
+describe('listDeploymentFiles', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'deploy-plan-'))
+  })
+
+  afterEach(async () => {
+    await rm(dir, {force: true, recursive: true})
+  })
+
+  test('lists nested files as sorted paths with sizes, relative to fromDir', async () => {
+    await mkdir(join(dir, 'dist', 'assets'), {recursive: true})
+    await writeFile(join(dir, 'dist', 'index.html'), 'x')
+    await writeFile(join(dir, 'dist', 'assets', 'app.js'), 'xyz')
+
+    const files = await listDeploymentFiles(join(dir, 'dist'), dir)
+
+    expect(files).toEqual([
+      {path: 'dist/assets/app.js', size: 3},
+      {path: 'dist/index.html', size: 1},
+    ])
+  })
+
+  test('returns an empty list when the directory is missing', async () => {
+    expect(await listDeploymentFiles(join(dir, 'missing'), dir)).toEqual([])
+  })
+})
+
+const studioPlan = (checks: DeployCheck[], files: DeploymentFile[] = []): DeploymentPlan => ({
+  checks,
+  files,
+  type: 'studio',
+})
+
+describe('renderDeploymentPlan', () => {
+  const lines: string[] = []
+  const output = {log: (message: string) => lines.push(message)} as unknown as Output
+
+  beforeEach(() => {
+    lines.length = 0
+  })
+
+  test('reports a deployable studio with its files and sizes', () => {
+    renderDeploymentPlan(
+      studioPlan(
+        [{message: 'Project: p1', status: 'pass'}],
+        [{path: 'dist/index.html', size: 1_572_864}],
+      ),
+      output,
+    )
+
+    const text = lines.join('\n')
+    expect(text).toContain('Dry run — no changes made.')
+    expect(text).toContain('Project: p1')
+    expect(text).toContain('This studio can be deployed.')
+    expect(text).toContain('Files to deploy (1.50 MB):')
+    expect(text).toContain('dist/index.html (1.50 MB)')
+  })
+
+  test('reports non-deployable when a check failed', () => {
+    renderDeploymentPlan(studioPlan([{message: 'Missing project id', status: 'fail'}]), output)
+
+    const text = lines.join('\n')
+    expect(text).toContain('cannot be deployed')
+    expect(text).toContain('Files to deploy (0.00 MB):')
+  })
+
+  test('labels a core app deploy as an application', () => {
+    renderDeploymentPlan({checks: [], files: [], type: 'coreApp'}, output)
+
+    expect(lines.join('\n')).toContain('This application can be deployed.')
+  })
+})

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -101,6 +101,18 @@ describe('renderDeploymentPlan', () => {
     expect(text).not.toContain('Files to deploy')
   })
 
+  test('omits the files section for a blocked plan even when files are present', () => {
+    renderDeploymentPlan(
+      studioPlan(
+        [{message: 'No project ID configured', status: 'fail'}],
+        [{path: 'dist/index.html', size: 1_048_576}],
+      ),
+      output,
+    )
+
+    expect(lines.join('\n')).not.toContain('Files to deploy')
+  })
+
   test('surfaces warnings in their own section', () => {
     renderDeploymentPlan(
       studioPlan([

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -84,8 +84,7 @@ describe('renderDeploymentPlan', () => {
     const text = lines.join('\n')
     expect(text).toContain("This studio can't be deployed.")
     expect(text).toContain('Problems to fix:')
-    expect(text).toContain('No project ID configured')
-    expect(text).toContain('→ Add `api.projectId`')
+    expect(text).toContain('No project ID configured: Add `api.projectId`')
     expect(text).toContain('Files to deploy (0.00 MB):')
   })
 
@@ -101,8 +100,7 @@ describe('renderDeploymentPlan', () => {
     const text = lines.join('\n')
     expect(text).toContain('This studio can be deployed.')
     expect(text).toContain('Warnings:')
-    expect(text).toContain('The `autoUpdates` config has moved')
-    expect(text).toContain('→ Move it')
+    expect(text).toContain('The `autoUpdates` config has moved: Move it')
   })
 
   test('labels a core app deploy as an application', () => {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -73,12 +73,36 @@ describe('renderDeploymentPlan', () => {
     expect(text).toContain('dist/index.html (1.50 MB)')
   })
 
-  test('reports non-deployable when a check failed', () => {
-    renderDeploymentPlan(studioPlan([{message: 'Missing project id', status: 'fail'}]), output)
+  test('lists problems with their solutions when a check failed', () => {
+    renderDeploymentPlan(
+      studioPlan([
+        {message: 'No project ID configured', solution: 'Add `api.projectId`', status: 'fail'},
+      ]),
+      output,
+    )
 
     const text = lines.join('\n')
-    expect(text).toContain('cannot be deployed')
+    expect(text).toContain("This studio can't be deployed.")
+    expect(text).toContain('Problems to fix:')
+    expect(text).toContain('No project ID configured')
+    expect(text).toContain('→ Add `api.projectId`')
     expect(text).toContain('Files to deploy (0.00 MB):')
+  })
+
+  test('surfaces warnings in their own section', () => {
+    renderDeploymentPlan(
+      studioPlan([
+        {message: 'Project: p1', status: 'pass'},
+        {message: 'The `autoUpdates` config has moved', solution: 'Move it', status: 'warn'},
+      ]),
+      output,
+    )
+
+    const text = lines.join('\n')
+    expect(text).toContain('This studio can be deployed.')
+    expect(text).toContain('Warnings:')
+    expect(text).toContain('The `autoUpdates` config has moved')
+    expect(text).toContain('→ Move it')
   })
 
   test('labels a core app deploy as an application', () => {

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -20,6 +20,7 @@ import {extractCoreAppManifest, resolveTitleUpdate} from '../manifest/extractCor
 import {type CoreAppManifest} from '../manifest/types.js'
 import {createUserApplication} from './createUserApplication.js'
 import {
+  checkAppTarget,
   checkAutoUpdates,
   checkBuild,
   checkPackageVersion,
@@ -27,24 +28,32 @@ import {
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
+import {listDeploymentFiles} from './deploymentPlan.js'
 import {runDeploy} from './deployRunner.js'
 import {findUserApplication} from './findUserApplication.js'
 import {type DeployAppOptions} from './types.js'
 
 export function deployApp(options: DeployAppOptions): Promise<void> {
-  return runDeploy(options, {run: runAppDeployment, type: 'coreApp'})
+  return runDeploy(options, {
+    listFiles: ({projectRoot, sourceDir}) => listDeploymentFiles(sourceDir, projectRoot.directory),
+    run: runAppDeployment,
+    type: 'coreApp',
+  })
 }
 
 /**
  * Validates the deploy, syncs the title from the manifest, and ships the build.
- * Every step reports through `reporter`, and the first failure exits — so
- * reaching any later step means the earlier ones passed.
+ *
+ * Every step reports through `reporter`; a real deploy exits on the first
+ * failure, a dry run collects them. The one `dry-run` stop below marks the line
+ * between read-only checks and the mutations a real deploy performs.
  */
 async function runAppDeployment(options: DeployAppOptions, reporter: CheckReporter): Promise<void> {
   const {cliConfig, flags, output, sourceDir} = options
   const workDir = options.projectRoot.directory
   const organizationId = cliConfig.app?.organizationId
   const workbench = getWorkbench(cliConfig)
+  const dryRun = !!flags['dry-run']
 
   // A federated app with no entry, view or service would ship a remote with
   // nothing to load — reported first so it fails before any prompt or API call.
@@ -86,7 +95,7 @@ async function runAppDeployment(options: DeployAppOptions, reporter: CheckReport
       status: 'fail',
     })
   } else {
-    application = await resolveAppApplication(options)
+    application = await resolveAppApplication(options, {dryRun, reporter})
   }
 
   await checkBuild(reporter, {
@@ -120,6 +129,9 @@ async function runAppDeployment(options: DeployAppOptions, reporter: CheckReport
     })
   }
 
+  // Dry run stops here — everything below mutates.
+  if (dryRun) return
+
   // A real deploy has already exited if anything failed; landing here without a
   // resolved application or version means the deploy target was never resolved.
   if (!application || !version) return
@@ -130,10 +142,22 @@ async function runAppDeployment(options: DeployAppOptions, reporter: CheckReport
   logAppDeployed({application, cliConfig, output})
 }
 
-/** Finds the application a deploy targets, creating one when none is configured. */
-async function resolveAppApplication(options: DeployAppOptions): Promise<UserApplication | null> {
+/**
+ * Finds the application a real deploy targets, creating one when none is
+ * configured. In a dry run it resolves and reports the target read-only —
+ * prompting and creation are the mutations a dry run skips.
+ */
+async function resolveAppApplication(
+  options: DeployAppOptions,
+  {dryRun, reporter}: {dryRun: boolean; reporter: CheckReporter},
+): Promise<UserApplication | null> {
   const {cliConfig, flags, output} = options
   const organizationId = cliConfig.app?.organizationId ?? ''
+
+  if (dryRun) {
+    await checkAppTarget(reporter, {appId: getAppId(cliConfig), organizationId})
+    return null
+  }
 
   let application = await findUserApplication({
     cliConfig,

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -20,6 +20,7 @@ import {extractCoreAppManifest, resolveTitleUpdate} from '../manifest/extractCor
 import {type CoreAppManifest} from '../manifest/types.js'
 import {createUserApplication} from './createUserApplication.js'
 import {
+  checkAppId,
   checkAppTarget,
   checkAutoUpdates,
   checkBuild,
@@ -148,6 +149,7 @@ async function resolveAppApplication(
   const organizationId = cliConfig.app?.organizationId ?? ''
 
   if (dryRun) {
+    checkAppId(reporter, {cliConfig})
     await checkAppTarget(reporter, {appId: getAppId(cliConfig), organizationId})
     return null
   }

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -41,13 +41,7 @@ export function deployApp(options: DeployAppOptions): Promise<void> {
   })
 }
 
-/**
- * Validates the deploy, syncs the title from the manifest, and ships the build.
- *
- * Every step reports through `reporter`; a real deploy exits on the first
- * failure, a dry run collects them. The one `dry-run` stop below marks the line
- * between read-only checks and the mutations a real deploy performs.
- */
+/** Validates the deploy, syncs the title from the manifest, and ships the build. */
 async function runAppDeployment(options: DeployAppOptions, reporter: CheckReporter): Promise<void> {
   const {cliConfig, flags, output, sourceDir} = options
   const workDir = options.projectRoot.directory
@@ -144,8 +138,7 @@ async function runAppDeployment(options: DeployAppOptions, reporter: CheckReport
 
 /**
  * Finds the application a real deploy targets, creating one when none is
- * configured. In a dry run it resolves and reports the target read-only —
- * prompting and creation are the mutations a dry run skips.
+ * configured. A dry run resolves and reports the target read-only instead.
  */
 async function resolveAppApplication(
   options: DeployAppOptions,

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -82,6 +82,8 @@ async function runAppDeployment(options: DeployAppOptions, reporter: CheckReport
         },
   )
 
+  checkAppId(reporter, {cliConfig})
+
   let application: UserApplication | null = null
   if (flags.external) {
     reporter.report({
@@ -149,7 +151,6 @@ async function resolveAppApplication(
   const organizationId = cliConfig.app?.organizationId ?? ''
 
   if (dryRun) {
-    checkAppId(reporter, {cliConfig})
     await checkAppTarget(reporter, {appId: getAppId(cliConfig), organizationId})
     return null
   }

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -1,12 +1,9 @@
-import {type CliConfig, getLocalPackageVersion, type Output} from '@sanity/cli-core'
+import {type CliConfig, exitCodes, getLocalPackageVersion, type Output} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {checkBuiltOutput} from '@sanity/workbench-cli/deploy'
 
 import {resolveAppIdIssue} from '../../util/appId.js'
-import {
-  APP_ID_NOT_FOUND_IN_ORGANIZATION,
-  cannotPromptForStudioHost,
-} from '../../util/errorMessages.js'
+import {APP_ID_NOT_FOUND_IN_ORGANIZATION} from '../../util/errorMessages.js'
 import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {
   getAutoUpdateIssueMessage,
@@ -43,6 +40,8 @@ export interface CheckReporter {
 export function createFailFastReporter(output: Output): CheckReporter {
   return {
     report(check) {
+      // Fixes surface in both modes: appended after the message here, and in the
+      // dry-run report, so the problem and its fix never drift apart.
       const text = check.solution ? `${check.message}: ${check.solution}` : check.message
       if (check.status === 'fail') {
         output.error(text, {exit: check.exitCode ?? 1})
@@ -245,6 +244,8 @@ export async function checkAppTarget(
         }
         case 'needs-input': {
           reporter.report({
+            // Matches the exit code an unattended real deploy uses (findUserApplication)
+            exitCode: exitCodes.USAGE_ERROR,
             message: `No \`deployment.appId\` configured and ${resolution.existing.length} existing ${resolution.existing.length === 1 ? 'application' : 'applications'} found — a real deploy would prompt`,
             solution: 'Add `deployment.appId` to sanity.cli.ts',
             status: 'fail',
@@ -316,6 +317,8 @@ export async function checkStudioTarget(
         }
         case 'invalid': {
           reporter.report({
+            // A bad host is a usage error; other invalid targets exit 1 — same as findUserApplicationForStudio
+            exitCode: resolution.reason === 'invalid-host' ? exitCodes.USAGE_ERROR : 1,
             message: resolution.message,
             solution: 'Check `studioHost` and `deployment.appId` in sanity.cli.ts',
             status: 'fail',
@@ -323,10 +326,16 @@ export async function checkStudioTarget(
           return
         }
         case 'needs-input': {
-          // The same constraint an unattended deploy enforces, with the same message
+          // Dry-run only; a real deploy prompts, or errors in findUserApplication.
           reporter.report({
-            message: cannotPromptForStudioHost(isExternal),
-            solution: 'Set `studioHost` in sanity.cli.ts, or pass a hostname with --url',
+            // Matches the exit code an unattended real deploy uses (findUserApplicationForStudio)
+            exitCode: exitCodes.USAGE_ERROR,
+            message: isExternal
+              ? 'No external studio URL configured'
+              : 'No studio hostname configured',
+            solution: isExternal
+              ? 'Set `studioHost` in sanity.cli.ts, or pass the full URL with --url'
+              : 'Set `studioHost` in sanity.cli.ts, or pass a hostname with --url',
             status: 'fail',
           })
           return

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -2,6 +2,7 @@ import {type CliConfig, getLocalPackageVersion, type Output} from '@sanity/cli-c
 import {spinner} from '@sanity/cli-core/ux'
 import {checkBuiltOutput} from '@sanity/workbench-cli/deploy'
 
+import {resolveAppIdIssue} from '../../util/appId.js'
 import {
   APP_ID_NOT_FOUND_IN_ORGANIZATION,
   cannotPromptForStudioHost,
@@ -125,6 +126,28 @@ export function checkAutoUpdates(
   }
 
   return enabled
+}
+
+/**
+ * The dry-run form of the `app.id` config check a real deploy runs in
+ * `findUserApplication`: a conflict fails (both `app.id` and `deployment.appId`
+ * set), the deprecated config alone warns.
+ */
+export function checkAppId(reporter: CheckReporter, {cliConfig}: {cliConfig: CliConfig}): void {
+  const issue = resolveAppIdIssue(cliConfig)
+  if (issue === 'conflicting-config') {
+    reporter.report({
+      message: 'Both `app.id` (deprecated) and `deployment.appId` are set',
+      solution: 'Remove `app.id` from sanity.cli.ts',
+      status: 'fail',
+    })
+  } else if (issue === 'deprecated-config') {
+    reporter.report({
+      message: 'The `app.id` config is deprecated',
+      solution: 'Move it to `deployment.appId` in sanity.cli.ts',
+      status: 'warn',
+    })
+  }
 }
 
 export async function checkBuild(

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -12,7 +12,12 @@ import {
 } from '../build/shouldAutoUpdate.js'
 import {checkDir} from './checkDir.js'
 import {deployDebug} from './deployDebug.js'
-import {resolveAppDeployTarget, resolveStudioDeployTarget} from './resolveDeployTarget.js'
+import {
+  type AppDeployTargetResolution,
+  resolveAppDeployTarget,
+  resolveStudioDeployTarget,
+  type StudioDeployTargetResolution,
+} from './resolveDeployTarget.js'
 import {type DeployFlags} from './types.js'
 
 type DeployCheckStatus = 'fail' | 'pass' | 'skip' | 'warn'
@@ -204,10 +209,57 @@ export async function verifyOutputDir({
 }
 
 /**
- * Reports the read-only app deploy-target verdict. The rules live in
- * resolveDeployTarget; a real deploy consumes the same verdicts through
- * findUserApplication.
+ * The single diagnosis for each app deploy-target verdict, shared by the
+ * dry-run report and the real deploy's unattended error paths so message,
+ * fix, and exit code can't drift between the two.
  */
+export function describeAppTarget(resolution: AppDeployTargetResolution): DeployCheck {
+  switch (resolution.type) {
+    case 'blocked': {
+      return {message: `Deploy target not resolved — ${resolution.message}`, status: 'skip'}
+    }
+    case 'found': {
+      const {application} = resolution
+      return {
+        message: `Deploys to existing application "${application.title ?? application.appHost}"`,
+        status: 'pass',
+      }
+    }
+    case 'invalid': {
+      return {
+        message: APP_ID_NOT_FOUND_IN_ORGANIZATION,
+        solution: 'Check `deployment.appId` matches an app in your organization',
+        status: 'fail',
+      }
+    }
+    case 'needs-input': {
+      return {
+        exitCode: exitCodes.USAGE_ERROR,
+        message: `No \`deployment.appId\` configured (${resolution.existing.length} existing ${resolution.existing.length === 1 ? 'application' : 'applications'} to choose from)`,
+        solution: 'Add `deployment.appId` to sanity.cli.ts',
+        status: 'fail',
+      }
+    }
+    // Creating an application prompts for a title, which no unattended run
+    // (including a dry run) can answer
+    case 'would-create': {
+      return {
+        exitCode: exitCodes.USAGE_ERROR,
+        message: 'No application to deploy to — creating one needs an interactive prompt',
+        solution:
+          'Run `sanity deploy` interactively once, or add `deployment.appId` to sanity.cli.ts',
+        status: 'fail',
+      }
+    }
+  }
+}
+
+export function describeAppTargetError(err: unknown, organizationId: string | undefined): string {
+  return (err as {statusCode?: number})?.statusCode === 403
+    ? `You don’t have permission to view applications for the configured organization ID ("${organizationId}"). Verify the organization ID, or ask your organization’s admin for access.`
+    : `Failed to resolve deploy target: ${getErrorMessage(err)}`
+}
+
 export async function checkAppTarget(
   reporter: CheckReporter,
   {appId, organizationId}: {appId: string | undefined; organizationId: string | undefined},
@@ -215,70 +267,62 @@ export async function checkAppTarget(
   await runStep(
     reporter,
     'target',
-    async () => {
-      const resolution = await resolveAppDeployTarget({appId, organizationId})
-
-      switch (resolution.type) {
-        case 'blocked': {
-          reporter.report({
-            message: `Deploy target not resolved — ${resolution.message}`,
-            status: 'skip',
-          })
-          return
-        }
-        case 'found': {
-          const {application} = resolution
-          reporter.report({
-            message: `Deploys to existing application "${application.title ?? application.appHost}"`,
-            status: 'pass',
-          })
-          return
-        }
-        case 'invalid': {
-          reporter.report({
-            message: APP_ID_NOT_FOUND_IN_ORGANIZATION,
-            solution: 'Check `deployment.appId` matches an app in your organization',
-            status: 'fail',
-          })
-          return
-        }
-        case 'needs-input': {
-          reporter.report({
-            // Matches the exit code an unattended real deploy uses (findUserApplication)
-            exitCode: exitCodes.USAGE_ERROR,
-            message: `No \`deployment.appId\` configured and ${resolution.existing.length} existing ${resolution.existing.length === 1 ? 'application' : 'applications'} found — a real deploy would prompt`,
-            solution: 'Add `deployment.appId` to sanity.cli.ts',
-            status: 'fail',
-          })
-          return
-        }
-        case 'would-create': {
-          reporter.report({message: 'Would create a new application deployment', status: 'pass'})
-          return
-        }
-      }
-    },
-    (err) =>
-      (err as {statusCode?: number})?.statusCode === 403
-        ? `You don’t have permission to view applications for the configured organization ID ("${organizationId}"). Verify the organization ID, or ask your organization’s admin for access.`
-        : `Failed to resolve deploy target: ${getErrorMessage(err)}`,
+    async () =>
+      reporter.report(describeAppTarget(await resolveAppDeployTarget({appId, organizationId}))),
+    (err) => describeAppTargetError(err, organizationId),
   )
 }
 
-/**
- * Reports the read-only studio deploy-target verdict. The rules live in
- * resolveDeployTarget; a real deploy consumes the same verdicts through
- * findUserApplicationForStudio.
- */
+/** Same contract as {@link describeAppTarget}, for the studio verdicts. */
+export function describeStudioTarget(
+  resolution: StudioDeployTargetResolution,
+  {isExternal}: {isExternal: boolean},
+): DeployCheck {
+  const studioUrl = (host: string) => (isExternal ? host : `https://${host}.sanity.studio`)
+
+  switch (resolution.type) {
+    case 'blocked': {
+      return {message: `Deploy target not resolved — ${resolution.message}`, status: 'skip'}
+    }
+    case 'found': {
+      return {
+        message: `Deploys to existing studio ${studioUrl(resolution.application.appHost)}`,
+        status: 'pass',
+      }
+    }
+    case 'invalid': {
+      return {
+        // A bad host is a usage error; other invalid targets exit 1
+        exitCode: resolution.reason === 'invalid-host' ? exitCodes.USAGE_ERROR : 1,
+        message: resolution.message,
+        solution: 'Check `studioHost` and `deployment.appId` in sanity.cli.ts',
+        status: 'fail',
+      }
+    }
+    case 'needs-input': {
+      return {
+        exitCode: exitCodes.USAGE_ERROR,
+        message: isExternal ? 'No external studio URL configured' : 'No studio hostname configured',
+        solution: isExternal
+          ? 'Set `studioHost` in sanity.cli.ts, or pass the full URL with --url'
+          : 'Set `studioHost` in sanity.cli.ts, or pass a hostname with --url',
+        status: 'fail',
+      }
+    }
+    case 'would-create': {
+      return {
+        message: isExternal
+          ? `Would register external studio at ${resolution.appHost}`
+          : `Would create studio hostname ${studioUrl(resolution.appHost)} (name availability is checked on deploy)`,
+        status: 'pass',
+      }
+    }
+  }
+}
+
 export async function checkStudioTarget(
   reporter: CheckReporter,
-  {
-    appId,
-    isExternal,
-    projectId,
-    studioHost,
-    urlFlag,
-  }: {
+  options: {
     appId: string | undefined
     isExternal: boolean
     projectId: string | undefined
@@ -286,72 +330,15 @@ export async function checkStudioTarget(
     urlFlag: string | undefined
   },
 ): Promise<void> {
-  const studioUrl = (host: string) => (isExternal ? host : `https://${host}.sanity.studio`)
-
   await runStep(
     reporter,
     'target',
-    async () => {
-      const resolution = await resolveStudioDeployTarget({
-        appId,
-        isExternal,
-        projectId,
-        studioHost,
-        urlFlag,
-      })
-
-      switch (resolution.type) {
-        case 'blocked': {
-          reporter.report({
-            message: `Deploy target not resolved — ${resolution.message}`,
-            status: 'skip',
-          })
-          return
-        }
-        case 'found': {
-          reporter.report({
-            message: `Deploys to existing studio ${studioUrl(resolution.application.appHost)}`,
-            status: 'pass',
-          })
-          return
-        }
-        case 'invalid': {
-          reporter.report({
-            // A bad host is a usage error; other invalid targets exit 1 — same as findUserApplicationForStudio
-            exitCode: resolution.reason === 'invalid-host' ? exitCodes.USAGE_ERROR : 1,
-            message: resolution.message,
-            solution: 'Check `studioHost` and `deployment.appId` in sanity.cli.ts',
-            status: 'fail',
-          })
-          return
-        }
-        case 'needs-input': {
-          // Dry-run only; a real deploy prompts, or errors in findUserApplication.
-          reporter.report({
-            // Matches the exit code an unattended real deploy uses (findUserApplicationForStudio)
-            exitCode: exitCodes.USAGE_ERROR,
-            message: isExternal
-              ? 'No external studio URL configured'
-              : 'No studio hostname configured',
-            solution: isExternal
-              ? 'Set `studioHost` in sanity.cli.ts, or pass the full URL with --url'
-              : 'Set `studioHost` in sanity.cli.ts, or pass a hostname with --url',
-            status: 'fail',
-          })
-          return
-        }
-        case 'would-create': {
-          const {appHost} = resolution
-          reporter.report({
-            message: isExternal
-              ? `Would register external studio at ${appHost}`
-              : `Would create studio hostname ${studioUrl(appHost)} (name availability is checked on deploy)`,
-            status: 'pass',
-          })
-          return
-        }
-      }
-    },
+    async () =>
+      reporter.report(
+        describeStudioTarget(await resolveStudioDeployTarget(options), {
+          isExternal: options.isExternal,
+        }),
+      ),
     (err) => `Failed to resolve deploy target: ${getErrorMessage(err)}`,
   )
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -1,28 +1,48 @@
 import {CLIError} from '@oclif/core/errors'
 import {type Output} from '@sanity/cli-core'
 
-import {type CheckReporter, createFailFastReporter} from './deployChecks.js'
+import {
+  type CheckReporter,
+  createCollectingReporter,
+  createFailFastReporter,
+} from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
+import {type DeploymentFile, renderDeploymentPlan} from './deploymentPlan.js'
 import {type DeployAppOptions} from './types.js'
 
 /**
  * A deploy flow, split into the parts that differ between core apps and studios.
- * Everything the two share — reporter setup and error handling — lives in
- * `runDeploy`, so both types read as the same sequence.
+ * Everything the two share — mode selection, error handling, the dry-run plan —
+ * lives in `runDeploy`, so both types read as the same sequence.
  */
 export interface DeploySpec {
+  /** Files a real deploy would upload, listed only for the dry-run plan. */
+  listFiles: (options: DeployAppOptions) => Promise<DeploymentFile[]>
   /** The step sequence; every step reports through `reporter`. */
   run: (options: DeployAppOptions, reporter: CheckReporter) => Promise<void>
   type: 'coreApp' | 'studio'
 }
 
 /**
- * Runs a deploy flow: the steps report through a fail-fast reporter — the first
- * failure prints and exits — and any escaping error is normalized to an exit
- * code.
+ * Runs a deploy flow in whichever mode the flags select. A real deploy fails
+ * fast and mutates; `--dry-run` collects every check and renders a plan without
+ * mutating. Both drive the same `run` sequence, so the modes can't drift — the
+ * mode lives only in the reporter and in the dry-run stop inside `run`.
  */
 export async function runDeploy(options: DeployAppOptions, spec: DeploySpec): Promise<void> {
   const {output} = options
+
+  if (options.flags['dry-run']) {
+    const reporter = createCollectingReporter()
+    await spec.run(options, reporter)
+    const files = await spec.listFiles(options)
+    renderDeploymentPlan({checks: reporter.results, files, type: spec.type}, output)
+    // Exit non-zero when the plan isn't deployable so scripts can gate on it.
+    if (reporter.results.some((check) => check.status === 'fail')) {
+      output.error('Deploy blocked by failing checks.', {exit: 1})
+    }
+    return
+  }
 
   try {
     await spec.run(options, createFailFastReporter(output))

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -7,7 +7,7 @@ import {
   createFailFastReporter,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
-import {type DeploymentFile, renderDeploymentPlan} from './deploymentPlan.js'
+import {type DeploymentFile, type DeploymentPlan, renderDeploymentPlan} from './deploymentPlan.js'
 import {type DeployAppOptions} from './types.js'
 
 /**
@@ -33,11 +33,16 @@ export async function runDeploy(options: DeployAppOptions, spec: DeploySpec): Pr
   if (options.flags['dry-run']) {
     const reporter = createCollectingReporter()
     await spec.run(options, reporter)
-    const files = await spec.listFiles(options)
-    renderDeploymentPlan({checks: reporter.results, files, type: spec.type}, output)
+    const failed = reporter.results.find((check) => check.status === 'fail')
+    const plan: DeploymentPlan = {
+      checks: reporter.results,
+      // A blocked deploy uploads nothing, so only enumerate files for a deployable plan.
+      files: failed ? [] : await spec.listFiles(options),
+      type: spec.type,
+    }
+    renderDeploymentPlan(plan, output)
     // Exit like a real (fail-fast) deploy would on the first failing check, so a
     // script gating on the exit code sees the same status.
-    const failed = reporter.results.find((check) => check.status === 'fail')
     if (failed) output.error('Deploy blocked by failing checks.', {exit: failed.exitCode ?? 1})
     return
   }

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -35,10 +35,10 @@ export async function runDeploy(options: DeployAppOptions, spec: DeploySpec): Pr
     await spec.run(options, reporter)
     const files = await spec.listFiles(options)
     renderDeploymentPlan({checks: reporter.results, files, type: spec.type}, output)
-    // Exit non-zero when the plan isn't deployable so scripts can gate on it.
-    if (reporter.results.some((check) => check.status === 'fail')) {
-      output.error('Deploy blocked by failing checks.', {exit: 1})
-    }
+    // Exit like a real (fail-fast) deploy would on the first failing check, so a
+    // script gating on the exit code sees the same status.
+    const failed = reporter.results.find((check) => check.status === 'fail')
+    if (failed) output.error('Deploy blocked by failing checks.', {exit: failed.exitCode ?? 1})
     return
   }
 

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -11,9 +11,8 @@ import {type DeploymentFile, renderDeploymentPlan} from './deploymentPlan.js'
 import {type DeployAppOptions} from './types.js'
 
 /**
- * A deploy flow, split into the parts that differ between core apps and studios.
- * Everything the two share — mode selection, error handling, the dry-run plan —
- * lives in `runDeploy`, so both types read as the same sequence.
+ * The parts of a deploy that differ between core apps and studios. The shared
+ * sequence — mode selection, error handling, the dry-run plan — lives in `runDeploy`.
  */
 export interface DeploySpec {
   /** Files a real deploy would upload, listed only for the dry-run plan. */
@@ -24,10 +23,9 @@ export interface DeploySpec {
 }
 
 /**
- * Runs a deploy flow in whichever mode the flags select. A real deploy fails
- * fast and mutates; `--dry-run` collects every check and renders a plan without
- * mutating. Both drive the same `run` sequence, so the modes can't drift — the
- * mode lives only in the reporter and in the dry-run stop inside `run`.
+ * Runs a deploy in the mode the flags select. A real deploy fails fast and
+ * mutates; `--dry-run` drives the same `run` sequence read-only and renders a
+ * plan. The mode lives only in the reporter, so the two can't drift.
  */
 export async function runDeploy(options: DeployAppOptions, spec: DeploySpec): Promise<void> {
   const {output} = options

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -19,22 +19,31 @@ import {
   checkBuild,
   checkPackageVersion,
   type CheckReporter,
+  checkStudioTarget,
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
+import {listDeploymentFiles} from './deploymentPlan.js'
 import {runDeploy} from './deployRunner.js'
 import {deployStudioSchemasAndManifests} from './deployStudioSchemasAndManifests.js'
 import {findUserApplicationForStudio} from './findUserApplication.js'
 import {type DeployAppOptions} from './types.js'
 
 export function deployStudio(options: DeployAppOptions): Promise<void> {
-  return runDeploy(options, {run: runStudioDeployment, type: 'studio'})
+  return runDeploy(options, {
+    listFiles: ({flags, projectRoot, sourceDir}) =>
+      flags.external ? Promise.resolve([]) : listDeploymentFiles(sourceDir, projectRoot.directory),
+    run: runStudioDeployment,
+    type: 'studio',
+  })
 }
 
 /**
  * Validates the deploy, extracts and uploads the schema, and ships the build.
- * Every step reports through `reporter`, and the first failure exits — so
- * reaching any later step means the earlier ones passed.
+ *
+ * Every step reports through `reporter`; a real deploy exits on the first
+ * failure, a dry run collects them. The one `dry-run` stop below marks the line
+ * between read-only checks and the mutations a real deploy performs.
  */
 async function runStudioDeployment(
   options: DeployAppOptions,
@@ -45,6 +54,7 @@ async function runStudioDeployment(
   const isExternal = !!flags.external
   const isWorkbenchApp = getWorkbench(cliConfig) !== null
   const projectId = cliConfig.api?.projectId
+  const dryRun = !!flags['dry-run']
 
   const isAutoUpdating = checkAutoUpdates(reporter, {cliConfig, flags})
 
@@ -74,7 +84,7 @@ async function runStudioDeployment(
         },
   )
 
-  const application = await resolveStudioApplication(options)
+  const application = await resolveStudioApplication(options, {dryRun, reporter})
 
   await checkBuild(reporter, {
     build: () =>
@@ -95,6 +105,9 @@ async function runStudioDeployment(
     await verifyOutputDir({isWorkbenchApp, reporter, sourceDir})
   }
 
+  // Dry run stops here — everything below mutates.
+  if (dryRun) return
+
   // A real deploy has already exited if anything failed; landing here without a
   // resolved application or version means the deploy target was never resolved.
   if (!application || !version) return
@@ -110,14 +123,30 @@ async function runStudioDeployment(
   })
 }
 
-/** Finds the application a deploy targets, registering a studio host when none is configured. */
+/**
+ * Finds the application a real deploy targets, registering a studio host when
+ * none is configured. In a dry run it resolves and reports the target read-only
+ * — prompting and registration are the mutations a dry run skips.
+ */
 async function resolveStudioApplication(
   options: DeployAppOptions,
+  {dryRun, reporter}: {dryRun: boolean; reporter: CheckReporter},
 ): Promise<UserApplication | null> {
   const {cliConfig, flags, output} = options
   const isExternal = !!flags.external
-  const projectId = cliConfig.api?.projectId ?? ''
 
+  if (dryRun) {
+    await checkStudioTarget(reporter, {
+      appId: getAppId(cliConfig),
+      isExternal,
+      projectId: cliConfig.api?.projectId,
+      studioHost: cliConfig.studioHost,
+      urlFlag: flags.url,
+    })
+    return null
+  }
+
+  const projectId = cliConfig.api?.projectId ?? ''
   let application = await findUserApplicationForStudio({
     appId: getAppId(cliConfig),
     isExternal,

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -38,13 +38,7 @@ export function deployStudio(options: DeployAppOptions): Promise<void> {
   })
 }
 
-/**
- * Validates the deploy, extracts and uploads the schema, and ships the build.
- *
- * Every step reports through `reporter`; a real deploy exits on the first
- * failure, a dry run collects them. The one `dry-run` stop below marks the line
- * between read-only checks and the mutations a real deploy performs.
- */
+/** Validates the deploy, extracts and uploads the schema, and ships the build. */
 async function runStudioDeployment(
   options: DeployAppOptions,
   reporter: CheckReporter,
@@ -125,8 +119,7 @@ async function runStudioDeployment(
 
 /**
  * Finds the application a real deploy targets, registering a studio host when
- * none is configured. In a dry run it resolves and reports the target read-only
- * — prompting and registration are the mutations a dry run skips.
+ * none is configured. A dry run resolves and reports the target read-only instead.
  */
 async function resolveStudioApplication(
   options: DeployAppOptions,

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -1,0 +1,111 @@
+import {readdir, stat} from 'node:fs/promises'
+import {join, relative, sep} from 'node:path'
+import {styleText} from 'node:util'
+
+import {type Output} from '@sanity/cli-core'
+import {logSymbols} from '@sanity/cli-core/ux'
+
+import {type DeployCheck} from './deployChecks.js'
+
+/** A file a real deploy would upload, with its on-disk size. */
+export interface DeploymentFile {
+  /** Path relative to the project root, POSIX-style. */
+  path: string
+  /** Size in bytes. */
+  size: number
+}
+
+/**
+ * What a `--dry-run` deploy would do, gathered by running the real deploy
+ * sequence with every mutation gated off. The shape is intentionally small;
+ * extend it (schema diff, bundle size, …) as the dry run grows.
+ */
+export interface DeploymentPlan {
+  /** Every check the deploy sequence reported, in order. */
+  checks: DeployCheck[]
+  /** Files a real deploy would upload, relative to the project root. */
+  files: DeploymentFile[]
+  type: 'coreApp' | 'studio'
+}
+
+/**
+ * Lists the files a deploy would pack from `sourceDir`, as paths relative to
+ * `fromDir` with their sizes. A missing directory yields an empty list rather
+ * than throwing.
+ */
+export async function listDeploymentFiles(
+  sourceDir: string,
+  fromDir: string,
+): Promise<DeploymentFile[]> {
+  const walk = async (dir: string): Promise<string[]> => {
+    let entries
+    try {
+      entries = await readdir(dir, {withFileTypes: true})
+    } catch {
+      return []
+    }
+    const nested = await Promise.all(
+      entries.map((entry) => {
+        const full = join(dir, entry.name)
+        return entry.isDirectory() ? walk(full) : Promise.resolve([full])
+      }),
+    )
+    return nested.flat()
+  }
+
+  const absolute = await walk(sourceDir)
+  const files = await Promise.all(
+    absolute.map(async (file) => ({
+      // Deploy paths are POSIX-style regardless of the host OS (Windows gives `\`).
+      path: relative(fromDir, file).split(sep).join('/'),
+      size: (await stat(file)).size,
+    })),
+  )
+  return files.toSorted((a, b) => a.path.localeCompare(b.path))
+}
+
+/** Renders a deployment plan as a minimal, human-readable report. */
+export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void {
+  const label = plan.type === 'coreApp' ? 'application' : 'studio'
+  const deployable = plan.checks.every((check) => check.status !== 'fail')
+  const totalBytes = plan.files.reduce((sum, file) => sum + file.size, 0)
+
+  output.log('\nDry run — no changes made.\n')
+
+  for (const check of plan.checks) {
+    output.log(`  ${statusIcon(check.status)} ${check.message}`)
+  }
+
+  output.log(
+    deployable
+      ? styleText('green', `\nThis ${label} can be deployed.`)
+      : styleText('red', `\nThis ${label} cannot be deployed — resolve the issues above.`),
+  )
+
+  output.log(`\nFiles to deploy (${formatMB(totalBytes)}):`)
+  for (const file of plan.files) {
+    output.log(`  ${file.path} (${formatMB(file.size)})`)
+  }
+}
+
+/** Bytes as megabytes with two decimals, e.g. `1.50 MB`. */
+function formatMB(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+}
+
+function statusIcon(status: DeployCheck['status']): string {
+  switch (status) {
+    case 'fail': {
+      return logSymbols.error
+    }
+    case 'skip': {
+      return logSymbols.info
+    }
+    case 'warn': {
+      return logSymbols.warning
+    }
+    default: {
+      return logSymbols.success
+    }
+  }
+}

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -67,24 +67,43 @@ export async function listDeploymentFiles(
 /** Renders a deployment plan as a minimal, human-readable report. */
 export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void {
   const label = plan.type === 'coreApp' ? 'application' : 'studio'
-  const deployable = plan.checks.every((check) => check.status !== 'fail')
+  const problems = plan.checks.filter((check) => check.status === 'fail')
+  const warnings = plan.checks.filter((check) => check.status === 'warn')
   const totalBytes = plan.files.reduce((sum, file) => sum + file.size, 0)
 
   output.log('\nDry run — no changes made.\n')
 
+  // Checks that passed or were skipped; problems and warnings get their own
+  // sections below so each fix sits next to the thing it fixes.
   for (const check of plan.checks) {
-    output.log(`  ${statusIcon(check.status)} ${check.message}`)
+    if (check.status === 'pass' || check.status === 'skip') {
+      output.log(`  ${statusIcon(check.status)} ${check.message}`)
+    }
   }
 
   output.log(
-    deployable
+    problems.length === 0
       ? styleText('green', `\nThis ${label} can be deployed.`)
-      : styleText('red', `\nThis ${label} cannot be deployed — resolve the issues above.`),
+      : styleText('red', `\nThis ${label} can't be deployed.`),
   )
+
+  renderIssues(output, 'Problems to fix:', problems)
+  renderIssues(output, 'Warnings:', warnings)
 
   output.log(`\nFiles to deploy (${formatMB(totalBytes)}):`)
   for (const file of plan.files) {
     output.log(`  ${file.path} (${formatMB(file.size)})`)
+  }
+}
+
+/** Renders a titled list of checks, each with its fix indented beneath. */
+function renderIssues(output: Output, title: string, checks: DeployCheck[]): void {
+  if (checks.length === 0) return
+
+  output.log(`\n${title}`)
+  for (const check of checks) {
+    output.log(`  ${statusIcon(check.status)} ${check.message}`)
+    if (check.solution) output.log(`      → ${check.solution}`)
   }
 }
 

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -79,9 +79,12 @@ export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void
   renderIssues(output, 'Problems to fix:', problems)
   renderIssues(output, 'Warnings:', warnings)
 
-  output.log(`\nFiles to deploy (${formatMB(totalBytes)}):`)
-  for (const file of plan.files) {
-    output.log(`  ${file.path} (${formatMB(file.size)})`)
+  // A blocked plan often has no files; skip the section rather than show "0.00 MB".
+  if (plan.files.length > 0) {
+    output.log(`\nFiles to deploy (${formatMB(totalBytes)}):`)
+    for (const file of plan.files) {
+      output.log(`  ${file.path} (${formatMB(file.size)})`)
+    }
   }
 }
 

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -7,31 +7,22 @@ import {logSymbols} from '@sanity/cli-core/ux'
 
 import {type DeployCheck} from './deployChecks.js'
 
-/** A file a real deploy would upload, with its on-disk size. */
 export interface DeploymentFile {
   /** Path relative to the project root, POSIX-style. */
   path: string
-  /** Size in bytes. */
   size: number
 }
 
-/**
- * What a `--dry-run` deploy would do, gathered by running the real deploy
- * sequence with every mutation gated off. The shape is intentionally small;
- * extend it (schema diff, bundle size, …) as the dry run grows.
- */
+/** What a `--dry-run` deploy would do: the real deploy sequence with every mutation gated off. */
 export interface DeploymentPlan {
-  /** Every check the deploy sequence reported, in order. */
   checks: DeployCheck[]
-  /** Files a real deploy would upload, relative to the project root. */
   files: DeploymentFile[]
   type: 'coreApp' | 'studio'
 }
 
 /**
  * Lists the files a deploy would pack from `sourceDir`, as paths relative to
- * `fromDir` with their sizes. A missing directory yields an empty list rather
- * than throwing.
+ * `fromDir`. A missing directory yields an empty list rather than throwing.
  */
 export async function listDeploymentFiles(
   sourceDir: string,
@@ -64,7 +55,6 @@ export async function listDeploymentFiles(
   return files.toSorted((a, b) => a.path.localeCompare(b.path))
 }
 
-/** Renders a deployment plan as a minimal, human-readable report. */
 export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void {
   const label = plan.type === 'coreApp' ? 'application' : 'studio'
   const problems = plan.checks.filter((check) => check.status === 'fail')
@@ -73,8 +63,7 @@ export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void
 
   output.log('\nDry run — no changes made.\n')
 
-  // Checks that passed or were skipped; problems and warnings get their own
-  // sections below so each fix sits next to the thing it fixes.
+  // Only pass/skip here; problems and warnings render below with their fixes.
   for (const check of plan.checks) {
     if (check.status === 'pass' || check.status === 'skip') {
       output.log(`  ${statusIcon(check.status)} ${check.message}`)
@@ -96,7 +85,6 @@ export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void
   }
 }
 
-/** Renders a titled list of checks, each with its fix indented beneath. */
 function renderIssues(output: Output, title: string, checks: DeployCheck[]): void {
   if (checks.length === 0) return
 
@@ -107,7 +95,6 @@ function renderIssues(output: Output, title: string, checks: DeployCheck[]): voi
   }
 }
 
-/** Bytes as megabytes with two decimals, e.g. `1.50 MB`. */
 function formatMB(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(2)} MB`
 }

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -90,8 +90,8 @@ function renderIssues(output: Output, title: string, checks: DeployCheck[]): voi
 
   output.log(`\n${title}`)
   for (const check of checks) {
-    output.log(`  ${statusIcon(check.status)} ${check.message}`)
-    if (check.solution) output.log(`      → ${check.solution}`)
+    const fix = check.solution ? `: ${check.solution}` : ''
+    output.log(`  ${statusIcon(check.status)} ${check.message}${fix}`)
   }
 }
 

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -79,8 +79,8 @@ export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void
   renderIssues(output, 'Problems to fix:', problems)
   renderIssues(output, 'Warnings:', warnings)
 
-  // A blocked plan often has no files; skip the section rather than show "0.00 MB".
-  if (plan.files.length > 0) {
+  // A blocked deploy uploads nothing, so only list files for a deployable plan.
+  if (problems.length === 0 && plan.files.length > 0) {
     output.log(`\nFiles to deploy (${formatMB(totalBytes)}):`)
     for (const file of plan.files) {
       output.log(`  ${file.path} (${formatMB(file.size)})`)

--- a/packages/@sanity/cli/src/actions/deploy/findUserApplication.ts
+++ b/packages/@sanity/cli/src/actions/deploy/findUserApplication.ts
@@ -4,15 +4,18 @@
  * and exits. Dry runs consume the same verdicts read-only (see deployChecks).
  */
 
-import {type CliConfig, exitCodes, type Output} from '@sanity/cli-core'
+import {type CliConfig, type Output} from '@sanity/cli-core'
 import {select, Separator, spinner} from '@sanity/cli-core/ux'
 
 import {createUserApplication, type UserApplication} from '../../services/userApplications.js'
-import {checkForDeprecatedAppId, getAppId} from '../../util/appId.js'
+import {getAppId} from '../../util/appId.js'
+import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {
-  APP_ID_NOT_FOUND_IN_ORGANIZATION,
-  cannotPromptForStudioHost,
-} from '../../util/errorMessages.js'
+  createFailFastReporter,
+  describeAppTarget,
+  describeAppTargetError,
+  describeStudioTarget,
+} from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
 import {resolveAppDeployTarget, resolveStudioDeployTarget} from './resolveDeployTarget.js'
 
@@ -28,92 +31,40 @@ export async function findUserApplication(
   options: FindUserApplicationOptions,
 ): Promise<UserApplication | null> {
   const {cliConfig, organizationId, output, unattended = false} = options
-
-  // May throw when both app.id (deprecated) and deployment.appId are set — let
-  // it surface with its own exit code rather than get re-wrapped below.
-  checkForDeprecatedAppId({cliConfig, output})
-
   const spin = spinner('Checking application info...').start()
 
   let resolution
   try {
-    deployDebug('Resolving the deploy target from the local app config')
     resolution = await resolveAppDeployTarget({appId: getAppId(cliConfig), organizationId})
     deployDebug('Resolved app deploy target', resolution)
   } catch (error) {
-    // User can't access applications for the org
-    if (error?.statusCode === 403) {
-      spin.clear()
-      deployDebug(
-        'User does not have permission to get applications for the org, or the org ID is malformed/doesn’t exist',
-        error,
-      )
-      output.error(
-        `You don’t have permission to view applications for the configured organization ID ("${organizationId}")`,
-        {
-          exit: 1,
-          suggestions: [
-            'Verify that you’ve entered the correct organization ID',
-            'Ask your Sanity organization’s admin to provide you with the proper permissions',
-          ],
-        },
-      )
-      return null
-    }
-
-    // We've failed for some other reason
     spin.clear()
     deployDebug('Error finding user application for app', error)
-    output.error(error)
+    output.error(describeAppTargetError(error, organizationId), {exit: 1})
     return null
   }
 
-  switch (resolution.type) {
-    // The deploy validates organizationId before resolving, so this shouldn't happen
-    case 'blocked': {
-      spin.clear()
-      output.error(resolution.message, {exit: 1})
-      return null
-    }
-    case 'found': {
-      spin.succeed()
-      return resolution.application
-    }
-    // The provided application ID doesn't exist in the org
-    case 'invalid': {
-      spin.clear()
-      output.error(APP_ID_NOT_FOUND_IN_ORGANIZATION, {
-        exit: 1,
-        suggestions: ['Verify the appId in your configuration matches an existing application'],
-      })
-      return null
-    }
-    case 'needs-input': {
-      spin.info('No application ID configured')
-      // Nobody to prompt in unattended mode — a real deploy would hang otherwise
-      if (unattended) {
-        output.error(
-          'No `deployment.appId` configured. Set it in sanity.cli.ts to deploy without prompting.',
-          {exit: exitCodes.USAGE_ERROR},
-        )
-        return null
-      }
-      return promptForExistingApp(resolution.existing)
-    }
-    // No appId configured and no existing applications — the deploy creates one
-    case 'would-create': {
-      spin.info('No application ID configured')
-      // Creating one needs an interactive title prompt, which unattended can't answer
-      if (unattended) {
-        output.error(
-          'No application to deploy to. Run `sanity deploy` interactively once to create one.',
-          {exit: exitCodes.USAGE_ERROR},
-        )
-        return null
-      }
-      return null
-    }
+  if (resolution.type === 'found') {
+    spin.succeed()
+    return resolution.application
   }
+
+  // An interactive deploy prompts for a target (needs-input) or goes on to
+  // create one (would-create); everything else exits with the shared diagnosis.
+  if (!unattended && (resolution.type === 'needs-input' || resolution.type === 'would-create')) {
+    spin.info('No application ID configured')
+    return resolution.type === 'needs-input' ? promptForExistingApp(resolution.existing) : null
+  }
+
+  spin.clear()
+  // 'blocked' diagnoses as a skip (its root cause fails an earlier check), so it
+  // needs an explicit exit here to not fall through to application creation
+  if (resolution.type === 'blocked') {
+    output.error(resolution.message, {exit: 1})
+    return null
+  }
+  createFailFastReporter(output).report(describeAppTarget(resolution))
+  return null
 }
 
 interface FindUserApplicationForStudioOptions {
@@ -132,7 +83,6 @@ export async function findUserApplicationForStudio(
 ): Promise<UserApplication | null> {
   const {appId, isExternal, output, projectId, studioHost, unattended = false, urlFlag} = options
   const urlType = isExternal ? 'external' : 'internal'
-
   const spin = spinner('Checking project info').start()
 
   let resolution
@@ -144,60 +94,41 @@ export async function findUserApplicationForStudio(
       studioHost,
       urlFlag,
     })
+    deployDebug('Resolved studio deploy target', resolution)
   } catch (error) {
     spin.fail()
     deployDebug('Error finding user application', error)
-    output.error(
-      `Error finding user application: ${error instanceof Error ? error.message : String(error)}`,
-      {exit: 1},
-    )
+    output.error(`Failed to resolve deploy target: ${getErrorMessage(error)}`, {exit: 1})
     return null
   }
 
-  deployDebug('Resolved studio deploy target', resolution)
-
-  switch (resolution.type) {
-    case 'blocked': {
-      // The deploy validates projectId before resolving, so this shouldn't happen
-      spin.fail()
-      output.error(resolution.message, {exit: 1})
-      return null
-    }
-    case 'found': {
-      spin.succeed()
-      return resolution.application
-    }
-    case 'invalid': {
-      spin.fail()
-      if (resolution.reason === 'invalid-host') {
-        output.error(resolution.message, {exit: exitCodes.USAGE_ERROR})
-      } else {
-        output.error(`Error finding user application: ${resolution.message}`, {exit: 1})
-      }
-      return null
-    }
-    case 'needs-input': {
-      spin.succeed()
-      const {existing} = resolution
-
-      // In unattended mode there is nobody to ask
-      if (unattended) {
-        output.error(cannotPromptForStudioHost(isExternal), {exit: exitCodes.USAGE_ERROR})
-        return null
-      }
-
-      // Nothing to select from — the caller prompts for a brand new host
-      if (existing.length === 0) {
-        return null
-      }
-
-      return promptForExistingStudio({existing, urlType})
-    }
-    case 'would-create': {
-      spin.succeed()
-      return createFromConfiguredHost({appHost: resolution.appHost, output, projectId, urlType})
-    }
+  if (resolution.type === 'found') {
+    spin.succeed()
+    return resolution.application
   }
+
+  // The configured host isn't registered yet — a deploy registers it without prompting
+  if (resolution.type === 'would-create') {
+    spin.succeed()
+    return createFromConfiguredHost({appHost: resolution.appHost, output, projectId, urlType})
+  }
+
+  if (resolution.type === 'needs-input' && !unattended) {
+    spin.succeed()
+    // Nothing to select from — the caller prompts for a brand new host
+    if (resolution.existing.length === 0) return null
+    return promptForExistingStudio({existing: resolution.existing, urlType})
+  }
+
+  spin.fail()
+  // 'blocked' diagnoses as a skip (its root cause fails an earlier check), so it
+  // needs an explicit exit here
+  if (resolution.type === 'blocked') {
+    output.error(resolution.message, {exit: 1})
+    return null
+  }
+  createFailFastReporter(output).report(describeStudioTarget(resolution, {isExternal}))
+  return null
 }
 
 /**

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -51,6 +51,10 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
       description:
         'Build the studio before deploying (use --no-build to deploy existing `dist/` output)',
     }),
+    'dry-run': Flags.boolean({
+      default: false,
+      description: 'Report what would be deployed without uploading or creating anything',
+    }),
     external: Flags.boolean({
       default: false,
       description: 'Register an externally hosted studio',
@@ -103,8 +107,8 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
         relativeOutput = `./${relativeOutput}`
       }
 
-      // Unattended runs (--yes or a non-interactive terminal) skip the overwrite prompt
-      if (!this.isUnattended()) {
+      // Unattended runs (--yes or a non-interactive terminal) and dry runs skip the overwrite prompt
+      if (!this.isUnattended() && !flags['dry-run']) {
         const isEmpty = await dirIsEmptyOrNonExistent(sourceDir)
         const shouldProceed =
           isEmpty ||

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -125,9 +125,10 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
       this.output.log(`Building to ${relativeOutput}\n`)
     }
 
-    // An unattended run (--yes or a non-interactive terminal) deploys without any
-    // prompts downstream (application resolution, the build).
-    const deployFlags = this.isUnattended() ? {...flags, yes: true} : flags
+    // Unattended runs (--yes or a non-interactive terminal) and dry runs deploy
+    // without any downstream prompts — application resolution and the build
+    // (buildApp/buildStudio) otherwise stop for prerelease/version choices.
+    const deployFlags = this.isUnattended() || flags['dry-run'] ? {...flags, yes: true} : flags
 
     if (isApp) {
       deployDebug('Deploying app')

--- a/packages/@sanity/cli/src/util/__tests__/appId.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/appId.test.ts
@@ -1,6 +1,7 @@
+import {type CliConfig} from '@sanity/cli-core'
 import {describe, expect, test} from 'vitest'
 
-import {getAppId} from '../appId'
+import {getAppId, resolveAppIdIssue} from '../appId'
 
 const newCliConfig = {
   deployment: {
@@ -31,5 +32,21 @@ describe('getAppId', () => {
       ...oldCliConfig,
     })
     expect(result).toBe('new-id')
+  })
+})
+
+describe('resolveAppIdIssue', () => {
+  test('flags a conflict when both config styles are present', () => {
+    expect(resolveAppIdIssue({...newCliConfig, ...oldCliConfig} as CliConfig)).toBe(
+      'conflicting-config',
+    )
+  })
+
+  test('flags the deprecated config when only app.id is present', () => {
+    expect(resolveAppIdIssue(oldCliConfig as CliConfig)).toBe('deprecated-config')
+  })
+
+  test('returns null for the current config', () => {
+    expect(resolveAppIdIssue(newCliConfig as CliConfig)).toBeNull()
   })
 })

--- a/packages/@sanity/cli/src/util/appId.ts
+++ b/packages/@sanity/cli/src/util/appId.ts
@@ -25,17 +25,30 @@ function hasDeprecatedAppId(cliConfig: CliConfig) {
   return Boolean(getDeprecatedAppId(cliConfig))
 }
 
+/** The one app-id configuration problem to surface, if any. */
+export type AppIdIssue = 'conflicting-config' | 'deprecated-config'
+
+/**
+ * Decides which app-id problem a config has: both the deprecated `app.id` and
+ * `deployment.appId` (a conflict), only the deprecated one, or neither. Shared
+ * so the real deploy and the dry-run check reach the same verdict.
+ * @internal
+ */
+export function resolveAppIdIssue(cliConfig: CliConfig): AppIdIssue | null {
+  if (!hasDeprecatedAppId(cliConfig)) return null
+  return hasNewAppId(cliConfig) ? 'conflicting-config' : 'deprecated-config'
+}
+
 /**
  * Checks if an SDK app uses the deprecated app.id config & throws a warning if so.
  * @remarks Throws an error if an app uses both deployment.appId and app.id
  * @internal
  */
 export function checkForDeprecatedAppId({cliConfig, output}: Options): void {
-  const hasNew = hasNewAppId(cliConfig)
-  const hasOld = hasDeprecatedAppId(cliConfig)
+  const issue = resolveAppIdIssue(cliConfig)
 
-  // Throw an error if both the old and new app ID configs are found
-  if (hasOld && hasNew) {
+  // Both configs set: a real deploy can't pick one, so stop here
+  if (issue === 'conflicting-config') {
     output.error(
       `${styleText('bold', 'Found both app.id (deprecated) and deployment.appId in your application configuration.')}
 
@@ -47,7 +60,7 @@ Please remove app.id from your sanity.cli.js or sanity.cli.ts file.`,
   }
 
   // Just warn if only the old app ID config is found
-  if (hasOld) {
+  if (issue === 'deprecated-config') {
     output.warn(
       `${styleText('bold', 'The `app.id` config has moved to `deployment.appId`.')}
 

--- a/packages/@sanity/cli/src/util/errorMessages.ts
+++ b/packages/@sanity/cli/src/util/errorMessages.ts
@@ -3,8 +3,3 @@ export const NO_ORGANIZATION_ID = `sanity.cli.ts does not contain an organizatio
 export const NO_MEDIA_LIBRARY_ASPECTS_PATH = `sanity.cli.ts does not contain a media library aspects path ("mediaLibrary.aspectsPath"), which is required for the Sanity CLI to manage aspects.`
 export const EXTERNAL_APP_NOT_SUPPORTED = `Deploying an app to an external host is not supported.`
 export const APP_ID_NOT_FOUND_IN_ORGANIZATION = `The \`appId\` provided in your configuration’s \`deployment\` object cannot be found in your organization`
-
-export function cannotPromptForStudioHost(isExternal: boolean): string {
-  const subject = isExternal ? 'external studio URL' : 'studio hostname'
-  return `Cannot prompt for ${subject} in unattended mode. Use --url to specify the ${subject}.`
-}

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -887,6 +887,30 @@ describe('#deploy app', () => {
     expect(error?.oclif?.exit).toBe(1)
   })
 
+  test('a dry run also blocks when app.id and deployment.appId are both set', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    // The dry run must surface the same conflict a real deploy fails on, rather
+    // than reporting the app as deployable.
+    const {error} = await testCommand(DeployCommand, ['--dry-run', '--no-build'], {
+      config: {root: cwd},
+      mocks: {
+        cliConfig: {
+          ...defaultMocks.cliConfig,
+          app: {
+            id: appId,
+            organizationId,
+          },
+        },
+      },
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.message).toContain('Deploy blocked')
+  })
+
   test('should show a warning if app.id (deprecated) is used', async () => {
     const cwd = await testFixture('basic-app')
     process.cwd = () => cwd

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -181,6 +181,21 @@ describe('#deploy app', () => {
     expect(error?.oclif?.exit).toBe(1)
   })
 
+  test('a dry run does not prompt to overwrite a non-empty output directory', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    mockDirIsEmptyOrNonExistent.mockResolvedValue(false)
+
+    // A dry run is a preview; it must not block on the interactive overwrite prompt.
+    await testCommand(DeployCommand, ['build', '--dry-run', '--no-build'], {
+      config: {root: cwd},
+      mocks: defaultMocks,
+    })
+
+    expect(mockConfirm).not.toHaveBeenCalled()
+  })
+
   test('should re-deploy app if it already exists', async () => {
     const cwd = await testFixture('basic-app')
     process.cwd = () => cwd

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -942,8 +942,9 @@ describe('#deploy app', () => {
       },
     })
 
-    // oclif wraps the warning at terminal width; flatten before asserting the full copy
-    const flatStderr = stderr.replaceAll(/\s*\n\s*›?\s*/g, ' ')
+    // oclif wraps the warning at terminal width and prefixes continuation lines
+    // (`›` on Unix, `»` on Windows); flatten before asserting the full copy
+    const flatStderr = stderr.replaceAll(/\s*\n\s*[›»]?\s*/g, ' ')
     expect(flatStderr).toContain(
       'The `app.id` config is deprecated: Move it to `deployment.appId` in sanity.cli.ts',
     )

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -1,3 +1,6 @@
+import {mkdir, writeFile} from 'node:fs/promises'
+import {join} from 'node:path'
+
 import {confirm, input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
 import {unstable_defineApp} from '@sanity/workbench-cli'
@@ -220,6 +223,61 @@ describe('#deploy app', () => {
     expect(stderr).toContain('Deploying...')
 
     expect(stdout).toContain('Success! Application deployed')
+  })
+
+  test('should report the target and files in a dry run without deploying', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    await mkdir(join(cwd, 'dist'), {recursive: true})
+    await writeFile(join(cwd, 'dist', 'index.html'), '<html></html>')
+
+    // Read-only target lookup; no deployment POST is mocked, so a real ship
+    // would fail nock — proving the dry run never mutates.
+    mockApi({
+      apiVersion: USER_APPLICATIONS_API_VERSION,
+      query: {appType: 'coreApp'},
+      uri: `/user-applications/${appId}`,
+    }).reply(200, {
+      appHost: 'existing-host',
+      createdAt: '2024-01-01T00:00:00Z',
+      id: appId,
+      organizationId: 'org-id',
+      projectId: null,
+      title: 'Existing App',
+      type: 'coreApp',
+      updatedAt: '2024-01-01T00:00:00Z',
+      urlType: 'internal',
+    })
+
+    const {error, stdout} = await testCommand(DeployCommand, ['--dry-run'], {
+      config: {root: cwd},
+      mocks: defaultMocks,
+    })
+
+    if (error) throw error
+    expect(stdout).toContain('Dry run — no changes made.')
+    expect(stdout).toContain('Deploys to existing application "Existing App"')
+    expect(stdout).toContain('This application can be deployed.')
+    expect(stdout).toContain('Files to deploy (')
+    expect(stdout).toContain('dist/index.html (')
+    expect(stdout).not.toContain('Success! Application deployed')
+  })
+
+  test('should exit non-zero for a dry run that cannot deploy', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    // No organizationId configured → the target check fails, so the plan isn't
+    // deployable and the dry run must exit non-zero (usable as a CI gate).
+    const {error} = await testCommand(DeployCommand, ['--dry-run', '--no-build'], {
+      config: {root: cwd},
+      mocks: {cliConfig: {app: {}}},
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.message).toContain('Deploy blocked')
   })
 
   test('should check the federation build dir for an unstable_defineApp app', async () => {

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -789,7 +789,7 @@ describe('#deploy app', () => {
       },
     })
 
-    expect(error?.message).toContain('Error deploying application')
+    expect(error?.message).toContain('Failed to resolve deploy target')
     expect(error?.oclif?.exit).toBe(1)
   })
 
@@ -897,7 +897,7 @@ describe('#deploy app', () => {
     })
 
     expect(error?.message).toContain(
-      'Found both app.id (deprecated) and deployment.appId in your application configuration.\n\nPlease remove app.id from your sanity.cli.js or sanity.cli.ts file.',
+      'Both `app.id` (deprecated) and `deployment.appId` are set: Remove `app.id` from sanity.cli.ts',
     )
     expect(error?.oclif?.exit).toBe(1)
   })
@@ -942,7 +942,11 @@ describe('#deploy app', () => {
       },
     })
 
-    expect(stderr).toContain('The `app.id` config has moved to `deployment.appId`.')
+    // oclif wraps the warning at terminal width; flatten before asserting the full copy
+    const flatStderr = stderr.replaceAll(/\s*\n\s*›?\s*/g, ' ')
+    expect(flatStderr).toContain(
+      'The `app.id` config is deprecated: Move it to `deployment.appId` in sanity.cli.ts',
+    )
   })
 
   test('should handle app creation with retry when host is taken', async () => {

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.external.test.ts
@@ -724,8 +724,10 @@ describe('#deploy studio (external)', () => {
       })
 
       expect(error).toBeInstanceOf(Error)
-      expect(error?.message).toContain('Cannot prompt for external studio URL in unattended mode')
-      expect(error?.message).toContain('Use --url to specify the external studio URL')
+      expect(error?.message).toContain('No external studio URL configured')
+      expect(error?.message).toContain(
+        'Set `studioHost` in sanity.cli.ts, or pass the full URL with --url',
+      )
       expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
 
@@ -775,8 +777,10 @@ describe('#deploy studio (external)', () => {
       })
 
       expect(error).toBeInstanceOf(Error)
-      expect(error?.message).toContain('Cannot prompt for external studio URL in unattended mode')
-      expect(error?.message).toContain('Use --url to specify the external studio URL')
+      expect(error?.message).toContain('No external studio URL configured')
+      expect(error?.message).toContain(
+        'Set `studioHost` in sanity.cli.ts, or pass the full URL with --url',
+      )
       expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
       expect(mockSelect).not.toHaveBeenCalled()
     })

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -310,32 +310,6 @@ describe('#deploy studio', () => {
     )
   })
 
-  test('a dry run exits with the blocking check exit code, not a bare 1', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.cwd = () => cwd
-
-    // A federated studio can't deploy to an external host: the check reports a
-    // USAGE_ERROR, and the dry run should exit with that code like a real deploy.
-    const app = unstable_defineApp({
-      name: 'test-studio',
-      organizationId: 'org-1',
-      title: 'Test Studio',
-    }) as unknown as NonNullable<CliConfig['app']> & {applicationType?: string}
-    app.applicationType = 'studio'
-
-    const {error} = await testCommand(
-      DeployCommand,
-      ['--dry-run', '--external', '--url', 'https://studio.example.com'],
-      {
-        config: {root: cwd},
-        mocks: {cliConfig: {api: {projectId: 'test-project-id'}, app} as CliConfig},
-      },
-    )
-
-    expect(error).toBeInstanceOf(Error)
-    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
-  })
-
   test('should validate the federation build shape for an unstable_defineApp studio', async () => {
     const cwd = await testFixture('basic-studio')
     process.cwd = () => cwd

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -1,3 +1,6 @@
+import {mkdir, writeFile} from 'node:fs/promises'
+import {join} from 'node:path'
+
 import {type CliConfig, exitCodes, getCliTelemetry, studioWorkerTask} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
@@ -228,6 +231,48 @@ describe('#deploy studio', () => {
     expect(stderr).toContain('Verifying local content')
     expect(stderr).toContain('Deploying to sanity.studio')
     expect(stdout).toContain('Success! Studio deployed')
+  })
+
+  test('should report the target and files in a dry run without deploying', async () => {
+    const cwd = await testFixture('basic-studio')
+    process.cwd = () => cwd
+
+    const projectId = 'test-project-id'
+    const studioHost = 'existing-studio'
+
+    // A built output the deploy would pack.
+    await mkdir(join(cwd, 'dist'), {recursive: true})
+    await writeFile(join(cwd, 'dist', 'index.html'), '<html></html>')
+
+    // The target lookup is read-only; no deployment POST is mocked, so a real
+    // ship would fail nock — proving the dry run never mutates.
+    mockApi({
+      apiVersion: USER_APPLICATIONS_API_VERSION,
+      query: {appHost: studioHost, appType: 'studio'},
+      uri: `/projects/${projectId}/user-applications`,
+    }).reply(200, {
+      appHost: studioHost,
+      createdAt: '2024-01-01T00:00:00Z',
+      id: 'studio-app-id',
+      projectId,
+      title: 'Existing Studio',
+      type: 'studio',
+      updatedAt: '2024-01-01T00:00:00Z',
+      urlType: 'internal',
+    })
+
+    const {error, stdout} = await testCommand(DeployCommand, ['--dry-run'], {
+      config: {root: cwd},
+      mocks: {cliConfig: {api: {projectId}, studioHost}},
+    })
+
+    if (error) throw error
+    expect(stdout).toContain('Dry run — no changes made.')
+    expect(stdout).toContain('Deploys to existing studio')
+    expect(stdout).toContain('This studio can be deployed.')
+    expect(stdout).toContain('Files to deploy (')
+    expect(stdout).toContain('dist/index.html (')
+    expect(stdout).not.toContain('Success! Studio deployed')
   })
 
   test('should validate the federation build shape for an unstable_defineApp studio', async () => {

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -275,6 +275,67 @@ describe('#deploy studio', () => {
     expect(stdout).not.toContain('Success! Studio deployed')
   })
 
+  test('runs the dry-run build unattended so it cannot prompt', async () => {
+    const cwd = await testFixture('basic-studio')
+    process.cwd = () => cwd
+
+    const projectId = 'test-project-id'
+    const studioHost = 'existing-studio'
+
+    await mkdir(join(cwd, 'dist'), {recursive: true})
+    await writeFile(join(cwd, 'dist', 'index.html'), '<html></html>')
+
+    mockApi({
+      apiVersion: USER_APPLICATIONS_API_VERSION,
+      query: {appHost: studioHost, appType: 'studio'},
+      uri: `/projects/${projectId}/user-applications`,
+    }).reply(200, {
+      appHost: studioHost,
+      createdAt: '2024-01-01T00:00:00Z',
+      id: 'studio-app-id',
+      projectId,
+      title: 'Existing Studio',
+      type: 'studio',
+      updatedAt: '2024-01-01T00:00:00Z',
+      urlType: 'internal',
+    })
+
+    await testCommand(DeployCommand, ['--dry-run'], {
+      config: {root: cwd},
+      mocks: {cliConfig: {api: {projectId}, studioHost}},
+    })
+
+    expect(mockBuildStudio).toHaveBeenCalledWith(
+      expect.objectContaining({flags: expect.objectContaining({yes: true})}),
+    )
+  })
+
+  test('a dry run exits with the blocking check exit code, not a bare 1', async () => {
+    const cwd = await testFixture('basic-studio')
+    process.cwd = () => cwd
+
+    // A federated studio can't deploy to an external host: the check reports a
+    // USAGE_ERROR, and the dry run should exit with that code like a real deploy.
+    const app = unstable_defineApp({
+      name: 'test-studio',
+      organizationId: 'org-1',
+      title: 'Test Studio',
+    }) as unknown as NonNullable<CliConfig['app']> & {applicationType?: string}
+    app.applicationType = 'studio'
+
+    const {error} = await testCommand(
+      DeployCommand,
+      ['--dry-run', '--external', '--url', 'https://studio.example.com'],
+      {
+        config: {root: cwd},
+        mocks: {cliConfig: {api: {projectId: 'test-project-id'}, app} as CliConfig},
+      },
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+  })
+
   test('should validate the federation build shape for an unstable_defineApp studio', async () => {
     const cwd = await testFixture('basic-studio')
     process.cwd = () => cwd

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -948,7 +948,7 @@ describe('#deploy studio', () => {
       },
     })
 
-    expect(error?.message).toContain('Error finding user application')
+    expect(error?.message).toContain('Failed to resolve deploy target')
     expect(error?.oclif?.exit).toBe(1)
   })
 
@@ -1325,8 +1325,8 @@ describe('#deploy studio', () => {
       },
     })
 
-    expect(error?.message).toContain('Error finding user application')
     expect(error?.message).toContain(`Cannot find app with app ID ${studioAppId}`)
+    expect(error?.message).toContain('Check `studioHost` and `deployment.appId` in sanity.cli.ts')
     expect(error?.oclif?.exit).toBe(1)
   })
 
@@ -1364,8 +1364,8 @@ describe('#deploy studio', () => {
       },
     })
 
-    expect(error?.message).toContain('Error finding user application')
     expect(error?.message).toContain(`Cannot find app with app ID ${studioAppId}`)
+    expect(error?.message).toContain('Check `studioHost` and `deployment.appId` in sanity.cli.ts')
     expect(error?.oclif?.exit).toBe(1)
   })
 
@@ -1736,8 +1736,10 @@ describe('#deploy studio', () => {
       })
 
       expect(error).toBeInstanceOf(Error)
-      expect(error?.message).toContain('Cannot prompt for studio hostname in unattended mode')
-      expect(error?.message).toContain('Use --url to specify the studio hostname')
+      expect(error?.message).toContain('No studio hostname configured')
+      expect(error?.message).toContain(
+        'Set `studioHost` in sanity.cli.ts, or pass a hostname with --url',
+      )
       expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
 
@@ -1787,8 +1789,10 @@ describe('#deploy studio', () => {
       })
 
       expect(error).toBeInstanceOf(Error)
-      expect(error?.message).toContain('Cannot prompt for studio hostname in unattended mode')
-      expect(error?.message).toContain('Use --url to specify the studio hostname')
+      expect(error?.message).toContain('No studio hostname configured')
+      expect(error?.message).toContain(
+        'Set `studioHost` in sanity.cli.ts, or pass a hostname with --url',
+      )
       expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
       expect(mockSelect).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
### Description

> [!NOTE]
> Third in the deploy stack — builds on #1407. This is the payoff the earlier PRs laid the foundation for.

`sanity deploy --dry-run` reports whether the studio or app can be deployed and lists the files a deploy would upload (with sizes) — without uploading, creating, or prompting for anything. When something blocks the deploy it lists every problem with a fix, and surfaces warnings.

A blocked studio:

```
Dry run — no changes made.

  ✓ Using sanity 3.99.0
  ✓ Studio built

This studio can't be deployed.

Problems to fix:
  ✗ No studio hostname configured: Set `studioHost` in sanity.cli.ts, or pass a hostname with --url

Warnings:
  ⚠ The autoUpdates config has moved to deployment.autoUpdates.

Files to deploy (0.50 MB):
  dist/index.html (0.50 MB)
```

Each check carries its fix in a `solution` field, so the same fix renders in both modes — appended after the problem in the dry-run report and in a real deploy's error (instead of baking the fix into the message).

A deployable one just lists the files:

```
Dry run — no changes made.

  ✓ Using sanity 3.99.0
  ✓ Project: my-project
  ✓ Deploys to existing studio https://my-studio.sanity.studio
  ✓ Studio built

This studio can be deployed.

Files to deploy (1.53 MB):
  dist/assets/app.js (1.53 MB)
  dist/index.html (0.00 MB)
```

The design property that matters: dry-run drives the **same** `runDeploy` sequence (`runAppDeployment` / `runStudioDeployment`, harmonized in #1407) as a real deploy, so the two can't drift. The only difference is the mode — a collecting reporter instead of the fail-fast one, and every network mutation gated off: the target is resolved read-only (`checkAppTarget` / `checkStudioTarget`, the same verdict resolver the real path uses), and the title update, schema upload, and deployment upload sit below a single dry-run stop. The build still runs locally, so the file list is accurate.

A small `deploymentPlan` module owns the plan shape and the report — a deep seam that's easy to extend later (schema diff, more per-file detail, …).

Deliberately not covered yet: schema validation doesn't run in a dry run, since it's coupled to the upload step. Straightforward follow-up on the same seam.

### What to review

- The dry-run stop + read-only target resolution in `runAppDeployment` / `runStudioDeployment` — confirm a dry run can't reach any POST or prompt.
- `deploymentPlan.ts` (plan shape + render) and that the command stays a thin caller.

### Testing

Unit tests cover `listDeploymentFiles` and `renderDeploymentPlan` (including the problems-with-fixes and warnings sections); integration tests run `deploy --dry-run` for a studio and an app and assert the report renders with no deployment POST (none is mocked, so a ship would fail). E2E tests (`deploy.test.ts`) drive the real CLI against both a studio and a core app, asserting the plan lists real built files including `index.html`, surfaces the blocking problem with its fix, and reports the deprecated `--auto-updates` flag as a warning — skipped in registry/smoke mode since `--dry-run` isn't on the published CLI yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core deploy pipeline and exit-code behavior for CI gating, but mutations stay gated and coverage is broad (unit, integration, e2e).
> 
> **Overview**
> Adds **`sanity deploy --dry-run`**, which runs the same studio/app deploy validation and local build as a real deploy, then prints a **deployment plan** (checks, problems with fixes, warnings, and file list with sizes) without uploads, creates, or prompts.
> 
> **`runDeploy`** switches on the flag: a collecting reporter runs the shared **`runAppDeployment` / `runStudioDeployment`** path; **`renderDeploymentPlan`** prints the report; blocked plans skip file listing and exit with the **same code** as fail-fast deploy. Dry-run paths use read-only **`checkAppTarget` / `checkStudioTarget`** and return before schema upload, title sync, and tarball POST.
> 
> Shared **`describeAppTarget` / `describeStudioTarget`**, **`checkAppId`** (via **`resolveAppIdIssue`**), and **`findUserApplication`** refactors keep dry-run and unattended real-deploy messages and exit codes aligned. **`--dry-run`** also skips the non-empty output-dir confirm and forces **`yes: true`** for build prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1333f260d381162f40aacdb30024d298f1b3ce83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->