### PR TITLE
fix(init): gate MCP setup on unattended mode

### DIFF
--- a/.changeset/init-mcp-unattended.md
+++ b/.changeset/init-mcp-unattended.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+fix(init): gate MCP setup on unattended mode rather than `--yes` alone, so a non-interactive `init` (including `--json`) configures MCP with defaults instead of blocking on its prompt

--- a/packages/@sanity/cli/src/commands/init.ts
+++ b/packages/@sanity/cli/src/commands/init.ts
@@ -224,7 +224,8 @@ export class InitCommand extends SanityCommand<typeof InitCommand> {
     let mcpMode: 'auto' | 'prompt' | 'skip' = 'prompt'
     if (!this.flags.mcp || !this.resolveIsInteractive()) {
       mcpMode = 'skip'
-    } else if (this.flags.yes) {
+    } else if (this.isUnattended()) {
+      // Any unattended run (e.g. --yes, --json) configures MCP with defaults rather than prompting
       mcpMode = 'auto'
     }
 


### PR DESCRIPTION
### Description

`init`'s MCP setup switched to non-prompting `auto` only when `--yes` was passed. Every other unattended path still fell through to `prompt` — a non-TTY run, and (once #1420 lands) a `--json` run — so an init that's meant to be non-interactive could still block on the MCP editor prompt.

Gate the `auto` branch on `isUnattended()` instead of `flags.yes`. The non-interactive terminal case is already handled by the `skip` branch above, so this is behaviour-neutral for `--yes` today and closes the gap for `--json` once it's treated as unattended.

Found while sweeping for other spots that gate prompts on `--yes` directly rather than `isUnattended()` — this was the only one; every other command with a `--json` flag already threads `isUnattended()` (or its derived `unattended` boolean) through.

### What to review

- `init.ts`: the `mcpMode` derivation now uses `this.isUnattended()` for the `auto` branch. `resolveIsInteractive()` still short-circuits to `skip` first, so the change only affects interactive, unattended runs.

### Testing

Behaviour-neutral on its own (in the `auto` branch `isUnattended()` reduces to `flags.yes` until `--json` is folded into it by #1420), so existing `init` unit tests cover it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change in init CLI prompt gating; behavior-neutral for current `--yes` usage and no auth or data-path changes.
> 
> **Overview**
> **`sanity init` MCP setup** now picks non-prompting `auto` mode when the command is **unattended** (`isUnattended()`), not only when `--yes` is set.
> 
> That aligns MCP with how other init options treat unattended runs (including future `--json` flows) so a non-interactive init can apply MCP defaults instead of blocking on the editor prompt. Disabling MCP or non-interactive terminals still use `skip` first, so behavior for `--yes` today stays the same until `--json` is folded into unattended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f3fb0f7351d463c99efbc9ab8e479bcb7dd817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->