### PR TITLE
feat(workbench): stamp the app's bus identity into its bundle

### DIFF
--- a/.changeset/pr-1438.md
+++ b/.changeset/pr-1438.md
@@ -1,0 +1,8 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+'@sanity/cli': minor
+'@sanity/workbench-cli': minor
+---
+
+feat(workbench): stamp the app's bus identity into its bundle

--- a/fixtures/federated-studio/appId.ts
+++ b/fixtures/federated-studio/appId.ts
@@ -1,5 +1,0 @@
-// e2e probe: the CLI stamps the app's bus identity into served/bundled modules
-// as `__SANITY_APP_ID__`; the workbench dev e2e fetches this module and asserts
-// the define was applied.
-declare const __SANITY_APP_ID__: string | undefined
-export const appId = typeof __SANITY_APP_ID__ === 'string' ? __SANITY_APP_ID__ : 'unset'

--- a/fixtures/federated-studio/appId.ts
+++ b/fixtures/federated-studio/appId.ts
@@ -1,0 +1,5 @@
+// e2e probe: the CLI stamps the app's bus identity into served/bundled modules
+// as `__SANITY_APP_ID__`; the workbench dev e2e fetches this module and asserts
+// the define was applied.
+declare const __SANITY_APP_ID__: string | undefined
+export const appId = typeof __SANITY_APP_ID__ === 'string' ? __SANITY_APP_ID__ : 'unset'

--- a/packages/@sanity/cli-build/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildApp.ts
@@ -48,6 +48,9 @@ export interface BuildOptions {
   workDir: string
 
   exposes?: WorkbenchExposes
+
+  /** The workbench app's bus identity (`__SANITY_APP_ID__`). */
+  workbenchAppId?: string
 }
 
 /**
@@ -197,6 +200,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
       schemaExtraction: options.schemaExtraction,
       sourceMap: options.sourceMap,
       vite: options.vite,
+      workbenchAppId: options.workbenchAppId,
     })
 
     trace.log({

--- a/packages/@sanity/cli-build/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildStaticFiles.ts
@@ -44,6 +44,8 @@ interface StaticBuildOptions {
   schemaExtraction?: CliConfig['schemaExtraction']
   sourceMap?: boolean
   vite?: UserViteConfig
+  /** The workbench app's bus identity (`__SANITY_APP_ID__`). */
+  workbenchAppId?: string
 }
 
 /**
@@ -69,6 +71,7 @@ export async function buildStaticFiles(
     schemaExtraction,
     sourceMap = false,
     vite: extendViteConfig,
+    workbenchAppId,
   } = options
 
   const mode = 'production'
@@ -98,6 +101,7 @@ export async function buildStaticFiles(
       // so a federated studio extracts its schema like the legacy studio build.
       schemaExtraction,
       sourceMap,
+      workbenchAppId,
     })
 
     // Apply the user's Vite config so plugins like `@vanilla-extract/vite-plugin`

--- a/packages/@sanity/cli-build/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildStudio.ts
@@ -50,6 +50,9 @@ export interface BuildOptions {
   workDir: string
 
   exposes?: WorkbenchExposes
+
+  /** The workbench app's bus identity (`__SANITY_APP_ID__`). */
+  workbenchAppId?: string
 }
 
 /**
@@ -248,6 +251,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
       schemaExtraction,
       sourceMap,
       vite,
+      workbenchAppId: options.workbenchAppId,
     })
 
     trace.log({

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -109,6 +109,12 @@ interface ViteOptions {
    * Whether or not to enable source maps
    */
   sourceMap?: boolean
+
+  /**
+   * The workbench app's bus identity, stamped into its modules as
+   * `__SANITY_APP_ID__` for `@sanity/runtime`. Only read for workbench apps.
+   */
+  workbenchAppId?: string
 }
 
 /**
@@ -134,6 +140,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     server,
     // default to `true` when `mode=development`
     sourceMap = options.mode === 'development',
+    workbenchAppId,
   } = options
 
   const basePath = normalizeBasePath(rawBasePath)
@@ -198,7 +205,10 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
       // Federation builds only need the federation plugin — skip client-specific
       // plugins (favicons, runtime rewrite, build entries)
       ...(isWorkbenchApp
-        ? [...sharedPlugins, await workbenchVitePlugins({cwd, entries, exposes, isApp})]
+        ? [
+            ...sharedPlugins,
+            await workbenchVitePlugins({appId: workbenchAppId, cwd, entries, exposes, isApp}),
+          ]
         : [
             ...sharedPlugins,
             sanityFaviconsPlugin({

--- a/packages/@sanity/cli-e2e/__tests__/dev/dev.workbench.test.ts
+++ b/packages/@sanity/cli-e2e/__tests__/dev/dev.workbench.test.ts
@@ -44,14 +44,15 @@ describe.skipIf(isRegistryMode)('sanity dev (workbench/federation)', {timeout: 1
     expect(output).toContain(`http://localhost:${port}`)
     expect(output).toContain(`app on port ${port + 1}`)
 
-    // The app server stamps the app's bus identity (`__SANITY_APP_ID__`) into
-    // the modules it serves — `@sanity/runtime` reads it where it connects. The
-    // fixture's probe module makes the define observable without the runtime.
-    const probe = await fetch(`http://localhost:${port + 1}/appId.ts`)
-    expect(probe.ok).toBe(true)
-    const probeSource = await probe.text()
-    expect(probeSource).toContain('"federated-studio"')
-    expect(probeSource).not.toContain('__SANITY_APP_ID__')
+    // The app server carries the app's bus identity (`__SANITY_APP_ID__`) for
+    // `@sanity/runtime`. In dev, Vite delivers `define` entries through the
+    // per-server `/@vite/env` module rather than by text replacement, so that
+    // module is where the id is observable.
+    const env = await fetch(`http://localhost:${port + 1}/@vite/env`)
+    expect(env.ok).toBe(true)
+    const envSource = await env.text()
+    expect(envSource).toContain('__SANITY_APP_ID__')
+    expect(envSource).toContain('"federated-studio"')
 
     session.sendControl('c')
     await session.waitForExit(15_000).catch(() => session.kill())

--- a/packages/@sanity/cli-e2e/__tests__/dev/dev.workbench.test.ts
+++ b/packages/@sanity/cli-e2e/__tests__/dev/dev.workbench.test.ts
@@ -44,6 +44,15 @@ describe.skipIf(isRegistryMode)('sanity dev (workbench/federation)', {timeout: 1
     expect(output).toContain(`http://localhost:${port}`)
     expect(output).toContain(`app on port ${port + 1}`)
 
+    // The app server stamps the app's bus identity (`__SANITY_APP_ID__`) into
+    // the modules it serves — `@sanity/runtime` reads it where it connects. The
+    // fixture's probe module makes the define observable without the runtime.
+    const probe = await fetch(`http://localhost:${port + 1}/appId.ts`)
+    expect(probe.ok).toBe(true)
+    const probeSource = await probe.text()
+    expect(probeSource).toContain('"federated-studio"')
+    expect(probeSource).not.toContain('__SANITY_APP_ID__')
+
     session.sendControl('c')
     await session.waitForExit(15_000).catch(() => session.kill())
   })

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -48,6 +48,9 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     stats: flags.stats,
     unattendedMode: flags.yes,
     vite: cliConfig.vite,
+    // The bus identity `@sanity/runtime` stamps on messages: the deployed
+    // application id when configured, else the app's `unstable_defineApp` name.
+    workbenchAppId: workbench ? (appId ?? workbench.name) : undefined,
     workDir,
   })
 }

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -48,9 +48,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     stats: flags.stats,
     unattendedMode: flags.yes,
     vite: cliConfig.vite,
-    // The bus identity `@sanity/runtime` stamps on messages: the deployed
-    // application id when configured, else the app's `unstable_defineApp` name.
-    workbenchAppId: workbench ? (appId ?? workbench.name) : undefined,
+    workbenchAppId: workbench?.name,
     workDir,
   })
 }

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -62,9 +62,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     unattendedMode: Boolean(flags.yes),
     upgradePackages: upgradePkgs,
     vite: cliConfig.vite,
-    // The bus identity `@sanity/runtime` stamps on messages: the deployed
-    // application id when configured, else the app's `unstable_defineApp` name.
-    workbenchAppId: workbench ? (appId ?? workbench.name) : undefined,
+    workbenchAppId: workbench?.name,
     workDir,
   })
 }

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -62,6 +62,9 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     unattendedMode: Boolean(flags.yes),
     upgradePackages: upgradePkgs,
     vite: cliConfig.vite,
+    // The bus identity `@sanity/runtime` stamps on messages: the deployed
+    // application id when configured, else the app's `unstable_defineApp` name.
+    workbenchAppId: workbench ? (appId ?? workbench.name) : undefined,
     workDir,
   })
 }

--- a/packages/@sanity/cli/src/actions/dev/servers/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/getDevServerConfig.ts
@@ -5,6 +5,7 @@ import {logSymbols, spinner} from '@sanity/cli-core/ux'
 import {isWorkbenchApp} from '@sanity/workbench-cli'
 
 import {type DevServerOptions} from '../../../server/devServer.js'
+import {getAppId} from '../../../util/appId.js'
 import {determineIsApp} from '../../../util/determineIsApp.js'
 import {getSharedServerConfig} from '../../../util/getSharedServerConfig.js'
 import {resolveReactStrictMode} from '../../../util/resolveReactStrictMode.js'
@@ -71,5 +72,9 @@ export function getDevServerConfig({
     reactStrictMode,
     staticPath: path.join(workDir, 'static'),
     typegen: cliConfig?.typegen,
+    // The bus identity `@sanity/runtime` stamps on messages: the deployed
+    // application id when configured, else the app's `unstable_defineApp` name.
+    workbenchAppId:
+      isWorkbenchApp(app) && cliConfig ? (getAppId(cliConfig) ?? app.name) : undefined,
   }
 }

--- a/packages/@sanity/cli/src/actions/dev/servers/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/getDevServerConfig.ts
@@ -5,7 +5,6 @@ import {logSymbols, spinner} from '@sanity/cli-core/ux'
 import {isWorkbenchApp} from '@sanity/workbench-cli'
 
 import {type DevServerOptions} from '../../../server/devServer.js'
-import {getAppId} from '../../../util/appId.js'
 import {determineIsApp} from '../../../util/determineIsApp.js'
 import {getSharedServerConfig} from '../../../util/getSharedServerConfig.js'
 import {resolveReactStrictMode} from '../../../util/resolveReactStrictMode.js'
@@ -72,9 +71,6 @@ export function getDevServerConfig({
     reactStrictMode,
     staticPath: path.join(workDir, 'static'),
     typegen: cliConfig?.typegen,
-    // The bus identity `@sanity/runtime` stamps on messages: the deployed
-    // application id when configured, else the app's `unstable_defineApp` name.
-    workbenchAppId:
-      isWorkbenchApp(app) && cliConfig ? (getAppId(cliConfig) ?? app.name) : undefined,
+    workbenchAppId: isWorkbenchApp(app) ? app.name : undefined,
   }
 }

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -42,6 +42,8 @@ export interface DevServerOptions {
   schemaExtraction?: CliConfig['schemaExtraction']
   typegen?: CliConfig['typegen']
   vite?: UserViteConfig
+  /** The workbench app's bus identity (`__SANITY_APP_ID__`). */
+  workbenchAppId?: string
 }
 
 interface DevServer {
@@ -68,6 +70,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     schemaExtraction,
     typegen,
     vite: extendViteConfig,
+    workbenchAppId,
   } = options
 
   debug('Writing Sanity runtime files')
@@ -115,6 +118,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactCompiler,
     schemaExtraction,
     server: {host: httpHost, port: httpPort},
+    workbenchAppId,
   })
 
   // Opt into Vite's experimental bundled dev mode. Set before the user-config

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/__tests__/workbench-vite-plugins.unit.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/__tests__/workbench-vite-plugins.unit.test.ts
@@ -20,6 +20,26 @@ afterEach(() => {
 })
 
 describe('workbenchVitePlugins', () => {
+  test('appends the app-id define plugin when an appId is given', async () => {
+    const result = await workbenchVitePlugins({
+      appId: 'drop-desk',
+      cwd,
+      entries: {relativeConfigLocation: '../../sanity.config.ts', relativeEntry: null},
+    })
+    expect(result).toEqual([
+      {name: 'sanity/federation'},
+      expect.objectContaining({name: 'sanity/workbench/app-id'}),
+    ])
+  })
+
+  test('returns only the federation plugin without an appId', async () => {
+    const result = await workbenchVitePlugins({
+      cwd,
+      entries: {relativeConfigLocation: '../../sanity.config.ts', relativeEntry: null},
+    })
+    expect(result).toEqual({name: 'sanity/federation'})
+  })
+
   test('builds a studio remote from its sanity.config path', async () => {
     await workbenchVitePlugins({
       cwd,

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-app-id.node.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-app-id.node.test.ts
@@ -1,0 +1,11 @@
+import {expect, test} from 'vitest'
+
+import {sanityAppId} from './plugin-sanity-app-id.js'
+
+test('defines the app id for the pipeline and for dev dep pre-bundling', () => {
+  const plugin = sanityAppId('favorites')
+  const config = (plugin.config as () => Record<string, unknown>)()
+
+  const define = {__SANITY_APP_ID__: '"favorites"'}
+  expect(config).toEqual({define, optimizeDeps: {esbuildOptions: {define}}})
+})

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-app-id.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-app-id.ts
@@ -1,0 +1,16 @@
+import {type Plugin} from 'vite'
+
+/**
+ * Bake the app's bus identity into its bundle: `@sanity/runtime` reads
+ * `__SANITY_APP_ID__` where it connects. `define` covers everything the
+ * pipeline transforms (all of a production build, and dev-served source); the
+ * esbuild define covers dev's pre-bundled dependencies, which skip Vite's
+ * define transform.
+ */
+export function sanityAppId(appId: string): Plugin {
+  const define = {__SANITY_APP_ID__: JSON.stringify(appId)}
+  return {
+    config: () => ({define, optimizeDeps: {esbuildOptions: {define}}}),
+    name: 'sanity/workbench/app-id',
+  }
+}

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/workbench-vite-plugins.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/workbench-vite-plugins.ts
@@ -12,6 +12,7 @@ import {type PluginOption} from 'vite'
 
 import {type WorkbenchExposes} from '../../../resolveWorkbenchApp.js'
 import {federation} from './plugin.js'
+import {sanityAppId} from './plugins/plugin-sanity-app-id.js'
 
 interface WorkbenchViteOptions {
   /** Project root — read for the federation remote name, and the plugin workDir. */
@@ -22,6 +23,9 @@ interface WorkbenchViteOptions {
    * `relativeConfigLocation` is the studio's `sanity.config.*` (null when absent).
    */
   entries: {relativeConfigLocation: string | null; relativeEntry: string | null}
+
+  /** The app's bus identity, stamped into its modules for `@sanity/runtime`. */
+  appId?: string
 
   exposes?: WorkbenchExposes
   /** App (vs studio) build — selects the discriminated federation option shape. */
@@ -47,10 +51,10 @@ function requireStudioConfigPath(relativeConfigLocation: string | null): string 
 
 /** Build the Vite plugins for a workbench app's module-federation remote. */
 export async function workbenchVitePlugins(options: WorkbenchViteOptions): Promise<PluginOption> {
-  const {cwd, entries, exposes, isApp} = options
+  const {appId, cwd, entries, exposes, isApp} = options
   const pkgJson = await readPackageJson(path.join(cwd, 'package.json'))
 
-  return federation({
+  const federationPlugin = federation({
     ...(isApp
       ? {
           // `null` relativeEntry (a branded app with no `entry`) → omit `appEntry`,
@@ -66,4 +70,6 @@ export async function workbenchVitePlugins(options: WorkbenchViteOptions): Promi
     pkgJson,
     workDir: cwd,
   })
+
+  return appId === undefined ? federationPlugin : [federationPlugin, sanityAppId(appId)]
 }

--- a/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
@@ -20,6 +20,8 @@ export interface WorkbenchExposes {
 
 /** @public */
 export interface ResolvedWorkbenchApp {
+  /** The app's unique `name` from `unstable_defineApp`. */
+  readonly name: string
   /** Background worker services the app declares. */
   readonly services: NonNullable<DefineAppInput['services']>
   /** Dock panel views the app declares. */
@@ -44,6 +46,7 @@ export function resolveWorkbenchApp(
   return {
     applicationType: app.applicationType,
     entry: app.entry,
+    name: app.name,
     services: app.services ?? [],
     views: app.views ?? [],
   }


### PR DESCRIPTION
The workbench OS bus ([`@sanity/runtime`](https://github.com/sanity-io/workbench/pull/260)) reads `__SANITY_APP_ID__` where an app's copy connects, so every message an app emits is attributable — the hook that single-owner topics and per-app teardown key on. Until now nothing injected the id, so every copy fell back to the host's.

One vite plugin in `@sanity/workbench-cli` covers both pipelines:

- **Build**: `define` bakes the id statically into the app's bundle.
- **Dev**: Vite serves `define` values through each server's `/@vite/env` module, and `optimizeDeps` bakes them into pre-bundled deps — per-app dep caches, so ids can't collide across apps sharing one workbench shell page.

The id is the app's `unstable_defineApp` name, resolved inside `workbench-cli`; the `cli`/`cli-build` layers thread one optional string alongside `exposes`. Only the workbench branch of dev/build is touched.

Verified against a linked workbench checkout: a live bus message carried `meta.appId: "favorites"` in dev, and the built output is statically stamped. Draft until sanity-io/workbench#260 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are scoped to workbench dev/build Vite config and optional string plumbing; non-workbench studios and apps are untouched.
> 
> **Overview**
> Workbench apps now get their **`unstable_defineApp` `name`** baked into the bundle as **`__SANITY_APP_ID__`** so `@sanity/runtime` can attribute bus traffic per app instead of inheriting the host id.
> 
> A new Vite plugin (`sanity/workbench/app-id`) sets **`define`** for production and dev-served code, plus **`optimizeDeps.esbuildOptions.define`** so pre-bundled deps get the same id in dev. **`workbench-cli`** attaches it next to the federation plugin when an `appId` is present; **`cli`** / **`cli-build`** thread an optional **`workbenchAppId`** through dev and build only on the workbench path. **`resolveWorkbenchApp`** now includes **`name`** as the source of that id.
> 
> E2E coverage asserts the federated-studio fixture exposes **`"federated-studio"`** via the app dev server’s **`/@vite/env`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c21d62ca5d47a6b3f2ac97d52cb4b2040a0fb6c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->