### PR TITLE
test: Mock spinner

### DIFF
--- a/packages/@sanity/cli-test/src/index.ts
+++ b/packages/@sanity/cli-test/src/index.ts
@@ -1,5 +1,6 @@
 export * from './test/constants.js'
 export * from './test/createMockHttpServer.js'
+export {createMockSpinner} from './test/createMockSpinner.js'
 export * from './test/createMockWatcher.js'
 export * from './test/createTestClient.js'
 export * from './test/createTestToken.js'

--- a/packages/@sanity/cli-test/src/test/createMockSpinner.ts
+++ b/packages/@sanity/cli-test/src/test/createMockSpinner.ts
@@ -1,10 +1,10 @@
-import type {SpinnerInstance} from '@sanity/cli-core/ux'
-import type {PersistOptions} from 'ora'
+import {type SpinnerInstance} from '@sanity/cli-core/ux'
+import {type PersistOptions} from 'ora'
 import {Mock, vi} from 'vitest'
 
 /**
  * Creates a mock spinner function to avoid writing output to stdout.
- * @param overrides Pass any mocks or stubs for test expectations
+ * @param overrides - Pass any mocks or stubs for test expectations
  * @internal
  */
 export function createMockSpinner(
@@ -12,45 +12,45 @@ export function createMockSpinner(
 ): Mock<(options: string) => SpinnerInstance> {
   return vi.fn(() => {
     return {
-      text: '',
-      prefixText: '',
-      suffixText: '',
-      color: false,
-      indent: 0,
-      spinner: {
-        interval: undefined,
-        frames: [],
+      clear: function (): SpinnerInstance {
+        throw new Error('Function not implemented.')
       },
-      isSpinning: false,
+      color: false,
+      fail: function (_text?: string): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      frame: function (): string {
+        throw new Error('Function not implemented.')
+      },
+      indent: 0,
+      info: function (_text?: string): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
       interval: 0,
-      start: function (text?: string): SpinnerInstance {
+      isSpinning: false,
+      prefixText: '',
+      render: function (): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      spinner: {
+        frames: [],
+        interval: undefined,
+      },
+      start: function (_text?: string): SpinnerInstance {
         throw new Error('Function not implemented.')
       },
       stop: function (): SpinnerInstance {
         throw new Error('Function not implemented.')
       },
-      succeed: function (text?: string): SpinnerInstance {
+      stopAndPersist: function (_options?: PersistOptions): SpinnerInstance {
         throw new Error('Function not implemented.')
       },
-      fail: function (text?: string): SpinnerInstance {
+      succeed: function (_text?: string): SpinnerInstance {
         throw new Error('Function not implemented.')
       },
-      warn: function (text?: string): SpinnerInstance {
-        throw new Error('Function not implemented.')
-      },
-      info: function (text?: string): SpinnerInstance {
-        throw new Error('Function not implemented.')
-      },
-      stopAndPersist: function (options?: PersistOptions): SpinnerInstance {
-        throw new Error('Function not implemented.')
-      },
-      clear: function (): SpinnerInstance {
-        throw new Error('Function not implemented.')
-      },
-      render: function (): SpinnerInstance {
-        throw new Error('Function not implemented.')
-      },
-      frame: function (): string {
+      suffixText: '',
+      text: '',
+      warn: function (_text?: string): SpinnerInstance {
         throw new Error('Function not implemented.')
       },
       ...overrides,

--- a/packages/@sanity/cli-test/src/test/createMockSpinner.ts
+++ b/packages/@sanity/cli-test/src/test/createMockSpinner.ts
@@ -1,0 +1,59 @@
+import type {SpinnerInstance} from '@sanity/cli-core/ux'
+import type {PersistOptions} from 'ora'
+import {Mock, vi} from 'vitest'
+
+/**
+ * Creates a mock spinner function to avoid writing output to stdout.
+ * @param overrides Pass any mocks or stubs for test expectations
+ * @internal
+ */
+export function createMockSpinner(
+  overrides?: Partial<SpinnerInstance>,
+): Mock<(options: string) => SpinnerInstance> {
+  return vi.fn(() => {
+    return {
+      text: '',
+      prefixText: '',
+      suffixText: '',
+      color: false,
+      indent: 0,
+      spinner: {
+        interval: undefined,
+        frames: [],
+      },
+      isSpinning: false,
+      interval: 0,
+      start: function (text?: string): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      stop: function (): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      succeed: function (text?: string): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      fail: function (text?: string): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      warn: function (text?: string): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      info: function (text?: string): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      stopAndPersist: function (options?: PersistOptions): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      clear: function (): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      render: function (): SpinnerInstance {
+        throw new Error('Function not implemented.')
+      },
+      frame: function (): string {
+        throw new Error('Function not implemented.')
+      },
+      ...overrides,
+    }
+  })
+}

--- a/packages/@sanity/cli-test/tsconfig.json
+++ b/packages/@sanity/cli-test/tsconfig.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "paths": {
-      "@sanity/cli-core": ["./node_modules/@sanity/cli-core/src/_exports/index.ts"]
+      "@sanity/cli-core": ["./node_modules/@sanity/cli-core/src/_exports/index.ts"],
+      "@sanity/cli-core/*": ["./node_modules/@sanity/cli-core/src/_exports/*"]
     }
   }
 }

--- a/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
@@ -3,10 +3,10 @@ import {tmpdir} from 'node:os'
 import path from 'node:path'
 
 import {type Output} from '@sanity/cli-core'
+import {createMockSpinner} from '@sanity/cli-test'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {resolveLatestVersions} from '../../../../src/util/resolveLatestVersions.js'
-import {createMockSpinner} from '@sanity/cli-test'
 
 const mockedSpinnerStart = vi.fn().mockReturnThis()
 const mockedSpinnerSucceed = vi.fn().mockReturnThis()

--- a/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
@@ -5,8 +5,15 @@ import path from 'node:path'
 import {type Output} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {bootstrapLocalTemplate} from '../../../../src/actions/init/bootstrapLocalTemplate.js'
 import {resolveLatestVersions} from '../../../../src/util/resolveLatestVersions.js'
+import {createMockSpinner} from '@sanity/cli-test'
+
+const mockedSpinnerStart = vi.fn().mockReturnThis()
+const mockedSpinnerSucceed = vi.fn().mockReturnThis()
+const mockedSpinner = createMockSpinner({
+  start: mockedSpinnerStart,
+  succeed: mockedSpinnerSucceed,
+})
 
 vi.mock('../../../../src/util/resolveLatestVersions.js', () => ({
   resolveLatestVersions: vi.fn().mockImplementation(async (deps: Record<string, string>) => {
@@ -20,15 +27,17 @@ vi.mock('../../../../src/actions/init/updateInitialTemplateMetadata.js', () => (
   updateInitialTemplateMetadata: vi.fn().mockResolvedValue(undefined),
 }))
 
+vi.mock('@sanity/cli-core/ux', async () => ({
+  spinner: mockedSpinner,
+}))
+
+const {bootstrapLocalTemplate} =
+  await import('../../../../src/actions/init/bootstrapLocalTemplate.js')
+
 function makeOutput() {
   return {
-    clear: vi.fn(),
     error: vi.fn(),
     log: vi.fn(),
-    print: vi.fn(),
-    spinner: vi.fn(() => ({
-      start: () => ({fail: vi.fn(), succeed: vi.fn()}),
-    })),
     warn: vi.fn(),
   } as unknown as Output
 }
@@ -60,6 +69,10 @@ describe('bootstrapLocalTemplate (app templates)', () => {
       },
     })
 
+    expect(mockedSpinner).toHaveBeenCalledWith('Bootstrapping files from template')
+    expect(mockedSpinnerStart).toHaveBeenCalledTimes(3)
+    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+
     const appTsx = await readFile(path.join(tmp, 'src', 'App.tsx'), 'utf8')
     expect(appTsx).toContain(`projectId: 'abc123'`)
     expect(appTsx).toContain(`dataset: 'production'`)
@@ -83,6 +96,8 @@ describe('bootstrapLocalTemplate (app templates)', () => {
         workbench: false,
       },
     })
+
+    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
 
     const appTsx = await readFile(path.join(tmp, 'src', 'App.tsx'), 'utf8')
     expect(appTsx).toContain(`projectId: ''`)
@@ -119,6 +134,8 @@ describe('bootstrapLocalTemplate (workbench)', () => {
       },
     })
 
+    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+
     expect(resolveLatestVersions).toHaveBeenCalledOnce()
     const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
     expect(resolvedDeps.sanity).toBe('workbench')
@@ -144,6 +161,8 @@ describe('bootstrapLocalTemplate (workbench)', () => {
       },
     })
 
+    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+
     expect(resolveLatestVersions).toHaveBeenCalledOnce()
     const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
     expect(resolvedDeps.sanity).toBe('latest')
@@ -166,6 +185,8 @@ describe('bootstrapLocalTemplate (workbench)', () => {
       },
     })
 
+    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+
     expect(resolveLatestVersions).toHaveBeenCalledOnce()
     const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
     expect(resolvedDeps.sanity).toBe('workbench')
@@ -187,6 +208,8 @@ describe('bootstrapLocalTemplate (workbench)', () => {
         workbench: true,
       },
     })
+
+    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
 
     const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
     expect(cliConfig).toContain(`import {defineCliConfig, unstable_defineApp} from 'sanity/cli'`)
@@ -215,6 +238,8 @@ describe('bootstrapLocalTemplate (workbench)', () => {
       },
     })
 
+    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+
     const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
     expect(cliConfig).toContain(`import {defineCliConfig, unstable_defineApp} from 'sanity/cli'`)
     // App init derives `name` from the output directory, same as package.json
@@ -241,6 +266,8 @@ describe('bootstrapLocalTemplate (workbench)', () => {
         workbench: false,
       },
     })
+
+    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
 
     const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
     expect(cliConfig).not.toContain('unstable_defineApp')


### PR DESCRIPTION
### Description

Mock spinner allows tests to avoid sending output to stderr.

### Testing

Fixed the bootstrapLocalTemplate tests and added some assertions as an example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and test-helper changes with no production runtime behavior.
> 
> **Overview**
> Adds **`createMockSpinner`** to `@sanity/cli-test`: a Vitest mock factory for `@sanity/cli-core/ux`’s `spinner` that returns a full `SpinnerInstance` stub (with optional overrides) so CLI tests avoid real terminal output.
> 
> **`bootstrapLocalTemplate` integration tests** now mock `spinner` from `@sanity/cli-core/ux` via that helper, dynamically import the module under test after mocks are registered, and drop the old `output.spinner` / `print` / `clear` stubs on the fake `Output`. Tests assert spinner usage (e.g. initial message, three `start`/`succeed` cycles per bootstrap).
> 
> `@sanity/cli-test` **tsconfig** gains a `@sanity/cli-core/*` path alias so the new helper can import `SpinnerInstance` from the ux subpath.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064a258e89a3eddd7529ab8759ba2548b0db908c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->