### PR TITLE
feat(workbench): deploy app interfaces

### DIFF
--- a/.changeset/deploy-interfaces.md
+++ b/.changeset/deploy-interfaces.md
@@ -1,0 +1,6 @@
+---
+'@sanity/workbench-cli': minor
+'@sanity/cli': minor
+---
+
+feat(workbench): deploy workbench apps to the Sanity app registry on `sanity deploy`, registering their interfaces (app view, views, services). Plain studios and coreApps are unaffected.

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/createUserApplication.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/createUserApplication.test.ts
@@ -5,7 +5,7 @@ import {
   createUserApplication as createUserApplicationRequest,
   type UserApplication,
 } from '../../../services/userApplications.js'
-import {createUserApplication} from '../createUserApplication.js'
+import {createUserApplication, generateAppSlug} from '../createUserApplication.js'
 
 vi.mock('../../../services/userApplications.js', () => ({
   createUserApplication: vi.fn(),
@@ -43,5 +43,17 @@ describe('createUserApplication', () => {
       }),
     )
     expect(result).toBe(app)
+  })
+})
+
+describe('generateAppSlug', () => {
+  test('is 12 chars, lowercase, and letter-first', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(generateAppSlug()).toMatch(/^[a-z][a-z0-9]{11}$/)
+    }
+  })
+
+  test('is random across calls', () => {
+    expect(generateAppSlug()).not.toBe(generateAppSlug())
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployApp.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployApp.test.ts
@@ -1,34 +1,20 @@
 import {type CliConfig, type Output} from '@sanity/cli-core'
 import {describe, expect, test, vi} from 'vitest'
 
-import {type UserApplicationResolved} from '../../../services/userApplications.js'
 import {logAppDeployed} from '../deployApp.js'
 
 const mockOutput = () => ({log: vi.fn()}) as unknown as Output
-
-function application(overrides: Partial<UserApplicationResolved> = {}): UserApplicationResolved {
-  return {
-    appHost: 'app-host',
-    createdAt: '2024-01-01T00:00:00Z',
-    id: 'app-1',
-    organizationId: 'org-1',
-    projectId: null,
-    title: 'My App',
-    type: 'coreApp',
-    updatedAt: '2024-01-01T00:00:00Z',
-    urlType: 'internal',
-    ...overrides,
-  }
-}
 
 describe('logAppDeployed', () => {
   test("prints the dashboard URL from the deployed app's organization", () => {
     const output = mockOutput()
 
     logAppDeployed({
-      application: application(),
+      applicationId: 'app-1',
       cliConfig: {app: {organizationId: 'config-org'}, deployment: {appId: 'app-1'}} as CliConfig,
+      organizationId: 'org-1',
       output,
+      title: 'My App',
     })
 
     expect(output.log).toHaveBeenCalledWith(

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -1,4 +1,5 @@
 import {type CliConfig, exitCodes, type Output} from '@sanity/cli-core'
+import {type Application, getApplication} from '@sanity/workbench-cli/deploy'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {
@@ -17,13 +18,22 @@ import {
 import {resolveAppDeployTarget, resolveStudioDeployTarget} from '../resolveDeployTarget.js'
 import {type DeployFlags} from '../types.js'
 
-vi.mock('../resolveDeployTarget.js', () => ({
+// The user-applications resolvers are stubbed; the workbench resolvers stay real
+// and exercise the mocked getApplication.
+vi.mock('../resolveDeployTarget.js', async (importOriginal) => ({
+  ...(await importOriginal()),
   resolveAppDeployTarget: vi.fn(),
   resolveStudioDeployTarget: vi.fn(),
 }))
 
+vi.mock(import('@sanity/workbench-cli/deploy'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  getApplication: vi.fn(),
+}))
+
 const mockResolveStudio = vi.mocked(resolveStudioDeployTarget)
 const mockResolveApp = vi.mocked(resolveAppDeployTarget)
+const mockGetApplication = vi.mocked(getApplication)
 
 const mockOutput = () => ({error: vi.fn(), warn: vi.fn()}) as unknown as Output
 
@@ -334,6 +344,97 @@ describe('checkAppTarget', () => {
 
     expect(reporter.results[0]?.status).toBe('fail')
     expect(reporter.results[0]?.message).toContain('don’t have permission')
+  })
+})
+
+function workbenchApp(overrides: Partial<Application> = {}): Application {
+  return {
+    id: 'app-1',
+    organizationId: 'org-1',
+    slug: 'app',
+    title: 'My App',
+    type: 'coreApp',
+    ...overrides,
+  }
+}
+
+describe('checkAppTarget (workbench backend)', () => {
+  test('existing appId → pass check for the resolved application', async () => {
+    mockGetApplication.mockResolvedValue(workbenchApp({title: 'Drop Desk'}))
+    const reporter = createCollectingReporter()
+
+    await checkAppTarget(reporter, {appId: 'app-1', isWorkbenchApp: true, title: 'ignored'})
+
+    expect(reporter.results[0]).toMatchObject({status: 'pass'})
+    expect(reporter.results[0]?.message).toContain('Deploys to existing application "Drop Desk"')
+  })
+
+  test('unknown appId → fail check pointing to deployment.appId', async () => {
+    mockGetApplication.mockResolvedValue(null)
+    const reporter = createCollectingReporter()
+
+    await checkAppTarget(reporter, {appId: 'nope', isWorkbenchApp: true, title: 'ignored'})
+
+    expect(reporter.results[0]?.status).toBe('fail')
+    expect(reporter.results[0]?.solution).toContain('deployment.appId')
+  })
+
+  test('no appId → pass check for the application that would be created', async () => {
+    const reporter = createCollectingReporter()
+
+    await checkAppTarget(reporter, {appId: undefined, isWorkbenchApp: true, title: 'New App'})
+
+    expect(reporter.results[0]).toMatchObject({status: 'pass'})
+    expect(reporter.results[0]?.message).toContain('Would create a new application "New App"')
+    expect(mockGetApplication).not.toHaveBeenCalled()
+  })
+})
+
+describe('checkStudioTarget (workbench backend)', () => {
+  test('existing appId → pass check for the resolved studio, returns its target', async () => {
+    mockGetApplication.mockResolvedValue(workbenchApp({slug: 'my-studio', type: 'studio'}))
+    const reporter = createCollectingReporter()
+
+    const target = await checkStudioTarget(reporter, {
+      appId: 'app-1',
+      isWorkbenchApp: true,
+      studioHost: undefined,
+    })
+
+    expect(reporter.results[0]).toMatchObject({status: 'pass'})
+    expect(reporter.results[0]?.message).toContain(
+      'Deploys to existing studio https://my-studio.sanity.studio',
+    )
+    expect(target?.url).toBe('https://my-studio.sanity.studio')
+  })
+
+  test('no appId with a studioHost → pass check for the studio that would be created', async () => {
+    const reporter = createCollectingReporter()
+
+    await checkStudioTarget(reporter, {
+      appId: undefined,
+      isWorkbenchApp: true,
+      studioHost: 'my-studio',
+      title: 'New Studio',
+    })
+
+    expect(reporter.results[0]).toMatchObject({status: 'pass'})
+    expect(reporter.results[0]?.message).toContain('Would create studio hostname')
+    expect(reporter.results[0]?.message).toContain('titled "New Studio"')
+    expect(mockGetApplication).not.toHaveBeenCalled()
+  })
+
+  test('no appId and no studioHost → usage-error fail check', async () => {
+    const reporter = createCollectingReporter()
+
+    await checkStudioTarget(reporter, {
+      appId: undefined,
+      isWorkbenchApp: true,
+      studioHost: undefined,
+    })
+
+    expect(reporter.results[0]).toMatchObject({exitCode: exitCodes.USAGE_ERROR, status: 'fail'})
+    expect(reporter.results[0]?.solution).toContain('studioHost')
   })
 })
 

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -5,13 +5,14 @@ import {join} from 'node:path'
 import {type Output} from '@sanity/cli-core'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {type DeployCheck} from '../deployChecks.js'
+import {createCollectingReporter, type DeployCheck} from '../deployChecks.js'
 import {
   type DeploymentFile,
   type DeploymentPlan,
   deploymentPlanToJson,
   listDeploymentFiles,
   renderDeploymentPlan,
+  reportExposes,
 } from '../deploymentPlan.js'
 
 vi.mock(import('node:fs/promises'), async (importOriginal) => ({
@@ -57,7 +58,9 @@ describe('listDeploymentFiles', () => {
 
 const studioPlan = (checks: DeployCheck[], files: DeploymentFile[] = []): DeploymentPlan => ({
   checks,
+  exposes: [],
   files,
+  installationConfig: null,
   target: null,
   type: 'studio',
   version: '3.99.0',
@@ -76,6 +79,7 @@ describe('deploymentPlanToJson', () => {
       ),
     )
 
+    // No `exposes`/`installationConfig` keys — a plain (non-workbench) plan omits them.
     expect(json).toEqual({
       applicationType: 'studio',
       applicationVersion: '3.99.0',
@@ -96,7 +100,9 @@ describe('deploymentPlanToJson', () => {
     }
     const json = deploymentPlanToJson({
       checks: [],
+      exposes: [],
       files: [],
+      installationConfig: null,
       target,
       type: 'studio',
       version: null,
@@ -114,6 +120,42 @@ describe('deploymentPlanToJson', () => {
     expect(deploymentPlanToJson(studioPlan([{message: 'ok', status: 'pass'}])).isDeployable).toBe(
       true,
     )
+  })
+
+  test('surfaces the registered exposes and installation-config summary', () => {
+    const plan = studioPlan([{message: 'ok', status: 'pass'}])
+    plan.exposes = [{name: 'edit', title: 'Edit', type: 'panel'}]
+    plan.installationConfig = 'Media Library fields:\n  Title (title)'
+
+    const json = deploymentPlanToJson(plan)
+
+    expect(json.exposes).toEqual([{name: 'edit', title: 'Edit', type: 'panel'}])
+    expect(json.installationConfig).toBe('Media Library fields:\n  Title (title)')
+  })
+})
+
+describe('reportExposes', () => {
+  test('reports views and services and returns them structured', () => {
+    const reporter = createCollectingReporter()
+
+    const exposes = reportExposes(reporter, {
+      services: [{name: 'sync', src: './sync.ts', type: 'worker'}],
+      views: [{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}],
+    })
+
+    expect(exposes).toEqual([
+      {name: 'edit', title: 'Edit', type: 'panel'},
+      {name: 'sync', title: 'sync', type: 'worker'},
+    ])
+    expect(reporter.results.every((check) => check.status === 'pass')).toBe(true)
+    // The structured list rides on the first check so a dry run's collector reads it back.
+    expect(reporter.results[0].exposes).toEqual(exposes)
+  })
+
+  test('reports nothing and returns empty without views or services', () => {
+    const reporter = createCollectingReporter()
+    expect(reportExposes(reporter, {})).toEqual([])
+    expect(reporter.results).toEqual([])
   })
 })
 
@@ -187,7 +229,15 @@ describe('renderDeploymentPlan', () => {
 
   test('labels a core app deploy as an application', () => {
     renderDeploymentPlan(
-      {checks: [], files: [], target: null, type: 'coreApp', version: '1.0.0'},
+      {
+        checks: [],
+        exposes: [],
+        files: [],
+        installationConfig: null,
+        target: null,
+        type: 'coreApp',
+        version: '1.0.0',
+      },
       output,
     )
 

--- a/packages/@sanity/cli/src/actions/deploy/createUserApplication.ts
+++ b/packages/@sanity/cli/src/actions/deploy/createUserApplication.ts
@@ -11,6 +11,15 @@ import {NO_ORGANIZATION_ID} from '../../util/errorMessages.js'
 import {deployDebug} from './deployDebug.js'
 import {normalizeUrl, validateUrl} from './urlUtils.js'
 
+const LETTERS = 'abcdefghijklmnopqrstuvwxyz'
+
+// appHosts have some restrictions (no uppercase, must start with a letter)
+export function generateAppSlug(): string {
+  const firstChar = customAlphabet(LETTERS, 1)()
+  const rest = customAlphabet(`${LETTERS}0123456789`, 11)()
+  return `${firstChar}${rest}`
+}
+
 // TODO: replace with `Promise.withResolvers()` once it lands in node 22
 function promiseWithResolvers<T>() {
   let resolve!: (t: T) => void
@@ -95,17 +104,9 @@ export async function createUserApplication(
   return tryCreateApp(resolvedTitle, organizationId)
 }
 
-// appHosts have some restrictions (no uppercase, must start with a letter)
-const generateId = () => {
-  const letters = 'abcdefghijklmnopqrstuvwxyz'
-  const firstChar = customAlphabet(letters, 1)()
-  const rest = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 11)()
-  return `${firstChar}${rest}`
-}
-
 const tryCreateApp = async (title: string, organizationId: string) => {
   // we will likely prepend this with an org ID or other parameter in the future
-  const appHost = generateId()
+  const appHost = generateAppSlug()
 
   const spin = spinner('Creating application').start()
 

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -5,7 +5,9 @@ import {createGzip} from 'node:zlib'
 import {exitCodes} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {
+  buildExposes,
   deployInstallationConfig,
+  deployCoreApp as deployWorkbenchCoreApp,
   getWorkbench,
   resolveInstallationId,
   summarizeInstallationConfig,
@@ -24,7 +26,7 @@ import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {buildApp} from '../build/buildApp.js'
 import {extractCoreAppManifest, resolveTitleUpdate} from '../manifest/extractCoreAppManifest.js'
 import {type CoreAppManifest} from '../manifest/types.js'
-import {createUserApplication} from './createUserApplication.js'
+import {createUserApplication, generateAppSlug} from './createUserApplication.js'
 import {
   checkAppId,
   checkAppTarget,
@@ -35,7 +37,7 @@ import {
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
-import {listDeploymentFiles} from './deploymentPlan.js'
+import {listDeploymentFiles, reportExposes} from './deploymentPlan.js'
 import {type DeployResult, runDeploy} from './deployRunner.js'
 import {findUserApplication} from './findUserApplication.js'
 import {type DeployAppOptions} from './types.js'
@@ -63,9 +65,13 @@ async function runAppDeployment(
   const dryRun = !!flags['dry-run']
 
   // A singleton (the Media Library) persists its config instead of hosting an
-  // application; anything with interfaces still ships one.
+  // application; anything that exposes a view or service still ships one.
   const deploySingletonInstallationConfig = workbench?.deploySingletonInstallationConfig ?? false
   const deployApplication = !workbench || workbench.hasInterfaces
+
+  const appTitle = workbench
+    ? flags.title?.trim() || cliConfig.app?.title?.trim() || workbench.name
+    : ''
 
   // A federated app with no entry, view or service would ship a remote with
   // nothing to load — reported first so it fails before any prompt or API call.
@@ -112,6 +118,13 @@ async function runAppDeployment(
       solution: 'Remove the --external flag — apps deploy to Sanity hosting',
       status: 'fail',
     })
+  } else if (deployApplication && workbench) {
+    // Both modes, so a bad appId fails before the build rather than at the POST.
+    await checkAppTarget(reporter, {
+      appId: getAppId(cliConfig),
+      isWorkbenchApp: true,
+      title: appTitle,
+    })
   } else if (deployApplication) {
     application = await resolveAppApplication(options, {dryRun, reporter})
   }
@@ -150,6 +163,7 @@ async function runAppDeployment(
   // Resolve the installation in both modes so the report — dry-run and real —
   // shows whether the config is deployable; a missing one fails the deploy here.
   let installationId: string | undefined
+  let installationConfig: string | undefined
   const configAppType = workbench?.installationConfig?.appType
   if (
     deploySingletonInstallationConfig &&
@@ -158,9 +172,10 @@ async function runAppDeployment(
     configAppType
   ) {
     installationId = await resolveInstallationId({appType: configAppType, organizationId})
+    installationConfig = summarizeInstallationConfig(workbench.installationConfig)
     reporter.report(
       installationId
-        ? {message: summarizeInstallationConfig(workbench.installationConfig), status: 'pass'}
+        ? {installationConfig, message: installationConfig, status: 'pass'}
         : {
             exitCode: exitCodes.USAGE_ERROR,
             message: `No active "${configAppType}" installation for organization "${organizationId}"`,
@@ -169,6 +184,9 @@ async function runAppDeployment(
           },
     )
   }
+
+  // Report the exposes deploying with the application, both modes.
+  const exposes = deployApplication && workbench ? reportExposes(reporter, workbench) : []
 
   // Dry run stops here — everything below mutates.
   if (dryRun) return
@@ -186,21 +204,59 @@ async function runAppDeployment(
   // A config-only singleton ships no application, only its installation config.
   if (!deployApplication) {
     if (installationId && version) {
-      return {applicationType: 'coreApp', applicationVersion: version, installationId, target: null}
+      return {
+        applicationType: 'coreApp',
+        applicationVersion: version,
+        ...(installationConfig ? {installationConfig} : {}),
+        installationId,
+        target: null,
+      }
     }
     return
   }
 
+  // A real deploy already exited on a version-resolution failure; this narrows the type.
+  if (!version) return
+
+  // Workbench apps deploy to Brett; plain coreApps use user-applications.
+  if (workbench && organizationId) {
+    const {applicationId} = await deployWorkbenchCoreApp({
+      appId: getAppId(cliConfig),
+      interfaces: buildExposes(workbench, {
+        appName: workbench.name,
+        appTitle,
+        exposesAppView: workbench.entry !== undefined,
+        version,
+      }),
+      isAutoUpdating,
+      organizationId,
+      slug: generateAppSlug(),
+      sourceDir,
+      title: appTitle,
+      version,
+    })
+    logAppDeployed({applicationId, cliConfig, organizationId, output, title: appTitle})
+    return {
+      applicationType: 'coreApp',
+      applicationVersion: version,
+      ...(exposes.length > 0 ? {exposes} : {}),
+      target: {applicationId, title: appTitle, url: getCoreAppUrl(organizationId, applicationId)},
+    }
+  }
+
   // A real deploy has already exited if anything failed; landing here without a
-  // resolved application or version means the deploy target was never resolved.
-  if (!application || !version) return
+  // resolved application means the deploy target was never resolved.
+  if (!application) return
 
   application = await syncApplicationTitle({application, manifest, output})
-
   await shipAppDeployment({application, isAutoUpdating, manifest, sourceDir, version})
-
-  logAppDeployed({application, cliConfig, output})
-
+  logAppDeployed({
+    applicationId: application.id,
+    cliConfig,
+    organizationId: application.organizationId,
+    output,
+    title: application.title,
+  })
   return {
     applicationType: 'coreApp',
     applicationVersion: version,
@@ -318,16 +374,20 @@ async function shipAppDeployment({
 }
 
 export function logAppDeployed({
-  application,
+  applicationId,
   cliConfig,
+  organizationId,
   output,
+  title,
 }: {
-  application: UserApplicationResolved
+  applicationId: string
   cliConfig: DeployAppOptions['cliConfig']
+  organizationId: string
   output: DeployAppOptions['output']
+  title: string | null
 }): void {
-  const url = getCoreAppUrl(application.organizationId, application.id)
-  const named = application.title ? ` — "${application.title}"` : ''
+  const url = getCoreAppUrl(organizationId, applicationId)
+  const named = title ? ` — "${title}"` : ''
   output.log(`\nSuccess! Application deployed to ${styleText('cyan', url)}${named}`)
 
   if (getAppId(cliConfig)) return
@@ -346,7 +406,7 @@ ${styleText(
 ${styleText(
   ['bold', 'green'],
   `deployment: {
-  appId: '${application.id}',
+  appId: '${applicationId}',
 }\n`,
 )}`)
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -1,6 +1,6 @@
 import {type CliConfig, exitCodes, getLocalPackageVersion, type Output} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
-import {checkBuiltOutput} from '@sanity/workbench-cli/deploy'
+import {checkBuiltOutput, type DeployedExpose} from '@sanity/workbench-cli/deploy'
 
 import {resolveAppIdIssue} from '../../util/appId.js'
 import {APP_ID_NOT_FOUND_IN_ORGANIZATION} from '../../util/errorMessages.js'
@@ -16,6 +16,8 @@ import {
   type AppDeployTargetResolution,
   resolveAppDeployTarget,
   resolveStudioDeployTarget,
+  resolveWorkbenchApp,
+  resolveWorkbenchStudio,
   type StudioDeployTargetResolution,
 } from './resolveDeployTarget.js'
 import {type DeployFlags} from './types.js'
@@ -43,6 +45,10 @@ export interface DeployCheck {
 
   /** Exit code a real deploy uses when this check fails; defaults to 1 */
   exitCode?: number
+  /** Set on the exposes check with the workbench exposes both reporters read. */
+  exposes?: DeployedExpose[]
+  /** Set on the installation-config check with its summary both reporters read. */
+  installationConfig?: string
   /** Actionable fix, shown under a failing or warning check */
   solution?: string
   /** Set on the deploy-target check with the resolved target both reporters read. */
@@ -287,21 +293,43 @@ export function describeAppTargetError(err: unknown, organizationId: string | un
     : `Failed to resolve deploy target: ${getErrorMessage(err)}`
 }
 
+/**
+ * Reports the app deploy target as a check and returns the resolved target;
+ * `isWorkbenchApp` selects the backend. Both modes run it — a real deploy uses
+ * it to reject a bad `appId` before building.
+ */
 export async function checkAppTarget(
   reporter: CheckReporter,
-  {
-    appId,
-    organizationId,
-    title,
-  }: {appId: string | undefined; organizationId: string | undefined; title?: string},
-): Promise<void> {
-  await runStep(
+  options:
+    | {appId: string | undefined; isWorkbenchApp: true; title?: string}
+    | {
+        appId: string | undefined
+        isWorkbenchApp?: false
+        organizationId: string | undefined
+        title?: string
+      },
+): Promise<DeployTarget | null> {
+  const {title} = options
+  if (options.isWorkbenchApp) {
+    const {appId} = options
+    return runStep(reporter, 'target', async () => {
+      const check = describeAppTarget(await resolveWorkbenchApp({appId}), {title})
+      reporter.report(check)
+      return check.target ?? null
+    })
+  }
+
+  const {appId, organizationId} = options
+  return runStep(
     reporter,
     'target',
-    async () =>
-      reporter.report(
-        describeAppTarget(await resolveAppDeployTarget({appId, organizationId}), {title}),
-      ),
+    async () => {
+      const check = describeAppTarget(await resolveAppDeployTarget({appId, organizationId}), {
+        title,
+      })
+      reporter.report(check)
+      return check.target ?? null
+    },
     (err) => describeAppTargetError(err, organizationId),
   )
 }
@@ -362,27 +390,46 @@ export function describeStudioTarget(
   }
 }
 
+/**
+ * Reports the studio deploy target as a check and returns the resolved target;
+ * `isWorkbenchApp` selects the backend. Both modes run it — a real deploy uses
+ * the returned target to reject a bad `appId` before building and to report the
+ * studio URL from the resolved slug.
+ */
 export async function checkStudioTarget(
   reporter: CheckReporter,
-  options: {
-    appId: string | undefined
-    isExternal: boolean
-    projectId: string | undefined
-    studioHost: string | undefined
-    title: string | undefined
-    urlFlag: string | undefined
-  },
-): Promise<void> {
-  await runStep(
+  options:
+    | {
+        appId: string | undefined
+        isExternal: boolean
+        isWorkbenchApp?: false
+        projectId: string | undefined
+        studioHost: string | undefined
+        title: string | undefined
+        urlFlag: string | undefined
+      }
+    | {
+        appId: string | undefined
+        isWorkbenchApp: true
+        studioHost: string | undefined
+        title?: string
+      },
+): Promise<DeployTarget | null> {
+  const {title} = options
+  const resolve = options.isWorkbenchApp
+    ? resolveWorkbenchStudio({appId: options.appId, studioHost: options.studioHost})
+    : resolveStudioDeployTarget(options)
+  // Workbench studios always deploy to Sanity hosting, never an external URL.
+  const isExternal = options.isWorkbenchApp ? false : options.isExternal
+
+  return runStep(
     reporter,
     'target',
-    async () =>
-      reporter.report(
-        describeStudioTarget(await resolveStudioDeployTarget(options), {
-          isExternal: options.isExternal,
-          title: options.title,
-        }),
-      ),
+    async () => {
+      const check = describeStudioTarget(await resolve, {isExternal, title})
+      reporter.report(check)
+      return check.target ?? null
+    },
     (err) => `Failed to resolve deploy target: ${getErrorMessage(err)}`,
   )
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -2,6 +2,7 @@ import {format} from 'node:util'
 
 import {CLIError} from '@oclif/core/errors'
 import {type Output} from '@sanity/cli-core'
+import {type DeployedExpose} from '@sanity/workbench-cli/deploy'
 
 import {
   type CheckReporter,
@@ -30,6 +31,10 @@ export interface DeployResult {
    */
   target: DeployTarget | null
 
+  /** Workbench views and services registered with the deploy. */
+  exposes?: DeployedExpose[]
+  /** Media-library installation config summary, when a singleton config deployed. */
+  installationConfig?: string
   /** Set when a media-library singleton deployed its installation config. */
   installationId?: string
 }
@@ -92,7 +97,10 @@ async function collectPlan(options: DeployAppOptions, spec: DeploySpec): Promise
   await spec.run(options, reporter)
   const plan: DeploymentPlan = {
     checks: reporter.results,
+    exposes: reporter.results.find((check) => check.exposes)?.exposes ?? [],
     files: [],
+    installationConfig:
+      reporter.results.find((check) => check.installationConfig)?.installationConfig ?? null,
     target: reporter.results.find((check) => check.target)?.target ?? null,
     type: spec.type,
     version: reporter.results.find((check) => check.version)?.version ?? null,

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -5,13 +5,17 @@ import {createGzip, type Gzip} from 'node:zlib'
 import {formatSchemaValidation, SchemaExtractionError} from '@sanity/cli-build/_internal/extract'
 import {exitCodes} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
-import {getWorkbench} from '@sanity/workbench-cli/deploy'
+import {
+  buildExposes,
+  deployStudio as deployWorkbenchStudio,
+  getWorkbench,
+} from '@sanity/workbench-cli/deploy'
 import {type StudioManifest} from 'sanity'
 import {pack} from 'tar-fs'
 
 import {createDeployment, type UserApplication} from '../../services/userApplications.js'
 import {getAppId} from '../../util/appId.js'
-import {NO_PROJECT_ID} from '../../util/errorMessages.js'
+import {NO_ORGANIZATION_ID, NO_PROJECT_ID} from '../../util/errorMessages.js'
 import {buildStudio} from '../build/buildStudio.js'
 import {createStudioUserApplication} from './createUserApplication.js'
 import {
@@ -20,10 +24,11 @@ import {
   checkPackageVersion,
   type CheckReporter,
   checkStudioTarget,
+  type DeployTarget,
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
-import {listDeploymentFiles} from './deploymentPlan.js'
+import {listDeploymentFiles, reportExposes} from './deploymentPlan.js'
 import {type DeployResult, runDeploy} from './deployRunner.js'
 import {deployStudioSchemasAndManifests} from './deployStudioSchemasAndManifests.js'
 import {findUserApplicationForStudio} from './findUserApplication.js'
@@ -48,15 +53,15 @@ async function runStudioDeployment(
   const {cliConfig, flags, output, sourceDir} = options
   const workDir = options.projectRoot.directory
   const isExternal = !!flags.external
-  const isWorkbenchApp = getWorkbench(cliConfig) !== null
+  const workbench = getWorkbench(cliConfig)
+  const isWorkbenchApp = workbench !== null
   const projectId = cliConfig.api?.projectId
+  const organizationId = cliConfig.app?.organizationId
   const dryRun = !!flags['dry-run']
 
-  const isAutoUpdating = checkAutoUpdates(reporter, {cliConfig, flags})
-
+  // A federated app deploys through Sanity's build/hosting pipeline, which
+  // --external skips — fail before doing any other work.
   if (isExternal && isWorkbenchApp) {
-    // A federated app deploys through Sanity's build/hosting pipeline, which
-    // --external skips.
     reporter.report({
       exitCode: exitCodes.USAGE_ERROR,
       message: 'Deploying a federated application to an external host is not yet supported',
@@ -64,6 +69,12 @@ async function runStudioDeployment(
       status: 'fail',
     })
   }
+
+  const appTitle = workbench
+    ? flags.title?.trim() || cliConfig.app?.title?.trim() || workbench.name
+    : ''
+
+  const isAutoUpdating = checkAutoUpdates(reporter, {cliConfig, flags})
 
   const version = await checkPackageVersion(reporter, {
     moduleName: STUDIO_PACKAGE,
@@ -80,7 +91,31 @@ async function runStudioDeployment(
         },
   )
 
-  const application = await resolveStudioApplication(options, {dryRun, reporter})
+  // Workbench studios deploy to Brett (which needs the org); plain studios
+  // resolve/create on user-applications, unchanged.
+  let application: UserApplication | null = null
+  let studioTarget: DeployTarget | null = null
+  if (workbench && !isExternal) {
+    reporter.report(
+      organizationId
+        ? {message: `Organization: ${organizationId}`, status: 'pass'}
+        : {
+            message: NO_ORGANIZATION_ID,
+            solution: 'Add `app.organizationId` to sanity.cli.ts',
+            status: 'fail',
+          },
+    )
+    // Both modes, so a bad appId fails before the build; its resolved URL feeds
+    // the deploy result.
+    studioTarget = await checkStudioTarget(reporter, {
+      appId: getAppId(cliConfig),
+      isWorkbenchApp: true,
+      studioHost: cliConfig.studioHost,
+      title: appTitle,
+    })
+  } else {
+    application = await resolveStudioApplication(options, {dryRun, reporter})
+  }
 
   await checkBuild(reporter, {
     build: () =>
@@ -101,14 +136,47 @@ async function runStudioDeployment(
     await verifyOutputDir({isWorkbenchApp, reporter, sourceDir})
   }
 
+  // Report the exposes deploying with the studio, both modes. External studios
+  // host their own bundle, so nothing registers.
+  const exposes = workbench && !isExternal ? reportExposes(reporter, workbench) : []
+
   // Dry run stops here — everything below mutates.
   if (dryRun) return
 
   // A real deploy has already exited if anything failed; landing here without a
-  // resolved application or version means the deploy target was never resolved.
-  if (!application || !version) return
+  // resolved version means the deploy target was never resolved.
+  if (!version) return
 
   const studioManifest = await uploadStudioSchema(options, {isExternal})
+  // Workbench studios deploy to Brett; plain studios use user-applications.
+  if (workbench && !isExternal && organizationId) {
+    const {applicationId} = await deployWorkbenchStudio({
+      appId: getAppId(cliConfig),
+      interfaces: buildExposes(workbench, {
+        appName: workbench.name,
+        appTitle,
+        exposesAppView: true,
+        version,
+      }),
+      isAutoUpdating,
+      organizationId,
+      output,
+      projectId,
+      sourceDir,
+      studioHost: cliConfig.studioHost,
+      title: appTitle,
+      version,
+    })
+    logWorkbenchStudioDeployed({applicationId, cliConfig, output})
+    return {
+      applicationType: 'studio',
+      applicationVersion: version,
+      ...(exposes.length > 0 ? {exposes} : {}),
+      target: {applicationId, title: appTitle, url: studioTarget?.url ?? null},
+    }
+  }
+
+  if (!application) return
   const location = await shipStudioDeployment({
     application,
     isAutoUpdating,
@@ -285,6 +353,24 @@ export default defineCliConfig({
   output.log(`\n${example}`)
 
   return location
+}
+
+/** Renders the workbench studio's deploy result; the appId hint shows only when none is configured. */
+function logWorkbenchStudioDeployed({
+  applicationId,
+  cliConfig,
+  output,
+}: {
+  applicationId: string
+  cliConfig: DeployAppOptions['cliConfig']
+  output: DeployAppOptions['output']
+}): void {
+  output.log(`\nSuccess! Studio deployed`)
+  if (getAppId(cliConfig)) return
+
+  output.log(`\nAdd ${styleText('cyan', `appId: '${applicationId}'`)}`)
+  output.log(`to the \`deployment\` section in sanity.cli.js or sanity.cli.ts`)
+  output.log(`to avoid prompting for application id on next deploy.`)
 }
 
 function studioBuildSkipReason({build, isExternal}: {build: boolean; isExternal: boolean}) {

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -4,9 +4,10 @@ import {styleText} from 'node:util'
 
 import {type Output} from '@sanity/cli-core'
 import {logSymbols} from '@sanity/cli-core/ux'
+import {type DeployedExpose, summarizeExposes} from '@sanity/workbench-cli/deploy'
 
 import {pluralize} from '../../util/pluralize.js'
-import {type DeployCheck, type DeployTarget} from './deployChecks.js'
+import {type CheckReporter, type DeployCheck, type DeployTarget} from './deployChecks.js'
 
 export interface DeploymentFile {
   /** Path relative to the project root, POSIX-style. */
@@ -17,7 +18,11 @@ export interface DeploymentFile {
 /** What a `--dry-run` deploy would do: the real deploy sequence with every mutation gated off. */
 export interface DeploymentPlan {
   checks: DeployCheck[]
+  /** Workbench views and services registered with the deploy. */
+  exposes: DeployedExpose[]
   files: DeploymentFile[]
+  /** Media-library installation config summary; `null` unless a config deploys. */
+  installationConfig: string | null
   /** The resolved deploy target; `null` when the checks can't determine one. */
   target: DeployTarget | null
   type: 'coreApp' | 'studio'
@@ -77,7 +82,9 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
   applicationType: DeploymentPlan['type']
   applicationVersion: string | null
   errors: Record<string, string | null>
+  exposes?: DeployedExpose[]
   files: DeploymentFile[]
+  installationConfig?: string
   isDeployable: boolean
   target: DeployTarget | null
   totalBytes: number
@@ -90,16 +97,35 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
     else if (check.status === 'warn') warnings.push(check.message)
   }
 
+  // `exposes` and `installationConfig` are workbench-only; plain apps omit them.
   return {
     applicationType: plan.type,
     applicationVersion: plan.version,
     errors,
+    ...(plan.exposes.length > 0 ? {exposes: plan.exposes} : {}),
     files: plan.files,
+    ...(plan.installationConfig ? {installationConfig: plan.installationConfig} : {}),
     isDeployable: isDeployable(plan),
     target: plan.target,
     totalBytes: totalBytes(plan.files),
     warnings,
   }
+}
+
+/**
+ * Reports an app's exposes as pass checks and returns them structured for the
+ * `--json` payload. The structured list rides on the first check so a dry run's
+ * collector can read it back.
+ */
+export function reportExposes(
+  reporter: CheckReporter,
+  app: Parameters<typeof summarizeExposes>[0],
+): DeployedExpose[] {
+  const {exposes, lines} = summarizeExposes(app)
+  for (const [index, message] of lines.entries()) {
+    reporter.report({exposes: index === 0 ? exposes : undefined, message, status: 'pass'})
+  }
+  return exposes
 }
 
 export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void {

--- a/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
+++ b/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
@@ -1,15 +1,30 @@
+import {getApplication} from '@sanity/workbench-cli/deploy'
+
 import {
   getUserApplication,
   getUserApplications,
   type UserApplication,
   type UserApplicationResolved,
 } from '../../services/userApplications.js'
+import {APP_ID_NOT_FOUND_IN_ORGANIZATION} from '../../util/errorMessages.js'
 import {normalizeUrl, validateUrl} from './urlUtils.js'
+
+/** The application fields a deploy-target verdict carries for reporting. */
+interface DeployTargetApp {
+  appHost: string
+  id: string
+  title: string | null
+}
+
+/** A coreApp verdict also carries the organization, for the dashboard URL. */
+interface DeployTargetCoreApp extends DeployTargetApp {
+  organizationId: string
+}
 
 /**
  * The read-only outcome of resolving where a deploy would go.
  *
- * - `found` — the deploy targets this existing user application
+ * - `found` — the deploy targets this existing application
  * - `would-create` — nothing registered yet; a deploy would create it without prompting
  * - `needs-input` — config doesn't determine a target; a deploy would prompt
  *   (`existing` lists the applications a prompt would offer)
@@ -17,19 +32,23 @@ import {normalizeUrl, validateUrl} from './urlUtils.js'
  * - `blocked` — resolution requires config that's missing (projectId/organizationId)
  *
  * Transport errors (network, permissions) throw — they're not verdicts.
+ *
+ * The user-applications resolvers carry the full {@link UserApplication} (the
+ * real deploy needs it); the workbench resolvers and the report only need
+ * {@link DeployTargetApp}, so `App` defaults to that widened shape.
  */
-type CommonDeployTargetResolution<App extends UserApplication = UserApplication> =
+type CommonDeployTargetResolution<App = DeployTargetApp> =
   | {application: App; type: 'found'}
   | {existing: App[]; type: 'needs-input'}
   | {message: string; reason: 'app-not-found' | 'invalid-host'; type: 'invalid'}
   | {message: string; type: 'blocked'}
 
-export type StudioDeployTargetResolution =
-  | CommonDeployTargetResolution
+export type StudioDeployTargetResolution<App = DeployTargetApp> =
+  | CommonDeployTargetResolution<App>
   | {appHost: string; type: 'would-create'}
 
-export type AppDeployTargetResolution =
-  | CommonDeployTargetResolution<UserApplicationResolved>
+export type AppDeployTargetResolution<App = DeployTargetCoreApp> =
+  | CommonDeployTargetResolution<App>
   | {type: 'would-create'}
 
 /**
@@ -45,7 +64,7 @@ export async function resolveStudioDeployTarget(options: {
   projectId: string | undefined
   studioHost: string | undefined
   urlFlag: string | undefined
-}): Promise<StudioDeployTargetResolution> {
+}): Promise<StudioDeployTargetResolution<UserApplication>> {
   const {appId, isExternal, projectId, studioHost, urlFlag} = options
 
   // appId wins over host config (and undeploy resolves it the same way): a
@@ -112,7 +131,7 @@ export async function resolveStudioDeployTarget(options: {
 export async function resolveAppDeployTarget(options: {
   appId: string | undefined
   organizationId: string | undefined
-}): Promise<AppDeployTargetResolution> {
+}): Promise<AppDeployTargetResolution<UserApplicationResolved>> {
   const {appId, organizationId} = options
 
   if (appId) {
@@ -137,6 +156,54 @@ export async function resolveAppDeployTarget(options: {
   }
 
   return {type: 'would-create'}
+}
+
+/**
+ * The dry-run counterpart to a workbench app's create-on-deploy: a configured
+ * `appId` is looked up read-only, otherwise a coreApp would be created.
+ * @internal
+ */
+export async function resolveWorkbenchApp({
+  appId,
+}: {
+  appId: string | undefined
+}): Promise<AppDeployTargetResolution> {
+  return appId ? resolveAppById(appId) : {type: 'would-create'}
+}
+
+/**
+ * The studio counterpart to {@link resolveWorkbenchApp}: a configured
+ * `studioHost` would create that hostname, and without one a deploy would prompt.
+ *
+ * @internal
+ */
+export async function resolveWorkbenchStudio({
+  appId,
+  studioHost,
+}: {
+  appId: string | undefined
+  studioHost: string | undefined
+}): Promise<StudioDeployTargetResolution> {
+  if (appId) return resolveAppById(appId)
+  if (studioHost) return {appHost: studioHost, type: 'would-create'}
+  return {existing: [], type: 'needs-input'}
+}
+
+async function resolveAppById(
+  appId: string,
+): Promise<CommonDeployTargetResolution<DeployTargetCoreApp>> {
+  const application = await getApplication(appId)
+  return application
+    ? {
+        application: {
+          appHost: application.slug ?? '',
+          id: application.id,
+          organizationId: application.organizationId,
+          title: application.title,
+        },
+        type: 'found',
+      }
+    : {message: APP_ID_NOT_FOUND_IN_ORGANIZATION, reason: 'app-not-found', type: 'invalid'}
 }
 
 async function listStudioApplications(

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -297,60 +297,6 @@ describe('#deploy app', () => {
     expect(error?.message).toContain('Deploy blocked')
   })
 
-  test('should check the federation build dir for an unstable_defineApp app', async () => {
-    const cwd = await testFixture('basic-app')
-    process.cwd = () => cwd
-
-    mockApi({
-      apiVersion: USER_APPLICATIONS_API_VERSION,
-      query: {
-        appType: 'coreApp',
-      },
-      uri: `/user-applications/${appId}`,
-    }).reply(200, {
-      appHost: 'existing-host',
-      createdAt: '2024-01-01T00:00:00Z',
-      id: appId,
-      organizationId: 'org-id',
-      projectId: null,
-      title: 'Existing App',
-      type: 'coreApp',
-      updatedAt: '2024-01-01T00:00:00Z',
-      urlType: 'internal',
-    })
-
-    mockApi({
-      apiVersion: USER_APPLICATIONS_API_VERSION,
-      method: 'post',
-      query: {
-        appType: 'coreApp',
-      },
-      uri: `/user-applications/${appId}/deployments`,
-    }).reply(201, {id: 'deployment-id'}, {location: 'https://existing-host.sanity.app/'})
-
-    const app = unstable_defineApp({
-      entry: './src/App.tsx',
-      name: 'workbench-app',
-      organizationId,
-      title: 'Workbench App',
-    })
-
-    const {error, stdout} = await testCommand(DeployCommand, [], {
-      config: {root: cwd},
-      mocks: {
-        cliConfig: {
-          app,
-          deployment: {appId},
-        },
-      },
-    })
-    if (error) throw error
-
-    expect(mockCheckBuiltOutput).toHaveBeenCalledWith(expect.any(String))
-    expect(mockCheckDir).not.toHaveBeenCalled()
-    expect(stdout).toContain('Success! Application deployed')
-  })
-
   test('should reject an unstable_defineApp app that declares no interfaces', async () => {
     const cwd = await testFixture('basic-app')
     process.cwd = () => cwd

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -1,10 +1,9 @@
 import {mkdir, writeFile} from 'node:fs/promises'
 import {join} from 'node:path'
 
-import {type CliConfig, exitCodes, getCliTelemetry, studioWorkerTask} from '@sanity/cli-core'
+import {exitCodes, getCliTelemetry, studioWorkerTask} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
-import {unstable_defineApp} from '@sanity/workbench-cli'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -309,73 +308,6 @@ describe('#deploy studio', () => {
     expect(mockBuildStudio).toHaveBeenCalledWith(
       expect.objectContaining({flags: expect.objectContaining({yes: true})}),
     )
-  })
-
-  test('should validate the federation build shape for an unstable_defineApp studio', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.cwd = () => cwd
-
-    const projectId = 'test-project-id'
-    const studioHost = 'existing-studio'
-    const studioAppId = 'studio-app-id'
-
-    mockApi({
-      apiVersion: USER_APPLICATIONS_API_VERSION,
-      query: {
-        appHost: studioHost,
-        appType: 'studio',
-      },
-      uri: `/projects/${projectId}/user-applications`,
-    }).reply(200, {
-      appHost: studioHost,
-      createdAt: '2024-01-01T00:00:00Z',
-      id: studioAppId,
-      projectId,
-      title: 'Existing Studio',
-      type: 'studio',
-      updatedAt: '2024-01-01T00:00:00Z',
-      urlType: 'internal',
-    })
-
-    mockApi({
-      apiVersion: USER_APPLICATIONS_API_VERSION,
-      method: 'post',
-      query: {
-        appType: 'studio',
-      },
-      uri: `/projects/${projectId}/user-applications/${studioAppId}/deployments`,
-    }).reply(
-      201,
-      {id: 'deployment-id', location: `https://${studioHost}.sanity.studio`},
-      {location: `https://${studioHost}.sanity.studio`},
-    )
-
-    // Brand the config as a studio so the deploy command routes it through
-    // deployStudio.
-    const app = unstable_defineApp({
-      name: 'test-studio',
-      organizationId: 'org-1',
-      title: 'Test Studio',
-    }) as unknown as NonNullable<CliConfig['app']> & {applicationType?: string}
-    app.applicationType = 'studio'
-
-    const {error, stdout} = await testCommand(DeployCommand, [], {
-      config: {root: cwd},
-      mocks: {
-        cliConfig: {
-          api: {
-            projectId,
-          },
-          app,
-          studioHost,
-        } as CliConfig,
-      },
-    })
-
-    if (error) throw error
-    expect(mockCheckBuiltOutput).toHaveBeenCalledWith(expect.any(String))
-    expect(mockCheckDir).not.toHaveBeenCalled()
-    expect(stdout).toContain('Success! Studio deployed')
   })
 
   test('should create new studio hostname when studioHost is provided but does not exist', async () => {

--- a/packages/@sanity/workbench-cli/src/__tests__/defineMediaLibrary.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineMediaLibrary.test.ts
@@ -4,11 +4,20 @@ import {
   type DefineMediaLibraryInput,
   isWorkbenchApp,
   unstable_defineMediaLibrary,
+  type WorkbenchApp,
 } from '../defineApp.js'
 
 // Same global-registry brand `unstable_defineApp` stamps — a media library is a
 // workbench app, so the CLI discriminates it the same way.
 const WORKBENCH_APP = Symbol.for('sanity.workbench.defineApp')
+
+// The public result type hides the fields a media library stamps
+// (installationConfig, applicationType); narrow past it via the runtime guard.
+function mediaLibrary(input: DefineMediaLibraryInput): WorkbenchApp {
+  const app = unstable_defineMediaLibrary(input)
+  if (!isWorkbenchApp(app)) throw new Error('expected a workbench app')
+  return app
+}
 
 describe('unstable_defineMediaLibrary', () => {
   test('brands the result with the shared workbench brand', () => {
@@ -18,18 +27,14 @@ describe('unstable_defineMediaLibrary', () => {
   })
 
   test('declares a media-library singleton with a stable name', () => {
-    const app = unstable_defineMediaLibrary({organizationId: 'org-1'}) as unknown as {
-      applicationType?: string
-      isSingleton?: boolean
-      name?: string
-    }
+    const app = mediaLibrary({organizationId: 'org-1'})
     expect(app.applicationType).toBe('media-library')
     expect(app.isSingleton).toBe(true)
     expect(app.name).toBe('media-library')
   })
 
   test('collects all fields into one installation config', () => {
-    const app = unstable_defineMediaLibrary({
+    const app = mediaLibrary({
       fields: [
         {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
         {name: 'language', src: './src/language.ts', title: 'Language'},
@@ -46,7 +51,7 @@ describe('unstable_defineMediaLibrary', () => {
   })
 
   test('declares no config when no fields are given', () => {
-    const app = unstable_defineMediaLibrary({organizationId: 'org-1'})
+    const app = mediaLibrary({organizationId: 'org-1'})
     expect(app.installationConfig).toBeUndefined()
   })
 

--- a/packages/@sanity/workbench-cli/src/_exports/deploy.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/deploy.ts
@@ -1,7 +1,19 @@
+export {
+  type BrettInterface,
+  buildExposes,
+  type DeployedExpose,
+  summarizeExposes,
+} from '../actions/deploy/buildExposes.js'
 export {checkBuiltOutput} from '../actions/deploy/checkBuiltOutput.js'
 export {
   deployInstallationConfig,
   resolveInstallationId,
   summarizeInstallationConfig,
 } from '../actions/deploy/deployInstallationConfig.js'
+export {
+  type Application,
+  deployCoreApp,
+  deployStudio,
+  getApplication,
+} from '../actions/deploy/deployWorkbenchApp.js'
 export {getWorkbench} from '../actions/deploy/getWorkbench.js'

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, test} from 'vitest'
+
+import {type WorkbenchExposes} from '../../../resolveWorkbenchApp.js'
+import {buildExposes, summarizeExposes} from '../buildExposes.js'
+
+const context = {
+  appName: 'drop-desk',
+  appTitle: 'Drop Desk',
+  exposesAppView: true,
+  version: '1.2.3',
+}
+
+describe('buildExposes', () => {
+  test('maps the app view, views, and services to Brett interface records', () => {
+    const exposes: WorkbenchExposes = {
+      services: [{name: 'unread', src: './src/unread.ts', title: 'Unread', type: 'worker'}],
+      views: [{name: 'feed', src: './src/feed.tsx', title: 'Feed', type: 'panel'}],
+    }
+
+    expect(buildExposes(exposes, context)).toEqual([
+      {moduleId: 'App', name: 'drop-desk', title: 'Drop Desk', type: 'app', version: '1.2.3'},
+      {moduleId: 'views/feed', name: 'feed', title: 'Feed', type: 'panel', version: '1.2.3'},
+      {
+        moduleId: 'services/unread',
+        name: 'unread',
+        title: 'Unread',
+        type: 'worker',
+        version: '1.2.3',
+      },
+    ])
+  })
+
+  test('builds remote-relative moduleIds (no app-name prefix)', () => {
+    const exposes: WorkbenchExposes = {
+      services: [{name: 'unread', src: './src/unread.ts', type: 'worker'}],
+      views: [{name: 'feed', src: './src/feed.tsx', type: 'panel'}],
+    }
+    expect(buildExposes(exposes, context).map((record) => record.moduleId)).toEqual([
+      'App',
+      'views/feed',
+      'services/unread',
+    ])
+  })
+
+  test('omits the app view when the build does not expose one', () => {
+    const records = buildExposes({}, {...context, exposesAppView: false})
+    expect(records).toEqual([])
+  })
+
+  test('falls back to the interface name when no title is declared', () => {
+    const exposes: WorkbenchExposes = {
+      views: [{name: 'feed', src: './src/feed.tsx', type: 'panel'}],
+    }
+    expect(buildExposes(exposes, {...context, exposesAppView: false})[0]).toMatchObject({
+      name: 'feed',
+      title: 'feed',
+    })
+  })
+
+  test('forwards the declared type unchanged for the server to validate', () => {
+    const exposes: WorkbenchExposes = {
+      views: [{name: 'feed', src: './src/feed.tsx', type: 'panel'}],
+    }
+    expect(buildExposes(exposes, {...context, exposesAppView: false})[0]?.type).toBe('panel')
+  })
+})
+
+describe('summarizeExposes', () => {
+  test('returns views-then-services records with a report line per group', () => {
+    const {exposes, lines} = summarizeExposes({
+      services: [{name: 'sync', src: './src/sync.ts', type: 'worker'}],
+      views: [{name: 'feed', src: './src/feed.tsx', title: 'Feed', type: 'panel'}],
+    })
+
+    expect(exposes).toEqual([
+      {name: 'feed', title: 'Feed', type: 'panel'},
+      {name: 'sync', title: 'sync', type: 'worker'},
+    ])
+    expect(lines).toEqual(['Views:\n  Feed (feed)', 'Services:\n  sync (sync)'])
+  })
+
+  test('is empty when nothing is exposed', () => {
+    expect(summarizeExposes({})).toEqual({exposes: [], lines: []})
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -1,0 +1,227 @@
+import {Readable} from 'node:stream'
+import {type Gzip} from 'node:zlib'
+
+import {getGlobalCliClient, type Output} from '@sanity/cli-core'
+import FormData from 'form-data'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {type BrettInterface} from '../buildExposes.js'
+import {
+  createApplication,
+  createDeployment,
+  deployCoreApp,
+  deployStudio,
+  getApplication,
+} from '../deployWorkbenchApp.js'
+
+vi.mock(import('@sanity/cli-core'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  getGlobalCliClient: vi.fn(),
+}))
+
+vi.mock('@sanity/cli-core/ux', () => ({
+  spinner: () => ({start: () => ({clear: vi.fn(), fail: vi.fn(), succeed: vi.fn()})}),
+}))
+
+vi.mock('tar-fs', () => ({pack: () => ({pipe: () => Readable.from(['tar'])})}))
+
+const mockClient = {request: vi.fn()}
+const output = {error: vi.fn(), log: vi.fn()} as unknown as Output
+// A gzip stream is opaque to the service; a readable stands in for the tarball.
+const tarball = () => Readable.from(['remote']) as unknown as Gzip
+const interfaces: BrettInterface[] = [
+  {moduleId: 'App', name: 'app', title: 'App', type: 'app', version: '1.0.0'},
+]
+
+/** The (name, value) pairs a call appended to its FormData. */
+function appendedFields(): Array<[string, unknown]> {
+  return appendSpy.mock.calls.map((call: unknown[]) => [call[0], call[1]] as [string, unknown])
+}
+let appendSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  vi.mocked(getGlobalCliClient).mockResolvedValue(mockClient as never)
+  appendSpy = vi.spyOn(FormData.prototype, 'append')
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+})
+
+describe('getApplication', () => {
+  test('resolves the application at vX with a user session', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'app_1', title: 'App', type: 'coreApp'})
+
+    expect(await getApplication('app_1')).toMatchObject({id: 'app_1'})
+    expect(getGlobalCliClient).toHaveBeenCalledWith({apiVersion: 'vX', requireUser: true})
+    expect(mockClient.request).toHaveBeenCalledWith({uri: '/applications/app_1'})
+  })
+
+  test('returns null when the application does not exist (404)', async () => {
+    mockClient.request.mockRejectedValueOnce({statusCode: 404})
+    expect(await getApplication('missing')).toBeNull()
+  })
+
+  test('rethrows any non-404 error', async () => {
+    mockClient.request.mockRejectedValueOnce({statusCode: 500})
+    await expect(getApplication('app_1')).rejects.toMatchObject({statusCode: 500})
+  })
+})
+
+describe('createApplication', () => {
+  test('POSTs a coreApp create with the deployment parts, no studio config', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'app_1'})
+
+    await createApplication({
+      interfaces,
+      organizationId: 'org-1',
+      slug: 'abc123',
+      tarball: tarball(),
+      title: 'Drop Desk',
+      type: 'coreApp',
+      version: '1.2.3',
+    })
+
+    const post = mockClient.request.mock.calls[0][0]
+    expect(post).toMatchObject({method: 'POST', uri: '/applications'})
+    expect(post.headers['content-type']).toMatch(/multipart\/form-data/)
+
+    const fields = appendedFields()
+    expect(fields).toContainEqual(['type', 'coreApp'])
+    expect(fields).toContainEqual(['title', 'Drop Desk'])
+    expect(fields).toContainEqual(['organizationId', 'org-1'])
+    expect(fields).toContainEqual(['slug', 'abc123'])
+    expect(fields).toContainEqual(['version', '1.2.3'])
+    expect(fields).toContainEqual(['interfaces', JSON.stringify(interfaces)])
+    expect(fields.map(([name]) => name)).toContain('tarball')
+    expect(fields.map(([name]) => name)).not.toContain('config')
+  })
+
+  test('sends studio config as a JSON part for a studio create', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'app_1'})
+
+    await createApplication({
+      interfaces,
+      organizationId: 'org-1',
+      projectId: 'proj-1',
+      slug: 'my-studio',
+      tarball: tarball(),
+      title: 'My Studio',
+      type: 'studio',
+      version: '3.0.0',
+    })
+
+    const fields = appendedFields()
+    expect(fields).toContainEqual(['type', 'studio'])
+    expect(fields).toContainEqual(['config', JSON.stringify({studio: {projectId: 'proj-1'}})])
+  })
+})
+
+describe('createDeployment', () => {
+  test('POSTs a redeploy to the application, no config part', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'})
+
+    await createDeployment({
+      applicationId: 'app_1',
+      interfaces,
+      isAutoUpdating: true,
+      tarball: tarball(),
+      version: '1.2.4',
+    })
+
+    const post = mockClient.request.mock.calls[0][0]
+    expect(post).toMatchObject({method: 'POST', uri: '/applications/app_1/deployments'})
+
+    const fields = appendedFields()
+    expect(fields).toContainEqual(['version', '1.2.4'])
+    expect(fields).toContainEqual(['isAutoUpdating', 'true'])
+    expect(fields).toContainEqual(['interfaces', JSON.stringify(interfaces)])
+    expect(fields.map(([name]) => name)).not.toContain('config')
+  })
+})
+
+const coreAppOptions = {
+  interfaces,
+  isAutoUpdating: false,
+  organizationId: 'org-1',
+  slug: 'abc123',
+  sourceDir: '/tmp/build/app',
+  title: 'Drop Desk',
+  version: '1.0.0',
+}
+
+describe('deployCoreApp', () => {
+  test('redeploys to an existing deployment.appId', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'})
+
+    expect(await deployCoreApp({...coreAppOptions, appId: 'app_1'})).toEqual({
+      applicationId: 'app_1',
+    })
+    expect(mockClient.request.mock.calls[0][0]).toMatchObject({
+      method: 'POST',
+      uri: '/applications/app_1/deployments',
+    })
+  })
+
+  test('creates a new application at the given slug when no appId is set', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'app_new'})
+
+    expect(await deployCoreApp({...coreAppOptions, appId: undefined})).toEqual({
+      applicationId: 'app_new',
+    })
+    expect(mockClient.request.mock.calls[0][0]).toMatchObject({
+      method: 'POST',
+      uri: '/applications',
+    })
+    expect(appendedFields()).toContainEqual(['slug', 'abc123'])
+  })
+})
+
+const studioOptions = {
+  interfaces,
+  isAutoUpdating: false,
+  organizationId: 'org-1',
+  output,
+  projectId: 'proj-1',
+  sourceDir: '/tmp/build/studio',
+  title: 'My Studio',
+  version: '3.0.0',
+}
+
+describe('deployStudio', () => {
+  test('redeploys to an existing deployment.appId', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'})
+
+    expect(await deployStudio({...studioOptions, appId: 'app_1', studioHost: undefined})).toEqual({
+      applicationId: 'app_1',
+    })
+    expect(mockClient.request.mock.calls[0][0]).toMatchObject({
+      method: 'POST',
+      uri: '/applications/app_1/deployments',
+    })
+  })
+
+  test('creates a studio at studioHost when no appId is set', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'studio_new'})
+
+    expect(
+      await deployStudio({...studioOptions, appId: undefined, studioHost: 'my-studio'}),
+    ).toEqual({applicationId: 'studio_new'})
+    expect(mockClient.request.mock.calls[0][0]).toMatchObject({
+      method: 'POST',
+      uri: '/applications',
+    })
+    expect(appendedFields()).toContainEqual(['slug', 'my-studio'])
+  })
+
+  test('fails without deploying when no appId and no studioHost are set', async () => {
+    await deployStudio({...studioOptions, appId: undefined, studioHost: undefined})
+
+    expect(output.error).toHaveBeenCalledWith(
+      expect.stringContaining('studio hostname'),
+      expect.objectContaining({exit: expect.any(Number)}),
+    )
+    expect(mockClient.request).not.toHaveBeenCalled()
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/deploy/apiVersion.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/apiVersion.ts
@@ -1,0 +1,3 @@
+// The app endpoints (applications + installations) live behind the
+// experimental `vX` version; a dated version returns 501.
+export const APP_WORKBENCH_API_VERSION = 'vX'

--- a/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
@@ -1,0 +1,86 @@
+import {type WorkbenchExposes} from '../../resolveWorkbenchApp.js'
+
+/**
+ * An interface as Brett stores it: the declared `type` (validated server-side,
+ * not here) and the remote-relative `moduleId` the workbench loads it by — the
+ * host prepends the app's own id.
+ * @internal
+ */
+export interface BrettInterface {
+  moduleId: string
+  name: string
+  title: string
+  type: string
+  version: string
+}
+
+interface BuildExposesContext {
+  appName: string
+  appTitle: string
+  /** Whether the build exposes the app view (`./App`) — apps with an `entry`, and every studio. */
+  exposesAppView: boolean
+  version: string
+}
+
+/**
+ * The interface records deploy sends: the app view (only when `exposesAppView`),
+ * every view, and every service.
+ * @internal
+ */
+export function buildExposes(
+  exposes: WorkbenchExposes,
+  {appName, appTitle, exposesAppView, version}: BuildExposesContext,
+): BrettInterface[] {
+  const toRecord = (
+    prefix: string,
+    decl: {name: string; title?: string; type: string},
+  ): BrettInterface => ({
+    moduleId: `${prefix}/${decl.name}`,
+    name: decl.name,
+    title: decl.title ?? decl.name,
+    type: decl.type,
+    version,
+  })
+
+  const records: BrettInterface[] = []
+  if (exposesAppView) {
+    records.push({moduleId: 'App', name: appName, title: appTitle, type: 'app', version})
+  }
+  for (const view of exposes.views ?? []) records.push(toRecord('views', view))
+  for (const service of exposes.services ?? []) records.push(toRecord('services', service))
+  return records
+}
+
+/** A view or service as the deploy report and `--json` output surface it. */
+export interface DeployedExpose {
+  name: string
+  title: string
+  type: string
+}
+
+function summarizeExposeGroup(heading: string, items: readonly DeployedExpose[]): string {
+  return `${heading}:\n${items.map((item) => `  ${item.title} (${item.name})`).join('\n')}`
+}
+
+/**
+ * The deploy summary of an app's exposes: the structured records (for `--json`)
+ * and one report line per non-empty group (for the human report).
+ * @internal
+ */
+export function summarizeExposes({services, views}: WorkbenchExposes): {
+  exposes: DeployedExpose[]
+  lines: string[]
+} {
+  const toExpose = (decl: {name: string; title?: string; type: string}): DeployedExpose => ({
+    name: decl.name,
+    title: decl.title ?? decl.name,
+    type: decl.type,
+  })
+  const viewExposes = (views ?? []).map((view) => toExpose(view))
+  const serviceExposes = (services ?? []).map((service) => toExpose(service))
+
+  const lines: string[] = []
+  if (viewExposes.length > 0) lines.push(summarizeExposeGroup('Views', viewExposes))
+  if (serviceExposes.length > 0) lines.push(summarizeExposeGroup('Services', serviceExposes))
+  return {exposes: [...viewExposes, ...serviceExposes], lines}
+}

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployInstallationConfig.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployInstallationConfig.ts
@@ -7,8 +7,7 @@ import {getGlobalCliClient, type Output, subdebug} from '@sanity/cli-core'
 import FormData from 'form-data'
 import {pack} from 'tar-fs'
 
-// Brett's app-registry endpoints live behind the experimental `vX` version.
-const INSTALLATIONS_API_VERSION = 'vX'
+import {APP_WORKBENCH_API_VERSION} from './apiVersion.js'
 
 const debug = subdebug('deploy')
 
@@ -80,7 +79,7 @@ export async function deployInstallationConfig(options: {
   })
 
   const client = await getGlobalCliClient({
-    apiVersion: INSTALLATIONS_API_VERSION,
+    apiVersion: APP_WORKBENCH_API_VERSION,
     requireUser: true,
   })
   await client.request({
@@ -100,7 +99,7 @@ async function resolveSingletonInstallationId(
   slug: string,
 ): Promise<string | undefined> {
   const client = await getGlobalCliClient({
-    apiVersion: INSTALLATIONS_API_VERSION,
+    apiVersion: APP_WORKBENCH_API_VERSION,
     requireUser: true,
   })
   // `limit=none` returns every installation in one response, no pagination.

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
@@ -1,0 +1,214 @@
+import {basename, dirname} from 'node:path'
+import {PassThrough} from 'node:stream'
+import {createGzip, type Gzip} from 'node:zlib'
+
+import {exitCodes, getGlobalCliClient, type Output} from '@sanity/cli-core'
+import {spinner} from '@sanity/cli-core/ux'
+import FormData from 'form-data'
+import {pack} from 'tar-fs'
+
+import {APP_WORKBENCH_API_VERSION} from './apiVersion.js'
+import {type BrettInterface} from './buildExposes.js'
+
+export type ApplicationType = 'coreApp' | 'studio'
+
+export interface Application {
+  id: string
+  organizationId: string
+  slug: string | null
+  title: string
+  type: ApplicationType
+}
+
+export async function getApplication(applicationId: string): Promise<Application | null> {
+  const client = await getGlobalCliClient({
+    apiVersion: APP_WORKBENCH_API_VERSION,
+    requireUser: true,
+  })
+  try {
+    return await client.request({uri: `/applications/${applicationId}`})
+  } catch (err) {
+    if ((err as {statusCode?: number})?.statusCode === 404) return null
+    throw err
+  }
+}
+
+/** Create an application and its first deployment in one call. */
+export async function createApplication(options: {
+  interfaces: readonly BrettInterface[]
+  organizationId: string
+  projectId?: string
+  slug: string
+  tarball: Gzip
+  title: string
+  type: ApplicationType
+  version: string
+}): Promise<Application> {
+  const {interfaces, organizationId, projectId, slug, tarball, title, type, version} = options
+  const formData = new FormData()
+  formData.append('type', type)
+  formData.append('title', title)
+  formData.append('organizationId', organizationId)
+  formData.append('slug', slug)
+  // Studio config is set once, at create — it's immutable on redeploy.
+  if (projectId) appendJson(formData, 'config', {studio: {projectId}})
+  appendDeploymentParts(formData, {interfaces, tarball, version})
+  return request(`/applications`, formData)
+}
+
+/** Deploy a new active version to an existing application. */
+export async function createDeployment(options: {
+  applicationId: string
+  interfaces: readonly BrettInterface[]
+  isAutoUpdating: boolean
+  tarball: Gzip
+  version: string
+}): Promise<{id: string}> {
+  const {applicationId, interfaces, isAutoUpdating, tarball, version} = options
+  const formData = new FormData()
+  formData.append('isAutoUpdating', isAutoUpdating.toString())
+  appendDeploymentParts(formData, {interfaces, tarball, version})
+  return request(`/applications/${applicationId}/deployments`, formData)
+}
+
+function appendDeploymentParts(
+  formData: FormData,
+  {
+    interfaces,
+    tarball,
+    version,
+  }: {interfaces: readonly BrettInterface[]; tarball: Gzip; version: string},
+): void {
+  formData.append('version', version)
+  appendJson(formData, 'interfaces', interfaces)
+  formData.append('tarball', tarball, {contentType: 'application/gzip', filename: 'app.tar.gz'})
+}
+
+/** Structured parts must arrive as JSON so the server parses them. */
+function appendJson(formData: FormData, name: string, value: unknown): void {
+  formData.append(name, JSON.stringify(value), {contentType: 'application/json'})
+}
+
+async function request<T>(uri: string, formData: FormData): Promise<T> {
+  const client = await getGlobalCliClient({
+    apiVersion: APP_WORKBENCH_API_VERSION,
+    requireUser: true,
+  })
+  return client.request({
+    body: formData.pipe(new PassThrough()),
+    headers: formData.getHeaders(),
+    method: 'POST',
+    uri,
+  })
+}
+
+/**
+ * Deploy a workbench coreApp through Brett: redeploy when `appId` is set,
+ * otherwise create the application at `slug`. Returns the application id for the
+ * shell to report.
+ * @internal
+ */
+export async function deployCoreApp(options: {
+  appId: string | undefined
+  interfaces: readonly BrettInterface[]
+  isAutoUpdating: boolean
+  organizationId: string
+  slug: string
+  sourceDir: string
+  title: string
+  version: string
+}): Promise<{applicationId: string}> {
+  const {appId, interfaces, isAutoUpdating, organizationId, slug, sourceDir, title, version} =
+    options
+  const tarball = pack(dirname(sourceDir), {entries: [basename(sourceDir)]}).pipe(createGzip())
+
+  const spin = spinner('Deploying...').start()
+  try {
+    if (appId) {
+      await createDeployment({applicationId: appId, interfaces, isAutoUpdating, tarball, version})
+      spin.succeed()
+      return {applicationId: appId}
+    }
+
+    const {id} = await createApplication({
+      interfaces,
+      organizationId,
+      slug,
+      tarball,
+      title,
+      type: 'coreApp',
+      version,
+    })
+    spin.succeed()
+    return {applicationId: id}
+  } catch (error) {
+    spin.clear()
+    throw error
+  }
+}
+
+/**
+ * Deploy a workbench studio through Brett: redeploy when `appId` is set,
+ * otherwise create the studio at `studioHost`. Returns the application id for
+ * the shell to report; a missing `studioHost` on create is a usage error.
+ * @internal
+ */
+export async function deployStudio(options: {
+  appId: string | undefined
+  interfaces: readonly BrettInterface[]
+  isAutoUpdating: boolean
+  organizationId: string
+  output: Output
+  projectId: string | undefined
+  sourceDir: string
+  studioHost: string | undefined
+  title: string
+  version: string
+}): Promise<{applicationId: string}> {
+  const {
+    appId,
+    interfaces,
+    isAutoUpdating,
+    organizationId,
+    output,
+    projectId,
+    sourceDir,
+    studioHost,
+    title,
+    version,
+  } = options
+  const tarball = pack(dirname(sourceDir), {entries: [basename(sourceDir)]}).pipe(createGzip())
+
+  const spin = spinner('Deploying to sanity.studio').start()
+  try {
+    if (appId) {
+      await createDeployment({applicationId: appId, interfaces, isAutoUpdating, tarball, version})
+      spin.succeed()
+      return {applicationId: appId}
+    }
+
+    if (!studioHost) {
+      spin.fail()
+      return output.error(
+        'No studio hostname configured. Set `studioHost` in sanity.cli.ts to create a studio.',
+        {exit: exitCodes.USAGE_ERROR},
+      )
+    }
+
+    const application = await createApplication({
+      interfaces,
+      organizationId,
+      projectId,
+      slug: studioHost,
+      tarball,
+      title,
+      type: 'studio',
+      version,
+    })
+    spin.succeed()
+    return {applicationId: application.id}
+  } catch (error) {
+    spin.fail()
+    throw error
+  }
+}

--- a/packages/@sanity/workbench-cli/src/contract.ts
+++ b/packages/@sanity/workbench-cli/src/contract.ts
@@ -49,9 +49,15 @@ function extensionDeclarationFields(kind: 'Field' | 'Service' | 'View') {
   }
 }
 
+// Every interface (view, service) shares `name` + `src` + an optional display
+// `title` that defaults to `name` on deploy.
+function interfaceDeclarationFields(kind: 'Service' | 'View') {
+  return {...extensionDeclarationFields(kind), title: z.optional(z.string())}
+}
+
 const PanelViewSchema = z.object({
   type: z.literal('panel'),
-  ...extensionDeclarationFields('View'),
+  ...interfaceDeclarationFields('View'),
 })
 
 /** @internal */
@@ -59,7 +65,7 @@ export const InterfaceDeclarationSchema = z.discriminatedUnion('type', [PanelVie
 
 const WorkerServiceSchema = z.object({
   type: z.literal('worker'),
-  ...extensionDeclarationFields('Service'),
+  ...interfaceDeclarationFields('Service'),
 })
 
 /** @internal */


### PR DESCRIPTION
### Description

Workbench apps build their interfaces (app view, views, services) into the federation remote, but `sanity deploy` sent the build to `/user-applications`, which doesn't store interfaces — so the workbench couldn't discover a deployed app's panels or workers.

Workbench apps (`unstable_defineApp` coreApps and studios) now deploy to Brett's new `/applications` registry instead: redeploy to `deployment.appId`, or create the app and prompt to save the id. Interfaces ride along as a validated `interfaces` part, with remote-relative `moduleId`s (`App`, `views/<name>`, `services/<name>`).

Plain studios and coreApps are untouched — they stay on `/user-applications`.

The CLI doesn't gatekeep interface types: it forwards the declared `type` and lets the registry reject unknowns, so an unsupported `panel`/`worker` surfaces as a deploy error instead of a silent drop.

Closes SDK-1841.

> [!NOTE]
> The registry is experimental (`vX`, session-only). Studio `workspaces` aren't sent yet — a follow-up.

### What to review

It all lives in `@sanity/workbench-cli`; `@sanity/cli` delegates for the `isWorkbenchApp` branch and leaves `/user-applications` alone.

- `applicationRegistry` — the `/vX/applications` create/deploy/get calls.
- `deployWorkbenchApp` — `deployCoreApp` / `deployStudio` create-or-update.
- `deployChecks` — dry-run target reporting.

### Testing

Unit tests cover the registry service (requests, 404, slug), the dry-run checks, and `buildExposes`. The `/user-applications` paths are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new deploy backend and multipart registry API for workbench apps while leaving legacy paths intact; mis-routing or bad interface payloads would affect hosted discovery, but scope is gated to workbench configs and covered by new unit tests.
> 
> **Overview**
> **Workbench** core apps and studios no longer ship only through `/user-applications`. When the CLI detects a workbench app, `sanity deploy` creates or redeploys via Brett’s experimental **`/vX/applications`** API and sends a tarball plus an **`interfaces`** JSON payload (app view, views, services with remote-relative `moduleId`s). Plain studios and coreApps still use the existing user-applications flow.
> 
> `@sanity/workbench-cli` adds **`deployWorkbenchApp`** (`getApplication`, `deployCoreApp`, `deployStudio`), **`buildExposes` / `summarizeExposes`**, and shared **`APP_WORKBENCH_API_VERSION`**. `@sanity/cli` branches in **`deployApp`** / **`deployStudio`**, resolves targets with **`resolveWorkbenchApp` / `resolveWorkbenchStudio`**, and extends dry-run / **`--json`** output with **`exposes`** and installation-config summaries via **`reportExposes`**. Deploy-target checks run for workbench apps **before** build so a bad `deployment.appId` fails early. **`generateAppSlug`** is exported for new workbench core-app slugs; view/service declarations gain an optional **`title`** in the workbench contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f78f6fe7b40a05966bd1dff7f0bdf173adef1ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->