### PR TITLE
chore(test): always report vitest worst import time offenders

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,13 @@ export default defineConfig({
     },
     // Add explicit exclude for test execution
     exclude: ['**/node_modules/**', '**/dist/**', '**/tmp/**', '**/.git/**'],
+    experimental: {
+      // Show top-ten worst import times after test runs, helping to identify poorly-mocked tests and heavy import paths
+      importDurations: {
+        limit: 10,
+        print: true,
+      },
+    },
     onUnhandledError(error) {
       /**
        * Ignore worker unexpected exit errors due to SIGSEGV from rolldown v1.0.1+: https://github.com/rolldown/rolldown/issues/9722


### PR DESCRIPTION
### Description

Enables reporting the worst offenders in terms of import times when running tests. More details about this in [the Profiling Test Performance Vitest guide](https://vitest.dev/guide/profiling-test-performance.html#file-import).

The use of [barrel files](https://vite.dev/guide/performance.html#avoid-barrel-files) in this repository is the top contributor to long import times, but poor mocking in tests is also a factor.

Here is what this addition prints at the end of any vitest test runs (the following taken from [this Node 26 on ubuntu CI run in this PR](https://github.com/sanity-io/cli/actions/runs/28612041485/job/84846733686?pr=1428)):

```console
Test Files  245 passed (245)
      Tests  2585 passed | 7 skipped (2592)
   Start at  18:17:43
   Duration  63.16s (transform 16.05s, setup 956ms, import 128.57s, tests 16.27s, environment 18ms)

Import Duration Breakdown (Top 10)

Module                                               Self  Total
.../src/hooks/prerun/__tests__/warnings.test.ts     3.09s  3.26s  ████████████████████
...mmandNotFound/__tests__/topicAliases.test.ts     2.27s  2.90s  ██████████████████░░
...ests__/init/init.get-project-details.test.ts     115ms  2.49s  ███████████████░░░░░
.../__tests__/compareDependencyVersions.test.ts      25ms  1.92s  ████████████░░░░░░░░
 ↳ ...ty/cli/src/util/compareDependencyVersions.ts   15ms  1.90s  ████████████░░░░░░░░
 ↳ ...ty/cli-build/src/_exports/_internal/build.ts   63ms  1.88s  ████████████░░░░░░░░
 ↳ ...nity/cli-build/src/actions/build/buildApp.ts  139ms  1.77s  ███████████░░░░░░░░░
...ity/cli/src/commands/__tests__/login.test.ts      84ms  1.55s  █████████░░░░░░░░░░░
...src/actions/build/__tests__/buildApp.test.ts     168ms  1.51s  █████████░░░░░░░░░░░
...orker/__tests__/renderDocumentWorker.test.ts     180ms  1.49s  █████████░░░░░░░░░░░

Total imports: 2249
Slowest import (total-time): 3.26s
Total import time (self/total): 85.38s / 590.59s
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only test tooling with no runtime or production impact.
> 
> **Overview**
> Enables Vitest’s **experimental `importDurations`** in the root `vitest.config.ts` so every test run prints the **top 10 slowest imports** (self vs total time) plus aggregate import stats at the end of the run.
> 
> This is **observability only**—no change to which tests run, coverage, or reporters. It’s meant to surface heavy import chains (e.g. barrel files) and tests that pull in too much of the app without mocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31aa7cec112cb4f11134c8e870a27ff222acbe7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->