### PR TITLE
feat(workbench): deploy core applications as singletons

### DIFF
--- a/.changeset/deploy-singleton-core-apps.md
+++ b/.changeset/deploy-singleton-core-apps.md
@@ -1,0 +1,6 @@
+---
+'@sanity/workbench-cli': minor
+'@sanity/cli': minor
+---
+
+feat(workbench): send `isSingleton` on core-app create (`POST /applications`) when set, surface it in the deploy report and `--json`, and relay the API's rejection message on failure.

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
@@ -159,4 +159,33 @@ describe('runDeploy real deploy', () => {
     expect(output.log).not.toHaveBeenCalled()
     expect(output.error).toHaveBeenCalledWith(expect.stringContaining('boom'), {exit: 1})
   })
+
+  test('surfaces the server message on a rejected deploy, not a raw error dump', async () => {
+    const output = mockOutput()
+    const err = Object.assign(new Error('HTTP 403'), {
+      response: {
+        body: {message: 'You are not allowed to deploy this application as a singleton'},
+        headers: {},
+        method: 'POST',
+        statusCode: 403,
+        statusMessage: null,
+        url: 'https://api.sanity.io/vX/applications',
+      },
+      statusCode: 403,
+    })
+    const spec: DeploySpec = {
+      listFiles: async () => [],
+      run: async () => {
+        throw err
+      },
+      type: 'coreApp',
+    }
+
+    await runDeploy({...dryRunOptions(output), flags: {}} as DeployAppOptions, spec)
+
+    expect(output.error).toHaveBeenCalledWith(
+      'Error deploying application: You are not allowed to deploy this application as a singleton',
+      {exit: 1},
+    )
+  })
 })

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -132,6 +132,19 @@ describe('deploymentPlanToJson', () => {
     expect(json.exposes).toEqual([{name: 'edit', title: 'Edit', type: 'panel'}])
     expect(json.installationConfig).toBe('Media Library fields:\n  Title (title)')
   })
+
+  test('surfaces isSingleton only when the app sets it explicitly', () => {
+    const unset = deploymentPlanToJson(studioPlan([]))
+    expect(unset).not.toHaveProperty('isSingleton')
+
+    const explicitFalse = studioPlan([])
+    explicitFalse.isSingleton = false
+    expect(deploymentPlanToJson(explicitFalse).isSingleton).toBe(false)
+
+    const explicitTrue = studioPlan([])
+    explicitTrue.isSingleton = true
+    expect(deploymentPlanToJson(explicitTrue).isSingleton).toBe(true)
+  })
 })
 
 describe('reportExposes', () => {

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -188,6 +188,15 @@ async function runAppDeployment(
   // Report the exposes deploying with the application, both modes.
   const exposes = deployApplication && workbench ? reportExposes(reporter, workbench) : []
 
+  // Surface the app's explicit singleton flag when set, both modes.
+  if (deployApplication && workbench?.isSingleton !== undefined) {
+    reporter.report({
+      isSingleton: workbench.isSingleton,
+      message: `Singleton: ${workbench.isSingleton}`,
+      status: 'pass',
+    })
+  }
+
   // Dry run stops here — everything below mutates.
   if (dryRun) return
 
@@ -229,6 +238,7 @@ async function runAppDeployment(
         version,
       }),
       isAutoUpdating,
+      isSingleton: workbench.isSingleton,
       organizationId,
       slug: generateAppSlug(),
       sourceDir,
@@ -240,6 +250,7 @@ async function runAppDeployment(
       applicationType: 'coreApp',
       applicationVersion: version,
       ...(exposes.length > 0 ? {exposes} : {}),
+      ...(workbench.isSingleton === undefined ? {} : {isSingleton: workbench.isSingleton}),
       target: {applicationId, title: appTitle, url: getCoreAppUrl(organizationId, applicationId)},
     }
   }

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -49,6 +49,8 @@ export interface DeployCheck {
   exposes?: DeployedExpose[]
   /** Set on the installation-config check with its summary both reporters read. */
   installationConfig?: string
+  /** Set on the singleton check when the app declares the flag explicitly. */
+  isSingleton?: boolean
   /** Actionable fix, shown under a failing or warning check */
   solution?: string
   /** Set on the deploy-target check with the resolved target both reporters read. */

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -38,6 +38,8 @@ export interface DeployResult {
   installationConfig?: string
   /** Set when a media-library singleton deployed its installation config. */
   installationId?: string
+  /** The app's explicit `isSingleton` flag; omitted when the app doesn't set it. */
+  isSingleton?: boolean
 }
 
 /**
@@ -108,6 +110,7 @@ async function collectPlan(options: DeployAppOptions, spec: DeploySpec): Promise
     files: [],
     installationConfig:
       reporter.results.find((check) => check.installationConfig)?.installationConfig ?? null,
+    isSingleton: reporter.results.find((check) => check.isSingleton !== undefined)?.isSingleton,
     target: reporter.results.find((check) => check.target)?.target ?? null,
     type: spec.type,
     version: reporter.results.find((check) => check.version)?.version ?? null,

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -28,6 +28,9 @@ export interface DeploymentPlan {
   type: 'coreApp' | 'studio'
   /** Installed framework version the deploy would use; `null` when not found. */
   version: string | null
+
+  /** The app's explicit `isSingleton` flag; `undefined` when the app doesn't set it. */
+  isSingleton?: boolean
 }
 
 /**
@@ -86,6 +89,7 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
   files: DeploymentFile[]
   installationConfig?: string
   isDeployable: boolean
+  isSingleton?: boolean
   target: DeployTarget | null
   totalBytes: number
   warnings: string[]
@@ -97,7 +101,8 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
     else if (check.status === 'warn') warnings.push(check.message)
   }
 
-  // `exposes` and `installationConfig` are workbench-only; plain apps omit them.
+  // `exposes`, `installationConfig` and `isSingleton` are workbench-only; plain
+  // apps (and apps that don't set the flag) omit them.
   return {
     applicationType: plan.type,
     applicationVersion: plan.version,
@@ -106,6 +111,7 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
     files: plan.files,
     ...(plan.installationConfig ? {installationConfig: plan.installationConfig} : {}),
     isDeployable: isDeployable(plan),
+    ...(plan.isSingleton === undefined ? {} : {isSingleton: plan.isSingleton}),
     target: plan.target,
     totalBytes: totalBytes(plan.files),
     warnings,

--- a/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
@@ -25,7 +25,7 @@ describe('resolveWorkbenchApp', () => {
       applicationType: undefined,
       entry: undefined,
       installationConfig: undefined,
-      isSingleton: false,
+      isSingleton: undefined,
       name: 'my-app',
       services: [],
       views: [],

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -96,6 +96,25 @@ describe('createApplication', () => {
     expect(fields).toContainEqual(['interfaces', JSON.stringify(interfaces)])
     expect(fields.map(([name]) => name)).toContain('tarball')
     expect(fields.map(([name]) => name)).not.toContain('config')
+    // isSingleton is opt-in; a regular create omits it.
+    expect(fields.map(([name]) => name)).not.toContain('isSingleton')
+  })
+
+  test('flags a singleton create when isSingleton is set', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'app_1'})
+
+    await createApplication({
+      interfaces,
+      isSingleton: true,
+      organizationId: 'org-1',
+      slug: 'dashboard',
+      tarball: tarball(),
+      title: 'Dashboard',
+      type: 'coreApp',
+      version: '1.0.0',
+    })
+
+    expect(appendedFields()).toContainEqual(['isSingleton', 'true'])
   })
 
   test('sends studio config as a JSON part for a studio create', async () => {
@@ -144,6 +163,7 @@ describe('createDeployment', () => {
 const coreAppOptions = {
   interfaces,
   isAutoUpdating: false,
+  isSingleton: false,
   organizationId: 'org-1',
   slug: 'abc123',
   sourceDir: '/tmp/build/app',
@@ -175,6 +195,14 @@ describe('deployCoreApp', () => {
       uri: '/applications',
     })
     expect(appendedFields()).toContainEqual(['slug', 'abc123'])
+  })
+
+  test('forwards isSingleton when creating a singleton core app', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'app_new'})
+
+    await deployCoreApp({...coreAppOptions, appId: undefined, isSingleton: true})
+
+    expect(appendedFields()).toContainEqual(['isSingleton', 'true'])
   })
 })
 

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
@@ -36,6 +36,7 @@ export async function getApplication(applicationId: string): Promise<Application
 /** Create an application and its first deployment in one call. */
 export async function createApplication(options: {
   interfaces: readonly BrettInterface[]
+  isSingleton?: boolean
   organizationId: string
   projectId?: string
   slug: string
@@ -44,12 +45,14 @@ export async function createApplication(options: {
   type: ApplicationType
   version: string
 }): Promise<Application> {
-  const {interfaces, organizationId, projectId, slug, tarball, title, type, version} = options
+  const {interfaces, isSingleton, organizationId, projectId, slug, tarball, title, type, version} =
+    options
   const formData = new FormData()
   formData.append('type', type)
   formData.append('title', title)
   formData.append('organizationId', organizationId)
   formData.append('slug', slug)
+  if (isSingleton !== undefined) formData.append('isSingleton', String(isSingleton))
   // Studio config is set once, at create — it's immutable on redeploy.
   if (projectId) appendJson(formData, 'config', {studio: {projectId}})
   appendDeploymentParts(formData, {interfaces, tarball, version})
@@ -112,14 +115,24 @@ export async function deployCoreApp(options: {
   appId: string | undefined
   interfaces: readonly BrettInterface[]
   isAutoUpdating: boolean
+  isSingleton?: boolean
   organizationId: string
   slug: string
   sourceDir: string
   title: string
   version: string
 }): Promise<{applicationId: string}> {
-  const {appId, interfaces, isAutoUpdating, organizationId, slug, sourceDir, title, version} =
-    options
+  const {
+    appId,
+    interfaces,
+    isAutoUpdating,
+    isSingleton,
+    organizationId,
+    slug,
+    sourceDir,
+    title,
+    version,
+  } = options
   const tarball = pack(dirname(sourceDir), {entries: [basename(sourceDir)]}).pipe(createGzip())
 
   const spin = spinner('Deploying...').start()
@@ -132,6 +145,7 @@ export async function deployCoreApp(options: {
 
     const {id} = await createApplication({
       interfaces,
+      isSingleton,
       organizationId,
       slug,
       tarball,

--- a/packages/@sanity/workbench-cli/src/actions/deploy/getWorkbench.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/getWorkbench.ts
@@ -40,7 +40,7 @@ export function getWorkbench(
   return {
     ...app,
 
-    deploySingletonInstallationConfig: isSingleton && !!installationConfig,
+    deploySingletonInstallationConfig: !!isSingleton && !!installationConfig,
     hasInterfaces: !!entry || views.length > 0 || services.length > 0,
 
     assertDeployable() {

--- a/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
@@ -26,8 +26,6 @@ export interface WorkbenchExposes {
 
 /** @public */
 export interface ResolvedWorkbenchApp {
-  /** A Sanity-owned singleton (e.g. the Media Library) — deploys its config, not an application. */
-  readonly isSingleton: boolean
   /** The app's unique `name` from `unstable_defineApp`. */
   readonly name: string
   /** Background worker services the app declares. */
@@ -42,6 +40,8 @@ export interface ResolvedWorkbenchApp {
   readonly entry?: string
   /** Deploys on its own path, separate from the interfaces. */
   readonly installationConfig?: WorkbenchApp['installationConfig']
+  /** Explicit singleton flag (a Sanity-owned app); `undefined` when the app doesn't set it. */
+  readonly isSingleton?: boolean
 }
 
 /**
@@ -58,7 +58,7 @@ export function resolveWorkbenchApp(
     applicationType: app.applicationType,
     entry: app.entry,
     installationConfig: readInstallationConfig(app),
-    isSingleton: app.isSingleton ?? false,
+    isSingleton: app.isSingleton,
     name: app.name,
     services: app.services ?? [],
     views: app.views ?? [],


### PR DESCRIPTION
### Description

Internal teams need to deploy core applications as singletons (Sanity-owned products like Dashboard). The applications API already accepts an `isSingleton` flag on create, but the CLI never sent it.

An app that sets `isSingleton` via `unstable_defineApp` now deploys like a regular workbench core app and forwards `isSingleton` on the create request. The flag stays hidden — it's not in the public `unstable_defineApp` input type (set the same internal way as `applicationType`/`installationConfig`).

Eligibility (org membership) is enforced by the server, not the CLI — none of it is encoded here. A rejected deploy now surfaces the server's own message cleanly instead of a raw error dump, so the reason reaches the user without leaking internals.

Builds on #1442 (merged).

### What to review

- `deployWorkbenchApp.ts` — `createApplication`/`deployCoreApp` thread `isSingleton` onto the create POST only (Brett fixes singleton-ness at creation, so redeploys don't resend it).
- `deployApp.ts` — forwards `workbench.isSingleton` into the deploy.
- `deployRunner.ts` — `normalizeDeployError` routes through `getErrorMessage`, so an API rejection shows its message, not a dump.

### Testing

Unit: create sends `isSingleton` when set and omits it otherwise; `deployCoreApp` forwards it on create; a rejected deploy surfaces the server message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deploy/create paths and singleton semantics for workbench apps; server still enforces eligibility, but wrong flag handling could affect org-scoped application creation.
> 
> **Overview**
> Workbench core-app deploys can now forward an **explicit** `isSingleton` flag from `unstable_defineApp` to `POST /applications` on **create only** (redeploys omit it). The flag is **opt-in**: unset apps no longer default to `false` in resolution, and the multipart field is only sent when the app sets the property.
> 
> Deploy **dry-run**, human checks, **`--json`**, and successful deploy envelopes include `isSingleton` only when explicitly declared; installation-config singleton behavior now keys off a truthy flag rather than a defaulted `false`.
> 
> Failed deploys continue to route errors through `getErrorMessage`, so API rejections (e.g. singleton not allowed) show the server’s `message` instead of a raw HTTP dump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26290717f6ce84aae29f16b9f737ad2f443095ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
