### PR TITLE
feat(deploy): carry the resolved deployment URL through the dry-run plan

### DIFF
--- a/.changeset/deploy-json-target.md
+++ b/.changeset/deploy-json-target.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": minor
+---
+
+feat(deploy): surface the resolved deploy target (appId + URL) in the `--json` dry-run plan, computed once so the human and JSON reports can't drift

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -147,6 +147,11 @@ describe('checkStudioTarget', () => {
     expect(reporter.results[0]?.message).toContain(
       'Deploys to existing studio https://my-studio.sanity.studio',
     )
+    // The URL the human report shows is the same one the JSON reporter reads
+    expect(reporter.results[0]?.target).toEqual({
+      applicationId: 'app-1',
+      url: 'https://my-studio.sanity.studio',
+    })
   })
 
   test('would-create → pass check', async () => {
@@ -267,6 +272,8 @@ describe('checkAppTarget', () => {
     expect(reporter.results[0]).toMatchObject({status: 'pass'})
     expect(reporter.results[0]?.message).toContain('Deploys to existing application "My App"')
     expect(reporter.results[0]?.message).toContain('/@org-1/application/core-1')
+    expect(reporter.results[0]?.target?.applicationId).toBe('core-1')
+    expect(reporter.results[0]?.target?.url).toContain('/@org-1/application/core-1')
   })
 
   test('would-create without a title → fail check pointing to --title', async () => {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -58,6 +58,7 @@ describe('listDeploymentFiles', () => {
 const studioPlan = (checks: DeployCheck[], files: DeploymentFile[] = []): DeploymentPlan => ({
   checks,
   files,
+  target: null,
   type: 'studio',
   version: '3.99.0',
 })
@@ -81,9 +82,22 @@ describe('deploymentPlanToJson', () => {
       errors: {'No studio hostname configured': 'Set `studioHost`'},
       files: [{path: 'dist/index.html', size: 1_048_576}],
       isDeployable: false,
+      target: null,
       totalBytes: 1_048_576,
       warnings: ['The autoUpdates config has moved'],
     })
+  })
+
+  test('passes the resolved target through to the JSON', () => {
+    const target = {applicationId: 'app-1', url: 'https://my-studio.sanity.studio'}
+    const json = deploymentPlanToJson({
+      checks: [],
+      files: [],
+      target,
+      type: 'studio',
+      version: null,
+    })
+    expect(json.target).toEqual(target)
   })
 
   test('an error without a solution maps to null', () => {
@@ -168,7 +182,10 @@ describe('renderDeploymentPlan', () => {
   })
 
   test('labels a core app deploy as an application', () => {
-    renderDeploymentPlan({checks: [], files: [], type: 'coreApp', version: '1.0.0'}, output)
+    renderDeploymentPlan(
+      {checks: [], files: [], target: null, type: 'coreApp', version: '1.0.0'},
+      output,
+    )
 
     expect(lines.join('\n')).toContain('This application can be deployed.')
   })

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -23,6 +23,18 @@ import {getCoreAppUrl} from './urlUtils.js'
 
 type DeployCheckStatus = 'fail' | 'pass' | 'skip' | 'warn'
 
+/**
+ * Where a deploy resolves to, computed once from the deploy-target verdict. The
+ * dry-run report and its JSON both read this, so the human and machine outputs
+ * can't drift.
+ */
+export interface DeployTarget {
+  /** The application the deploy targets; `null` when a deploy would create one. */
+  applicationId: string | null
+  /** Where the deployed studio/app is reachable; `null` when it can't be resolved yet. */
+  url: string | null
+}
+
 export interface DeployCheck {
   message: string
   status: DeployCheckStatus
@@ -31,6 +43,8 @@ export interface DeployCheck {
   exitCode?: number
   /** Actionable fix, shown under a failing or warning check */
   solution?: string
+  /** Set on the deploy-target check with the resolved target both reporters read. */
+  target?: DeployTarget
 }
 
 /**
@@ -225,9 +239,11 @@ export function describeAppTarget(
     case 'found': {
       const {application} = resolution
       const title = application.title ?? application.appHost
+      const url = getCoreAppUrl(application.organizationId, application.id)
       return {
-        message: `Deploys to existing application "${title}" at ${getCoreAppUrl(application.organizationId, application.id)}`,
+        message: `Deploys to existing application "${title}" at ${url}`,
         status: 'pass',
+        target: {applicationId: application.id, url},
       }
     }
     case 'invalid': {
@@ -298,9 +314,11 @@ export function describeStudioTarget(
       return {message: `Deploy target not resolved — ${resolution.message}`, status: 'skip'}
     }
     case 'found': {
+      const url = studioUrl(resolution.application.appHost)
       return {
-        message: `Deploys to existing studio ${studioUrl(resolution.application.appHost)}`,
+        message: `Deploys to existing studio ${url}`,
         status: 'pass',
+        target: {applicationId: resolution.application.id, url},
       }
     }
     case 'invalid': {
@@ -323,12 +341,14 @@ export function describeStudioTarget(
       }
     }
     case 'would-create': {
+      const url = studioUrl(resolution.appHost)
       const titled = title ? ` titled "${title}"` : ''
       return {
         message: isExternal
           ? `Would register external studio at ${resolution.appHost}${titled}`
-          : `Would create studio hostname ${studioUrl(resolution.appHost)}${titled} (name availability is checked on deploy)`,
+          : `Would create studio hostname ${url}${titled} (name availability is checked on deploy)`,
         status: 'pass',
+        target: {applicationId: null, url},
       }
     }
   }

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -88,6 +88,7 @@ async function collectPlan(options: DeployAppOptions, spec: DeploySpec): Promise
   const plan: DeploymentPlan = {
     checks: reporter.results,
     files: [],
+    target: reporter.results.find((check) => check.target)?.target ?? null,
     type: spec.type,
     version: await getLocalPackageVersion(spec.packageName, options.projectRoot.directory),
   }

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -6,7 +6,7 @@ import {type Output} from '@sanity/cli-core'
 import {logSymbols} from '@sanity/cli-core/ux'
 
 import {pluralize} from '../../util/pluralize.js'
-import {type DeployCheck} from './deployChecks.js'
+import {type DeployCheck, type DeployTarget} from './deployChecks.js'
 
 export interface DeploymentFile {
   /** Path relative to the project root, POSIX-style. */
@@ -18,6 +18,8 @@ export interface DeploymentFile {
 export interface DeploymentPlan {
   checks: DeployCheck[]
   files: DeploymentFile[]
+  /** The resolved deploy target; `null` when the checks can't determine one. */
+  target: DeployTarget | null
   type: 'coreApp' | 'studio'
   /** Installed framework version the deploy would use; `null` when not found. */
   version: string | null
@@ -77,6 +79,7 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
   errors: Record<string, string | null>
   files: DeploymentFile[]
   isDeployable: boolean
+  target: DeployTarget | null
   totalBytes: number
   warnings: string[]
 } {
@@ -93,6 +96,7 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
     errors,
     files: plan.files,
     isDeployable: isDeployable(plan),
+    target: plan.target,
     totalBytes: totalBytes(plan.files),
     warnings,
   }

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -319,6 +319,11 @@ describe('#deploy studio', () => {
     expect(plan.errors).toEqual({})
     expect(Array.isArray(plan.warnings)).toBe(true)
     expect(plan.files).toContainEqual(expect.objectContaining({path: 'dist/index.html'}))
+    // The target the human report names is carried structured in the JSON too
+    expect(plan.target).toEqual({
+      applicationId: 'studio-app-id',
+      url: 'https://existing-studio.sanity.studio',
+    })
   })
 
   test('keeps stdout pure JSON when --json is given a custom output directory', async () => {


### PR DESCRIPTION
### Description

The dry-run `--json` plan was built from the checks, and it dropped the passing ones — so the deploy target (the appId and URL the human report names) never reached the JSON. A tool parsing the plan couldn't tell where the deploy would land.

Now the target is computed once and carried on the plan, so the human report and the JSON read the same value — they can't drift.

Stacked on #1431 → #1416.

### What to review

- `DeployTarget` in `deployChecks.ts` — resolved once in `describe*Target`, feeding both the check message and the structured `target`.
- `collectPlan` lifts it onto the plan; `deploymentPlanToJson` passes it straight through.

### Testing

Unit: the target check carries `{applicationId, url}` for studios and apps, and the JSON passes it through. Integration: a `--dry-run --json` plan exposes `target` end-to-end. Type-check and lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JSON field on dry-run reporting only; deploy execution paths are unchanged aside from sharing the same URL string for human messages.
> 
> **Overview**
> **`sanity deploy --dry-run --json`** now exposes **`target`** (`applicationId`, `url`) on the plan, so tools parsing JSON can see where the deploy would land without scraping pass-check messages (which were omitted from JSON before).
> 
> The URL and app id are resolved **once** in `describeStudioTarget` / `describeAppTarget`, attached on the deploy-target **`DeployCheck`**, lifted onto **`DeploymentPlan`** in `collectPlan`, and passed through **`deploymentPlanToJson`**. For **would-create** studio hostnames, `applicationId` is `null` but `url` is still set; when target resolution fails or is skipped, `target` is `null`.
> 
> Unit and integration tests cover studio/core-app checks and end-to-end `--dry-run --json` output. Minor **`@sanity/cli`** changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dbc1e64148989d0e9a5e2b5963e89956598b027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->