### PR TITLE
fix(types): export ConfigStore in both /config and /types cli-core export sub-paths

### DIFF
--- a/.changeset/pr-1447.md
+++ b/.changeset/pr-1447.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': patch
+---
+
+fix(types): export ConfigStore in both /config and /types cli-core export sub-paths

--- a/packages/@sanity/cli-core/src/_exports/config.ts
+++ b/packages/@sanity/cli-core/src/_exports/config.ts
@@ -2,6 +2,7 @@
 
 export {
   clearCliTokenCache,
+  type ConfigStore,
   getCliToken,
   getCliUserConfig,
   getUserConfig,

--- a/packages/@sanity/cli-core/src/_exports/config.ts
+++ b/packages/@sanity/cli-core/src/_exports/config.ts
@@ -2,7 +2,6 @@
 
 export {
   clearCliTokenCache,
-  type ConfigStore,
   getCliToken,
   getCliUserConfig,
   getUserConfig,
@@ -10,6 +9,11 @@ export {
 } from '../config/cli/cliUserConfig.js'
 export {getCliConfig, getCliConfigUncached} from '../config/cli/getCliConfig.js'
 export {getCliConfigSync} from '../config/cli/getCliConfigSync.js'
+export {
+  type CliConfig,
+  type ConfigStore,
+  type TypeGenConfig,
+} from '../config/cli/types/cliConfig.js'
 export {isWorkbenchApp, parseWorkbenchCliConfig} from '../config/cli/workbenchApp.js'
 export {findProjectRoot} from '../config/findProjectRoot.js'
 export {findProjectRootSync} from '../config/findProjectRootSync.js'

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -10,7 +10,6 @@ export {
 } from '../apiClient.js'
 export {
   clearCliTokenCache,
-  type ConfigStore,
   getCliToken,
   getCliUserConfig,
   getUserConfig,
@@ -18,7 +17,7 @@ export {
 } from '../config/cli/cliUserConfig.js'
 export {getCliConfig, getCliConfigUncached} from '../config/cli/getCliConfig.js'
 export {getCliConfigSync} from '../config/cli/getCliConfigSync.js'
-export {type CliConfig} from '../config/cli/types/cliConfig.js'
+export {type CliConfig, type ConfigStore} from '../config/cli/types/cliConfig.js'
 export {type UserViteConfig} from '../config/cli/types/userViteConfig.js'
 export {type ApplicationType, isWorkbenchApp} from '../config/cli/workbenchApp.js'
 export {findProjectRoot} from '../config/findProjectRoot.js'

--- a/packages/@sanity/cli-core/src/_exports/types.ts
+++ b/packages/@sanity/cli-core/src/_exports/types.ts
@@ -1,4 +1,8 @@
-export {type CliConfig, type TypeGenConfig} from '../config/cli/types/cliConfig.js'
+export {
+  type CliConfig,
+  type ConfigStore,
+  type TypeGenConfig,
+} from '../config/cli/types/cliConfig.js'
 export {type UserViteConfig} from '../config/cli/types/userViteConfig.js'
 export {type ApplicationType} from '../config/cli/workbenchApp.js'
 export {type ProjectRootResult} from '../config/util/recursivelyResolveProjectRoot.js'

--- a/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
@@ -8,6 +8,7 @@ import {getSanityConfigDir} from '../../util/getSanityConfigDir.js'
 import {readJsonFileSync} from '../../util/readJsonFileSync.js'
 import {writeJsonFileSync} from '../../util/writeJsonFileSync.js'
 import {clearCliTokenCache, getCachedToken, setCachedToken} from './cliTokenCache.js'
+import {type ConfigStore} from './types/cliConfig.js'
 
 // Re-export so existing consumers don't break
 export {clearCliTokenCache} from './cliTokenCache.js'
@@ -95,22 +96,6 @@ export function getCliUserConfig(prop: 'authToken'): string | undefined {
   }
 
   return result.data
-}
-
-/**
- * A raw key-value store for CLI user configuration.
- * Unlike the typed `getCliUserConfig`/`setCliUserConfig`, this operates on
- * arbitrary keys without schema validation.
- *
- * @public
- */
-export interface ConfigStore {
-  /** Remove a key from the config file. */
-  delete: (key: string) => void
-  /** Read a value by key. Returns `undefined` if the key does not exist. */
-  get: (key: string) => unknown
-  /** Write a value by key, merging it into the existing config. */
-  set: (key: string, value: unknown) => void
 }
 
 /**

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -163,3 +163,19 @@ export interface CliConfig {
   /** Exposes the default Vite configuration for custom apps and the Studio so it can be changed and extended. */
   vite?: UserViteConfig
 }
+
+/**
+ * A raw key-value store for CLI user configuration.
+ * Unlike the typed `getCliUserConfig`/`setCliUserConfig`, this operates on
+ * arbitrary keys without schema validation.
+ *
+ * @public
+ */
+export interface ConfigStore {
+  /** Remove a key from the config file. */
+  delete: (key: string) => void
+  /** Read a value by key. Returns `undefined` if the key does not exist. */
+  get: (key: string) => unknown
+  /** Write a value by key, merging it into the existing config. */
+  set: (key: string, value: unknown) => void
+}


### PR DESCRIPTION
### Description

Forgot to export one type that was exported in the `cli-core` barrel that was not in the new granular sub-paths: `ConfigStore`. This adds that type to both `/config` and `/types` export sub-paths. Also relocated the type to be alongside other type-only CLI config `types.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only export and definition move with no runtime logic changes.
> 
> **Overview**
> **`ConfigStore` is now exported from the granular `@sanity/cli-core` entry points** (`/config` and `/types`) so it matches what the main barrel already exposed.
> 
> The **`ConfigStore` interface is relocated** from `cliUserConfig.ts` into `cliConfig.ts` alongside other CLI config types. The legacy barrel re-exports **`ConfigStore` from `cliConfig`** instead of pulling it through `cliUserConfig`. **`getUserConfig()`’s return type is unchanged**; only where the type is defined and how it is re-exported changes.
> 
> A **patch changeset** is included for `@sanity/cli-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895eeff5bed705efdf4338fdbeb9e7e0b71e2f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->