### PR TITLE
docs(deploy): plan extracting deploy into @sanity/cli-deploy

### DIFF
--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -45,7 +45,7 @@ function deployStudio(
     external: boolean
     uploadSchemaAndManifest: () => Promise<StudioManifest | null>
   },
-): Promise<DeployOutcome>
+): Promise<Deployment>
 
 function deployCoreApp(
   o: DeployContext & {
@@ -53,7 +53,7 @@ function deployCoreApp(
     organizationId: string | undefined
     extractManifest: () => Promise<CoreAppManifest | undefined>
   },
-): Promise<DeployOutcome>
+): Promise<Deployment>
 
 function undeployCoreApp(o: {
   output: Output
@@ -72,7 +72,7 @@ function undeployStudio(
 Return types — data only, no printing:
 
 ```ts
-type DeployOutcome =
+type Deployment =
   | {deployed: true; result: DeployResult}
   | {deployed: false; plan: DeploymentPlan} // dry run
 
@@ -84,7 +84,6 @@ interface DeployResult {
 }
 
 type UndeployOutcome = {
-  kind: 'undeployed'
   application: {id: string; type: 'coreApp' | 'studio'; appHost: string; title: string | null}
 } | null // nothing to undeploy — the target didn't resolve to an existing application
 ```
@@ -109,7 +108,7 @@ and `resolveAutoUpdates` + its message helpers ([`shouldAutoUpdate.ts`](../packa
 
 **Thin adapters left behind** — `commands/deploy.ts` and `commands/undeploy.ts` resolve
 config to primitives, inject the callbacks, own the oclif flags and the user-facing copy,
-and turn a `DeployOutcome` into human output or `--json`.
+and turn a `Deployment` into human output or `--json`.
 
 ## Phases
 
@@ -128,7 +127,7 @@ type of plain booleans and strings. The commands map their parsed flags onto it.
 
 ### Phase 2 — Return outcomes; stop exiting the process for control flow
 
-The entry points return `DeployOutcome` / `UndeployOutcome`. A failing check throws a typed
+The entry points return `Deployment` / `UndeployOutcome`. A failing check throws a typed
 `DeployCheckError` (message + exit code) instead of `output.error(msg, {exit})`. The
 commands catch it and exit; they also own the `--json` vs. human rendering
 (`renderDeploymentPlan` / `deploymentPlanToJson` become caller-side).

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -43,7 +43,7 @@ function deployStudio(
     projectId: string | undefined
     studioHost: string | undefined
     external: boolean
-    uploadSchemaAndManifest: () => Promise<StudioManifest | null>
+    deployStudioSchema: () => Promise<StudioManifest | null>
   },
 ): Promise<Deployment>
 
@@ -72,9 +72,7 @@ function undeployStudio(
 Return types — data only, no printing:
 
 ```ts
-type Deployment =
-  | {deployed: true; result: DeployResult}
-  | {deployed: false; plan: DeploymentPlan} // dry run
+type Deployment = {deployed: true; result: DeployResult} | {deployed: false; plan: DeploymentPlan} // dry run
 
 interface DeployResult {
   applicationId: string
@@ -86,7 +84,23 @@ interface DeployResult {
 type UndeployOutcome = {
   application: {id: string; type: 'coreApp' | 'studio'; appHost: string; title: string | null}
 } | null // nothing to undeploy — the target didn't resolve to an existing application
+
+class DeployError extends Error {
+  check: DeployCheck // the failing check: message, solution, exitCode
+}
 ```
+
+### Errors and control flow
+
+- `deployStudio` / `deployCoreApp` return a `Deployment` on success and on `--dry-run` — a
+  blocked dry run is data (`deployed: false`), not a throw.
+- A real deploy blocked by a failing check throws `DeployError`, carrying the `DeployCheck`
+  it stopped on (`message`, `solution`, `exitCode`).
+- Unexpected failures — network, build, schema extraction, filesystem — propagate unwrapped.
+- `undeployStudio` / `undeployCoreApp` return the removed application, or `null` when nothing
+  resolved; they throw only on an API failure.
+- Ctrl+C at a prompt surfaces as the prompt library's `ExitPromptError` and propagates.
+- `DeployError` is exported, so callers can tell a blocking check from an unexpected failure.
 
 ## Boundary
 
@@ -99,7 +113,7 @@ _types_, which already live in `@sanity/cli-core`).
 
 **Stays in `@sanity/cli`, injected as callbacks** — shared with other commands, so it
 can't move: the build wrappers (`build`), the studio schema/manifest worker
-(`uploadSchemaAndManifest`), and core-app manifest extraction (`extractManifest`). These
+(`deployStudioSchema`), and core-app manifest extraction (`extractManifest`). These
 sit on `actions/manifest` and `actions/schema`, used by `dev` and `manifest extract`.
 
 **Moves to `@sanity/cli-core`** — pure config resolvers now shared by build, dev, deploy,
@@ -128,7 +142,7 @@ type of plain booleans and strings. The commands map their parsed flags onto it.
 ### Phase 2 — Return outcomes; stop exiting the process for control flow
 
 The entry points return `Deployment` / `UndeployOutcome`. A failing check throws a typed
-`DeployCheckError` (message + exit code) instead of `output.error(msg, {exit})`. The
+`DeployError` (message + exit code) instead of `output.error(msg, {exit})`. The
 commands catch it and exit; they also own the `--json` vs. human rendering
 (`renderDeploymentPlan` / `deploymentPlanToJson` become caller-side).
 
@@ -159,7 +173,7 @@ build, and dev to import from cli-core.
 
 ### Phase 5 — Inject build and manifest/schema extraction
 
-The actions take `build`, `uploadSchemaAndManifest`, and `extractManifest` as callbacks.
+The actions take `build`, `deployStudioSchema`, and `extractManifest` as callbacks.
 The command wires the existing `buildStudio`/`buildApp`, the schema worker, and
 `extractCoreAppManifest`. Schema-error formatting moves into the injected callback so the
 action needn't know `SchemaExtractionError`.

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -89,40 +89,6 @@ type UndeployOutcome = {
 } | null // nothing to undeploy — the target didn't resolve to an existing application
 ```
 
-### Design rules behind the fields
-
-Names match `@sanity/cli-build` wherever the concept is shared: `output`, `workDir`,
-`isUnattended` (also the `SanityCommand.isUnattended()` method), `autoUpdatesEnabled`,
-`exposes`. `sourceDir` is the one deliberate divergence from build's `outDir` — deploy
-reads and uploads the directory, it doesn't write it.
-
-Optional vs. required is strict, and each `| undefined` earns its place:
-
-- `deploy*.appId` / `projectId` / `organizationId` / `studioHost` stay optional because
-  missing config is a real input the package turns into a failing check
-  (`NO_PROJECT_ID`, `NO_ORGANIZATION_ID`) — the dry-run report needs to name the problem.
-- `deploy*.appId` optional also covers the first deploy, where the package resolves,
-  prompts for, or creates the target.
-- `undeployCoreApp.appId` is **required** — an SDK app with no appId has nothing to remove.
-- `undeployStudio` is a **union**, not two optionals: you must pass an `appId`, or a
-  `studioHost` + `projectId` pair. The delete endpoint is global and keyed by the
-  application id, and `deployment.appId` _is_ that id, so an appId alone removes a studio.
-  `projectId` + `studioHost` are only the fallback for host-only studios that never got an appId.
-- `build: (() => Promise<void>) | null` — `null` is the explicit `--no-build` state.
-  Forcing the caller to pass it is stricter than an optional.
-- `UndeployOutcome` is `undeployed | null`, with no reason on the `null`. Because the
-  inputs above make an existing target mandatory, the only way to reach "nothing to undeploy"
-  inside the package is a target that didn't resolve — the missing-config cases are the
-  caller's to catch first, so there's nothing to distinguish.
-
-`exposes` (a `ResolvedWorkbenchApp`) replaces a boolean and a capability object at once.
-It's plain data — `{services, views, entry?, applicationType?, installationConfig?}` — so
-the package derives `isWorkbenchApp` from its presence, runs the "declares something
-deployable" guard against the data, reads `installationConfig` off it, and a report can
-enumerate the exposed surface. (Note: build's `WorkbenchExposes` type is missing `entry`;
-type this field as `ResolvedWorkbenchApp`, or add `entry` to `WorkbenchExposes` so both
-packages share one type.)
-
 ## Boundary
 
 **Moves into `@sanity/cli-deploy`** — deploy-intrinsic, and today only the command

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -133,8 +133,6 @@ The entry points return `DeployOutcome` / `UndeployOutcome`. A failing check thr
 commands catch it and exit; they also own the `--json` vs. human rendering
 (`renderDeploymentPlan` / `deploymentPlanToJson` become caller-side).
 
-- The core behavioural refactor. Coordinate with `feat/deploy-json`, which already pushes
-  presentation to the edges — rebase onto it or land this there first.
 - May split: **2a** return values on the success and dry-run paths; **2b** replace the
   `process.exit` calls with thrown errors.
 - **Done when:** no `actions/deploy` code calls `output.error(..., {exit})`; `output` is

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -1,0 +1,256 @@
+# Extracting deploy into `@sanity/cli-deploy`
+
+## Why
+
+`@sanity/cli-build` already lives on its own so [runtime-cli](https://github.com/sanity-io/runtime-cli)
+can build studios and apps without pulling in the whole CLI. Deploy can't be
+reused the same way yet. `runtime-cli` wants `deployCoreApp` / `deployStudio`
+(and their undeploy pair) the same way it consumes `buildApp` / `buildStudio`.
+
+Today the deploy action is welded to the CLI in four places:
+
+- **oclif flags** — [`types.ts`](../packages/@sanity/cli/src/actions/deploy/types.ts)
+  derives its options from `DeployCommand['flags']`, so it imports the command class.
+- **`process.exit`** — failing checks call `output.error(msg, {exit})`. A library
+  can't own the exit decision.
+- **the build step** — `deployStudio`/`deployApp` call the CLI's build wrappers directly.
+- **the manifest/schema stack** — the studio schema worker sits on `actions/manifest`
+  and `actions/schema`, which `dev` and `manifest extract` also use. Not deploy-specific.
+
+The end state mirrors `@sanity/cli-build`: entry points that take resolved values
+plus injected callbacks, return data, and leave presentation and process control
+to the caller.
+
+## Goal: the interfaces
+
+The four entry points, exported from `@sanity/cli-deploy/_internal/deploy`:
+
+```ts
+interface DeployContext {
+  output: Output
+  workDir: string
+  sourceDir: string
+  isUnattended: boolean
+  autoUpdatesEnabled: boolean
+  dryRun: boolean
+  build: (() => Promise<void>) | null // null = --no-build (validate existing output)
+  exposes?: ResolvedWorkbenchApp // absent = plain project
+}
+
+function deployStudio(
+  o: DeployContext & {
+    appId: string | undefined // undefined = resolve or create a target
+    projectId: string | undefined
+    studioHost: string | undefined
+    external: boolean
+    uploadSchemaAndManifest: () => Promise<StudioManifest | null>
+  },
+): Promise<DeployOutcome>
+
+function deployCoreApp(
+  o: DeployContext & {
+    appId: string | undefined
+    organizationId: string | undefined
+    extractManifest: () => Promise<CoreAppManifest | undefined>
+  },
+): Promise<DeployOutcome>
+
+function undeployCoreApp(o: {
+  output: Output
+  isUnattended: boolean
+  appId: string // required — nothing to undeploy without it
+}): Promise<UndeployOutcome>
+
+function undeployStudio(
+  o: {
+    output: Output
+    isUnattended: boolean
+  } & ({appId: string} | {studioHost: string; projectId: string}),
+): Promise<UndeployOutcome>
+```
+
+Return types — data only, no printing:
+
+```ts
+type DeployOutcome =
+  | {kind: 'deployed'; result: DeployResult}
+  | {kind: 'dry-run'; plan: DeploymentPlan}
+
+interface DeployResult {
+  applicationId: string
+  applicationType: 'coreApp' | 'studio'
+  applicationVersion: string // installed sanity / @sanity/sdk-react
+  location: string | null // studio URL; null for core apps
+}
+
+type UndeployOutcome =
+  | {
+      kind: 'undeployed'
+      application: {id: string; type: 'coreApp' | 'studio'; appHost: string; title: string | null}
+    }
+  | {kind: 'nothing-to-undeploy'; reason: 'no-app-id' | 'not-found'}
+```
+
+`DeployResult` and `DeploymentPlan` already exist on the in-flight `feat/deploy-json`
+branch ([`deployRunner.ts`](../packages/@sanity/cli/src/actions/deploy/deployRunner.ts),
+`deploymentPlan.ts`). This plan adopts them rather than inventing new shapes.
+
+### Design rules behind the fields
+
+Names match `@sanity/cli-build` wherever the concept is shared: `output`, `workDir`,
+`isUnattended` (also the `SanityCommand.isUnattended()` method), `autoUpdatesEnabled`,
+`exposes`. `sourceDir` is the one deliberate divergence from build's `outDir` — deploy
+reads and uploads the directory, it doesn't write it.
+
+Optional vs. required is strict, and each `| undefined` earns its place:
+
+- `deploy*.appId` / `projectId` / `organizationId` / `studioHost` stay optional because
+  missing config is a real input the package turns into a failing check
+  (`NO_PROJECT_ID`, `NO_ORGANIZATION_ID`) — the dry-run report needs to name the problem.
+- `deploy*.appId` optional also covers the first deploy, where the package resolves,
+  prompts for, or creates the target.
+- `undeployCoreApp.appId` is **required** — an SDK app with no appId has nothing to remove.
+- `undeployStudio` is a **union**, not two optionals: you must pass an `appId`, or a
+  `studioHost` + `projectId` pair. The delete endpoint is global and keyed by the
+  application id, and `deployment.appId` _is_ that id, so an appId alone removes a studio.
+  `projectId` + `studioHost` are only the fallback for host-only studios that never got an appId.
+- `build: (() => Promise<void>) | null` — `null` is the explicit `--no-build` state.
+  Forcing the caller to pass it is stricter than an optional.
+
+`exposes` (a `ResolvedWorkbenchApp`) replaces a boolean and a capability object at once.
+It's plain data — `{services, views, entry?, applicationType?, installationConfig?}` — so
+the package derives `isWorkbenchApp` from its presence, runs the "declares something
+deployable" guard against the data, reads `installationConfig` off it, and a report can
+enumerate the exposed surface. (Note: build's `WorkbenchExposes` type is missing `entry`;
+type this field as `ResolvedWorkbenchApp`, or add `entry` to `WorkbenchExposes` so both
+packages share one type.)
+
+## Boundary
+
+**Moves into `@sanity/cli-deploy`** — deploy-intrinsic, and today only the command
+consumes it: `deployApp` → `deployCoreApp`, `deployStudio`, `deployRunner`, `deployChecks`,
+`deploymentPlan`, `resolveDeployTarget`, `findUserApplication`, `createUserApplication`,
+`installationConfigDeployment`, `checkDir`, `urlUtils`, `deployDebug`, the undeploy
+resolver, and the API client `services/userApplications.ts` (it needs only manifest
+_types_, which already live in `@sanity/cli-core`).
+
+**Stays in `@sanity/cli`, injected as callbacks** — shared with other commands, so it
+can't move: the build wrappers (`build`), the studio schema/manifest worker
+(`uploadSchemaAndManifest`), and core-app manifest extraction (`extractManifest`). These
+sit on `actions/manifest` and `actions/schema`, used by `dev` and `manifest extract`.
+
+**Moves to `@sanity/cli-core`** — pure config resolvers now shared by build, dev, deploy,
+_and_ undeploy: `getAppId` / `resolveAppIdIssue` ([`util/appId.ts`](../packages/@sanity/cli/src/util/appId.ts))
+and `resolveAutoUpdates` + its message helpers ([`shouldAutoUpdate.ts`](../packages/@sanity/cli/src/actions/build/shouldAutoUpdate.ts)).
+
+**Thin adapters left behind** — `commands/deploy.ts` and `commands/undeploy.ts` resolve
+config to primitives, inject the callbacks, own the oclif flags and the user-facing copy,
+and turn a `DeployOutcome` into human output or `--json`.
+
+## Phases
+
+Each phase is one PR unless noted. The CLI stays green and behaviour is unchanged at every
+step until the package is consumed — these are refactors, not feature changes. The
+extraction (Phase 6) is a no-op move; all the shape work happens before it, in place.
+
+### Phase 1 — Decouple the deploy/undeploy actions from oclif flags
+
+Replace `flags: DeployFlags` (and the `DeployCommand` import) with an explicit options
+type of plain booleans and strings. The commands map their parsed flags onto it.
+
+- Mechanical, no behaviour change.
+- Removes the action → command import, the one hard blocker to moving anything.
+- **Done when:** nothing under `actions/deploy` imports from `commands/`.
+
+### Phase 2 — Return outcomes; stop exiting the process for control flow
+
+The entry points return `DeployOutcome` / `UndeployOutcome`. A failing check throws a typed
+`DeployCheckError` (message + exit code) instead of `output.error(msg, {exit})`. The
+commands catch it and exit; they also own the `--json` vs. human rendering
+(`renderDeploymentPlan` / `deploymentPlanToJson` become caller-side).
+
+- The core behavioural refactor. Coordinate with `feat/deploy-json`, which already pushes
+  presentation to the edges — rebase onto it or land this there first.
+- May split: **2a** return values on the success and dry-run paths; **2b** replace the
+  `process.exit` calls with thrown errors.
+- **Done when:** no `actions/deploy` code calls `output.error(..., {exit})`; `output` is
+  used only for progress.
+
+### Phase 3 — Resolve workbench to `exposes` data
+
+The actions take `exposes?: ResolvedWorkbenchApp` instead of calling `getWorkbench(cliConfig)`.
+Derive `isWorkbenchApp` from its presence, run the deployable guard on the data, and read
+`installationConfig` off it. The command resolves `resolveWorkbenchApp(cliConfig)` and
+passes the result.
+
+- Drops the capability-object dependency; unblocks reports listing the exposed surface.
+- Small: touches `deployApp`, `deployChecks` (`verifyOutputDir`), and the command.
+- **Done when:** `actions/deploy` no longer imports `getWorkbench`.
+
+### Phase 4 — Lift shared config resolvers into `@sanity/cli-core`
+
+Move `getAppId` / `resolveAppIdIssue` and `resolveAutoUpdates` + message helpers into
+`@sanity/cli-core`, re-export from the old paths to keep this PR a pure move. Update deploy,
+build, and dev to import from cli-core.
+
+- Independent of the rest; ships on its own.
+- **Done when:** the resolvers live in cli-core and deploy imports them from there.
+
+### Phase 5 — Inject build and manifest/schema extraction
+
+The actions take `build`, `uploadSchemaAndManifest`, and `extractManifest` as callbacks.
+The command wires the existing `buildStudio`/`buildApp`, the schema worker, and
+`extractCoreAppManifest`. Schema-error formatting moves into the injected callback so the
+action needn't know `SchemaExtractionError`.
+
+- After this, `actions/deploy` imports nothing from `actions/build`, `actions/manifest`, or
+  `actions/schema`.
+- **Done when:** the deploy action's only workspace imports are `@sanity/cli-core` and
+  `@sanity/workbench-cli`.
+
+### Phase 6 — Scaffold `@sanity/cli-deploy` and move the files
+
+Create the package from `@sanity/cli-build`'s scaffolding (`package.json`, `tsconfig*`,
+`package.config.ts`, `vitest.config.ts`, `eslint.config.mjs`). Move the leaf files and the
+API client, with their tests. Export `_internal/deploy`. Add the workspace dependency and
+point the command adapters at the package.
+
+- A move, not a rewrite — Phases 1–5 already made every file movable.
+- Update the API client's other importers (`undeploy`, `actions/undeploy`) to the new path.
+- **Done when:** `@sanity/cli` depends on `@sanity/cli-deploy`; the suite passes; `publint`
+  and depcheck are clean.
+
+### Phase 7 — Move the undeploy entries into the package
+
+Turn `getStudioOrAppUserApplication` into `undeployStudio` / `undeployCoreApp` behind the
+package export, reusing `resolveDeployTarget` for the studio lookup. `commands/undeploy.ts`
+becomes an adapter like `deploy`.
+
+- Small; the API client already moved in Phase 6.
+- **Done when:** `commands/undeploy.ts` imports its entry points from `@sanity/cli-deploy`.
+
+### Phase 8 — Adopt in runtime-cli (external)
+
+`runtime-cli` depends on `@sanity/cli-deploy` and wires its own `build` /
+`uploadSchemaAndManifest` / `extractManifest`, consuming the returned outcomes for its own
+reporting. Lands in the `runtime-cli` repo, out of scope here, but it's the reason for the
+shape.
+
+## Non-goals
+
+- No change to deploy behaviour, output, or exit codes for CLI users.
+- No new deploy features. `--json` is the `feat/deploy-json` branch's work; this plan only
+  makes its result types the package's contract.
+- Manifest and schema extraction stay in `@sanity/cli`. Moving that shared stack is a
+  separate effort.
+
+## Risks and coordination
+
+- **`feat/deploy-json` overlaps Phase 2.** Both rework the same runner. Sequence them — do
+  not develop in parallel. Rebasing this work onto that branch is the cleaner path.
+- **API client scope.** The studio undeploy short-circuit assumes the delete endpoint
+  accepts a studio delete by application id without the project scope. The code path is
+  global; confirm against the user-applications API before relying on it.
+- **Worker packaging.** The studio schema worker resolves itself via
+  `new URL(..., import.meta.url)` and stays in `@sanity/cli`. Keeping it out of the moved
+  package (injected instead) sidesteps shipping a worker inside a dependency.

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -73,8 +73,8 @@ Return types — data only, no printing:
 
 ```ts
 type DeployOutcome =
-  | {kind: 'deployed'; result: DeployResult}
-  | {kind: 'dry-run'; plan: DeploymentPlan}
+  | {deployed: true; result: DeployResult}
+  | {deployed: false; plan: DeploymentPlan} // dry run
 
 interface DeployResult {
   applicationId: string
@@ -88,10 +88,6 @@ type UndeployOutcome = {
   application: {id: string; type: 'coreApp' | 'studio'; appHost: string; title: string | null}
 } | null // nothing to undeploy — the target didn't resolve to an existing application
 ```
-
-`DeployResult` and `DeploymentPlan` already exist on the in-flight `feat/deploy-json`
-branch ([`deployRunner.ts`](../packages/@sanity/cli/src/actions/deploy/deployRunner.ts),
-`deploymentPlan.ts`). This plan adopts them rather than inventing new shapes.
 
 ### Design rules behind the fields
 

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -227,13 +227,6 @@ becomes an adapter like `deploy`.
 - Small; the API client already moved in Phase 6.
 - **Done when:** `commands/undeploy.ts` imports its entry points from `@sanity/cli-deploy`.
 
-### Phase 8 — Adopt in runtime-cli (external)
-
-`runtime-cli` depends on `@sanity/cli-deploy` and wires its own `build` /
-`uploadSchemaAndManifest` / `extractManifest`, consuming the returned outcomes for its own
-reporting. Lands in the `runtime-cli` repo, out of scope here, but it's the reason for the
-shape.
-
 ## Non-goals
 
 - No change to deploy behaviour, output, or exit codes for CLI users.
@@ -244,8 +237,6 @@ shape.
 
 ## Risks and coordination
 
-- **`feat/deploy-json` overlaps Phase 2.** Both rework the same runner. Sequence them — do
-  not develop in parallel. Rebasing this work onto that branch is the cleaner path.
 - **API client scope.** The studio undeploy short-circuit assumes the delete endpoint
   accepts a studio delete by application id without the project scope. The code path is
   global; confirm against the user-applications API before relying on it.

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -83,12 +83,10 @@ interface DeployResult {
   location: string | null // studio URL; null for core apps
 }
 
-type UndeployOutcome =
-  | {
-      kind: 'undeployed'
-      application: {id: string; type: 'coreApp' | 'studio'; appHost: string; title: string | null}
-    }
-  | {kind: 'nothing-to-undeploy'; reason: 'no-app-id' | 'not-found'}
+type UndeployOutcome = {
+  kind: 'undeployed'
+  application: {id: string; type: 'coreApp' | 'studio'; appHost: string; title: string | null}
+} | null // nothing to undeploy — the target didn't resolve to an existing application
 ```
 
 `DeployResult` and `DeploymentPlan` already exist on the in-flight `feat/deploy-json`
@@ -116,6 +114,10 @@ Optional vs. required is strict, and each `| undefined` earns its place:
   `projectId` + `studioHost` are only the fallback for host-only studios that never got an appId.
 - `build: (() => Promise<void>) | null` — `null` is the explicit `--no-build` state.
   Forcing the caller to pass it is stricter than an optional.
+- `UndeployOutcome` is `undeployed | null`, with no reason on the `null`. Because the
+  inputs above make an existing target mandatory, the only way to reach "nothing to undeploy"
+  inside the package is a target that didn't resolve — the missing-config cases are the
+  caller's to catch first, so there's nothing to distinguish.
 
 `exposes` (a `ResolvedWorkbenchApp`) replaces a boolean and a capability object at once.
 It's plain data — `{services, views, entry?, applicationType?, installationConfig?}` — so

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -2,28 +2,27 @@
 
 ## Why
 
-`@sanity/cli-build` already lives on its own so [runtime-cli](https://github.com/sanity-io/runtime-cli)
-can build studios and apps without pulling in the whole CLI. Deploy can't be
-reused the same way yet. `runtime-cli` wants `deployCoreApp` / `deployStudio`
-(and `undeploy`) the same way it consumes `buildApp` / `buildStudio`.
+`@sanity/cli-build` is its own package, so [runtime-cli](https://github.com/sanity-io/runtime-cli)
+can build studios and apps without pulling in the whole CLI. Deploy can't be reused that way
+yet. We want `deployCoreApp`, `deployStudio`, and `undeploy` to be as reusable as `buildApp`
+and `buildStudio`.
 
-Today the deploy action is welded to the CLI in four places:
+Four things tie deploy to the CLI today:
 
-- **oclif flags** — [`types.ts`](../packages/@sanity/cli/src/actions/deploy/types.ts)
-  derives its options from `DeployCommand['flags']`, so it imports the command class.
-- **`process.exit`** — failing checks call `output.error(msg, {exit})`. A library
-  can't own the exit decision.
-- **the build step** — `deployStudio`/`deployApp` call the CLI's build wrappers directly.
-- **the manifest/schema stack** — the studio schema worker sits on `actions/manifest`
-  and `actions/schema`, which `dev` and `manifest extract` also use. Not deploy-specific.
+- **oclif flags** — [`types.ts`](../packages/@sanity/cli/src/actions/deploy/types.ts) builds its
+  options from `DeployCommand['flags']`, so it imports the command.
+- **`process.exit`** — a failing check calls `output.error(msg, {exit})`. A library shouldn't
+  decide when the process exits.
+- **the build step** — deploy calls the CLI's build wrappers directly.
+- **schema and manifest** — the studio worker sits on `actions/manifest` and `actions/schema`,
+  which `dev` and `manifest extract` also use.
 
-The end state mirrors `@sanity/cli-build`: entry points that take resolved values
-plus injected callbacks, return data, and leave presentation and process control
-to the caller.
+The goal: entry points that take plain values plus a few injected callbacks, return data, and
+leave printing and exit codes to the caller — the same shape `@sanity/cli-build` already has.
 
-## Goal: the interfaces
+## The interfaces
 
-The entry points, exported from `@sanity/cli-deploy/_internal/deploy`:
+Exported from `@sanity/cli-deploy/_internal/deploy`:
 
 ```ts
 interface DeployContext {
@@ -43,7 +42,7 @@ function deployStudio(
     projectId: string | undefined
     studioHost: string | undefined
     external: boolean
-    extractManifest: () => Promise<StudioManifest | null>
+    extractSchema: () => Promise<StudioSchema | null>
   },
 ): Promise<Deployment>
 
@@ -61,12 +60,9 @@ function undeploy(o: {
 }): Promise<{applicationId: string} | null>
 ```
 
-Both entries take one `extractManifest` callback returning the manifest, which they upload via
-`createDeployment`. For studios, producing the manifest also uploads the schema (see below), so
-`deployStudio` calls it only on a real deploy. `undeploy` returns `null` when there was nothing
-to remove.
-
-Return types:
+Each entry takes one extraction callback — `extractSchema` for a studio, `extractManifest` for
+a core app — and the deploy function does the uploading. `undeploy` returns the id it removed,
+or `null` when there was nothing to remove.
 
 ```ts
 type Deployment = {deployed: true; result: DeployResult} | {deployed: false; plan: DeploymentPlan}
@@ -85,153 +81,154 @@ class DeployError extends Error {
 
 ### Errors and control flow
 
-- `deployStudio` / `deployCoreApp` return a `Deployment` on success and on `--dry-run` — a
-  blocked dry run is data (`deployed: false`), not a throw.
-- A real deploy blocked by a failing check throws `DeployError`, carrying the `DeployCheck`
-  it stopped on (`message`, `solution`, `exitCode`).
-- Unexpected failures — network, build, schema extraction, filesystem — propagate unwrapped.
-- `undeploy` returns `null` when nothing was removed, and throws only on an API failure.
-- Ctrl+C at a prompt surfaces as the prompt library's `ExitPromptError` and propagates.
-- `DeployError` is exported, so callers can tell a blocking check from an unexpected failure.
+- A real deploy and a dry run both return a `Deployment`. A blocked dry run is data
+  (`deployed: false`), not a throw.
+- A real deploy that fails a check throws `DeployError`, carrying the check that stopped it
+  (its message, fix, and exit code).
+- Anything unexpected — network, build, schema extraction, filesystem — propagates untouched.
+- `undeploy` returns `null` when nothing was removed, and throws only if the API call fails.
+- Ctrl+C at a prompt comes through as the prompt library's `ExitPromptError`.
+- `DeployError` is exported, so a caller can tell a failed check from a real crash.
 
-### Schema and manifest (studio)
+### How the studio schema and manifest flow
 
-For a studio, `extractManifest` does more than its name suggests — it uploads the schema too.
-That's forced by how the pieces depend on each other, not something a cleaner split would fix.
+A studio deploy has to do three things with the schema: upload it, get back a descriptor id,
+and put that id in the manifest. Today a single worker call does all three — convert the schema,
+upload it, generate the manifest — and hands back the finished manifest. That's why the upload
+is buried inside "extract the manifest."
 
-Two constraints chain together. Uploading the schema to Lexicon returns a descriptor id, and
-the manifest has to embed that id — so the manifest can't be built until the schema is up. And
-the upload has to run in the worker: `uploadSchema` walks the live `Schema` to build the
-descriptor, and a live schema can't cross the worker boundary. So one worker pass uploads the
-schema and builds the manifest, then hands the manifest back.
+We want to pull those apart, and we can. The descriptor id is computed locally during conversion:
+`DESCRIPTOR_CONVERTER.get(schema)` returns it before any network call. The upload that follows
+just persists the descriptor. So the id doesn't depend on the upload.
 
-The payoff: a manifest can never reference a schema that wasn't uploaded — they stay in sync by
-construction. `deployStudio` runs this only on a real deploy, so a dry run uploads nothing.
+Where we're taking it:
 
-Core apps have no schema. Their `extractManifest` reads the icon and title from config and
-returns — pure, no upload.
+- **`extractSchema`** runs in the worker (it needs the live schema) and returns the descriptor,
+  its id, and each workspace's metadata. No network.
+- **`deployStudio`** takes over on the main thread: uploads the descriptor, builds the manifest
+  with the id, and attaches it.
 
-One refactor is on the table but doesn't touch the interface: `generateStudioManifest` builds
-from plain workspace metadata plus the descriptor ids, so manifest generation could move into
-`deployStudio` later. The Lexicon upload can't move without reworking the descriptor converter.
+The callback only extracts; `deployStudio` owns every upload. The manifest and the schema can't
+drift, because the manifest carries the exact id the extraction produced.
 
-## Boundary
+Getting there means splitting sanity's `uploadSchema` into convert and upload — see Phase 5.
+Core apps have no schema; their `extractManifest` just reads the icon and title from config.
 
-**Moves into `@sanity/cli-deploy`** — deploy-intrinsic, and today only the command
-consumes it: `deployApp` → `deployCoreApp`, `deployStudio`, `deployRunner`, `deployChecks`,
-`deploymentPlan`, `resolveDeployTarget`, `findUserApplication`, `createUserApplication`,
-`installationConfigDeployment`, `checkDir`, `urlUtils`, `deployDebug`, `undeploy`, and the
-API client `services/userApplications.ts` (it needs only manifest _types_, which already
-live in `@sanity/cli-core`).
+## What moves where
 
-**Stays in `@sanity/cli`, injected as callbacks** — shared with other commands, so it
-can't move: the build wrappers (`build`) and manifest extraction (`extractManifest`) — pure
-for core apps, worker-backed for studios (where producing the manifest also uploads the
-schema). These sit on `actions/manifest` and `actions/schema`, used by `dev` and `manifest
-extract`.
+**Into `@sanity/cli-deploy`** — the deploy logic, which today only the command uses: `deployApp`
+→ `deployCoreApp`, `deployStudio`, `deployRunner`, `deployChecks`, `deploymentPlan`,
+`resolveDeployTarget`, `findUserApplication`, `createUserApplication`,
+`installationConfigDeployment`, `checkDir`, `urlUtils`, `deployDebug`, `undeploy`, and the API
+client `services/userApplications.ts` (it only needs manifest _types_, which already live in
+`@sanity/cli-core`).
 
-**Moves to `@sanity/cli-core`** — pure config resolvers now shared by build, dev, deploy,
-_and_ undeploy: `getAppId` / `resolveAppIdIssue` ([`util/appId.ts`](../packages/@sanity/cli/src/util/appId.ts))
-and `resolveAutoUpdates` + its message helpers ([`shouldAutoUpdate.ts`](../packages/@sanity/cli/src/actions/build/shouldAutoUpdate.ts)).
+**Stays in `@sanity/cli`, passed in as callbacks** — the build wrappers (`build`) and the two
+extraction callbacks (`extractSchema`, `extractManifest`). Both are pure; the deploy functions
+do the uploads. These sit on `actions/manifest` and `actions/schema`, which `dev` and `manifest
+extract` share, so they can't move.
 
-**Thin adapters left behind** — `commands/deploy.ts` and `commands/undeploy.ts` resolve
-config to primitives, inject the callbacks, own the oclif flags and the user-facing copy,
+**To `@sanity/cli-core`** — the config resolvers build, dev, deploy, and undeploy all use:
+`getAppId` / `resolveAppIdIssue` ([`util/appId.ts`](../packages/@sanity/cli/src/util/appId.ts))
+and `resolveAutoUpdates` + its messages ([`shouldAutoUpdate.ts`](../packages/@sanity/cli/src/actions/build/shouldAutoUpdate.ts)).
+
+**Left behind as thin adapters** — `commands/deploy.ts` and `commands/undeploy.ts`. They resolve
+config to plain values, pass in the callbacks, keep the oclif flags and the user-facing text,
 and turn a `Deployment` into human output or `--json`.
 
 ## Phases
 
-Each phase is one PR unless noted. The CLI stays green and behaviour is unchanged at every
-step until the package is consumed — these are refactors, not feature changes. The
-extraction (Phase 6) is a no-op move; all the shape work happens before it, in place.
+One PR each. The CLI keeps working and its behaviour doesn't change until the package is wired
+in — these are refactors, not new features. The move itself (Phase 7) is mechanical; all the
+reshaping happens before it, in place.
 
-### Phase 1 — Decouple the deploy/undeploy actions from oclif flags
+### Phase 1 — Cut the oclif flag dependency
 
-Replace `flags: DeployFlags` (and the `DeployCommand` import) with an explicit options
-type of plain booleans and strings. The commands map their parsed flags onto it.
+Replace `flags: DeployFlags` (and the `DeployCommand` import) with a plain options type. The
+commands map their parsed flags onto it. Mechanical, no behaviour change — but it removes the
+action → command import, which is the one thing blocking every later move.
 
-- Mechanical, no behaviour change.
-- Removes the action → command import, the one hard blocker to moving anything.
 - **Done when:** nothing under `actions/deploy` imports from `commands/`.
 
-### Phase 2 — Return outcomes; stop exiting the process for control flow
+### Phase 2 — Return data; stop exiting the process
 
-`deployStudio` / `deployCoreApp` return `Deployment`. A failing check throws a typed
-`DeployError` (message + exit code) instead of `output.error(msg, {exit})`. The
-commands catch it and exit; they also own the `--json` vs. human rendering
-(`renderDeploymentPlan` / `deploymentPlanToJson` become caller-side).
+`deployStudio` / `deployCoreApp` return a `Deployment`. A failed check throws `DeployError`
+instead of calling `output.error(msg, {exit})`. The commands catch it, print, and exit, and own
+the `--json` vs. human rendering (`renderDeploymentPlan` / `deploymentPlanToJson` move to the
+caller). This is what makes deploy usable as a library — bigger than moving files.
 
-- May split: **2a** return values on the success and dry-run paths; **2b** replace the
-  `process.exit` calls with thrown errors.
-- **Done when:** no `actions/deploy` code calls `output.error(..., {exit})`; `output` is
-  used only for progress.
+- May split: **2a** return values; **2b** replace the `process.exit` calls with throws.
+- **Done when:** no `actions/deploy` code calls `output.error(..., {exit})`.
 
-### Phase 3 — Resolve workbench to `exposes` data
+### Phase 3 — Pass workbench in as `exposes`
 
 The actions take `exposes?: ResolvedWorkbenchApp` instead of calling `getWorkbench(cliConfig)`.
-Derive `isWorkbenchApp` from its presence, run the deployable guard on the data, and read
-`installationConfig` off it. The command resolves `resolveWorkbenchApp(cliConfig)` and
-passes the result.
+They derive whether it's a workbench app from its presence, run the deployable check on the
+data, and read `installationConfig` off it. The command resolves it and passes it in. This also
+gives a report the data it needs to list what's exposed.
 
-- Drops the capability-object dependency; unblocks reports listing the exposed surface.
-- Small: touches `deployApp`, `deployChecks` (`verifyOutputDir`), and the command.
 - **Done when:** `actions/deploy` no longer imports `getWorkbench`.
 
-### Phase 4 — Lift shared config resolvers into `@sanity/cli-core`
+### Phase 4 — Move the config resolvers to `@sanity/cli-core`
 
-Move `getAppId` / `resolveAppIdIssue` and `resolveAutoUpdates` + message helpers into
-`@sanity/cli-core`, re-export from the old paths to keep this PR a pure move. Update deploy,
-build, and dev to import from cli-core.
+Move `getAppId` / `resolveAppIdIssue` and `resolveAutoUpdates` + its messages into
+`@sanity/cli-core`, re-exporting from the old paths so this stays a pure move. Point deploy,
+build, and dev at the new home. Independent of the rest.
 
-- Independent of the rest; ships on its own.
 - **Done when:** the resolvers live in cli-core and deploy imports them from there.
 
-### Phase 5 — Inject build and manifest/schema extraction
+### Phase 5 — Split `uploadSchema` in `sanity`
 
-The actions take `build` and `extractManifest` as callbacks, and attach the returned manifest
-via `createDeployment`. The command wires the existing `buildStudio`/`buildApp`, the
-schema/manifest worker (studio `extractManifest`), and `extractCoreAppManifest` (core app).
-Schema-error formatting moves into the callback so the action needn't know
-`SchemaExtractionError`.
+`uploadSchema` converts the live schema and uploads it in one call. Split it: `convertSchema`
+returns the descriptor and its id (already computed locally); `synchronizeDescriptor` does the
+upload. Both phases already exist inside the function — this draws a line and exports both.
 
-- After this, `actions/deploy` imports nothing from `actions/build`, `actions/manifest`, or
-  `actions/schema`.
-- **Done when:** the deploy action's only workspace imports are `@sanity/cli-core` and
-  `@sanity/workbench-cli`.
+Lands in the `sanity` repo. The CLI resolves these from the user's installed `sanity`, so it
+needs a version floor, or a fallback to the old `uploadSchema` for older installs.
 
-### Phase 6 — Scaffold `@sanity/cli-deploy` and move the files
+- **Done when:** `sanity` exports both, with `uploadSchema` built from them.
 
-Create the package from `@sanity/cli-build`'s scaffolding (`package.json`, `tsconfig*`,
-`package.config.ts`, `vitest.config.ts`, `eslint.config.mjs`). Move the leaf files and the
-API client, with their tests. Export `_internal/deploy`. Add the workspace dependency and
-point the command adapters at the package.
+### Phase 6 — Inject extraction; own the uploads
 
-- A move, not a rewrite — Phases 1–5 already made every file movable.
-- Update the API client's other importers (`undeploy`, `actions/undeploy`) to the new path.
-- **Done when:** `@sanity/cli` depends on `@sanity/cli-deploy`; the suite passes; `publint`
+The actions take `build`, `extractSchema` (studio), and `extractManifest` (core app) — all pure.
+`deployStudio` uploads the descriptor, builds the manifest, and attaches it via
+`createDeployment`; `deployCoreApp` attaches its config manifest the same way. The command wires
+the worker and `extractCoreAppManifest`. Schema errors format inside the callback, so the action
+never touches `SchemaExtractionError`.
+
+- **Done when:** the deploy action only imports `@sanity/cli-core` and `@sanity/workbench-cli`.
+
+### Phase 7 — Create `@sanity/cli-deploy` and move the files
+
+Scaffold the package from `@sanity/cli-build` (`package.json`, `tsconfig*`, `package.config.ts`,
+`vitest.config.ts`, `eslint.config.mjs`). Move the files and their tests, export
+`_internal/deploy`, add the workspace dependency, and point the command adapters at it. A move,
+not a rewrite — Phases 1–6 already made every file movable.
+
+- Point the API client's other users (`undeploy`, `actions/undeploy`) at the new path.
+- **Done when:** `@sanity/cli` depends on `@sanity/cli-deploy`, the suite passes, and `publint`
   and depcheck are clean.
 
-### Phase 7 — Move undeploy into the package
+### Phase 8 — Move undeploy into the package
 
-Replace `getStudioOrAppUserApplication` with a single `undeploy` behind the package export.
-`commands/undeploy.ts` resolves the target for the confirm, then calls `undeploy` — an
-adapter like `deploy`.
+Replace `getStudioOrAppUserApplication` with `undeploy`. `commands/undeploy.ts` resolves the
+target for the confirm prompt, then calls it — an adapter like `deploy`.
 
-- Small; the API client already moved in Phase 6.
 - **Done when:** `commands/undeploy.ts` imports `undeploy` from `@sanity/cli-deploy`.
 
 ## Non-goals
 
-- No change to deploy behaviour, output, or exit codes for CLI users.
-- No new deploy features (`--json` output is separate work).
-- Manifest and schema extraction stay in `@sanity/cli`. Moving that shared stack is a
-  separate effort.
+- Deploy behaviour, output, and exit codes stay the same for CLI users.
+- No new deploy features. (`--json` output is separate work.)
+- Schema and manifest extraction stay in `@sanity/cli`; moving that shared stack is its own job.
 
-## Risks and coordination
+## Risks
 
-- **`undeploy` inputs.** Deleting is a global endpoint keyed by application id. Confirm the
-  user-applications API accepts a studio delete without the project scope, whether it needs
-  the `appType` query (drop `type` if not), and whether it surfaces not-found so `undeploy`
-  can return `null`.
-- **Worker packaging.** The studio schema worker resolves itself via
-  `new URL(..., import.meta.url)` and stays in `@sanity/cli`. Keeping it out of the moved
-  package (injected instead) sidesteps shipping a worker inside a dependency.
+- **`undeploy` inputs.** Delete is a global endpoint keyed by application id. Confirm the API
+  takes a studio delete without the project scope, whether it needs the `appType` query (drop
+  `type` if not), and whether it reports not-found so `undeploy` can return `null`.
+- **The descriptor payload.** Phase 5 assumes the converted descriptor can cross the worker
+  boundary. It's built from encodable values, so it should — worth a spike before committing.
+- **Worker packaging.** The studio worker resolves itself with `new URL(..., import.meta.url)`
+  and stays in `@sanity/cli`. Keeping it out of the moved package avoids shipping a worker
+  inside a dependency.

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -23,7 +23,7 @@ to the caller.
 
 ## Goal: the interfaces
 
-The four entry points, exported from `@sanity/cli-deploy/_internal/deploy`:
+The entry points, exported from `@sanity/cli-deploy/_internal/deploy`:
 
 ```ts
 interface DeployContext {
@@ -55,18 +55,15 @@ function deployCoreApp(
   },
 ): Promise<Deployment>
 
-function undeployCoreApp(o: {
+// Resolve the target first with the exported resolveStudioDeployTarget /
+// resolveAppDeployTarget, then hand the resolved application to undeploy. Once
+// resolved it's the same for both kinds — the delete is global, the appType
+// comes from application.type.
+function undeploy(o: {
   output: Output
   isUnattended: boolean
-  appId: string // required — nothing to undeploy without it
-}): Promise<UndeployOutcome>
-
-function undeployStudio(
-  o: {
-    output: Output
-    isUnattended: boolean
-  } & ({appId: string} | {studioHost: string; projectId: string}),
-): Promise<UndeployOutcome>
+  application: {id: string; type: 'coreApp' | 'studio'; appHost: string; title: string | null}
+}): Promise<void>
 ```
 
 Return types — data only, no printing:
@@ -81,10 +78,6 @@ interface DeployResult {
   location: string | null // studio URL; null for core apps
 }
 
-type UndeployOutcome = {
-  application: {id: string; type: 'coreApp' | 'studio'; appHost: string; title: string | null}
-} | null // nothing to undeploy — the target didn't resolve to an existing application
-
 class DeployError extends Error {
   check: DeployCheck // the failing check: message, solution, exitCode
 }
@@ -97,8 +90,8 @@ class DeployError extends Error {
 - A real deploy blocked by a failing check throws `DeployError`, carrying the `DeployCheck`
   it stopped on (`message`, `solution`, `exitCode`).
 - Unexpected failures — network, build, schema extraction, filesystem — propagate unwrapped.
-- `undeployStudio` / `undeployCoreApp` return the removed application, or `null` when nothing
-  resolved; they throw only on an API failure.
+- `undeploy` operates on an already-resolved application; the caller resolves the target first
+  and skips the call when nothing resolves. It throws only on an API failure.
 - Ctrl+C at a prompt surfaces as the prompt library's `ExitPromptError` and propagates.
 - `DeployError` is exported, so callers can tell a blocking check from an unexpected failure.
 
@@ -107,9 +100,9 @@ class DeployError extends Error {
 **Moves into `@sanity/cli-deploy`** — deploy-intrinsic, and today only the command
 consumes it: `deployApp` → `deployCoreApp`, `deployStudio`, `deployRunner`, `deployChecks`,
 `deploymentPlan`, `resolveDeployTarget`, `findUserApplication`, `createUserApplication`,
-`installationConfigDeployment`, `checkDir`, `urlUtils`, `deployDebug`, the undeploy
-resolver, and the API client `services/userApplications.ts` (it needs only manifest
-_types_, which already live in `@sanity/cli-core`).
+`installationConfigDeployment`, `checkDir`, `urlUtils`, `deployDebug`, `undeploy`, and the
+API client `services/userApplications.ts` (it needs only manifest _types_, which already
+live in `@sanity/cli-core`).
 
 **Stays in `@sanity/cli`, injected as callbacks** — shared with other commands, so it
 can't move: the build wrappers (`build`), the studio schema/manifest worker
@@ -141,7 +134,7 @@ type of plain booleans and strings. The commands map their parsed flags onto it.
 
 ### Phase 2 — Return outcomes; stop exiting the process for control flow
 
-The entry points return `Deployment` / `UndeployOutcome`. A failing check throws a typed
+`deployStudio` / `deployCoreApp` return `Deployment`. A failing check throws a typed
 `DeployError` (message + exit code) instead of `output.error(msg, {exit})`. The
 commands catch it and exit; they also own the `--json` vs. human rendering
 (`renderDeploymentPlan` / `deploymentPlanToJson` become caller-side).
@@ -195,14 +188,14 @@ point the command adapters at the package.
 - **Done when:** `@sanity/cli` depends on `@sanity/cli-deploy`; the suite passes; `publint`
   and depcheck are clean.
 
-### Phase 7 — Move the undeploy entries into the package
+### Phase 7 — Move undeploy into the package
 
-Turn `getStudioOrAppUserApplication` into `undeployStudio` / `undeployCoreApp` behind the
-package export, reusing `resolveDeployTarget` for the studio lookup. `commands/undeploy.ts`
-becomes an adapter like `deploy`.
+Replace `getStudioOrAppUserApplication` with a single `undeploy` behind the package export.
+`commands/undeploy.ts` resolves the target with the exported resolvers, then calls `undeploy`
+— an adapter like `deploy`.
 
 - Small; the API client already moved in Phase 6.
-- **Done when:** `commands/undeploy.ts` imports its entry points from `@sanity/cli-deploy`.
+- **Done when:** `commands/undeploy.ts` imports `undeploy` from `@sanity/cli-deploy`.
 
 ## Non-goals
 
@@ -213,9 +206,9 @@ becomes an adapter like `deploy`.
 
 ## Risks and coordination
 
-- **API client scope.** The studio undeploy short-circuit assumes the delete endpoint
-  accepts a studio delete by application id without the project scope. The code path is
-  global; confirm against the user-applications API before relying on it.
+- **API client scope.** `undeploy` deletes by application id via the global endpoint (no
+  project scope). The code path is global today; confirm the user-applications API accepts a
+  studio delete this way before relying on it.
 - **Worker packaging.** The studio schema worker resolves itself via
   `new URL(..., import.meta.url)` and stays in `@sanity/cli`. Keeping it out of the moved
   package (injected instead) sidesteps shipping a worker inside a dependency.

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -44,7 +44,6 @@ function deployStudio(
     studioHost: string | undefined
     external: boolean
     extractManifest: () => Promise<StudioManifest | null>
-    extractSchema: () => Promise<StudioSchema | null>
   },
 ): Promise<Deployment>
 
@@ -62,9 +61,10 @@ function undeploy(o: {
 }): Promise<{applicationId: string} | null>
 ```
 
-The extraction callbacks only extract; `deployStudio` / `deployCoreApp` own every
-upload (the manifest via `createDeployment`, the studio schema to the store), so the
-two can't drift. `undeploy` returns `null` when there was nothing to remove.
+Both entries take one `extractManifest` callback returning the manifest, which they upload via
+`createDeployment`. For studios, producing the manifest also uploads the schema (see below), so
+`deployStudio` calls it only on a real deploy. `undeploy` returns `null` when there was nothing
+to remove.
 
 Return types:
 
@@ -94,6 +94,18 @@ class DeployError extends Error {
 - Ctrl+C at a prompt surfaces as the prompt library's `ExitPromptError` and propagates.
 - `DeployError` is exported, so callers can tell a blocking check from an unexpected failure.
 
+### Schema and manifest (studio)
+
+The studio `extractManifest` also uploads the schema, and that's forced, not a naming choice.
+`uploadSchema` takes the live `Schema` and walks the graph to build the Lexicon descriptor, so
+it runs in the worker; `generateStudioManifest` then embeds the descriptor id the upload
+returns. The manifest can't be built until the schema is uploaded, so one callback does both.
+A manifest/schema mismatch is impossible by construction. `deployStudio` calls it only on the
+real-deploy path, so a dry run uploads nothing. (`generateStudioManifest` works from
+serializable workspace metadata + descriptor ids, so manifest generation could later move into
+`deployStudio`; the Lexicon upload can't, short of reworking the descriptor converter.) Core
+apps have no schema — their `extractManifest` reads icon/title and is pure.
+
 ## Boundary
 
 **Moves into `@sanity/cli-deploy`** — deploy-intrinsic, and today only the command
@@ -104,9 +116,10 @@ API client `services/userApplications.ts` (it needs only manifest _types_, which
 live in `@sanity/cli-core`).
 
 **Stays in `@sanity/cli`, injected as callbacks** — shared with other commands, so it
-can't move: the build wrappers (`build`), and manifest/schema extraction (`extractManifest`,
-`extractSchema`). These sit on `actions/manifest` and `actions/schema`, used by `dev` and
-`manifest extract`. The callbacks extract; the deploy functions perform the uploads.
+can't move: the build wrappers (`build`) and manifest extraction (`extractManifest`) — pure
+for core apps, worker-backed for studios (where producing the manifest also uploads the
+schema). These sit on `actions/manifest` and `actions/schema`, used by `dev` and `manifest
+extract`.
 
 **Moves to `@sanity/cli-core`** — pure config resolvers now shared by build, dev, deploy,
 _and_ undeploy: `getAppId` / `resolveAppIdIssue` ([`util/appId.ts`](../packages/@sanity/cli/src/util/appId.ts))
@@ -163,14 +176,13 @@ build, and dev to import from cli-core.
 - Independent of the rest; ships on its own.
 - **Done when:** the resolvers live in cli-core and deploy imports them from there.
 
-### Phase 5 — Inject extraction; own the uploads
+### Phase 5 — Inject build and manifest/schema extraction
 
-The actions take `build`, `extractManifest`, and (studio) `extractSchema` as callbacks, and
-perform the uploads themselves — the manifest via `createDeployment`, the studio schema to
-the store. The command wires the existing `buildStudio`/`buildApp`, the manifest/schema
-worker, and `extractCoreAppManifest`. This is where the worker moves from uploading to
-returning serializable artifacts (see Risks); schema-error formatting moves into the injected
-callback so the action needn't know `SchemaExtractionError`.
+The actions take `build` and `extractManifest` as callbacks, and attach the returned manifest
+via `createDeployment`. The command wires the existing `buildStudio`/`buildApp`, the
+schema/manifest worker (studio `extractManifest`), and `extractCoreAppManifest` (core app).
+Schema-error formatting moves into the callback so the action needn't know
+`SchemaExtractionError`.
 
 - After this, `actions/deploy` imports nothing from `actions/build`, `actions/manifest`, or
   `actions/schema`.
@@ -207,10 +219,6 @@ adapter like `deploy`.
 
 ## Risks and coordination
 
-- **Upload vs. extraction.** The studio manifest and schema are generated from live studio
-  objects in a worker; `uploadSchemaToLexicon` both generates the manifest and uploads it.
-  Moving the upload into `deployStudio` needs the worker to return serializable artifacts and
-  the deploy function to upload them — generation stays worker-bound.
 - **`undeploy` inputs.** Deleting is a global endpoint keyed by application id. Confirm the
   user-applications API accepts a studio delete without the project scope, whether it needs
   the `appType` query (drop `type` if not), and whether it surfaces not-found so `undeploy`

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -96,15 +96,24 @@ class DeployError extends Error {
 
 ### Schema and manifest (studio)
 
-The studio `extractManifest` also uploads the schema, and that's forced, not a naming choice.
-`uploadSchema` takes the live `Schema` and walks the graph to build the Lexicon descriptor, so
-it runs in the worker; `generateStudioManifest` then embeds the descriptor id the upload
-returns. The manifest can't be built until the schema is uploaded, so one callback does both.
-A manifest/schema mismatch is impossible by construction. `deployStudio` calls it only on the
-real-deploy path, so a dry run uploads nothing. (`generateStudioManifest` works from
-serializable workspace metadata + descriptor ids, so manifest generation could later move into
-`deployStudio`; the Lexicon upload can't, short of reworking the descriptor converter.) Core
-apps have no schema — their `extractManifest` reads icon/title and is pure.
+For a studio, `extractManifest` does more than its name suggests — it uploads the schema too.
+That's forced by how the pieces depend on each other, not something a cleaner split would fix.
+
+Two constraints chain together. Uploading the schema to Lexicon returns a descriptor id, and
+the manifest has to embed that id — so the manifest can't be built until the schema is up. And
+the upload has to run in the worker: `uploadSchema` walks the live `Schema` to build the
+descriptor, and a live schema can't cross the worker boundary. So one worker pass uploads the
+schema and builds the manifest, then hands the manifest back.
+
+The payoff: a manifest can never reference a schema that wasn't uploaded — they stay in sync by
+construction. `deployStudio` runs this only on a real deploy, so a dry run uploads nothing.
+
+Core apps have no schema. Their `extractManifest` reads the icon and title from config and
+returns — pure, no upload.
+
+One refactor is on the table but doesn't touch the interface: `generateStudioManifest` builds
+from plain workspace metadata plus the descriptor ids, so manifest generation could move into
+`deployStudio` later. The Lexicon upload can't move without reworking the descriptor converter.
 
 ## Boundary
 

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -5,7 +5,7 @@
 `@sanity/cli-build` already lives on its own so [runtime-cli](https://github.com/sanity-io/runtime-cli)
 can build studios and apps without pulling in the whole CLI. Deploy can't be
 reused the same way yet. `runtime-cli` wants `deployCoreApp` / `deployStudio`
-(and their undeploy pair) the same way it consumes `buildApp` / `buildStudio`.
+(and `undeploy`) the same way it consumes `buildApp` / `buildStudio`.
 
 Today the deploy action is welded to the CLI in four places:
 
@@ -33,53 +33,53 @@ interface DeployContext {
   isUnattended: boolean
   autoUpdatesEnabled: boolean
   dryRun: boolean
-  build: (() => Promise<void>) | null // null = --no-build (validate existing output)
-  exposes?: ResolvedWorkbenchApp // absent = plain project
+  build: (() => Promise<void>) | null
+  exposes?: ResolvedWorkbenchApp
 }
 
 function deployStudio(
   o: DeployContext & {
-    appId: string | undefined // undefined = resolve or create a target
+    applicationId: string | undefined
     projectId: string | undefined
     studioHost: string | undefined
     external: boolean
-    deployStudioSchema: () => Promise<StudioManifest | null>
+    extractManifest: () => Promise<StudioManifest | null>
+    extractSchema: () => Promise<StudioSchema | null>
   },
 ): Promise<Deployment>
 
 function deployCoreApp(
   o: DeployContext & {
-    appId: string | undefined
+    applicationId: string | undefined
     organizationId: string | undefined
     extractManifest: () => Promise<CoreAppManifest | undefined>
   },
 ): Promise<Deployment>
 
-// Resolve the target first with the exported resolveStudioDeployTarget /
-// resolveAppDeployTarget, then hand the resolved application to undeploy. Once
-// resolved it's the same for both kinds — the delete is global, the appType
-// comes from application.type.
 function undeploy(o: {
-  output: Output
-  isUnattended: boolean
-  application: {id: string; type: 'coreApp' | 'studio'; appHost: string; title: string | null}
-}): Promise<void>
+  applicationId: string
+  type: 'coreApp' | 'studio'
+}): Promise<{applicationId: string} | null>
 ```
 
-Return types — data only, no printing:
+The extraction callbacks only extract; `deployStudio` / `deployCoreApp` own every
+upload (the manifest via `createDeployment`, the studio schema to the store), so the
+two can't drift. `undeploy` returns `null` when there was nothing to remove.
+
+Return types:
 
 ```ts
-type Deployment = {deployed: true; result: DeployResult} | {deployed: false; plan: DeploymentPlan} // dry run
+type Deployment = {deployed: true; result: DeployResult} | {deployed: false; plan: DeploymentPlan}
 
 interface DeployResult {
   applicationId: string
   applicationType: 'coreApp' | 'studio'
-  applicationVersion: string // installed sanity / @sanity/sdk-react
-  location: string | null // studio URL; null for core apps
+  applicationVersion: string
+  location: string | null
 }
 
 class DeployError extends Error {
-  check: DeployCheck // the failing check: message, solution, exitCode
+  check: DeployCheck
 }
 ```
 
@@ -90,8 +90,7 @@ class DeployError extends Error {
 - A real deploy blocked by a failing check throws `DeployError`, carrying the `DeployCheck`
   it stopped on (`message`, `solution`, `exitCode`).
 - Unexpected failures — network, build, schema extraction, filesystem — propagate unwrapped.
-- `undeploy` operates on an already-resolved application; the caller resolves the target first
-  and skips the call when nothing resolves. It throws only on an API failure.
+- `undeploy` returns `null` when nothing was removed, and throws only on an API failure.
 - Ctrl+C at a prompt surfaces as the prompt library's `ExitPromptError` and propagates.
 - `DeployError` is exported, so callers can tell a blocking check from an unexpected failure.
 
@@ -105,9 +104,9 @@ API client `services/userApplications.ts` (it needs only manifest _types_, which
 live in `@sanity/cli-core`).
 
 **Stays in `@sanity/cli`, injected as callbacks** — shared with other commands, so it
-can't move: the build wrappers (`build`), the studio schema/manifest worker
-(`deployStudioSchema`), and core-app manifest extraction (`extractManifest`). These
-sit on `actions/manifest` and `actions/schema`, used by `dev` and `manifest extract`.
+can't move: the build wrappers (`build`), and manifest/schema extraction (`extractManifest`,
+`extractSchema`). These sit on `actions/manifest` and `actions/schema`, used by `dev` and
+`manifest extract`. The callbacks extract; the deploy functions perform the uploads.
 
 **Moves to `@sanity/cli-core`** — pure config resolvers now shared by build, dev, deploy,
 _and_ undeploy: `getAppId` / `resolveAppIdIssue` ([`util/appId.ts`](../packages/@sanity/cli/src/util/appId.ts))
@@ -164,12 +163,14 @@ build, and dev to import from cli-core.
 - Independent of the rest; ships on its own.
 - **Done when:** the resolvers live in cli-core and deploy imports them from there.
 
-### Phase 5 — Inject build and manifest/schema extraction
+### Phase 5 — Inject extraction; own the uploads
 
-The actions take `build`, `deployStudioSchema`, and `extractManifest` as callbacks.
-The command wires the existing `buildStudio`/`buildApp`, the schema worker, and
-`extractCoreAppManifest`. Schema-error formatting moves into the injected callback so the
-action needn't know `SchemaExtractionError`.
+The actions take `build`, `extractManifest`, and (studio) `extractSchema` as callbacks, and
+perform the uploads themselves — the manifest via `createDeployment`, the studio schema to
+the store. The command wires the existing `buildStudio`/`buildApp`, the manifest/schema
+worker, and `extractCoreAppManifest`. This is where the worker moves from uploading to
+returning serializable artifacts (see Risks); schema-error formatting moves into the injected
+callback so the action needn't know `SchemaExtractionError`.
 
 - After this, `actions/deploy` imports nothing from `actions/build`, `actions/manifest`, or
   `actions/schema`.
@@ -191,8 +192,8 @@ point the command adapters at the package.
 ### Phase 7 — Move undeploy into the package
 
 Replace `getStudioOrAppUserApplication` with a single `undeploy` behind the package export.
-`commands/undeploy.ts` resolves the target with the exported resolvers, then calls `undeploy`
-— an adapter like `deploy`.
+`commands/undeploy.ts` resolves the target for the confirm, then calls `undeploy` — an
+adapter like `deploy`.
 
 - Small; the API client already moved in Phase 6.
 - **Done when:** `commands/undeploy.ts` imports `undeploy` from `@sanity/cli-deploy`.
@@ -206,9 +207,14 @@ Replace `getStudioOrAppUserApplication` with a single `undeploy` behind the pack
 
 ## Risks and coordination
 
-- **API client scope.** `undeploy` deletes by application id via the global endpoint (no
-  project scope). The code path is global today; confirm the user-applications API accepts a
-  studio delete this way before relying on it.
+- **Upload vs. extraction.** The studio manifest and schema are generated from live studio
+  objects in a worker; `uploadSchemaToLexicon` both generates the manifest and uploads it.
+  Moving the upload into `deployStudio` needs the worker to return serializable artifacts and
+  the deploy function to upload them — generation stays worker-bound.
+- **`undeploy` inputs.** Deleting is a global endpoint keyed by application id. Confirm the
+  user-applications API accepts a studio delete without the project scope, whether it needs
+  the `appType` query (drop `type` if not), and whether it surfaces not-found so `undeploy`
+  can return `null`.
 - **Worker packaging.** The studio schema worker resolves itself via
   `new URL(..., import.meta.url)` and stays in `@sanity/cli`. Keeping it out of the moved
   package (injected instead) sidesteps shipping a worker inside a dependency.

--- a/docs/deploy-cli-extraction.md
+++ b/docs/deploy-cli-extraction.md
@@ -194,8 +194,7 @@ becomes an adapter like `deploy`.
 ## Non-goals
 
 - No change to deploy behaviour, output, or exit codes for CLI users.
-- No new deploy features. `--json` is the `feat/deploy-json` branch's work; this plan only
-  makes its result types the package's contract.
+- No new deploy features (`--json` output is separate work).
 - Manifest and schema extraction stay in `@sanity/cli`. Moving that shared stack is a
   separate effort.
 


### PR DESCRIPTION
### Description

Design plan for pulling deploy out of `@sanity/cli` into a standalone `@sanity/cli-deploy`, mirroring `@sanity/cli-build`, so [runtime-cli](https://github.com/sanity-io/runtime-cli) can reuse it. Docs only — [`docs/deploy-cli-extraction.md`](docs/deploy-cli-extraction.md). Agree the interfaces and phasing before any code.

### What to review

The doc. Focus on the four entry-point interfaces and return types, the boundary (moves in / injected / to cli-core), and whether each phase is a sensibly-sized PR.

### Testing

Docs only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or deploy behavior impact.
> 
> **Overview**
> Adds **`docs/deploy-cli-extraction.md`**, a design doc for splitting deploy out of `@sanity/cli` into **`@sanity/cli-deploy`** (same pattern as `@sanity/cli-build`) so **runtime-cli** can call `deployStudio` / `deployCoreApp` and undeploy without the full CLI.
> 
> The doc spells out **target APIs** (`DeployContext`, `deployStudio`, `deployCoreApp`, `undeploy`), **data-only returns** (`Deployment`, `DeployResult`, `DeployError`), and **error/control-flow** rules (dry-run as data, checks as throws, caller owns exit and output).
> 
> It also defines the **package boundary** (what moves into cli-deploy vs stays in CLI as injected build/manifest/schema callbacks vs moves to cli-core), **seven incremental refactor phases** with done criteria, **non-goals** (no user-visible behavior change), and **risks** (global undeploy API, schema worker packaging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fb3cd7b15ac322e84b2654d38a56bd0d5186b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->