### PR TITLE
feat(cli): treat --json as unattended mode

### DIFF
--- a/.changeset/json-implies-unattended.md
+++ b/.changeset/json-implies-unattended.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli-core": minor
+---
+
+feat(cli): treat `--json` as unattended mode, so a command emitting machine-readable output never stops at a prompt a caller can't answer

--- a/packages/@sanity/cli-core/src/SanityCommand.ts
+++ b/packages/@sanity/cli-core/src/SanityCommand.ts
@@ -240,10 +240,11 @@ export abstract class SanityCommand<T extends typeof Command>
    *
    * Most commands should take an explicit `--yes` flag to enable unattended mode, but
    * some commands may also be run in unattended mode if `process.stdin` is not a TTY
-   * (eg when running in a CI environment).
+   * (eg when running in a CI environment), or when `--json` asks for machine-readable
+   * output (a caller parsing JSON can't answer a prompt).
    */
   public isUnattended(): boolean {
-    return this.flags.yes || !this.resolveIsInteractive()
+    return this.flags.yes || this.flags.json || !this.resolveIsInteractive()
   }
 
   /**

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
@@ -178,6 +178,8 @@ describe('#tokens:add', () => {
 
     const parsedOutput = JSON.parse(stdout)
     expect(parsedOutput).toEqual(mockToken)
+    expect(mockedSelect).not.toHaveBeenCalled()
+    expect(mockedInput).not.toHaveBeenCalled()
   })
 
   test('works in unattended mode with --yes flag', async () => {
@@ -207,6 +209,8 @@ describe('#tokens:add', () => {
 
     expect(stdout).toContain('Token created successfully!')
     expect(stdout).toContain('Label: Unattended Token')
+    expect(mockedSelect).not.toHaveBeenCalled()
+    expect(mockedInput).not.toHaveBeenCalled()
   })
 
   test('handles invalid role error', async () => {

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
@@ -152,18 +152,6 @@ describe('#tokens:add', () => {
   })
 
   test('outputs JSON when --json flag is used', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-    ]
-
     const mockToken = {
       id: 'token-json',
       key: 'sk_test_json1234',
@@ -177,11 +165,7 @@ describe('#tokens:add', () => {
       ],
     }
 
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
-
+    // --json is unattended, so the role defaults to viewer without a roles prompt
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'post',


### PR DESCRIPTION
### Description

A command that emits machine-readable output can't stop at a prompt — the caller parsing its stdout has no way to answer. `--json` should therefore behave like `--yes`: use defaults, error on missing input, never prompt.

Rather than each command re-deriving this, `--json` is folded into `SanityCommand.isUnattended()`. Every command that already respects unattended mode now also skips prompts under `--json`.

### What to review

- `SanityCommand.isUnattended()` now returns true for `--json` as well as `--yes`/non-TTY.
- The commands that branch on it and expose a `--json` flag inherit the change: `init`, `projects create`, `tokens add` (and `deploy`, once its refactor lands). Notably `tokens add --json` now uses the default `viewer` role instead of prompting.

### Testing

`tokens add`'s `--json` unit test was updated to reflect that the role now defaults instead of prompting (no roles fetch). Other affected commands' unit tests pass unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Central CLI behavior change affects every command using `isUnattended()` with `--json`, which may alter defaults (e.g. token role) for scripts that previously hung on prompts.
> 
> **Overview**
> **`SanityCommand.isUnattended()`** now treats **`--json`** like **`--yes`** and non-TTY stdin: commands must not prompt and should use defaults or fail with a non-zero exit when input is missing. The docblock explains that machine-readable callers cannot answer interactive prompts.
> 
> Any command that already branches on **`isUnattended()`** and exposes **`--json`** picks up this behavior centrally (e.g. **`tokens add --json`** defaults the role to **`viewer`** instead of fetching roles and prompting).
> 
> The **`tokens add`** **`--json`** test was aligned with that: no roles API mock, and assertions that **`select`** / **`input`** are never called. A changeset records a minor **`@sanity/cli-core`** release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41138e8190e353d078e53878e823b7bd1da67097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->