### PR TITLE
feat(deploy): show the deployed title in the summary, dry-run, and --json report

### DIFF
--- a/.changeset/deploy-report-title.md
+++ b/.changeset/deploy-report-title.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': minor
+---
+
+feat(deploy): surface the application or studio title across the deploy summary, dry-run report, and `--json` output

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -150,6 +150,7 @@ describe('checkStudioTarget', () => {
     // The URL the human report shows is the same one the JSON reporter reads
     expect(reporter.results[0]?.target).toEqual({
       applicationId: 'app-1',
+      title: null,
       url: 'https://my-studio.sanity.studio',
     })
   })

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -89,7 +89,11 @@ describe('deploymentPlanToJson', () => {
   })
 
   test('passes the resolved target through to the JSON', () => {
-    const target = {applicationId: 'app-1', url: 'https://my-studio.sanity.studio'}
+    const target = {
+      applicationId: 'app-1',
+      title: 'My Studio',
+      url: 'https://my-studio.sanity.studio',
+    }
     const json = deploymentPlanToJson({
       checks: [],
       files: [],

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -199,6 +199,7 @@ async function runAppDeployment(
 
   return {
     applicationId: application.id,
+    applicationTitle: application.title,
     applicationType: 'coreApp',
     applicationVersion: version,
     location: null,
@@ -320,7 +321,8 @@ export function logAppDeployed({
   output: DeployAppOptions['output']
 }): void {
   const url = getCoreAppUrl(application.organizationId, application.id)
-  output.log(`\nSuccess! Application deployed to ${styleText('cyan', url)}`)
+  const named = application.title ? ` — "${application.title}"` : ''
+  output.log(`\nSuccess! Application deployed to ${styleText('cyan', url)}${named}`)
 
   if (getAppId(cliConfig)) return
 

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -31,6 +31,8 @@ type DeployCheckStatus = 'fail' | 'pass' | 'skip' | 'warn'
 export interface DeployTarget {
   /** The application the deploy targets; `null` when a deploy would create one. */
   applicationId: string | null
+  /** The application's title; `null` when it has none (or isn't created yet). */
+  title: string | null
   /** Where the deployed studio/app is reachable; `null` when it can't be resolved yet. */
   url: string | null
 }
@@ -243,7 +245,7 @@ export function describeAppTarget(
       return {
         message: `Deploys to existing application "${title}" at ${url}`,
         status: 'pass',
-        target: {applicationId: application.id, url},
+        target: {applicationId: application.id, title: application.title ?? null, url},
       }
     }
     case 'invalid': {
@@ -318,7 +320,11 @@ export function describeStudioTarget(
       return {
         message: `Deploys to existing studio ${url}`,
         status: 'pass',
-        target: {applicationId: resolution.application.id, url},
+        target: {
+          applicationId: resolution.application.id,
+          title: resolution.application.title ?? null,
+          url,
+        },
       }
     }
     case 'invalid': {
@@ -348,7 +354,7 @@ export function describeStudioTarget(
           ? `Would register external studio at ${resolution.appHost}${titled}`
           : `Would create studio hostname ${url}${titled} (name availability is checked on deploy)`,
         status: 'pass',
-        target: {applicationId: null, url},
+        target: {applicationId: null, title: null, url},
       }
     }
   }

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -21,6 +21,8 @@ import {type DeployAppOptions} from './types.js'
 /** What a real deploy produced — the payload `--json` reports. */
 export interface DeployResult {
   applicationId: string
+  /** The deployed application's title; `null` when it has none. */
+  applicationTitle: string | null
   applicationType: 'coreApp' | 'studio'
   /** Installed framework version the deploy used (`sanity` or `@sanity/sdk-react`). */
   applicationVersion: string

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -121,6 +121,7 @@ async function runStudioDeployment(
 
   return {
     applicationId: application.id,
+    applicationTitle: application.title,
     applicationType: 'studio',
     applicationVersion: version,
     location,
@@ -264,10 +265,11 @@ async function shipStudioDeployment({
   }
   spin.succeed()
 
+  const named = application.title ? ` — "${application.title}"` : ''
   output.log(
     isExternal
-      ? `\nSuccess! Studio registered`
-      : `\nSuccess! Studio deployed to ${styleText('cyan', location)}`,
+      ? `\nSuccess! Studio registered${named}`
+      : `\nSuccess! Studio deployed to ${styleText('cyan', location)}${named}`,
   )
 
   if (getAppId(cliConfig)) return location

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -237,7 +237,9 @@ describe('#deploy app', () => {
     expect(stderr).toContain('Verifying local content')
     expect(stderr).toContain('Deploying...')
 
-    expect(stdout).toContain('Success! Application deployed')
+    expect(stdout).toContain('Success! Application deployed to')
+    expect(stdout).toContain('/@org-id/application/app-id')
+    expect(stdout).toContain('— "Existing App"')
   })
 
   test('should report the target and files in a dry run without deploying', async () => {

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -231,6 +231,7 @@ describe('#deploy studio', () => {
     expect(stderr).toContain('Verifying local content')
     expect(stderr).toContain('Deploying to sanity.studio')
     expect(stdout).toContain('Success! Studio deployed')
+    expect(stdout).toContain('— "Existing Studio"')
   })
 
   test('should report the target and files in a dry run without deploying', async () => {
@@ -322,6 +323,7 @@ describe('#deploy studio', () => {
     // The target the human report names is carried structured in the JSON too
     expect(plan.target).toEqual({
       applicationId: 'studio-app-id',
+      title: 'Existing Studio',
       url: 'https://existing-studio.sanity.studio',
     })
   })
@@ -411,6 +413,7 @@ describe('#deploy studio', () => {
     const result = JSON.parse(stdout)
     expect(result).toEqual({
       applicationId: studioAppId,
+      applicationTitle: 'Existing Studio',
       applicationType: 'studio',
       applicationVersion: expect.any(String),
       deployed: true,


### PR DESCRIPTION
### Description

Stacked on #1433. Makes the deploy report — human summary, `--dry-run`, and `--json` — carry the application/studio title, so agents and humans see which app a deploy targets.

- `DeployTarget` gains `title`, so the dry-run plan feeds it into both the human report and the `--json` payload from one place (no drift).
- `DeployResult` gains `applicationTitle`, so a real deploy's `--json` includes it.
- The success summary appends the title for apps and studios.

Title is read from the resolved application, so this stands alone on the report stack — independent of #1436 (the `--title`/`app.title` create work). When both land, a created app's title flows straight through.

### What to review

- `deployChecks.ts`: `title` on `DeployTarget`, set for `found` (app + studio) and studio `would-create`.
- `deployRunner.ts`: `applicationTitle` on `DeployResult`.
- Summaries in `deployApp.ts`/`deployStudio.ts` append the title.

### Testing

Unit covers target/plan-JSON passthrough; integration covers the studio `--json` payload, dry-run `target`, and the human summary for app + studio. Full deploy suite green.
