### PR TITLE
test(chore): moving some SanityCommand.getProjectId tests from cli to cli-core

### DIFF
--- a/packages/@sanity/cli-core/src/__tests__/SanityCommand.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/SanityCommand.test.ts
@@ -94,7 +94,7 @@ describe('SanityCommand', () => {
       expect(id).toEqual('default-project')
     })
 
-    test('should invoke explictly-provided fallback function as return', async () => {
+    test('should invoke explictly-provided fallback function as return if nothing returned from cliConfig', async () => {
       const cmdClass = createMockedRunCommand({
         run: async function () {
           id = await this.getProjectId({
@@ -106,6 +106,54 @@ describe('SanityCommand', () => {
       })
       await cmdClass.run([])
       expect(id).toEqual('manhattan')
+    })
+
+    test('propagates non-NonInteractiveError from fallback', async () => {
+      expect.assertions(1)
+      const cmdClass = createMockedRunCommand({
+        run: async function () {
+          try {
+            await this.getProjectId({
+              async fallback() {
+                throw new Error('boom')
+              },
+            })
+            expect.fail('expected getProjectId to throw')
+          } catch (err) {
+            expect(err.message).toMatch('boom')
+          }
+        },
+      })
+      await cmdClass.run([])
+    })
+
+    test('does not call fallback when project ID is found from config', async () => {
+      const fallback = vi.fn(() => {
+        throw new Error('fallback should not have been called!')
+      })
+      const cmdClass = createMockedRunCommand({
+        cliConfig: vi.fn(() => ({api: {projectId: 'default-project'}})),
+        run: async function () {
+          id = await this.getProjectId({fallback})
+        },
+      })
+      await cmdClass.run([])
+      expect(id).toEqual('default-project')
+      expect(fallback).not.toHaveBeenCalled()
+    })
+
+    test('does not call fallback when --project-id flag is provided', async () => {
+      const fallback = vi.fn(() => {
+        throw new Error('fallback should not have been called!')
+      })
+      const cmdClass = createMockedRunCommand({
+        run: async function () {
+          id = await this.getProjectId({fallback})
+        },
+      })
+      await cmdClass.run(['--project-id', 'torment nexus'])
+      expect(id).toEqual('torment nexus')
+      expect(fallback).not.toHaveBeenCalled()
     })
 
     test('should throw if no project ID was resolved', async () => {


### PR DESCRIPTION
### Description

Many of the command-specific tests in `cli` test logic that is part of `cli-core/SanityCommand`. Adding test coverage to the `getProjectId` method in `SanityCommand` so that we can remove the tests in `cli` that exercise this particular behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications.
> 
> **Overview**
> Adds **unit test coverage** for `SanityCommand.getProjectId` in `cli-core`, so the same behavior can be asserted on the base class instead of in per-command tests under `cli`.
> 
> The fallback test is renamed to clarify it runs when config does not supply a project ID. **New cases** assert that errors from a custom fallback propagate, that the fallback is **not** invoked when the ID comes from CLI config or `--project-id`, and existing “unresolved ID” coverage stays in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36c3677ef34a83ad74cc3d9bb83a51df174bbdf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->