### PR TITLE
fix(dev): align dev server typegen defaults with `sanity typegen generate`

### DIFF
--- a/.changeset/pr-1426.md
+++ b/.changeset/pr-1426.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(dev): align dev server typegen defaults with `sanity typegen generate`

--- a/packages/@sanity/cli/src/server/vite/__tests__/plugin-typegen.test.ts
+++ b/packages/@sanity/cli/src/server/vite/__tests__/plugin-typegen.test.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import {CLITelemetryStore} from '@sanity/cli-core'
 import {createMockHttpServer, createMockWatcher} from '@sanity/cli-test'
+import {configDefinition} from '@sanity/codegen'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {sanityTypegenPlugin} from '../plugin-typegen.js'
@@ -272,7 +273,7 @@ describe('sanityTypegenPlugin', () => {
     })
   })
 
-  it('applies default config values', async () => {
+  it('applies the same default config values as `sanity typegen generate`', async () => {
     vi.useRealTimers()
 
     const plugin = sanityTypegenPlugin({
@@ -288,12 +289,7 @@ describe('sanityTypegenPlugin', () => {
     await buildEnd()
 
     expect(runTypegenGenerate).toHaveBeenCalledWith({
-      config: expect.objectContaining({
-        formatGeneratedCode: false,
-        generates: 'sanity.types.ts',
-        overloadClientMethods: false,
-        schema: 'schema.json',
-      }),
+      config: configDefinition.parse({}),
       workDir: TEST_PROJECT_DIR,
     })
   })

--- a/packages/@sanity/cli/src/server/vite/plugin-typegen.ts
+++ b/packages/@sanity/cli/src/server/vite/plugin-typegen.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import {CLITelemetryStore} from '@sanity/cli-core'
 import {logSymbols} from '@sanity/cli-core/ux'
 import {
+  configDefinition,
   type GenerationResult,
   runTypegenGenerate,
   type TypeGenConfig,
@@ -17,12 +18,6 @@ import picomatch from 'picomatch'
 import {type Plugin} from 'vite'
 
 import {toForwardSlashes} from '../../util/toForwardSlashes.js'
-
-/**
- * Default glob patterns to watch for query file changes.
- * Covers common source directory naming conventions.
- */
-const DEFAULT_QUERY_PATTERNS = ['./src/**/*.{ts,tsx,js,jsx}', './app/**/*.{ts,tsx,js,jsx}']
 
 /** Default debounce delay in milliseconds */
 const DEFAULT_DEBOUNCE_MS = 1000
@@ -85,14 +80,9 @@ interface TypegenPluginOptions {
 export function sanityTypegenPlugin(options: TypegenPluginOptions): Plugin {
   const {config: inputConfig, output = console, telemetryLogger, workDir} = options
 
-  // Apply defaults to config
-  const config: TypeGenConfig = {
-    formatGeneratedCode: inputConfig.formatGeneratedCode ?? false,
-    generates: inputConfig.generates ?? 'sanity.types.ts',
-    overloadClientMethods: inputConfig.overloadClientMethods ?? false,
-    path: inputConfig.path ?? DEFAULT_QUERY_PATTERNS,
-    schema: inputConfig.schema ?? 'schema.json',
-  }
+  // Apply defaults through the same schema as `sanity typegen generate`,
+  // so watch mode and manual generation produce identical output
+  const config: TypeGenConfig = configDefinition.parse(inputConfig)
 
   // Build query patterns from config
   const queryPatterns = Array.isArray(config.path) ? config.path : [config.path]


### PR DESCRIPTION
### Description

The typegen vite plugin used by `sanity dev`/`sanity build` hand-rolled its config defaults, defaulting `formatGeneratedCode` and `overloadClientMethods` to `false` (and using a narrower set of default query patterns). Meanwhile, `sanity typegen generate` applies defaults through `configDefinition.parse()` from `@sanity/codegen`, where both default to `true`. As a result, the same `sanity.cli.ts` config produced different output depending on whether types were generated by the dev server or by the manual command: the dev server emitted unformatted code (large git diffs) without the `@sanity/client` query typemap.

This PR replaces the hand-rolled defaults with `configDefinition.parse(inputConfig)` — the exact same zod schema the `typegen generate` command uses — so the two code paths share one source of truth and can't drift again. The schema strips the extra `enabled` key from the CLI config, and the plugin's now-redundant local default query patterns were removed.

Fixes https://github.com/sanity-io/cli/issues/1425

### What to review

- `packages/@sanity/cli/src/server/vite/plugin-typegen.ts`: config resolution now goes through `configDefinition.parse()`. Note this intentionally changes the dev-server defaults: `formatGeneratedCode: true`, `overloadClientMethods: true`, `generates: './sanity.types.ts'`, and the broader default query patterns from `@sanity/codegen` (including `.astro`/`.vue`/`.svelte` and `./sanity/**`).
- Explicitly-set config values are still respected (defaults only fill in unset fields).

### Testing

- Updated the plugin unit test that had baked in the old (wrong) defaults to assert the plugin passes `configDefinition.parse({})` verbatim, so it stays in lockstep with `@sanity/codegen`.
- Verified end-to-end in `fixtures/basic-studio` with the issue reporter's config shape (`enabled: true`, format/overload unset):
  - `sanity typegen generate` output vs. dev-server-generated output is now **byte-identical** (prettier-formatted, with the `declare module "@sanity/client"` typemap).
  - Watch-mode regeneration after editing a query file remains identical to manual generation.
  - Explicit opt-out (`formatGeneratedCode: false, overloadClientMethods: false`) still produces unformatted output without the typemap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default generated `sanity.types.ts` output changes for projects that relied on implicit dev-server defaults (formatting and client typemap), though explicit config opt-outs still apply.
> 
> **Overview**
> The Vite typegen plugin used by **`sanity dev`** / **`sanity build`** no longer applies its own default config. It now resolves options with **`configDefinition.parse()`** from **`@sanity/codegen`**, the same path as **`sanity typegen generate`**, so watch/build and manual runs share one source of truth.
> 
> **Behavior change when fields are left unset:** dev-server generation now defaults **`formatGeneratedCode`** and **`overloadClientMethods`** to **`true`**, uses **`@sanity/codegen`**’s output path and query globs (broader than the removed local patterns), and strips CLI-only keys like **`enabled`** via the schema. Explicit **`sanity.cli.ts`** values are unchanged.
> 
> The plugin unit test now expects **`runTypegenGenerate`** to receive **`configDefinition.parse({})`** instead of the old hand-rolled defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70333a05081f53a4a0c3909f085039786fb369e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->