### PR TITLE
feat(workbench): submit studio workspaces to the applications API

### DIFF
--- a/.changeset/deploy-studio-workspaces.md
+++ b/.changeset/deploy-studio-workspaces.md
@@ -1,0 +1,6 @@
+---
+'@sanity/workbench-cli': minor
+'@sanity/cli': minor
+---
+
+feat(workbench): send studio workspaces (project, dataset, base path, title, icon) with workbench studio deploys, so the dashboard can surface them.

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -6,6 +6,7 @@ import {formatSchemaValidation, SchemaExtractionError} from '@sanity/cli-build/_
 import {exitCodes} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {
+  type BrettWorkspace,
   buildExposes,
   deployStudio as deployWorkbenchStudio,
   getWorkbench,
@@ -166,6 +167,7 @@ async function runStudioDeployment(
       studioHost: cliConfig.studioHost,
       title: appTitle,
       version,
+      workspaces: toWorkspaces(studioManifest),
     })
     logWorkbenchStudioDeployed({applicationId, cliConfig, output})
     return {
@@ -353,6 +355,18 @@ export default defineCliConfig({
   output.log(`\n${example}`)
 
   return location
+}
+
+function toWorkspaces(manifest: StudioManifest | null): BrettWorkspace[] {
+  return (manifest?.workspaces ?? []).map((workspace) => ({
+    basePath: workspace.basePath,
+    dataset: workspace.dataset,
+    icon: workspace.icon,
+    name: workspace.name,
+    projectId: workspace.projectId,
+    subtitle: workspace.subtitle,
+    title: workspace.title,
+  }))
 }
 
 /** Renders the workbench studio's deploy result; the appId hint shows only when none is configured. */

--- a/packages/@sanity/workbench-cli/src/_exports/deploy.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/deploy.ts
@@ -12,6 +12,7 @@ export {
 } from '../actions/deploy/deployInstallationConfig.js'
 export {
   type Application,
+  type BrettWorkspace,
   deployCoreApp,
   deployStudio,
   getApplication,

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -7,6 +7,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {type BrettInterface} from '../buildExposes.js'
 import {
+  type BrettWorkspace,
   createApplication,
   createDeployment,
   deployCoreApp,
@@ -31,6 +32,9 @@ const output = {error: vi.fn(), log: vi.fn()} as unknown as Output
 const tarball = () => Readable.from(['remote']) as unknown as Gzip
 const interfaces: BrettInterface[] = [
   {moduleId: 'App', name: 'app', title: 'App', type: 'app', version: '1.0.0'},
+]
+const workspaces: BrettWorkspace[] = [
+  {basePath: '/', dataset: 'production', name: 'default', projectId: 'proj-1', title: 'Default'},
 ]
 
 /** The (name, value) pairs a call appended to its FormData. */
@@ -96,9 +100,10 @@ describe('createApplication', () => {
     expect(fields).toContainEqual(['interfaces', JSON.stringify(interfaces)])
     expect(fields.map(([name]) => name)).toContain('tarball')
     expect(fields.map(([name]) => name)).not.toContain('config')
+    expect(fields.map(([name]) => name)).not.toContain('workspaces')
   })
 
-  test('sends studio config as a JSON part for a studio create', async () => {
+  test('sends studio config and workspaces as JSON parts for a studio create', async () => {
     mockClient.request.mockResolvedValueOnce({id: 'app_1'})
 
     await createApplication({
@@ -110,11 +115,13 @@ describe('createApplication', () => {
       title: 'My Studio',
       type: 'studio',
       version: '3.0.0',
+      workspaces,
     })
 
     const fields = appendedFields()
     expect(fields).toContainEqual(['type', 'studio'])
     expect(fields).toContainEqual(['config', JSON.stringify({studio: {projectId: 'proj-1'}})])
+    expect(fields).toContainEqual(['workspaces', JSON.stringify(workspaces)])
   })
 })
 
@@ -138,6 +145,22 @@ describe('createDeployment', () => {
     expect(fields).toContainEqual(['isAutoUpdating', 'true'])
     expect(fields).toContainEqual(['interfaces', JSON.stringify(interfaces)])
     expect(fields.map(([name]) => name)).not.toContain('config')
+    expect(fields.map(([name]) => name)).not.toContain('workspaces')
+  })
+
+  test('includes workspaces as a JSON part when provided', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'})
+
+    await createDeployment({
+      applicationId: 'app_1',
+      interfaces,
+      isAutoUpdating: false,
+      tarball: tarball(),
+      version: '3.0.1',
+      workspaces,
+    })
+
+    expect(appendedFields()).toContainEqual(['workspaces', JSON.stringify(workspaces)])
   })
 })
 
@@ -187,6 +210,7 @@ const studioOptions = {
   sourceDir: '/tmp/build/studio',
   title: 'My Studio',
   version: '3.0.0',
+  workspaces,
 }
 
 describe('deployStudio', () => {
@@ -200,6 +224,7 @@ describe('deployStudio', () => {
       method: 'POST',
       uri: '/applications/app_1/deployments',
     })
+    expect(appendedFields()).toContainEqual(['workspaces', JSON.stringify(workspaces)])
   })
 
   test('creates a studio at studioHost when no appId is set', async () => {
@@ -213,6 +238,7 @@ describe('deployStudio', () => {
       uri: '/applications',
     })
     expect(appendedFields()).toContainEqual(['slug', 'my-studio'])
+    expect(appendedFields()).toContainEqual(['workspaces', JSON.stringify(workspaces)])
   })
 
   test('fails without deploying when no appId and no studioHost are set', async () => {

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
@@ -20,6 +20,18 @@ export interface Application {
   type: ApplicationType
 }
 
+/** A studio workspace as Brett stores it. */
+export interface BrettWorkspace {
+  dataset: string
+  projectId: string
+
+  basePath?: string
+  icon?: string
+  name?: string
+  subtitle?: string
+  title?: string
+}
+
 export async function getApplication(applicationId: string): Promise<Application | null> {
   const client = await getGlobalCliClient({
     apiVersion: APP_WORKBENCH_API_VERSION,
@@ -43,8 +55,10 @@ export async function createApplication(options: {
   title: string
   type: ApplicationType
   version: string
+  workspaces?: readonly BrettWorkspace[]
 }): Promise<Application> {
-  const {interfaces, organizationId, projectId, slug, tarball, title, type, version} = options
+  const {interfaces, organizationId, projectId, slug, tarball, title, type, version, workspaces} =
+    options
   const formData = new FormData()
   formData.append('type', type)
   formData.append('title', title)
@@ -52,7 +66,7 @@ export async function createApplication(options: {
   formData.append('slug', slug)
   // Studio config is set once, at create — it's immutable on redeploy.
   if (projectId) appendJson(formData, 'config', {studio: {projectId}})
-  appendDeploymentParts(formData, {interfaces, tarball, version})
+  appendDeploymentParts(formData, {interfaces, tarball, version, workspaces})
   return request(`/applications`, formData)
 }
 
@@ -63,11 +77,12 @@ export async function createDeployment(options: {
   isAutoUpdating: boolean
   tarball: Gzip
   version: string
+  workspaces?: readonly BrettWorkspace[]
 }): Promise<{id: string}> {
-  const {applicationId, interfaces, isAutoUpdating, tarball, version} = options
+  const {applicationId, interfaces, isAutoUpdating, tarball, version, workspaces} = options
   const formData = new FormData()
   formData.append('isAutoUpdating', isAutoUpdating.toString())
-  appendDeploymentParts(formData, {interfaces, tarball, version})
+  appendDeploymentParts(formData, {interfaces, tarball, version, workspaces})
   return request(`/applications/${applicationId}/deployments`, formData)
 }
 
@@ -77,10 +92,18 @@ function appendDeploymentParts(
     interfaces,
     tarball,
     version,
-  }: {interfaces: readonly BrettInterface[]; tarball: Gzip; version: string},
+    workspaces,
+  }: {
+    interfaces: readonly BrettInterface[]
+    tarball: Gzip
+    version: string
+    workspaces?: readonly BrettWorkspace[]
+  },
 ): void {
   formData.append('version', version)
   appendJson(formData, 'interfaces', interfaces)
+  // Studio-only — the server rejects a workspaces part on non-studio types.
+  if (workspaces?.length) appendJson(formData, 'workspaces', workspaces)
   formData.append('tarball', tarball, {contentType: 'application/gzip', filename: 'app.tar.gz'})
 }
 
@@ -164,6 +187,7 @@ export async function deployStudio(options: {
   studioHost: string | undefined
   title: string
   version: string
+  workspaces: readonly BrettWorkspace[]
 }): Promise<{applicationId: string}> {
   const {
     appId,
@@ -176,13 +200,21 @@ export async function deployStudio(options: {
     studioHost,
     title,
     version,
+    workspaces,
   } = options
   const tarball = pack(dirname(sourceDir), {entries: [basename(sourceDir)]}).pipe(createGzip())
 
   const spin = spinner('Deploying to sanity.studio').start()
   try {
     if (appId) {
-      await createDeployment({applicationId: appId, interfaces, isAutoUpdating, tarball, version})
+      await createDeployment({
+        applicationId: appId,
+        interfaces,
+        isAutoUpdating,
+        tarball,
+        version,
+        workspaces,
+      })
       spin.succeed()
       return {applicationId: appId}
     }
@@ -204,6 +236,7 @@ export async function deployStudio(options: {
       title,
       type: 'studio',
       version,
+      workspaces,
     })
     spin.succeed()
     return {applicationId: application.id}


### PR DESCRIPTION
### Description

Workbench studio deploys register their interfaces (#1442) but not their workspaces, so the dashboard has no way to know which project, dataset, or base path a deployed studio serves.

This sends each studio's workspaces — project, dataset, base path, title, subtitle, icon — as the `workspaces` part on create and redeploy, projected from the studio manifest the deploy already extracts (no extra config resolution or worker round-trip).

Studio-only: coreApp deploys never send it, and plain (non-workbench) studios and coreApps are untouched.

Builds on #1442 (merged). Requires the applications API to store the `workspaces` part.

### What to review

- `deployWorkbenchApp.ts` — `BrettWorkspace` (mirrors `BrettInterface`) and the optional `workspaces` part. `deployCoreApp` can't pass it, so coreApps omit it structurally rather than via a flag.
- `deployStudio.ts` — `toWorkspaces` maps the manifest's `StudioWorkspaceManifest[]` onto Brett's fields, dropping `schemaDescriptorId`/`mediaLibraryId`/`apiHost`; the return type enforces the projection.

### Testing

Unit tests cover it: the `workspaces` part is sent for studio create and redeploy, and omitted for coreApp deploys and empty-workspace studios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive deploy payload for workbench studios only; no changes to auth or plain studio deploy paths, but depends on the applications API accepting the new part.
> 
> **Overview**
> Workbench **studio** deploys now include a **`workspaces`** JSON multipart field on Brett application **create** and **redeploy**, so the dashboard can see each workspace’s project, dataset, base path, and display metadata.
> 
> The CLI maps the already-extracted **`StudioManifest`** via **`toWorkspaces`**, projecting only Brett-facing fields (e.g. dropping schema/media IDs). **`coreApp`** deploys and non-workbench studio flows are unchanged—they never send **`workspaces`**, and the part is omitted when the list is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bc2b42cca58d46b58bfaf176d887e6f61d972e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

