### PR TITLE
docs(test): updating agent doc and readmes to enshrine new testing approach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,11 @@ Read and respect rules and conventions from CONTRIBUTING.md. Additionally:
 
 All commands are run from the root of the repo.
 
-- `pnpm test` - run all unit tests
-- `pnpm test <test-file>` - run specific test file(s); the arg is a path substring match. Example: `pnpm test documents/__tests__/get`
-- `pnpm test --coverage` - run tests with coverage report (output in `coverage/`)
+- `pnpm test:unit` - run all unit tests - first line of defense, should be run first, takes ~20s on a modern machine
+- `pnpm test:coverage` - run unit tests with coverage report output to terminal (and report files to `coverage/`)
+- `pnpm test:integration` - run all integration tests - much more expensive, takes ~3 mins on a modern machine, use sparingly or as a final validation check
+- `pnpm test` - run all tests
+- `pnpm test[:unit|:integration] <test-file>` - run specific test file(s); the arg is a path substring match. Example: `pnpm test documents/__tests__/get`
 - `pnpm check:types` - TypeScript type checking
 - `pnpm check:lint` - ESLint + Prettier
 - `pnpm check:deps` - unused dependency / export check
@@ -18,80 +20,13 @@ All commands are run from the root of the repo.
 # Workflow
 
 - Be sure to typecheck, lint, build, depcheck and run tests when you are done.
-- Testing coverage should be maximized. Prefer running tests with coverage and the goal is to achieve maximum testing coverage for any new code added.
+- Testing coverage should be maximized. Prefer running tests with coverage and the goal is to achieve maximum unit testing coverage for any new code added.
 - When creating pull requests, always follow the template in `.github/PULL_REQUEST_TEMPLATE.md`. Do not use your own format.
 - Releasable changes need a changeset, normally auto-generated from the PR's "Notes for release" section (empty uses the PR title; `N/A` skips it). See CONTRIBUTING.md "Automatic Changesets"; a hand-authored `.changeset/` file also works and takes precedence.
 
 # Testing Rules
 
-## ALWAYS:
-
-1. Default to HTTP mocking with `mockApi()` as your first choice
-2. Mock at the highest level possible: HTTP > Client > Action (never Service)
-3. Use `vi.hoisted(() => vi.fn())` for client method mocks
-4. Clear mocks in `afterEach()` with `vi.clearAllMocks()`
-5. Test both success and error scenarios
-6. Use `if (error) throw error` in success tests - NOT `expect(error).toBeUndefined()`
-7. Assert `expect(error).toBeInstanceOf(Error)` in error tests, along with exit code and message
-8. Settle every command started in a test before the test ends, even when the test fails - a leaked running command consumes the next test's nock mocks and ports (see `activeLogins` in `login.test.ts`)
-
-## NEVER:
-
-1. Never mock service files - always use client or HTTP mocking
-2. Never leave mocks active between tests
-3. Never use `any` in mock types
-4. Never mock without verifying the mock was called
-5. Never wait for async work (servers starting, output appearing) with fixed `setTimeout` sleeps - poll for an observable signal (printed output via the `onOutput` capture option, mock calls via `vi.waitFor`) with a generous deadline that fails the test
-6. Never hardcode port numbers in tests - use OS-assigned ports (`server.listen(0)`, `vi.stubEnv('SANITY_CLI_CALLBACK_PORTS', '0')` for the auth callback server) and discover the actual port from output or mock calls
-
-## Quick Reference
-
-**Simple HTTP API test:**
-
-```typescript
-mockApi({uri: '/endpoint'}).reply(200, {...})
-```
-
-**Client method mocking:**
-
-```typescript
-const mockMethod = vi.hoisted(() => vi.fn())
-
-vi.mock('@sanity/cli-core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@sanity/cli-core')>()
-  return {
-    ...actual,
-    getProjectCliClient: vi.fn().mockResolvedValue({
-      resource: {method: mockMethod},
-    }),
-  }
-})
-```
-
-**HTTP with mocked methods:**
-
-```typescript
-const testClient = createTestClient({apiVersion: '...', token: '...'})
-
-vi.mock('@sanity/cli-core', async () => {
-  const actual = await vi.importActual('@sanity/cli-core')
-  return {
-    ...actual,
-    getGlobalCliClient: vi.fn().mockResolvedValue({
-      request: testClient.request,
-      users: {getById: vi.fn()},
-    }),
-  }
-})
-
-mockApi({uri: '/endpoint'}).reply(200, {...})
-```
-
-**Reference**: See `packages/@sanity/cli/src/commands/__tests__/init/init.plan.test.ts` for a complete example.
-
-# Testing
-
-Uses vitest. Suite is very large and slow. Minimize full runs.
+Follow all instructions and guidance laid out in the Testing Requirements section in `CONTRIBUTING.md`.
 
 **Never pipe test output.** The following are all forbidden:
 
@@ -111,25 +46,31 @@ First, compute the output path (derived from cwd, matches `vitest.config.ts`):
 TEST_RESULTS="/tmp/test-results-$(echo -n "$(pwd)" | sha1sum | cut -c1-8).json"
 ```
 
+Next determine whether to run unit tests or integration tests. Start with unit tests as they take less time to complete. Depending on the available resources of the local machine, integration tests may experience failures like test worker deaths from OS signals. Older node versions, like node v22, experience these more frequently than newer versions. Export a `RUNTASK` variable choosing which tests to run:
+
+```bash
+RUNTASK="test:unit" # or "test:integration" for integration tests, or simply "test" for all tests
+```
+
 Then run one of:
 
 ```bash
 # Only tests affected by uncommitted changes (preferred starting point)
-pnpm test --changed --bail=1
+pnpm $RUNTASK --changed --bail=1
 
 # Scoped to package
-pnpm test --project=@sanity/cli --bail=1
+pnpm $RUNTASK --project=@sanity/cli --bail=1
 
 # Single file (when debugging a specific failure) — the file arg is a substring
 # match against the path, so a unique fragment is enough
-pnpm test topicAliases
+pnpm $RUNTASK topicAliases
 
 # Single test within a file: by name (-t, a regex) or by line number (needs full path)
-pnpm test topicAliases -t "rewrites \"dataset list\""
-pnpm test packages/@sanity/cli/src/hooks/commandNotFound/__tests__/topicAliases.test.ts:23
+pnpm $RUNTASK topicAliases -t "rewrites \"dataset list\""
+pnpm $RUNTASK packages/@sanity/cli/src/hooks/commandNotFound/__tests__/topicAliases.test.ts:23
 
 # Full suite (avoid — only for final validation before committing)
-pnpm test --bail=3
+pnpm $RUNTASK --bail=3
 ```
 
 ## Reading test results
@@ -161,7 +102,7 @@ jq '{total: .numTotalTests, passed: .numPassedTests, failed: .numFailedTests, fi
 4. Read the failing test file and relevant source to understand the failure
 5. Fix the code
 6. Re-run ONLY the previously-failing files
-7. Once those pass, run the full affected package: `pnpm test --project=<pkg>`
+7. Once those pass, run the full affected package: `pnpm $RUNTASK --project=<pkg>`
 8. Full suite only as final validation before committing
 
 # Debugging

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We're trying out oclif as the CLI framework. It implements a lot of common CLI p
 
 New commands can be added by cd'ing into `packages/@sanity/cli` and running `npx oclif generate command <command-name>`. This will create a new command in the `src/commands` folder. You can also just copy one of the existing commands - they have some minor improvements to TypeScript.
 
-You _may_ have to run `npm run build` (`npm run watch` is also available) to build the CLI after adding a new command.
+You _may_ have to run `pnpm build:cli` (`pnpm watch:cli` is also available) to build the CLI after adding a new command.
 
 In development mode, all the command modules will be "loaded" (eg imported) in order to get their help description etc. At build time (pre-publish), a manifest file will be generated containing the available commands. This will be used by the CLI to determine which commands are available, and prevent loading commands that are not to be run (functionality provided by oclif, not specific to Sanity CLI).
 

--- a/packages/@sanity/cli-e2e/README.md
+++ b/packages/@sanity/cli-e2e/README.md
@@ -4,16 +4,9 @@ End-to-end tests for the Sanity CLI. These tests pack the CLI to a tarball, inst
 
 For test-writing patterns and conventions (test structure, naming, common mistakes), see the [`writing-cli-e2e-tests` skill](../../../.claude/skills/writing-cli-e2e-tests/SKILL.md). This README covers setup, infrastructure, and how to run/debug the tests.
 
-## Unit vs E2E
+## Unit vs Integration vs E2E
 
-Two tiers of tests live in this repo. Pick the right one for what you're verifying:
-
-|                  | Unit (`packages/@sanity/cli/src/commands/__tests__/`) | E2E (this package)                                          |
-| ---------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
-| **Runs against** | Mocked HTTP/client                                    | Real CLI binary, real API                                   |
-| **Speed**        | Milliseconds                                          | Seconds (each invocation ~10–60s)                           |
-| **Driver**       | `testCommand()`                                       | `runCli()`                                                  |
-| **Use for**      | Flag parsing, validation, error messages, edge cases  | Full flows: files generated, APIs called, prompts displayed |
+Three tiers of tests live in this repo. Pick the right one for what you're verifying - this is convered in more detail in [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) under the Testing Requirements section.
 
 Default to unit tests. Reach for an e2e test when the test only has value if the binary actually runs end-to-end.
 


### PR DESCRIPTION
Redirects all testing-related docs, where it makes sense, to the main `CONTRIBUTING.md`. Agent-specific docs can live in `AGENTS.md` but the principles the testing strategy is built upon apply to humans as well - that is the foundation.

Closes RUN-1445.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or test code changes—only documentation and command references for contributors and agents.
> 
> **Overview**
> **Documentation-only** update that aligns agent and contributor docs with the repo’s three-tier testing model (unit / integration / e2e) and with `pnpm` workflows.
> 
> **`AGENTS.md`** drops the long inline testing rules (ALWAYS/NEVER, `mockApi` / client mocking examples) and instead points readers to **Testing Requirements** in `CONTRIBUTING.md`. The quick reference now documents `pnpm test:unit`, `test:integration`, `test:coverage`, and when to use each; workflow text emphasizes **unit** coverage. Test-run examples use a **`RUNTASK`** variable (`test:unit` vs `test:integration` vs `test`) and note integration flakiness on resource-constrained or older Node versions.
> 
> **`README.md`** updates the post–new-command build hint from `npm run build` to **`pnpm build:cli`** / **`pnpm watch:cli`**.
> 
> **`packages/@sanity/cli-e2e/README.md`** reframes “Unit vs E2E” as **Unit vs Integration vs E2E** and defers tier choice to `CONTRIBUTING.md` instead of maintaining a comparison table in that README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a55e69a99504e9a7aa1ecddcec324e19af9ad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->