### PR TITLE
fix(deploy): show the studio title in a dry-run plan

### DIFF
--- a/.changeset/deploy-studio-title-in-plan.md
+++ b/.changeset/deploy-studio-title-in-plan.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+fix(deploy): carry the studio title in a dry-run plan's JSON target

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -163,6 +163,7 @@ describe('checkStudioTarget', () => {
 
     expect(reporter.results[0]).toMatchObject({status: 'pass'})
     expect(reporter.results[0]?.message).toContain('Would create studio hostname')
+    expect(reporter.results[0]?.target?.title).toBeNull()
   })
 
   test('would-create with a title → pass check names the title', async () => {
@@ -173,6 +174,22 @@ describe('checkStudioTarget', () => {
 
     expect(reporter.results[0]).toMatchObject({status: 'pass'})
     expect(reporter.results[0]?.message).toContain('titled "My Studio"')
+    // The JSON target echoes the requested title, matching the human message
+    expect(reporter.results[0]?.target).toEqual({
+      applicationId: null,
+      title: 'My Studio',
+      url: 'https://new-studio.sanity.studio',
+    })
+  })
+
+  test('would-create with an empty title → target.title null, like the message', async () => {
+    mockResolveStudio.mockResolvedValue({appHost: 'new-studio', type: 'would-create'})
+    const reporter = createCollectingReporter()
+
+    await checkStudioTarget(reporter, {...studioArgs, title: ''})
+
+    expect(reporter.results[0]?.message).not.toContain('titled')
+    expect(reporter.results[0]?.target?.title).toBeNull()
   })
 
   test('external would-create → pass check', async () => {

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -356,7 +356,9 @@ export function describeStudioTarget(
           ? `Would register external studio at ${resolution.appHost}${titled}`
           : `Would create studio hostname ${url}${titled} (name availability is checked on deploy)`,
         status: 'pass',
-        target: {applicationId: null, title: null, url},
+        // `title || null`, not `?? null`, so target.title tracks the same
+        // truthiness the message's `titled` suffix uses (an empty title is no title)
+        target: {applicationId: null, title: title || null, url},
       }
     }
   }


### PR DESCRIPTION
### Description

> [!NOTE]
> I've reviewed the `--json` and `--dry-run` output in an agent eval session and Claude had useful suggestions on how to improve it further. 

`sanity deploy --dry-run --title "<name>"` names the title in the human report (`... titled "<name>"`), but `--json` returns `target.title: null`. The two views of the same plan disagree.

The plan's `target.title` now carries the requested title, gated on the same truthiness the message's `titled` suffix uses (so an empty `--title ""` stays null in both). `applicationId`/`url` are unchanged.

### What to review

`deployChecks.ts` — `describeStudioTarget`, the `would-create` branch: `title: null` → `title: title || null`.

### Testing

Unit tests in `deployChecks.test.ts` cover a named title and an empty title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior fix in deploy dry-run reporting only; no deploy execution or auth paths change.
> 
> **Overview**
> **Aligns dry-run JSON with the human report** when a new studio hostname would be created: `describeStudioTarget`'s `would-create` branch now sets `target.title` from the requested `--title` using `title || null`, matching the same truthiness as the `titled "…"` suffix in the pass message.
> 
> Empty `--title ""` still yields `null` in both views. `applicationId` and `url` are unchanged. Unit tests assert named title, no title, and empty title on the JSON `target`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e9ac30977ddc52d2de3452263828b32583a1c3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->