### PR TITLE
fix(deploy): report a failed deploy as JSON

### DIFF
--- a/.changeset/deploy-json-failure-envelope.md
+++ b/.changeset/deploy-json-failure-envelope.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+fix(deploy): report a failed `deploy --json` as a `{deployed: false}` JSON envelope

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
@@ -1,3 +1,4 @@
+import {CLIError} from '@oclif/core/errors'
 import {type Output} from '@sanity/cli-core'
 import {describe, expect, test, vi} from 'vitest'
 
@@ -77,6 +78,31 @@ describe('runDeploy dry run', () => {
     const payload = JSON.parse(vi.mocked(output.log).mock.calls.at(-1)![0] as string)
     expect(payload.applicationVersion).toBe('9.9.9')
   })
+
+  test('a blocked --json dry run prints the plan only, never a deploy envelope', async () => {
+    const output = mockOutput()
+    // A real run's output.error throws to abort; the plan JSON is already out.
+    vi.mocked(output.error).mockImplementation(() => {
+      throw new CLIError('blocked')
+    })
+    const spec: DeploySpec = {
+      listFiles: async () => [],
+      run: async (_options, reporter) =>
+        reporter.report({exitCode: 2, message: 'boom', status: 'fail'}),
+      type: 'studio',
+    }
+
+    await expect(
+      runDeploy(
+        {...dryRunOptions(output), flags: {'dry-run': true, json: true}} as DeployAppOptions,
+        spec,
+      ),
+    ).rejects.toThrow()
+
+    const logged = vi.mocked(output.log).mock.calls.map((call) => call[0] as string)
+    expect(logged).toHaveLength(1)
+    expect(logged[0]).not.toContain('"deployed"')
+  })
 })
 
 describe('runDeploy real deploy', () => {
@@ -99,7 +125,7 @@ describe('runDeploy real deploy', () => {
     expect(payload).toEqual({deployed: true, ...result})
   })
 
-  test('a failed deploy writes no JSON — it errors on stderr and exits', async () => {
+  test('a failed deploy emits a {deployed: false} envelope and still errors on stderr', async () => {
     const output = mockOutput()
     const spec: DeploySpec = {
       listFiles: async () => [],
@@ -110,6 +136,25 @@ describe('runDeploy real deploy', () => {
     }
 
     await runDeploy({...dryRunOptions(output), flags: {json: true}} as DeployAppOptions, spec)
+
+    const payload = JSON.parse(vi.mocked(output.log).mock.calls.at(-1)![0] as string)
+    expect(payload.deployed).toBe(false)
+    expect(payload.error.message).toContain('boom')
+    // The envelope and the stderr message are the same diagnosis
+    expect(output.error).toHaveBeenCalledWith(payload.error.message, {exit: 1})
+  })
+
+  test('without --json a failed deploy stays on stderr, with no envelope', async () => {
+    const output = mockOutput()
+    const spec: DeploySpec = {
+      listFiles: async () => [],
+      run: async () => {
+        throw new Error('boom')
+      },
+      type: 'studio',
+    }
+
+    await runDeploy({...dryRunOptions(output), flags: {}} as DeployAppOptions, spec)
 
     expect(output.log).not.toHaveBeenCalled()
     expect(output.error).toHaveBeenCalledWith(expect.stringContaining('boom'), {exit: 1})

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -3,6 +3,7 @@ import {format} from 'node:util'
 import {CLIError} from '@oclif/core/errors'
 import {type Output} from '@sanity/cli-core'
 
+import {getErrorMessage} from '../../util/getErrorMessage.js'
 import {
   type CheckReporter,
   createCollectingReporter,
@@ -55,6 +56,7 @@ export interface DeploySpec {
 export async function runDeploy(options: DeployAppOptions, spec: DeploySpec): Promise<void> {
   const {output} = options
   const json = !!options.flags.json
+  const emitJson = (payload: unknown) => output.log(JSON.stringify(payload, null, 2))
 
   // The JSON payload owns stdout, so the run's progress logs go to stderr; only
   // the final JSON.stringify writes to stdout. Spinners are already on stderr.
@@ -72,17 +74,22 @@ export async function runDeploy(options: DeployAppOptions, spec: DeploySpec): Pr
   try {
     if (options.flags['dry-run']) {
       const plan = await collectPlan(runOptions, spec)
-      if (json) output.log(JSON.stringify(deploymentPlanToJson(plan), null, 2))
+      if (json) emitJson(deploymentPlanToJson(plan))
       else renderDeploymentPlan(plan, output)
       exitIfBlocked(plan, output)
       return
     }
 
     const result = await spec.run(runOptions, createFailFastReporter(runOptions.output))
-    if (json && result) output.log(JSON.stringify({deployed: true, ...result}, null, 2))
+    if (json && result) emitJson({deployed: true, ...result})
   } catch (error) {
-    // Failures signal via exit code and stderr, like every other command — no JSON on stdout.
-    normalizeDeployError(error, output, spec.type)
+    const failure = normalizeFailure(error, spec.type)
+    // A blocked dry run reaches this catch too (its exit throws) and already
+    // printed its plan, so only a real deploy adds the {deployed: false} envelope.
+    if (json && !options.flags['dry-run']) {
+      emitJson({deployed: false, error: {message: failure.message}})
+    }
+    output.error(failure.message, {exit: failure.exit})
   }
 }
 
@@ -109,16 +116,22 @@ function exitIfBlocked(plan: DeploymentPlan, output: Output): void {
   output.error('Deploy blocked by failing checks.', {exit: failed?.exitCode ?? 1})
 }
 
-function normalizeDeployError(error: unknown, output: Output, type: 'coreApp' | 'studio'): void {
-  const noun = type === 'coreApp' ? 'application' : 'studio'
-
+/** The one failure diagnosis both the stderr message and the `--json` envelope read. */
+function normalizeFailure(
+  error: unknown,
+  type: 'coreApp' | 'studio',
+): {exit: number; message: string} {
   // Ctrl+C on an interactive prompt isn't a real failure
   if (error instanceof Error && error.name === 'ExitPromptError') {
-    output.error('Deployment cancelled by user', {exit: 1})
-    return
+    return {exit: 1, message: 'Deployment cancelled by user'}
   }
-  // A failed check already carries its own message and exit code; rethrow untouched
-  if (error instanceof CLIError) throw error
-  deployDebug(`Error deploying ${noun}`, error)
-  output.error(`Error deploying ${noun}: ${error}`, {exit: 1})
+  // A failed check already carries its own message and exit code
+  if (error instanceof CLIError) {
+    return {exit: error.oclif?.exit ?? 1, message: error.message}
+  }
+  deployDebug(`Error deploying ${type === 'coreApp' ? 'application' : 'studio'}`, error)
+  return {
+    exit: 1,
+    message: `Error deploying ${type === 'coreApp' ? 'application' : 'studio'}: ${getErrorMessage(error)}`,
+  }
 }


### PR DESCRIPTION
### Description

> [!NOTE]
> I've reviewed the `--json` and `--dry-run` output in an agent eval session and Claude had useful suggestions on how to improve it further. 

`sanity deploy --json` only emits a payload on success (and for a `--dry-run` plan). When a real deploy *fails*, stdout stays empty — so a caller has to special-case failure by scraping stderr and the exit code.

This emits a `{deployed: false, error: {message}}` envelope on stdout when a real deploy fails, so success and failure parse through one path. The message is produced by a single diagnosis shared with the stderr output, so the human and JSON reports can't diverge.

### What to review

`deployRunner.ts`: `normalizeDeployError` (void, did the printing) became `normalizeFailure`, returning `{exit, message}` that both the stderr error and the JSON envelope read. The `!dry-run` guard keeps a blocked dry run — which also reaches this `catch` because its exit throws — from printing a second JSON object after its plan.

### Testing

Unit tests in `deployRunner.test.ts`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output contract change for `--json` failure only; deploy logic is unchanged aside from unified error messaging.
> 
> **Overview**
> **`sanity deploy --json` now prints a structured failure on stdout** when a real deploy fails: `{deployed: false, error: {message}}`, so callers can parse success and failure the same way instead of relying only on exit code and stderr.
> 
> Failure handling in `deployRunner` is refactored so **`normalizeFailure`** returns a single `{exit, message}` diagnosis used for both the stderr error and the JSON envelope (with `getErrorMessage` for generic errors). A **`!dry-run` guard** keeps blocked `--json` dry runs from emitting a second deploy envelope after the plan JSON.
> 
> Non-`--json` failures are unchanged (stderr only). Tests cover the new envelope, parity between envelope and stderr, and dry-run blocking behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438b3ea3e525b4184238472361fb98713823f39a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->