### PR TITLE
fix(deploy): report the pending app in a dry-run plan

### DIFF
--- a/.changeset/deploy-app-dryrun-target.md
+++ b/.changeset/deploy-app-dryrun-target.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+fix(deploy): carry the pending app's title in a dry-run plan's JSON target

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -297,6 +297,8 @@ describe('checkAppTarget', () => {
 
     expect(reporter.results[0]).toMatchObject({status: 'pass'})
     expect(reporter.results[0]?.message).toContain('Would create a new application "My App"')
+    // The JSON target carries the pending title; id and URL come on creation
+    expect(reporter.results[0]?.target).toEqual({applicationId: null, title: 'My App', url: null})
   })
 
   test('needs-input → fail check (would prompt)', async () => {

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -268,7 +268,11 @@ export function describeAppTarget(
     // Without --title, creating an app needs a prompt no unattended run can answer
     case 'would-create': {
       if (title) {
-        return {message: `Would create a new application "${title}"`, status: 'pass'}
+        return {
+          message: `Would create a new application "${title}"`,
+          status: 'pass',
+          target: {applicationId: null, title, url: null},
+        }
       }
       return {
         exitCode: exitCodes.USAGE_ERROR,


### PR DESCRIPTION
### Description

> [!NOTE]
> I've reviewed the `--json` and `--dry-run` output in an agent eval session and Claude had useful suggestions on how to improve it further. 

`sanity deploy --dry-run` for an app that would create a *new* one shows `Would create a new application "<title>"` in the human report, but `--json` returns `target: null`. The two views of the same plan disagree.

The plan's `target` now carries the pending title. `applicationId` and `url` stay null — the server assigns both on creation — so the shape matches `DeployTarget` and the studio `found` case. Existing apps (`found`) already populated the target; this closes the gap for new ones.

### What to review

`deployChecks.ts` — `describeAppTarget`, the `would-create` branch. One added `target` object.

### Testing

Unit test in `deployChecks.test.ts` asserts the target for a titled would-create.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field addition to a dry-run check result; no runtime deploy or auth behavior changes.
> 
> **Overview**
> **Fixes inconsistent dry-run output** when an app deploy would create a new application with `--title`: the human plan already said *Would create…*, but `--json` reported `target: null`.
> 
> For the app deploy-target check’s **`would-create` + title** pass path, `describeAppTarget` now sets **`target`** to `{ applicationId: null, title, url: null }`, matching the existing **`DeployTarget`** shape used for **`found`** (id and URL stay null until creation). A unit test asserts that target on the titled would-create case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 044118b072311e28a9af87a16d5fda4adcfca417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->