### PR TITLE
fix(deploy): print deployment URL for SDK apps

### DIFF
--- a/.changeset/deploy-app-target-url.md
+++ b/.changeset/deploy-app-target-url.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+fix(deploy): report a deployed app's dashboard URL in the deploy plan and success output, matching studios

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployApp.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployApp.test.ts
@@ -1,0 +1,51 @@
+import {type CliConfig, type Output} from '@sanity/cli-core'
+import {describe, expect, test, vi} from 'vitest'
+
+import {type UserApplication} from '../../../services/userApplications.js'
+import {logAppDeployed} from '../deployApp.js'
+
+const mockOutput = () => ({log: vi.fn()}) as unknown as Output
+
+function application(overrides: Partial<UserApplication> = {}): UserApplication {
+  return {
+    appHost: 'app-host',
+    createdAt: '2024-01-01T00:00:00Z',
+    id: 'app-1',
+    organizationId: 'org-1',
+    projectId: null,
+    title: 'My App',
+    type: 'coreApp',
+    updatedAt: '2024-01-01T00:00:00Z',
+    urlType: 'internal',
+    ...overrides,
+  }
+}
+
+describe('logAppDeployed', () => {
+  test("prints the dashboard URL from the app's own organization, not the config", () => {
+    const output = mockOutput()
+
+    logAppDeployed({
+      application: application(),
+      cliConfig: {app: {organizationId: 'config-org'}, deployment: {appId: 'app-1'}} as CliConfig,
+      output,
+    })
+
+    expect(output.log).toHaveBeenCalledWith(
+      expect.stringContaining('Success! Application deployed to'),
+    )
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('/@org-1/application/app-1'))
+  })
+
+  test('omits the URL when the application has no organization', () => {
+    const output = mockOutput()
+
+    logAppDeployed({
+      application: application({organizationId: null}),
+      cliConfig: {app: {organizationId: 'config-org'}, deployment: {appId: 'app-1'}} as CliConfig,
+      output,
+    })
+
+    expect(output.log).toHaveBeenCalledWith('\nSuccess! Application deployed')
+  })
+})

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployApp.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployApp.test.ts
@@ -1,12 +1,12 @@
 import {type CliConfig, type Output} from '@sanity/cli-core'
 import {describe, expect, test, vi} from 'vitest'
 
-import {type UserApplication} from '../../../services/userApplications.js'
+import {type UserApplicationResolved} from '../../../services/userApplications.js'
 import {logAppDeployed} from '../deployApp.js'
 
 const mockOutput = () => ({log: vi.fn()}) as unknown as Output
 
-function application(overrides: Partial<UserApplication> = {}): UserApplication {
+function application(overrides: Partial<UserApplicationResolved> = {}): UserApplicationResolved {
   return {
     appHost: 'app-host',
     createdAt: '2024-01-01T00:00:00Z',
@@ -22,7 +22,7 @@ function application(overrides: Partial<UserApplication> = {}): UserApplication 
 }
 
 describe('logAppDeployed', () => {
-  test("prints the dashboard URL from the app's own organization, not the config", () => {
+  test("prints the dashboard URL from the deployed app's organization", () => {
     const output = mockOutput()
 
     logAppDeployed({
@@ -35,17 +35,5 @@ describe('logAppDeployed', () => {
       expect.stringContaining('Success! Application deployed to'),
     )
     expect(output.log).toHaveBeenCalledWith(expect.stringContaining('/@org-1/application/app-1'))
-  })
-
-  test('omits the URL when the application has no organization', () => {
-    const output = mockOutput()
-
-    logAppDeployed({
-      application: application({organizationId: null}),
-      cliConfig: {app: {organizationId: 'config-org'}, deployment: {appId: 'app-1'}} as CliConfig,
-      output,
-    })
-
-    expect(output.log).toHaveBeenCalledWith('\nSuccess! Application deployed')
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -238,7 +238,13 @@ describe('checkStudioTarget', () => {
 
 describe('checkAppTarget', () => {
   test('found → pass check for the existing application', async () => {
-    const app = application({appHost: 'app-host', id: 'core-1', title: 'My App', type: 'coreApp'})
+    const app = application({
+      appHost: 'app-host',
+      id: 'core-1',
+      organizationId: 'org-1',
+      title: 'My App',
+      type: 'coreApp',
+    })
     mockResolveApp.mockResolvedValue({application: app, type: 'found'})
     const reporter = createCollectingReporter()
 
@@ -246,6 +252,7 @@ describe('checkAppTarget', () => {
 
     expect(reporter.results[0]).toMatchObject({status: 'pass'})
     expect(reporter.results[0]?.message).toContain('Deploys to existing application "My App"')
+    expect(reporter.results[0]?.message).toContain('/@org-1/application/core-1')
   })
 
   test('would-create → fail check (creating one needs an interactive prompt)', async () => {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -1,7 +1,10 @@
 import {type CliConfig, exitCodes, type Output} from '@sanity/cli-core'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {type UserApplication} from '../../../services/userApplications.js'
+import {
+  type UserApplication,
+  type UserApplicationResolved,
+} from '../../../services/userApplications.js'
 import {
   checkAppId,
   checkAppTarget,
@@ -244,7 +247,7 @@ describe('checkAppTarget', () => {
       organizationId: 'org-1',
       title: 'My App',
       type: 'coreApp',
-    })
+    }) as UserApplicationResolved
     mockResolveApp.mockResolvedValue({application: app, type: 'found'})
     const reporter = createCollectingReporter()
 
@@ -268,7 +271,7 @@ describe('checkAppTarget', () => {
 
   test('needs-input → fail check (would prompt)', async () => {
     mockResolveApp.mockResolvedValue({
-      existing: [application(), application()],
+      existing: [application(), application()] as UserApplicationResolved[],
       type: 'needs-input',
     })
     const reporter = createCollectingReporter()

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -120,7 +120,7 @@ describe('renderDeploymentPlan', () => {
     expect(text).toContain('Dry run — no changes made.')
     expect(text).toContain('Project: p1')
     expect(text).toContain('This studio can be deployed.')
-    expect(text).toContain('Files to deploy (1.50 MB):')
+    expect(text).toContain('Files to deploy (1 file, 1.50 MB):')
     expect(text).toContain('dist/index.html (1.50 MB)')
   })
 

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/urlUtils.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/urlUtils.test.ts
@@ -1,6 +1,12 @@
 import {describe, expect, test} from 'vitest'
 
-import {normalizeUrl, validateUrl} from '../urlUtils.js'
+import {getCoreAppUrl, normalizeUrl, validateUrl} from '../urlUtils.js'
+
+describe('getCoreAppUrl', () => {
+  test('points at the org-scoped application route in the dashboard', () => {
+    expect(getCoreAppUrl('org-1', 'app-1')).toMatch(/\/@org-1\/application\/app-1$/)
+  })
+})
 
 describe('validateUrl', () => {
   test('returns true for valid https URL', () => {

--- a/packages/@sanity/cli/src/actions/deploy/createUserApplication.ts
+++ b/packages/@sanity/cli/src/actions/deploy/createUserApplication.ts
@@ -5,6 +5,7 @@ import {customAlphabet} from 'nanoid'
 import {
   createUserApplication as createUserApplicationRequest,
   type UserApplication,
+  type UserApplicationResolved,
 } from '../../services/userApplications.js'
 import {NO_ORGANIZATION_ID} from '../../util/errorMessages.js'
 import {deployDebug} from './deployDebug.js'
@@ -75,7 +76,9 @@ export async function createStudioUserApplication(options: CreateStudioUserAppli
   return await promise
 }
 
-export async function createUserApplication(organizationId?: string): Promise<UserApplication> {
+export async function createUserApplication(
+  organizationId?: string,
+): Promise<UserApplicationResolved> {
   if (!organizationId) {
     throw new Error(NO_ORGANIZATION_ID)
   }

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -33,6 +33,7 @@ import {listDeploymentFiles} from './deploymentPlan.js'
 import {type DeployResult, runDeploy} from './deployRunner.js'
 import {findUserApplication} from './findUserApplication.js'
 import {type DeployAppOptions} from './types.js'
+import {getCoreAppUrl} from './urlUtils.js'
 
 const APP_PACKAGE = '@sanity/sdk-react'
 
@@ -263,7 +264,11 @@ function logAppDeployed({
   cliConfig: DeployAppOptions['cliConfig']
   output: DeployAppOptions['output']
 }): void {
-  output.log(`\n🚀 ${styleText('bold', 'Success!')} Application deployed`)
+  const organizationId = cliConfig.app?.organizationId ?? application.organizationId ?? undefined
+  const deployedTo = organizationId
+    ? ` to ${styleText('cyan', getCoreAppUrl(organizationId, application.id))}`
+    : ''
+  output.log(`\nSuccess! Application deployed${deployedTo}`)
 
   if (getAppId(cliConfig)) return
 

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -255,7 +255,7 @@ async function shipAppDeployment({
   spin.succeed()
 }
 
-function logAppDeployed({
+export function logAppDeployed({
   application,
   cliConfig,
   output,
@@ -264,9 +264,8 @@ function logAppDeployed({
   cliConfig: DeployAppOptions['cliConfig']
   output: DeployAppOptions['output']
 }): void {
-  const organizationId = cliConfig.app?.organizationId ?? application.organizationId ?? undefined
-  const deployedTo = organizationId
-    ? ` to ${styleText('cyan', getCoreAppUrl(organizationId, application.id))}`
+  const deployedTo = application.organizationId
+    ? ` to ${styleText('cyan', getCoreAppUrl(application.organizationId, application.id))}`
     : ''
   output.log(`\nSuccess! Application deployed${deployedTo}`)
 

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -11,6 +11,7 @@ import {
   createDeployment,
   updateUserApplication,
   type UserApplication,
+  type UserApplicationResolved,
 } from '../../services/userApplications.js'
 import {getAppId} from '../../util/appId.js'
 import {EXTERNAL_APP_NOT_SUPPORTED, NO_ORGANIZATION_ID} from '../../util/errorMessages.js'
@@ -91,7 +92,7 @@ async function runAppDeployment(
 
   checkAppId(reporter, {cliConfig})
 
-  let application: UserApplication | null = null
+  let application: UserApplicationResolved | null = null
   if (flags.external) {
     reporter.report({
       message: EXTERNAL_APP_NOT_SUPPORTED,
@@ -160,7 +161,7 @@ async function runAppDeployment(
 async function resolveAppApplication(
   options: DeployAppOptions,
   {dryRun, reporter}: {dryRun: boolean; reporter: CheckReporter},
-): Promise<UserApplication | null> {
+): Promise<UserApplicationResolved | null> {
   const {cliConfig, flags, output} = options
   const organizationId = cliConfig.app?.organizationId ?? ''
 
@@ -192,10 +193,10 @@ async function syncApplicationTitle({
   manifest,
   output,
 }: {
-  application: UserApplication
+  application: UserApplicationResolved
   manifest: CoreAppManifest | undefined
   output: DeployAppOptions['output']
-}): Promise<UserApplication> {
+}): Promise<UserApplicationResolved> {
   const titleUpdate = resolveTitleUpdate(manifest, application)
   if (!titleUpdate) return application
 
@@ -260,14 +261,12 @@ export function logAppDeployed({
   cliConfig,
   output,
 }: {
-  application: UserApplication
+  application: UserApplicationResolved
   cliConfig: DeployAppOptions['cliConfig']
   output: DeployAppOptions['output']
 }): void {
-  const deployedTo = application.organizationId
-    ? ` to ${styleText('cyan', getCoreAppUrl(application.organizationId, application.id))}`
-    : ''
-  output.log(`\nSuccess! Application deployed${deployedTo}`)
+  const url = getCoreAppUrl(application.organizationId, application.id)
+  output.log(`\nSuccess! Application deployed to ${styleText('cyan', url)}`)
 
   if (getAppId(cliConfig)) return
 

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -19,6 +19,7 @@ import {
   type StudioDeployTargetResolution,
 } from './resolveDeployTarget.js'
 import {type DeployFlags} from './types.js'
+import {getCoreAppUrl} from './urlUtils.js'
 
 type DeployCheckStatus = 'fail' | 'pass' | 'skip' | 'warn'
 
@@ -220,8 +221,12 @@ export function describeAppTarget(resolution: AppDeployTargetResolution): Deploy
     }
     case 'found': {
       const {application} = resolution
+      const title = application.title ?? application.appHost
+      const dashboardUrl = application.organizationId
+        ? ` at ${getCoreAppUrl(application.organizationId, application.id)}`
+        : ''
       return {
-        message: `Deploys to existing application "${application.title ?? application.appHost}"`,
+        message: `Deploys to existing application "${title}"${dashboardUrl}`,
         status: 'pass',
       }
     }

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -222,11 +222,8 @@ export function describeAppTarget(resolution: AppDeployTargetResolution): Deploy
     case 'found': {
       const {application} = resolution
       const title = application.title ?? application.appHost
-      const dashboardUrl = application.organizationId
-        ? ` at ${getCoreAppUrl(application.organizationId, application.id)}`
-        : ''
       return {
-        message: `Deploys to existing application "${title}"${dashboardUrl}`,
+        message: `Deploys to existing application "${title}" at ${getCoreAppUrl(application.organizationId, application.id)}`,
         status: 'pass',
       }
     }

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -5,6 +5,7 @@ import {styleText} from 'node:util'
 import {type Output} from '@sanity/cli-core'
 import {logSymbols} from '@sanity/cli-core/ux'
 
+import {pluralize} from '../../util/pluralize.js'
 import {type DeployCheck} from './deployChecks.js'
 
 export interface DeploymentFile {
@@ -122,7 +123,9 @@ export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void
 
   // A blocked deploy uploads nothing, so only list files for a deployable plan.
   if (isDeployable(plan) && plan.files.length > 0) {
-    output.log(`\nFiles to deploy (${formatMB(totalBytes(plan.files))}):`)
+    output.log(
+      `\nFiles to deploy (${plan.files.length} ${pluralize('file', plan.files.length)}, ${formatMB(totalBytes(plan.files))}):`,
+    )
     for (const file of plan.files) {
       output.log(`  ${file.path} (${formatMB(file.size)})`)
     }

--- a/packages/@sanity/cli/src/actions/deploy/findUserApplication.ts
+++ b/packages/@sanity/cli/src/actions/deploy/findUserApplication.ts
@@ -7,7 +7,11 @@
 import {type CliConfig, type Output} from '@sanity/cli-core'
 import {select, Separator, spinner} from '@sanity/cli-core/ux'
 
-import {createUserApplication, type UserApplication} from '../../services/userApplications.js'
+import {
+  createUserApplication,
+  type UserApplication,
+  type UserApplicationResolved,
+} from '../../services/userApplications.js'
 import {getAppId} from '../../util/appId.js'
 import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {
@@ -29,7 +33,7 @@ interface FindUserApplicationOptions {
 
 export async function findUserApplication(
   options: FindUserApplicationOptions,
-): Promise<UserApplication | null> {
+): Promise<UserApplicationResolved | null> {
   const {cliConfig, organizationId, output, unattended = false} = options
   const spin = spinner('Checking application info...').start()
 
@@ -184,7 +188,9 @@ async function createFromConfiguredHost({
   }
 }
 
-async function promptForExistingApp(existing: UserApplication[]): Promise<UserApplication | null> {
+async function promptForExistingApp(
+  existing: UserApplicationResolved[],
+): Promise<UserApplicationResolved | null> {
   const choices = existing.map((app) => ({name: app.title ?? app.appHost, value: app.appHost}))
 
   const selected = await select({

--- a/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
+++ b/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
@@ -2,6 +2,7 @@ import {
   getUserApplication,
   getUserApplications,
   type UserApplication,
+  type UserApplicationResolved,
 } from '../../services/userApplications.js'
 import {normalizeUrl, validateUrl} from './urlUtils.js'
 
@@ -17,9 +18,9 @@ import {normalizeUrl, validateUrl} from './urlUtils.js'
  *
  * Transport errors (network, permissions) throw — they're not verdicts.
  */
-type CommonDeployTargetResolution =
-  | {application: UserApplication; type: 'found'}
-  | {existing: UserApplication[]; type: 'needs-input'}
+type CommonDeployTargetResolution<App extends UserApplication = UserApplication> =
+  | {application: App; type: 'found'}
+  | {existing: App[]; type: 'needs-input'}
   | {message: string; reason: 'app-not-found' | 'invalid-host'; type: 'invalid'}
   | {message: string; type: 'blocked'}
 
@@ -27,7 +28,9 @@ export type StudioDeployTargetResolution =
   | CommonDeployTargetResolution
   | {appHost: string; type: 'would-create'}
 
-export type AppDeployTargetResolution = CommonDeployTargetResolution | {type: 'would-create'}
+export type AppDeployTargetResolution =
+  | CommonDeployTargetResolution<UserApplicationResolved>
+  | {type: 'would-create'}
 
 /**
  * Owns the studio deploy-target rules: the --url flag over studioHost config,

--- a/packages/@sanity/cli/src/actions/deploy/urlUtils.ts
+++ b/packages/@sanity/cli/src/actions/deploy/urlUtils.ts
@@ -1,3 +1,10 @@
+import {getSanityUrl} from '@sanity/cli-core'
+
+/** A deployed core app has no host of its own; it's only reachable in the dashboard. */
+export function getCoreAppUrl(organizationId: string, appId: string): string {
+  return getSanityUrl(`/@${organizationId}/application/${appId}`)
+}
+
 /**
  * Validates that the given string is a valid http or https URL.
  * Returns `true` if valid, or an error message string if invalid.

--- a/packages/@sanity/cli/src/actions/deploy/urlUtils.ts
+++ b/packages/@sanity/cli/src/actions/deploy/urlUtils.ts
@@ -1,6 +1,5 @@
 import {getSanityUrl} from '@sanity/cli-core'
 
-/** A deployed core app has no host of its own; it's only reachable in the dashboard. */
 export function getCoreAppUrl(organizationId: string, appId: string): string {
   return getSanityUrl(`/@${organizationId}/application/${appId}`)
 }

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -103,7 +103,7 @@ export async function extractCoreAppManifest(
     }
 
     if (!icon && !app.title) {
-      spin.succeed('Manifest creation skipped: no icon or title found in app configuration')
+      spin.info('Manifest creation skipped: no icon or title found in app configuration')
       return undefined
     }
 

--- a/packages/@sanity/cli/src/services/userApplications.ts
+++ b/packages/@sanity/cli/src/services/userApplications.ts
@@ -34,10 +34,28 @@ export interface UserApplication {
   activeDeployment?: ActiveDeployment | null
 }
 
+/** A core app always belongs to an organization. */
+export interface UserApplicationResolved extends UserApplication {
+  organizationId: string
+  type: 'coreApp'
+}
+
 type GetUserApplicationOptions =
   | {appHost?: never; appId: string; isSdkApp: true; projectId?: never}
   | {appHost?: string; appId?: string; isSdkApp: false; projectId: string}
 
+export async function getUserApplication(options: {
+  appHost?: never
+  appId: string
+  isSdkApp: true
+  projectId?: never
+}): Promise<UserApplicationResolved | null>
+export async function getUserApplication(options: {
+  appHost?: string
+  appId?: string
+  isSdkApp: false
+  projectId: string
+}): Promise<UserApplication | null>
 export async function getUserApplication({
   appHost,
   appId,
@@ -120,7 +138,7 @@ export async function updateUserApplication({
   applicationId,
   appType,
   body,
-}: UpdateUserApplicationOptions): Promise<UserApplication> {
+}: UpdateUserApplicationOptions): Promise<UserApplicationResolved> {
   const client = await getGlobalCliClient({
     apiVersion: USER_APPLICATIONS_API_VERSION,
     requireUser: true,
@@ -141,7 +159,7 @@ export async function getUserApplications(options: {
 export async function getUserApplications(options: {
   appType: 'coreApp'
   organizationId: string
-}): Promise<UserApplication[]>
+}): Promise<UserApplicationResolved[]>
 export async function getUserApplications(
   options:
     | {
@@ -192,7 +210,7 @@ export async function createUserApplication(options: {
     title?: string
   }
   organizationId?: string
-}): Promise<UserApplication>
+}): Promise<UserApplicationResolved>
 export async function createUserApplication(options: {
   appType: 'studio'
   body: Pick<UserApplication, 'appHost' | 'type' | 'urlType'> & {

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -237,7 +237,8 @@ describe('#deploy app', () => {
     expect(stderr).toContain('Verifying local content')
     expect(stderr).toContain('Deploying...')
 
-    expect(stdout).toContain('Success! Application deployed')
+    expect(stdout).toContain('Success! Application deployed to')
+    expect(stdout).toContain('/@org-id/application/app-id')
   })
 
   test('should report the target and files in a dry run without deploying', async () => {
@@ -273,6 +274,7 @@ describe('#deploy app', () => {
     if (error) throw error
     expect(stdout).toContain('Dry run — no changes made.')
     expect(stdout).toContain('Deploys to existing application "Existing App"')
+    expect(stdout).toContain(`/@org-id/application/${appId}`)
     expect(stdout).toContain('This application can be deployed.')
     expect(stdout).toContain('Files to deploy (')
     expect(stdout).toContain('dist/index.html (')

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -237,8 +237,7 @@ describe('#deploy app', () => {
     expect(stderr).toContain('Verifying local content')
     expect(stderr).toContain('Deploying...')
 
-    expect(stdout).toContain('Success! Application deployed to')
-    expect(stdout).toContain('/@org-id/application/app-id')
+    expect(stdout).toContain('Success! Application deployed')
   })
 
   test('should report the target and files in a dry run without deploying', async () => {
@@ -274,7 +273,6 @@ describe('#deploy app', () => {
     if (error) throw error
     expect(stdout).toContain('Dry run — no changes made.')
     expect(stdout).toContain('Deploys to existing application "Existing App"')
-    expect(stdout).toContain(`/@org-id/application/${appId}`)
     expect(stdout).toContain('This application can be deployed.')
     expect(stdout).toContain('Files to deploy (')
     expect(stdout).toContain('dist/index.html (')


### PR DESCRIPTION
### Description

An app deploy never showed where it landed — the dry-run plan and the success line had no URL, so you couldn't see the target or confirm it afterward. Studios already print their `sanity.studio` URL; now apps do too.

A core app has no host of its own (it runs in the dashboard), so both the plan and the success message report its dashboard URL — `…/@<org>/application/<appId>` — from one shared `getCoreAppUrl` helper.

Two smaller fixes rode along: a skipped manifest ("no icon or title") shows as informational (ℹ) instead of a green check, and the dry-run "Files to deploy" header shows a file count.

Stacked on #1416.

### What to review

- `getCoreAppUrl` in `urlUtils.ts`, used by both the dry-run plan (`describeAppTarget`) and the success line (`logAppDeployed`).
- Sanity check: run `sanity deploy --dry-run` and a real deploy on a core app, and compare against a studio.

### Testing

A unit test pins the dashboard URL format; the app/studio deploy unit and integration tests cover the plan message and the success line. Type-check and lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI messaging and TypeScript types only; no deploy upload or API behavior changes.
> 
> **Overview**
> SDK/core app deploys now surface **where the app lives** in the CLI, similar to studios. A shared **`getCoreAppUrl`** helper builds the org-scoped dashboard route (`…/@<org>/application/<appId>` via `getSanityUrl`).
> 
> **Dry-run** app target checks and **post-deploy success** both use that URL: `describeAppTarget` appends it to the “Deploys to existing application …” line, and `logAppDeployed` prints `Success! Application deployed to <url>` (using the app’s `organizationId`, not config).
> 
> Typing is tightened with **`UserApplicationResolved`** for core apps (`organizationId` required) on SDK fetch/list/create/update and through the deploy resolution path.
> 
> Also: skipped manifest extraction (no icon/title) uses an **info** spinner instead of success; dry-run **“Files to deploy”** includes a **file count** (`N file(s), X MB`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594fcca4124cf4203191aa518b79aafa03ca3924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->