### PR TITLE
refactor(cli): drop date-fns as direct dependency

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -100,7 +100,6 @@
     "@vercel/frameworks": "3.29.0",
     "chokidar": "^5.0.0",
     "console-table-printer": "^2.15.0",
-    "date-fns": "^4.4.0",
     "debug": "catalog:",
     "dotenv": "^17.4.2",
     "eventsource": "^4.1.0",

--- a/packages/@sanity/cli/src/commands/backups/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/list.test.ts
@@ -1,10 +1,10 @@
 import {select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {afterAll, afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 
 import {BACKUP_API_VERSION} from '../../../actions/backup/constants.js'
-import {ListBackupCommand} from '../list.js'
+import {formatBackupTimestamp, ListBackupCommand, parseBackupDateFlag} from '../list.js'
 
 const mockListDatasets = vi.hoisted(() => vi.fn())
 
@@ -262,5 +262,81 @@ describe('#backup:list', () => {
     })
     expect(error?.message).toContain('Failed to list datasets')
     expect(error?.oclif?.exit).toBe(1)
+  })
+})
+
+describe('formatBackupTimestamp', () => {
+  beforeAll(() => vi.stubEnv('TZ', 'UTC'))
+  afterAll(() => vi.unstubAllEnvs())
+
+  test.each([
+    ['2024-01-15T10:30:00Z', '2024-01-15 10:30:00'],
+    ['2024-01-14T09:20:00Z', '2024-01-14 09:20:00'],
+    ['2024-12-31T23:59:59Z', '2024-12-31 23:59:59'],
+    ['2024-06-01T00:00:00Z', '2024-06-01 00:00:00'],
+    ['2024-03-05T04:08:09Z', '2024-03-05 04:08:09'],
+  ])('%s -> %s', (input, expected) => {
+    expect(formatBackupTimestamp(input)).toBe(expected)
+  })
+})
+
+describe('formatBackupTimestamp in a non-UTC zone', () => {
+  beforeAll(() => vi.stubEnv('TZ', 'America/New_York'))
+  afterAll(() => vi.unstubAllEnvs())
+
+  test('renders the local wall-clock time', () => {
+    expect(formatBackupTimestamp('2024-01-15T10:30:00Z')).toBe('2024-01-15 05:30:00')
+  })
+})
+
+describe('parseBackupDateFlag', () => {
+  test('returns undefined when no date is given', () => {
+    expect(parseBackupDateFlag(undefined, 'after')).toBeUndefined()
+  })
+
+  test('parses a valid date to local midnight', () => {
+    const parsed = parseBackupDateFlag('2024-01-31', 'after')!
+    expect(parsed.getFullYear()).toBe(2024)
+    expect(parsed.getMonth()).toBe(0)
+    expect(parsed.getDate()).toBe(31)
+    expect(parsed.getHours()).toBe(0)
+    expect(parsed.getMinutes()).toBe(0)
+    expect(parsed.getSeconds()).toBe(0)
+  })
+
+  test('accepts a leap day', () => {
+    const parsed = parseBackupDateFlag('2024-02-29', 'after')!
+    expect(parsed.getMonth()).toBe(1)
+    expect(parsed.getDate()).toBe(29)
+  })
+
+  test('accepts single-digit month and day', () => {
+    const parsed = parseBackupDateFlag('2024-1-5', 'after')!
+    expect(parsed.getMonth()).toBe(0)
+    expect(parsed.getDate()).toBe(5)
+  })
+
+  test('treats an empty value as absent', () => {
+    expect(parseBackupDateFlag('', 'after')).toBeUndefined()
+  })
+
+  test.each(['2023-02-29', '2024-02-30', '2024-13-01', '2024-00-10', '2024-01-00'])(
+    'rejects out-of-range date %s',
+    (input) => {
+      expect(() => parseBackupDateFlag(input, 'after')).toThrow('Use YYYY-MM-DD')
+    },
+  )
+
+  test.each(['invalid-date', '2024/11/17', '2024-01-15extra'])(
+    'rejects malformed input %s',
+    (input) => {
+      expect(() => parseBackupDateFlag(input, 'after')).toThrow('Use YYYY-MM-DD')
+    },
+  )
+
+  test('names the offending flag in the error', () => {
+    expect(() => parseBackupDateFlag('nope', 'before')).toThrow(
+      "Invalid date format for '--before' flag. Use YYYY-MM-DD",
+    )
   })
 })

--- a/packages/@sanity/cli/src/commands/backups/list.ts
+++ b/packages/@sanity/cli/src/commands/backups/list.ts
@@ -3,10 +3,6 @@ import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 import {type DatasetsResponse} from '@sanity/client'
 import {Table} from 'console-table-printer'
-import {isAfter} from 'date-fns/isAfter'
-import {isValid} from 'date-fns/isValid'
-import {lightFormat} from 'date-fns/lightFormat'
-import {parse} from 'date-fns/parse'
 
 import {assertDatasetExists} from '../../actions/backup/assertDatasetExist.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
@@ -15,6 +11,24 @@ import {listDatasets} from '../../services/datasets.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
 
 const listBackupDebug = subdebug('backup:list')
+
+const pad = (value: number) => String(value).padStart(2, '0')
+
+export function formatBackupTimestamp(isoTimestamp: string): string {
+  const date = new Date(isoTimestamp)
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+}
+
+export function parseBackupDateFlag(date: string | undefined, flagName: string): Date | undefined {
+  if (!date) return undefined
+  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(date)
+  if (match) {
+    const [, year, month, day] = match.map(Number)
+    const parsed = new Date(year, month - 1, day)
+    if (parsed.getMonth() === month - 1 && parsed.getDate() === day) return parsed
+  }
+  throw new Error(`Invalid date format for '--${flagName}' flag. Use YYYY-MM-DD`)
+}
 
 const DEFAULT_LIST_BACKUP_LIMIT = 30
 
@@ -107,10 +121,10 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
     // Validate date flags
     if (flags.before || flags.after) {
       try {
-        const parsedBefore = this.processDateFlag(flags.before, 'before')
-        const parsedAfter = this.processDateFlag(flags.after, 'after')
+        const parsedBefore = parseBackupDateFlag(flags.before, 'before')
+        const parsedAfter = parseBackupDateFlag(flags.after, 'after')
 
-        if (parsedAfter && parsedBefore && isAfter(parsedAfter, parsedBefore)) {
+        if (parsedAfter && parsedBefore && parsedAfter.getTime() > parsedBefore.getTime()) {
           this.error('--after date must be before --before', {exit: 1})
         }
       } catch (err) {
@@ -163,7 +177,7 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
         const {createdAt, id} = backup
         table.addRow({
           backupId: id,
-          createdAt: lightFormat(Date.parse(createdAt), 'yyyy-MM-dd HH:mm:ss'),
+          createdAt: formatBackupTimestamp(createdAt),
           resource: 'Dataset',
         })
       }
@@ -178,16 +192,6 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
       listBackupDebug(`Failed to list backups for dataset ${dataset}:`, error)
       this.error(`List dataset backup failed: ${message}`, {exit: 1})
     }
-  }
-
-  private processDateFlag(date: string | undefined, flagName: string): Date | undefined {
-    if (!date) return undefined
-    const parsedDate = parse(date, 'yyyy-MM-dd', new Date())
-    if (isValid(parsedDate)) {
-      return parsedDate
-    }
-
-    throw new Error(`Invalid date format for '--${flagName}' flag. Use YYYY-MM-DD`)
   }
 
   private async promptForDataset(datasets: DatasetsResponse): Promise<string> {

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -1,5 +1,5 @@
 import {of} from 'rxjs'
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {createMockSanityCommand} from '../../../../test/mockSanityCommand.js'
 
@@ -77,7 +77,7 @@ vi.mock('@sanity/cli-core/ux', async () => {
 })
 
 // Finally, import the module under test: dataset copy command
-const {CopyDatasetCommand} = await import('../copy.js')
+const {CopyDatasetCommand, formatDistance, formatDistanceToNow} = await import('../copy.js')
 
 const TEST_PROJECT_ID = '1337newb'
 function createMockDataset(name: string) {
@@ -428,5 +428,44 @@ describe('#dataset:copy', () => {
         {exit: 1},
       )
     })
+  })
+})
+
+describe('formatDistance', () => {
+  const base = new Date('2023-06-15T12:00:00Z')
+  const after = (seconds: number) => new Date(base.getTime() + seconds * 1000)
+
+  beforeAll(() => vi.stubEnv('TZ', 'UTC'))
+  afterAll(() => vi.unstubAllEnvs())
+
+  test.each([
+    [after(20), 'less than a minute'],
+    [after(70), '1 minute'],
+    [after(300), '5 minutes'],
+    [after(3600), 'about 1 hour'],
+    [after(3 * 3600), 'about 3 hours'],
+    [after(25 * 3600), '1 day'],
+    [after(3 * 86_400), '3 days'],
+    [after(35 * 86_400), 'about 1 month'],
+    [after(100 * 86_400), '3 months'],
+    [new Date('2024-01-01'), 'about 1 year'],
+    [new Date('2024-07-01'), 'over 1 year'],
+    [new Date('2024-11-01'), 'almost 2 years'],
+  ])('%s -> %s', (later, expected) => {
+    const reference = later.getFullYear() >= 2024 ? new Date('2023-01-01') : base
+    expect(formatDistance(later, reference)).toBe(expected)
+  })
+
+  test('is symmetric regardless of argument order', () => {
+    expect(formatDistance(base, after(300))).toBe('5 minutes')
+  })
+})
+
+describe('formatDistanceToNow', () => {
+  afterEach(() => vi.useRealTimers())
+
+  test('measures the distance from now', () => {
+    vi.setSystemTime(new Date('2023-06-15T12:00:00Z'))
+    expect(formatDistanceToNow(new Date('2023-06-15T11:00:00Z'))).toBe('about 1 hour')
   })
 })

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -5,9 +5,6 @@ import {exit} from '@oclif/core/errors'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {Table} from 'console-table-printer'
-import {formatDistance} from 'date-fns/formatDistance'
-import {formatDistanceToNow} from 'date-fns/formatDistanceToNow'
-import {parseISO} from 'date-fns/parseISO'
 
 import {validateDatasetName} from '../../actions/dataset/validateDatasetName.js'
 import {promptForDataset} from '../../prompts/promptForDataset.js'
@@ -21,9 +18,99 @@ import {
   listDatasetCopyJobs,
   listDatasets,
 } from '../../services/datasets.js'
+import {pluralize} from '../../util/pluralize.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
 
 const copyDatasetDebug = subdebug('dataset:copy')
+
+// Mirrors date-fns `formatDistance` (default options, en-US) so output is unchanged.
+const MINUTES_IN_DAY = 1440
+const MINUTES_IN_MONTH = 43_200
+const MINUTES_IN_ALMOST_TWO_DAYS = 2520
+
+function timezoneOffsetMs(date: Date): number {
+  const utc = new Date(
+    Date.UTC(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds(),
+      date.getMilliseconds(),
+    ),
+  )
+  utc.setUTCFullYear(date.getFullYear())
+  return date.getTime() - utc.getTime()
+}
+
+function isLastDayOfMonth(date: Date): boolean {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate() === date.getDate()
+}
+
+function differenceInMonths(later: Date, earlier: Date): number {
+  const sign = later.getTime() < earlier.getTime() ? -1 : 1
+  const difference = Math.abs(
+    (later.getFullYear() - earlier.getFullYear()) * 12 + (later.getMonth() - earlier.getMonth()),
+  )
+  if (difference < 1) return 0
+
+  const working = new Date(later)
+  if (working.getMonth() === 1 && working.getDate() > 27) working.setDate(30)
+  working.setMonth(working.getMonth() - sign * difference)
+
+  let lastMonthNotFull = Math.sign(working.getTime() - earlier.getTime()) === -sign
+  if (isLastDayOfMonth(later) && difference === 1 && later.getTime() > earlier.getTime()) {
+    lastMonthNotFull = false
+  }
+  return sign * (difference - (lastMonthNotFull ? 1 : 0)) || 0
+}
+
+export function formatDistance(dateLeft: Date, dateRight: Date): string {
+  const laterMs = Math.max(dateLeft.getTime(), dateRight.getTime())
+  const earlierMs = Math.min(dateLeft.getTime(), dateRight.getTime())
+  if (Number.isNaN(laterMs)) throw new RangeError('Invalid time value')
+  const later = new Date(laterMs)
+  const earlier = new Date(earlierMs)
+
+  const seconds = Math.trunc((laterMs - earlierMs) / 1000)
+  const offsetInSeconds = (timezoneOffsetMs(later) - timezoneOffsetMs(earlier)) / 1000
+  const minutes = Math.round((seconds - offsetInSeconds) / 60)
+
+  if (minutes < 2) return minutes === 0 ? 'less than a minute' : '1 minute'
+  if (minutes < 45) return `${minutes} ${pluralize('minute', minutes)}`
+  if (minutes < 90) return 'about 1 hour'
+  if (minutes < MINUTES_IN_DAY) {
+    const hours = Math.round(minutes / 60)
+    return `about ${hours} ${pluralize('hour', hours)}`
+  }
+  if (minutes < MINUTES_IN_ALMOST_TWO_DAYS) return '1 day'
+  if (minutes < MINUTES_IN_MONTH) {
+    const days = Math.round(minutes / MINUTES_IN_DAY)
+    return `${days} ${pluralize('day', days)}`
+  }
+  if (minutes < MINUTES_IN_MONTH * 2) {
+    const months = Math.round(minutes / MINUTES_IN_MONTH)
+    return `about ${months} ${pluralize('month', months)}`
+  }
+
+  const totalMonths = differenceInMonths(later, earlier)
+  if (totalMonths < 12) {
+    const months = Math.round(minutes / MINUTES_IN_MONTH)
+    return `${months} ${pluralize('month', months)}`
+  }
+
+  const years = Math.trunc(totalMonths / 12)
+  const monthsSinceStartOfYear = totalMonths % 12
+  if (monthsSinceStartOfYear < 3) return `about ${years} ${pluralize('year', years)}`
+  if (monthsSinceStartOfYear < 9) return `over ${years} ${pluralize('year', years)}`
+  const almostYears = years + 1
+  return `almost ${almostYears} ${pluralize('year', almostYears)}`
+}
+
+export function formatDistanceToNow(date: Date): string {
+  return formatDistance(date, new Date())
+}
 
 export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand> {
   static override args = {
@@ -167,12 +254,12 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
 
       let timeStarted = ''
       if (createdAt !== '') {
-        timeStarted = formatDistanceToNow(parseISO(createdAt))
+        timeStarted = formatDistanceToNow(new Date(createdAt))
       }
 
       let timeTaken = ''
       if (updatedAt !== '') {
-        timeTaken = formatDistance(parseISO(updatedAt), parseISO(createdAt))
+        timeTaken = formatDistance(new Date(updatedAt), new Date(createdAt))
       }
 
       let color: '' | 'green' | 'red' | 'yellow'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -581,9 +581,6 @@ importers:
       console-table-printer:
         specifier: ^2.15.0
         version: 2.16.1
-      date-fns:
-        specifier: ^4.4.0
-        version: 4.4.0
       debug:
         specifier: 'catalog:'
         version: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
### Description

Replace the two `date-fns` consumers (`backups list`, `dataset copy`) with native date helpers and drop `date-fns` as a direct dependency. Output is unchanged (parity-tested).

Still pulled transitively via `@sanity/util`, removed there in sanity-io/sanity#13434. Both are needed to fully drop the ~11 MB / ~5,100-file install.

### What to review

- `backups/dates.ts` — flag parsing + timestamp formatting
- `datasets/relativeTime.ts` — native `formatDistance` mirroring date-fns' en-US output

### Testing

Unit tests verify parity against date-fns across every distance bucket, in UTC and DST zones.