### PR TITLE
refactor(workbench): rename installationConfig to config

### DIFF
--- a/.changeset/rename-installationconfig-to-config.md
+++ b/.changeset/rename-installationconfig-to-config.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-refactor(workbench): rename the internal `installationConfig` field, schemas, and exports to `config` (a workbench config always refers to an installation). The `installation_config` module-federation type and the `/installations` API are unchanged.
+refactor(workbench): rename the internal `installationConfig` field to `config`.

--- a/.changeset/rename-installationconfig-to-config.md
+++ b/.changeset/rename-installationconfig-to-config.md
@@ -1,0 +1,6 @@
+---
+'@sanity/workbench-cli': patch
+'@sanity/cli': patch
+---
+
+refactor(workbench): rename the internal `installationConfig` field, schemas, and exports to `config` (a workbench config always refers to an installation). The `installation_config` module-federation type and the `/installations` API are unchanged.

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -39,7 +39,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     entry: app?.entry,
     exposes: workbench
       ? {
-          installationConfig: workbench.installationConfig,
+          config: workbench.config,
           services: workbench.services,
           views: workbench.views,
         }

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -58,9 +58,9 @@ describe('listDeploymentFiles', () => {
 
 const studioPlan = (checks: DeployCheck[], files: DeploymentFile[] = []): DeploymentPlan => ({
   checks,
+  config: null,
   exposes: [],
   files,
-  installationConfig: null,
   target: null,
   type: 'studio',
   version: '3.99.0',
@@ -79,7 +79,7 @@ describe('deploymentPlanToJson', () => {
       ),
     )
 
-    // No `exposes`/`installationConfig` keys — a plain (non-workbench) plan omits them.
+    // No `exposes`/`config` keys — a plain (non-workbench) plan omits them.
     expect(json).toEqual({
       applicationType: 'studio',
       applicationVersion: '3.99.0',
@@ -100,9 +100,9 @@ describe('deploymentPlanToJson', () => {
     }
     const json = deploymentPlanToJson({
       checks: [],
+      config: null,
       exposes: [],
       files: [],
-      installationConfig: null,
       target,
       type: 'studio',
       version: null,
@@ -122,15 +122,15 @@ describe('deploymentPlanToJson', () => {
     )
   })
 
-  test('surfaces the registered exposes and installation-config summary', () => {
+  test('surfaces the registered exposes and config summary', () => {
     const plan = studioPlan([{message: 'ok', status: 'pass'}])
     plan.exposes = [{name: 'edit', title: 'Edit', type: 'panel'}]
-    plan.installationConfig = 'Media Library fields:\n  Title (title)'
+    plan.config = 'Media Library fields:\n  Title (title)'
 
     const json = deploymentPlanToJson(plan)
 
     expect(json.exposes).toEqual([{name: 'edit', title: 'Edit', type: 'panel'}])
-    expect(json.installationConfig).toBe('Media Library fields:\n  Title (title)')
+    expect(json.config).toBe('Media Library fields:\n  Title (title)')
   })
 
   test('surfaces isSingleton only when the app sets it explicitly', () => {
@@ -244,9 +244,9 @@ describe('renderDeploymentPlan', () => {
     renderDeploymentPlan(
       {
         checks: [],
+        config: null,
         exposes: [],
         files: [],
-        installationConfig: null,
         target: null,
         type: 'coreApp',
         version: '1.0.0',

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -6,11 +6,11 @@ import {exitCodes} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {
   buildExposes,
-  deployInstallationConfig,
+  deployConfig,
   deployCoreApp as deployWorkbenchCoreApp,
   getWorkbench,
   resolveInstallationId,
-  summarizeInstallationConfig,
+  summarizeConfig,
 } from '@sanity/workbench-cli/deploy'
 import {pack} from 'tar-fs'
 
@@ -66,7 +66,7 @@ async function runAppDeployment(
 
   // A singleton (the Media Library) persists its config instead of hosting an
   // application; anything that exposes a view or service still ships one.
-  const deploySingletonInstallationConfig = workbench?.deploySingletonInstallationConfig ?? false
+  const deploySingletonConfig = workbench?.deploySingletonConfig ?? false
   const deployApplication = !workbench || workbench.hasInterfaces
 
   const appTitle = workbench
@@ -95,7 +95,7 @@ async function runAppDeployment(
   let version: string | null = null
   if (deployApplication) {
     version = await checkPackageVersion(reporter, {moduleName: APP_PACKAGE, workDir})
-  } else if (deploySingletonInstallationConfig) {
+  } else if (deploySingletonConfig) {
     version = await checkPackageVersion(reporter, {moduleName: 'sanity', workDir})
   }
 
@@ -163,19 +163,14 @@ async function runAppDeployment(
   // Resolve the installation in both modes so the report — dry-run and real —
   // shows whether the config is deployable; a missing one fails the deploy here.
   let installationId: string | undefined
-  let installationConfig: string | undefined
-  const configAppType = workbench?.installationConfig?.appType
-  if (
-    deploySingletonInstallationConfig &&
-    organizationId &&
-    workbench?.installationConfig &&
-    configAppType
-  ) {
+  let config: string | undefined
+  const configAppType = workbench?.config?.appType
+  if (deploySingletonConfig && organizationId && workbench?.config && configAppType) {
     installationId = await resolveInstallationId({appType: configAppType, organizationId})
-    installationConfig = summarizeInstallationConfig(workbench.installationConfig)
+    config = summarizeConfig(workbench.config)
     reporter.report(
       installationId
-        ? {installationConfig, message: installationConfig, status: 'pass'}
+        ? {config, message: config, status: 'pass'}
         : {
             exitCode: exitCodes.USAGE_ERROR,
             message: `No active "${configAppType}" installation for organization "${organizationId}"`,
@@ -201,7 +196,7 @@ async function runAppDeployment(
   if (dryRun) return
 
   if (installationId && version && configAppType) {
-    await deployInstallationConfig({
+    await deployConfig({
       appType: configAppType,
       installationId,
       output,
@@ -210,13 +205,13 @@ async function runAppDeployment(
     })
   }
 
-  // A config-only singleton ships no application, only its installation config.
+  // A config-only singleton ships no application, only its config.
   if (!deployApplication) {
     if (installationId && version) {
       return {
         applicationType: 'coreApp',
         applicationVersion: version,
-        ...(installationConfig ? {installationConfig} : {}),
+        ...(config ? {config} : {}),
         installationId,
         target: null,
       }

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -43,12 +43,12 @@ export interface DeployCheck {
   message: string
   status: DeployCheckStatus
 
+  /** Set on the config check with its summary both reporters read. */
+  config?: string
   /** Exit code a real deploy uses when this check fails; defaults to 1 */
   exitCode?: number
   /** Set on the exposes check with the workbench exposes both reporters read. */
   exposes?: DeployedExpose[]
-  /** Set on the installation-config check with its summary both reporters read. */
-  installationConfig?: string
   /** Set on the singleton check when the app declares the flag explicitly. */
   isSingleton?: boolean
   /** Actionable fix, shown under a failing or warning check */

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -32,11 +32,11 @@ export interface DeployResult {
    */
   target: DeployTarget | null
 
+  /** Media-library config summary, when a singleton config deployed. */
+  config?: string
   /** Workbench views and services registered with the deploy. */
   exposes?: DeployedExpose[]
-  /** Media-library installation config summary, when a singleton config deployed. */
-  installationConfig?: string
-  /** Set when a media-library singleton deployed its installation config. */
+  /** Set when a media-library singleton deployed its config. */
   installationId?: string
   /** The app's explicit `isSingleton` flag; omitted when the app doesn't set it. */
   isSingleton?: boolean
@@ -106,10 +106,9 @@ async function collectPlan(options: DeployAppOptions, spec: DeploySpec): Promise
   await spec.run(options, reporter)
   const plan: DeploymentPlan = {
     checks: reporter.results,
+    config: reporter.results.find((check) => check.config)?.config ?? null,
     exposes: reporter.results.find((check) => check.exposes)?.exposes ?? [],
     files: [],
-    installationConfig:
-      reporter.results.find((check) => check.installationConfig)?.installationConfig ?? null,
     isSingleton: reporter.results.find((check) => check.isSingleton !== undefined)?.isSingleton,
     target: reporter.results.find((check) => check.target)?.target ?? null,
     type: spec.type,

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -18,11 +18,11 @@ export interface DeploymentFile {
 /** What a `--dry-run` deploy would do: the real deploy sequence with every mutation gated off. */
 export interface DeploymentPlan {
   checks: DeployCheck[]
+  /** Media-library config summary; `null` unless a config deploys. */
+  config: string | null
   /** Workbench views and services registered with the deploy. */
   exposes: DeployedExpose[]
   files: DeploymentFile[]
-  /** Media-library installation config summary; `null` unless a config deploys. */
-  installationConfig: string | null
   /** The resolved deploy target; `null` when the checks can't determine one. */
   target: DeployTarget | null
   type: 'coreApp' | 'studio'
@@ -84,10 +84,10 @@ function totalBytes(files: DeploymentFile[]): number {
 export function deploymentPlanToJson(plan: DeploymentPlan): {
   applicationType: DeploymentPlan['type']
   applicationVersion: string | null
+  config?: string
   errors: Record<string, string | null>
   exposes?: DeployedExpose[]
   files: DeploymentFile[]
-  installationConfig?: string
   isDeployable: boolean
   isSingleton?: boolean
   target: DeployTarget | null
@@ -101,7 +101,7 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
     else if (check.status === 'warn') warnings.push(check.message)
   }
 
-  // `exposes`, `installationConfig` and `isSingleton` are workbench-only; plain
+  // `exposes`, `config` and `isSingleton` are workbench-only; plain
   // apps (and apps that don't set the flag) omit them.
   return {
     applicationType: plan.type,
@@ -109,7 +109,7 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
     errors,
     ...(plan.exposes.length > 0 ? {exposes: plan.exposes} : {}),
     files: plan.files,
-    ...(plan.installationConfig ? {installationConfig: plan.installationConfig} : {}),
+    ...(plan.config ? {config: plan.config} : {}),
     isDeployable: isDeployable(plan),
     ...(plan.isSingleton === undefined ? {} : {isSingleton: plan.isSingleton}),
     target: plan.target,

--- a/packages/@sanity/cli/src/actions/dev/servers/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/getDevServerConfig.ts
@@ -63,7 +63,7 @@ export function getDevServerConfig({
     // view: the runtime/federation skip the `./App` render path entirely.
     entry: app?.entry,
     exposes: isWorkbenchApp(app)
-      ? {installationConfig: app.installationConfig, services: app.services, views: app.views}
+      ? {config: app.config, services: app.services, views: app.views}
       : undefined,
     // `devAction` passes an explicit port when a running workbench claimed the
     // configured one; otherwise the shared resolution stands.

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -318,7 +318,7 @@ describe('#deploy app', () => {
     })
 
     expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toContain('declares no entry, views, services or installation config')
+    expect(error?.message).toContain('declares no entry, views, services or config')
     expect(error?.oclif?.exit).toBe(2)
     // fails before any directory check or API call
     expect(mockCheckBuiltOutput).not.toHaveBeenCalled()

--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -6,7 +6,7 @@ import {
   type DefineAppResult,
   type DockGroup,
   isWorkbenchApp,
-  readInstallationConfig,
+  readConfig,
   unstable_defineApp,
   type WorkbenchApp,
 } from '../defineApp.js'
@@ -184,9 +184,9 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     expect(dupes.error?.issues[0]?.message).toMatch(/unique/)
   })
 
-  test('accepts an installation config and isSingleton', () => {
+  test('accepts an config and isSingleton', () => {
     const parsed = DefineAppInputSchema.parse({
-      installationConfig: {
+      config: {
         appType: 'media-library',
         fields: [
           {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
@@ -198,7 +198,7 @@ describe('DefineAppInputSchema (build-time validation)', () => {
       title: 'Media Library',
     })
     expect(parsed.isSingleton).toBe(true)
-    expect(parsed.installationConfig).toEqual({
+    expect(parsed.config).toEqual({
       appType: 'media-library',
       fields: [
         {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
@@ -206,9 +206,9 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     })
   })
 
-  test('rejects an installation config on a non-singleton app', () => {
+  test('rejects an config on a non-singleton app', () => {
     const result = DefineAppInputSchema.safeParse({
-      installationConfig: {
+      config: {
         appType: 'media-library',
         fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
       },
@@ -220,10 +220,10 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     expect(result.error?.issues.some((issue) => /singleton/.test(issue.message))).toBe(true)
   })
 
-  test('rejects an installation config without fields', () => {
+  test('rejects an config without fields', () => {
     expect(
       DefineAppInputSchema.safeParse({
-        installationConfig: {appType: 'media-library'},
+        config: {appType: 'media-library'},
         name: 'media-library',
         organizationId: 'org-1',
         title: 'Media Library',
@@ -231,9 +231,9 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     ).toBe(false)
   })
 
-  test('rejects duplicate field names within an installation config', () => {
+  test('rejects duplicate field names within an config', () => {
     const dupes = DefineAppInputSchema.safeParse({
-      installationConfig: {
+      config: {
         appType: 'media-library',
         fields: [
           {name: 'description', src: './src/a.ts', title: 'A'},
@@ -293,30 +293,30 @@ describe('type surface', () => {
     expectTypeOf<DefineAppResult['priority']>().toEqualTypeOf<number | undefined>()
   })
 
-  test('does not expose the internal applicationType, isSingleton, or installationConfig', () => {
+  test('does not expose the internal applicationType, isSingleton, or config', () => {
     expectTypeOf<DefineAppResult>().not.toHaveProperty('applicationType')
     expectTypeOf<DefineAppResult>().not.toHaveProperty('isSingleton')
-    expectTypeOf<DefineAppResult>().not.toHaveProperty('installationConfig')
+    expectTypeOf<DefineAppResult>().not.toHaveProperty('config')
   })
 })
 
-describe('readInstallationConfig', () => {
+describe('readConfig', () => {
   const config = {
     appType: 'media-library',
     fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
   }
 
   test('returns the config for a singleton', () => {
-    const app = {installationConfig: config, isSingleton: true} as unknown as WorkbenchApp
-    expect(readInstallationConfig(app)).toBe(config)
+    const app = {config: config, isSingleton: true} as unknown as WorkbenchApp
+    expect(readConfig(app)).toBe(config)
   })
 
   test('returns undefined when the app declares none', () => {
-    expect(readInstallationConfig({isSingleton: true} as unknown as WorkbenchApp)).toBeUndefined()
+    expect(readConfig({isSingleton: true} as unknown as WorkbenchApp)).toBeUndefined()
   })
 
   test('throws when a non-singleton declares a config', () => {
-    const app = {installationConfig: config} as unknown as WorkbenchApp
-    expect(() => readInstallationConfig(app)).toThrow(/only supported for singleton apps/)
+    const app = {config: config} as unknown as WorkbenchApp
+    expect(() => readConfig(app)).toThrow(/only supported for singleton apps/)
   })
 })

--- a/packages/@sanity/workbench-cli/src/__tests__/defineMediaLibrary.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineMediaLibrary.test.ts
@@ -12,7 +12,7 @@ import {
 const WORKBENCH_APP = Symbol.for('sanity.workbench.defineApp')
 
 // The public result type hides the fields a media library stamps
-// (installationConfig, applicationType); narrow past it via the runtime guard.
+// (config, applicationType); narrow past it via the runtime guard.
 function mediaLibrary(input: DefineMediaLibraryInput): WorkbenchApp {
   const app = unstable_defineMediaLibrary(input)
   if (!isWorkbenchApp(app)) throw new Error('expected a workbench app')
@@ -33,7 +33,7 @@ describe('unstable_defineMediaLibrary', () => {
     expect(app.name).toBe('media-library')
   })
 
-  test('collects all fields into one installation config', () => {
+  test('collects all fields into one config', () => {
     const app = mediaLibrary({
       fields: [
         {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
@@ -41,7 +41,7 @@ describe('unstable_defineMediaLibrary', () => {
       ],
       organizationId: 'org-1',
     })
-    expect(app.installationConfig).toEqual({
+    expect(app.config).toEqual({
       appType: 'media-library',
       fields: [
         {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
@@ -52,7 +52,7 @@ describe('unstable_defineMediaLibrary', () => {
 
   test('declares no config when no fields are given', () => {
     const app = mediaLibrary({organizationId: 'org-1'})
-    expect(app.installationConfig).toBeUndefined()
+    expect(app.config).toBeUndefined()
   })
 
   test('leaves the brand non-enumerable so it does not leak into config spreads', () => {

--- a/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
@@ -23,8 +23,8 @@ describe('resolveWorkbenchApp', () => {
 
     expect(resolveWorkbenchApp(config)).toEqual({
       applicationType: undefined,
+      config: undefined,
       entry: undefined,
-      installationConfig: undefined,
       isSingleton: undefined,
       name: 'my-app',
       services: [],
@@ -52,7 +52,7 @@ describe('resolveWorkbenchApp', () => {
     })
   })
 
-  test('resolves a media library singleton and its installation config', () => {
+  test('resolves a media library singleton and its config', () => {
     const config = asConfig(
       unstable_defineMediaLibrary({
         fields: [{name: 'rights', src: './src/rights.ts', title: 'Rights'}],
@@ -65,17 +65,17 @@ describe('resolveWorkbenchApp', () => {
       isSingleton: true,
       name: 'media-library',
     })
-    expect(resolved!.installationConfig).toEqual({
+    expect(resolved!.config).toEqual({
       appType: 'media-library',
       fields: [{name: 'rights', src: './src/rights.ts', title: 'Rights'}],
     })
   })
 
-  test('throws when a non-singleton declares an installation config', () => {
+  test('throws when a non-singleton declares an config', () => {
     const config = asConfig(
       unstable_defineApp({
-        // @ts-expect-error -- installationConfig is internal; forcing the invalid combination
-        installationConfig: {appType: 'media-library', fields: []},
+        // @ts-expect-error -- config is internal; forcing the invalid combination
+        config: {appType: 'media-library', fields: []},
         name: 'my-app',
         organizationId: 'org-123',
         title: 'My App',
@@ -83,7 +83,7 @@ describe('resolveWorkbenchApp', () => {
     )
 
     expect(() => resolveWorkbenchApp(config)).toThrow(
-      '`installationConfig` is only supported for singleton apps',
+      '`config` is only supported for singleton apps',
     )
   })
 })

--- a/packages/@sanity/workbench-cli/src/_exports/deploy.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/deploy.ts
@@ -6,10 +6,10 @@ export {
 } from '../actions/deploy/buildExposes.js'
 export {checkBuiltOutput} from '../actions/deploy/checkBuiltOutput.js'
 export {
-  deployInstallationConfig,
+  deployConfig,
   resolveInstallationId,
-  summarizeInstallationConfig,
-} from '../actions/deploy/deployInstallationConfig.js'
+  summarizeConfig,
+} from '../actions/deploy/deployConfig.js'
 export {
   type Application,
   type BrettWorkspace,

--- a/packages/@sanity/workbench-cli/src/actions/build/artifact.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/artifact.ts
@@ -1,5 +1,5 @@
 import {type WorkbenchExposes} from '../../resolveWorkbenchApp.js'
-import {installationConfigArtifacts} from './configs/artifact.js'
+import {configArtifacts} from './configs/artifact.js'
 import {serviceArtifacts} from './services/artifact.js'
 import {viewArtifacts} from './views/artifact.js'
 
@@ -65,6 +65,6 @@ export function workbenchArtifacts(exposes: WorkbenchExposes): GeneratedArtifact
   return [
     ...viewArtifacts(exposes.views ?? []),
     ...serviceArtifacts(exposes.services ?? []),
-    ...installationConfigArtifacts(exposes.installationConfig),
+    ...configArtifacts(exposes.config),
   ]
 }

--- a/packages/@sanity/workbench-cli/src/actions/build/configs/__tests__/artifact.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/configs/__tests__/artifact.test.ts
@@ -1,14 +1,14 @@
 import {describe, expect, test} from 'vitest'
 
-import {type ConfigArtifact, installationConfigArtifacts} from '../artifact.js'
+import {type ConfigArtifact, configArtifacts} from '../artifact.js'
 
 const resolveImport = (src: string) => `../../${src.replace('./', '')}`
 
 const config = (fields: ConfigArtifact['fields']): ConfigArtifact => ({fields})
 
-describe('installationConfigArtifacts', () => {
-  test('exposes one module for the installation config under ./configs/<type>', () => {
-    const [artifact] = installationConfigArtifacts(
+describe('configArtifacts', () => {
+  test('exposes one module for the config under ./configs/<type>', () => {
+    const [artifact] = configArtifacts(
       config([{name: 'description', src: './src/description.ts', title: 'Description'}]),
     )
     expect(artifact.expose).toBe('./configs/installation_config')
@@ -16,7 +16,7 @@ describe('installationConfigArtifacts', () => {
   })
 
   test('aggregates every field into one module under `config`', () => {
-    const [artifact] = installationConfigArtifacts(
+    const [artifact] = configArtifacts(
       config([
         {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
         {name: 'language', src: './src/language.ts', title: 'Language'},
@@ -31,7 +31,7 @@ describe('installationConfigArtifacts', () => {
   })
 
   test('surfaces each field metadata for the host to dispatch on', () => {
-    const [artifact] = installationConfigArtifacts(
+    const [artifact] = configArtifacts(
       config([
         {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
       ]),
@@ -44,20 +44,20 @@ describe('installationConfigArtifacts', () => {
   })
 
   test('defaults public to false when omitted', () => {
-    const [artifact] = installationConfigArtifacts(
+    const [artifact] = configArtifacts(
       config([{name: 'description', src: './src/description.ts', title: 'Description'}]),
     )
     expect(artifact.source({resolveImport})).toContain('public: false')
   })
 
   test('emits an HMR self-accept so a field edit swaps the config in place', () => {
-    const [artifact] = installationConfigArtifacts(
+    const [artifact] = configArtifacts(
       config([{name: 'description', src: './src/description.ts', title: 'Description'}]),
     )
     expect(artifact.source({resolveImport})).toContain('import.meta.hot.accept()')
   })
 
-  test('returns nothing when the app has no installation config', () => {
-    expect(installationConfigArtifacts(undefined)).toEqual([])
+  test('returns nothing when the app has no config', () => {
+    expect(configArtifacts(undefined)).toEqual([])
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/build/configs/artifact.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/configs/artifact.ts
@@ -1,29 +1,24 @@
-import {
-  INSTALLATION_CONFIG_TYPE,
-  MEDIA_LIBRARY_INSTALLATION_CONFIG_CONTRACT_VERSION,
-} from '../../../contract.js'
+import {INSTALLATION_CONFIG_TYPE, MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION} from '../../../contract.js'
 import {type GeneratedArtifact} from '../artifact.js'
 
 const CONFIGS_DIR_NAME = 'configs'
 
 /**
- * The installation config to generate a module for.
+ * The config to generate a module for.
  * @internal
  */
 export interface ConfigArtifact {
   fields: {name: string; public?: boolean; src: string; title: string}[]
 }
 
-/** Expand the installation config into one federation module aggregating all fields, so the host imports one live config value. */
-export function installationConfigArtifacts(
-  config: ConfigArtifact | undefined,
-): GeneratedArtifact[] {
+/** Expand the config into one federation module aggregating all fields, so the host imports one live config value. */
+export function configArtifacts(config: ConfigArtifact | undefined): GeneratedArtifact[] {
   if (!config) return []
   return [
     {
       expose: `./${CONFIGS_DIR_NAME}/${INSTALLATION_CONFIG_TYPE}`,
       path: `${CONFIGS_DIR_NAME}/${INSTALLATION_CONFIG_TYPE}.js`,
-      source: ({resolveImport}) => mediaLibraryInstallationConfigSource({config, resolveImport}),
+      source: ({resolveImport}) => mediaLibraryConfigSource({config, resolveImport}),
     },
   ]
 }
@@ -33,7 +28,7 @@ export function installationConfigArtifacts(
  * plus its live `defineField` value, the one thing the wire can't carry.
  * `appType` stays off the module — the host assigns it from the wire record.
  */
-function mediaLibraryInstallationConfigSource(input: {
+function mediaLibraryConfigSource(input: {
   config: ConfigArtifact
   resolveImport: (src: string) => string
 }): string {
@@ -54,7 +49,7 @@ function mediaLibraryInstallationConfigSource(input: {
 ${imports}
 
 export const type = ${JSON.stringify(INSTALLATION_CONFIG_TYPE)}
-export const version = ${MEDIA_LIBRARY_INSTALLATION_CONFIG_CONTRACT_VERSION}
+export const version = ${MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION}
 export const config = {
   fields: [
 ${entries}

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/__tests__/workbench-vite-plugins.unit.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/__tests__/workbench-vite-plugins.unit.test.ts
@@ -99,19 +99,17 @@ describe('workbenchVitePlugins', () => {
     )
   })
 
-  test('passes the installation config through to federation', async () => {
-    const installationConfig = {
+  test('passes the config through to federation', async () => {
+    const config = {
       appType: 'media-library' as const,
       fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
     }
     await workbenchVitePlugins({
       cwd,
       entries: {relativeConfigLocation: null, relativeEntry: null},
-      exposes: {installationConfig},
+      exposes: {config},
       isApp: true,
     })
-    expect(mockFederation).toHaveBeenCalledWith(
-      expect.objectContaining({exposes: {installationConfig}}),
-    )
+    expect(mockFederation).toHaveBeenCalledWith(expect.objectContaining({exposes: {config}}))
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployConfig.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployConfig.test.ts
@@ -3,11 +3,7 @@ import {Readable} from 'node:stream'
 import {type Output} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {
-  deployInstallationConfig,
-  resolveInstallationId,
-  summarizeInstallationConfig,
-} from '../deployInstallationConfig.js'
+import {deployConfig, resolveInstallationId, summarizeConfig} from '../deployConfig.js'
 
 const mockGetGlobalCliClient = vi.hoisted(() => vi.fn())
 const mockRequest = vi.hoisted(() => vi.fn())
@@ -71,7 +67,7 @@ describe('resolveInstallationId', () => {
   })
 })
 
-describe('deployInstallationConfig', () => {
+describe('deployConfig', () => {
   beforeEach(() => mockGetGlobalCliClient.mockResolvedValue({request: mockRequest}))
   afterEach(() => {
     vi.clearAllMocks()
@@ -81,7 +77,7 @@ describe('deployInstallationConfig', () => {
   test('POSTs the tarball to the installation as a session-token multipart upload', async () => {
     stubBrett([])
 
-    await deployInstallationConfig({
+    await deployConfig({
       appType: 'media-library',
       installationId: 'inst_ml',
       output,
@@ -98,10 +94,10 @@ describe('deployInstallationConfig', () => {
   })
 })
 
-describe('summarizeInstallationConfig', () => {
+describe('summarizeConfig', () => {
   test('lists a media library config as a heading with title/name per field', () => {
     expect(
-      summarizeInstallationConfig({
+      summarizeConfig({
         appType: 'media-library',
         fields: [
           {name: 'title', title: 'Title'},
@@ -112,7 +108,7 @@ describe('summarizeInstallationConfig', () => {
   })
 
   test('throws for an unhandled app type', () => {
-    expect(() => summarizeInstallationConfig({appType: 'canvas', fields: []})).toThrow(
+    expect(() => summarizeConfig({appType: 'canvas', fields: []})).toThrow(
       /unknown app type: canvas/,
     )
   })

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/getWorkbench.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/getWorkbench.test.ts
@@ -51,14 +51,14 @@ describe('getWorkbench', () => {
     expect(resolved.services).toHaveLength(1)
   })
 
-  test('exposes the installation config off a branded media library', () => {
+  test('exposes the config off a branded media library', () => {
     const resolved = mediaLibrary({
       fields: [
         {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
       ],
     })
     expect(resolved.applicationType).toBe('media-library')
-    expect(resolved.installationConfig).toMatchObject({fields: [{name: 'description'}]})
+    expect(resolved.config).toMatchObject({fields: [{name: 'description'}]})
     // a media library declares no interfaces
     expect(resolved.views).toHaveLength(0)
     expect(resolved.services).toHaveLength(0)
@@ -68,13 +68,13 @@ describe('getWorkbench', () => {
 describe('assertDeployable', () => {
   test('throws when the app declares no interfaces', () => {
     expect(() => workbench().assertDeployable()).toThrow(
-      'declares no entry, views, services or installation config',
+      'declares no entry, views, services or config',
     )
   })
 
   test('throws when views and services are empty arrays', () => {
     expect(() => workbench({services: [], views: []}).assertDeployable()).toThrow(
-      'declares no entry, views, services or installation config',
+      'declares no entry, views, services or config',
     )
   })
 
@@ -108,29 +108,29 @@ describe('assertDeployable', () => {
 
   test('throws when a media library declares no fields', () => {
     expect(() => mediaLibrary().assertDeployable()).toThrow(
-      'declares no entry, views, services or installation config',
+      'declares no entry, views, services or config',
     )
   })
 })
 
-describe('deploySingletonInstallationConfig / hasInterfaces', () => {
+describe('deploySingletonConfig / hasInterfaces', () => {
   test('a media library with fields deploys its config and hosts no interfaces', () => {
     const resolved = mediaLibrary({
       fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
     })
-    expect(resolved.deploySingletonInstallationConfig).toBe(true)
+    expect(resolved.deploySingletonConfig).toBe(true)
     expect(resolved.hasInterfaces).toBe(false)
   })
 
   test('a media library without fields carries no config to deploy', () => {
-    expect(mediaLibrary().deploySingletonInstallationConfig).toBe(false)
+    expect(mediaLibrary().deploySingletonConfig).toBe(false)
   })
 
   test('a non-singleton app never deploys a config, and reports its interfaces', () => {
     const resolved = workbench({
       views: [{name: 'views/panel', src: './src/panel.tsx', type: 'panel'}],
     })
-    expect(resolved.deploySingletonInstallationConfig).toBe(false)
+    expect(resolved.deploySingletonConfig).toBe(false)
     expect(resolved.hasInterfaces).toBe(true)
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployConfig.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployConfig.ts
@@ -31,7 +31,7 @@ export async function resolveInstallationId(options: {
       return resolveSingletonInstallationId(options.organizationId, 'media-library')
     }
     default: {
-      throw new Error(`Cannot create installation config for unknown app type: ${options.appType}`)
+      throw new Error(`Cannot create config for unknown app type: ${options.appType}`)
     }
   }
 }
@@ -41,7 +41,7 @@ export async function resolveInstallationId(options: {
  * one of potentially many shapes.
  * @internal
  */
-export function summarizeInstallationConfig(config: {
+export function summarizeConfig(config: {
   appType: string
   fields: {name: string; title: string}[]
 }): string {
@@ -51,7 +51,7 @@ export function summarizeInstallationConfig(config: {
       return `Media library fields:\n${items}`
     }
     default: {
-      throw new Error(`Cannot create installation config for unknown app type: ${config.appType}`)
+      throw new Error(`Cannot create config for unknown app type: ${config.appType}`)
     }
   }
 }
@@ -62,7 +62,7 @@ export function summarizeInstallationConfig(config: {
  * reaches this mutating step.
  * @internal
  */
-export async function deployInstallationConfig(options: {
+export async function deployConfig(options: {
   appType: string
   installationId: string
   output: Output
@@ -89,8 +89,8 @@ export async function deployInstallationConfig(options: {
     uri: `/installations/${installationId}/configs`,
   })
 
-  debug('Deployed installation config for app type: %s', appType)
-  output.log(`\n🚀 ${styleText('bold', 'Success!')} Installation config deployed`)
+  debug('Deployed config for app type: %s', appType)
+  output.log(`\n🚀 ${styleText('bold', 'Success!')} Config deployed`)
 }
 
 /** The org's active singleton installation, matched on its slug. */

--- a/packages/@sanity/workbench-cli/src/actions/deploy/getWorkbench.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/getWorkbench.ts
@@ -20,11 +20,11 @@ interface DeployableWorkbenchApp extends ResolvedWorkbenchApp {
    */
   buildViewDeploymentPayload(applicationId: string): ViewDeploymentPayload
   /**
-   * A singleton (the Media Library) that carries an installation config — deploy
+   * A singleton (the Media Library) that carries an config — deploy
    * persists the config to the org's installation. Independent of the interfaces,
    * which register regardless; non-singletons never carry a config.
    */
-  deploySingletonInstallationConfig: boolean
+  deploySingletonConfig: boolean
   /** Declares something to host as an application — an entry, view, or service. */
   hasInterfaces: boolean
 }
@@ -35,18 +35,18 @@ export function getWorkbench(
   const app = resolveWorkbenchApp(cliConfig)
   if (!app) return null
 
-  const {entry, installationConfig, isSingleton, services, views} = app
+  const {config, entry, isSingleton, services, views} = app
 
   return {
     ...app,
 
-    deploySingletonInstallationConfig: !!isSingleton && !!installationConfig,
+    deploySingletonConfig: !!isSingleton && !!config,
     hasInterfaces: !!entry || views.length > 0 || services.length > 0,
 
     assertDeployable() {
-      if (!entry && views.length === 0 && services.length === 0 && !installationConfig) {
+      if (!entry && views.length === 0 && services.length === 0 && !config) {
         throw new Error(
-          'Nothing to deploy: the app declares no entry, views, services or installation config. ' +
+          'Nothing to deploy: the app declares no entry, views, services or config. ' +
             'Add at least one to the app config.',
         )
       }

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -1,11 +1,7 @@
 import {type CliConfig} from '@sanity/cli-core'
 import {describe, expect, test} from 'vitest'
 
-import {
-  deriveInstallationConfigEntries,
-  deriveInstallationConfigs,
-  deriveInterfaces,
-} from '../deriveInterfaces.js'
+import {deriveConfigEntries, deriveConfigs, deriveInterfaces} from '../deriveInterfaces.js'
 import {workbenchApp} from './devTestHelpers.js'
 
 describe('deriveInterfaces', () => {
@@ -57,15 +53,15 @@ describe('deriveInterfaces', () => {
     ])
   })
 
-  test('does not put the installation config in the interface set', () => {
+  test('does not put the config in the interface set', () => {
     const app = workbenchApp({
-      installationConfig: {
+      config: {
         appType: 'media-library',
         fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
       },
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
     })
-    // only the panel — the config rides deriveInstallationConfigs, not interfaces
+    // only the panel — the config rides deriveConfigs, not interfaces
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
       {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
     ])
@@ -86,23 +82,21 @@ describe('deriveInterfaces', () => {
   })
 })
 
-describe('deriveInstallationConfigs', () => {
+describe('deriveConfigs', () => {
   test('returns [] for a non-branded app', () => {
-    expect(deriveInstallationConfigs({title: 'Plain'} as CliConfig['app'])).toEqual([])
-    expect(deriveInstallationConfigs(undefined)).toEqual([])
+    expect(deriveConfigs({title: 'Plain'} as CliConfig['app'])).toEqual([])
+    expect(deriveConfigs(undefined)).toEqual([])
   })
 
-  test('[] for an app with no installation config', () => {
+  test('[] for an app with no config', () => {
     expect(
-      deriveInstallationConfigs(
-        workbenchApp({views: [{name: 'feed', src: './f.tsx', type: 'panel'}]}),
-      ),
+      deriveConfigs(workbenchApp({views: [{name: 'feed', src: './f.tsx', type: 'panel'}]})),
     ).toEqual([])
   })
 
   test('forwards the serializable config on the wire, keeping `src` as each field entry', () => {
     const app = workbenchApp({
-      installationConfig: {
+      config: {
         appType: 'media-library',
         fields: [
           {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
@@ -111,7 +105,7 @@ describe('deriveInstallationConfigs', () => {
       },
       isSingleton: true,
     })
-    expect(deriveInstallationConfigs(app)).toEqual([
+    expect(deriveConfigs(app)).toEqual([
       {
         appType: 'media-library',
         fields: [
@@ -126,30 +120,30 @@ describe('deriveInstallationConfigs', () => {
   test("forwards the config's appType discriminator (assigns the singleton, no app id)", () => {
     const app = workbenchApp({
       applicationType: 'media-library',
-      installationConfig: {
+      config: {
         appType: 'media-library',
         fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
       },
       isSingleton: true,
     })
-    expect(deriveInstallationConfigs(app)[0]?.appType).toBe('media-library')
+    expect(deriveConfigs(app)[0]?.appType).toBe('media-library')
   })
 
-  test('rejects an installation config on a non-singleton app', () => {
+  test('rejects an config on a non-singleton app', () => {
     const app = workbenchApp({
-      installationConfig: {
+      config: {
         appType: 'media-library',
         fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
       },
     })
-    expect(() => deriveInstallationConfigs(app)).toThrow(/only supported for singleton apps/)
+    expect(() => deriveConfigs(app)).toThrow(/only supported for singleton apps/)
   })
 })
 
-describe('deriveInstallationConfigEntries', () => {
+describe('deriveConfigEntries', () => {
   test('projects each field to its name + src, dropping render-only metadata', () => {
     expect(
-      deriveInstallationConfigEntries({
+      deriveConfigEntries({
         appType: 'media-library',
         fields: [
           {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
@@ -163,12 +157,12 @@ describe('deriveInstallationConfigEntries', () => {
   })
 
   test('an empty field set yields no entries', () => {
-    expect(deriveInstallationConfigEntries({appType: 'media-library', fields: []})).toEqual([])
+    expect(deriveConfigEntries({appType: 'media-library', fields: []})).toEqual([])
   })
 
   test('throws on an app type it cannot handle', () => {
-    expect(() => deriveInstallationConfigEntries({appType: 'core-app', fields: []})).toThrow(
-      /unknown installation config appType: core-app/i,
+    expect(() => deriveConfigEntries({appType: 'core-app', fields: []})).toThrow(
+      /unknown config appType: core-app/i,
     )
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
@@ -14,7 +14,7 @@ const worker = (name: string, src = `./src/${name}.ts`): DevServerInterface => (
   interface_type: 'worker',
   name,
 })
-const installationConfig: DevServerConfig = {
+const config: DevServerConfig = {
   appType: 'media-library',
   fields: [{name: 'd', src: './src/d.ts', title: 'D'}],
 }
@@ -24,9 +24,9 @@ const server = (
   interfaces: DevServerInterface[],
   config?: DevServerConfig,
 ): DevServerManifest => ({
+  configs: config ? [config] : undefined,
   host: 'localhost',
   id,
-  installationConfigs: config ? [config] : undefined,
   interfaces,
   pid: 1,
   port,
@@ -61,17 +61,17 @@ describe('exposesSetId', () => {
     )
   })
 
-  test('the installation config toggles the id (its module is a new expose)', () => {
+  test('the config toggles the id (its module is a new expose)', () => {
     // adding the config changes the expose set → rebuild
     expect(exposesSetId({interfaces: [panel('a')]})).not.toBe(
-      exposesSetId({installationConfigs: [installationConfig], interfaces: [panel('a')]}),
+      exposesSetId({configs: [config], interfaces: [panel('a')]}),
     )
   })
 
   test('a zero-field config still toggles the id — its module is an expose on its own', () => {
     const empty: DevServerConfig = {appType: 'media-library', fields: []}
     expect(exposesSetId({interfaces: [panel('a')]})).not.toBe(
-      exposesSetId({installationConfigs: [empty], interfaces: [panel('a')]}),
+      exposesSetId({configs: [empty], interfaces: [panel('a')]}),
     )
   })
 
@@ -91,12 +91,8 @@ describe('exposesSetId', () => {
       appType: 'media-library',
       fields: [{name: 'locale', src: './src/d.ts', title: 'Description'}],
     }
-    expect(exposesSetId({installationConfigs: [one]})).not.toBe(
-      exposesSetId({installationConfigs: [added]}),
-    )
-    expect(exposesSetId({installationConfigs: [one]})).not.toBe(
-      exposesSetId({installationConfigs: [renamed]}),
-    )
+    expect(exposesSetId({configs: [one]})).not.toBe(exposesSetId({configs: [added]}))
+    expect(exposesSetId({configs: [one]})).not.toBe(exposesSetId({configs: [renamed]}))
   })
 
   test('a config field pointed at a different file is a rebuild — the module reimports it', () => {
@@ -108,9 +104,7 @@ describe('exposesSetId', () => {
       appType: 'media-library',
       fields: [{name: 'x', src: './src/y.ts', title: 'X'}],
     }
-    expect(exposesSetId({installationConfigs: [before]})).not.toBe(
-      exposesSetId({installationConfigs: [after]}),
-    )
+    expect(exposesSetId({configs: [before]})).not.toBe(exposesSetId({configs: [after]}))
   })
 
   test('reordering config fields is not a change', () => {
@@ -128,7 +122,7 @@ describe('exposesSetId', () => {
         {name: 'x', src: './src/x.ts', title: 'X'},
       ],
     }
-    expect(exposesSetId({installationConfigs: [a]})).toBe(exposesSetId({installationConfigs: [b]}))
+    expect(exposesSetId({configs: [a]})).toBe(exposesSetId({configs: [b]}))
   })
 
   test('a field title/public edit is not a rebuild — those ride the wire, not the module', () => {
@@ -140,7 +134,7 @@ describe('exposesSetId', () => {
       appType: 'media-library',
       fields: [{name: 'x', public: false, src: './src/x.ts', title: 'Renamed'}],
     }
-    expect(exposesSetId({installationConfigs: [a]})).toBe(exposesSetId({installationConfigs: [b]}))
+    expect(exposesSetId({configs: [a]})).toBe(exposesSetId({configs: [b]}))
   })
 
   // The id is what both detection sites compare against their last-seen value;
@@ -177,11 +171,9 @@ describe('trackExposesSet', () => {
     expect(set.changed({interfaces: [panel('a')]})).toBe(true) // removed — a new change off the committed set
   })
 
-  test('the installation config appearing is a change off the seeded set', () => {
+  test('the config appearing is a change off the seeded set', () => {
     const set = trackExposesSet({interfaces: [panel('a')]})
-    expect(set.changed({installationConfigs: [installationConfig], interfaces: [panel('a')]})).toBe(
-      true,
-    )
+    expect(set.changed({configs: [config], interfaces: [panel('a')]})).toBe(true)
   })
 
   test('treats undefined and empty as the same set', () => {
@@ -201,10 +193,10 @@ describe('createExposesTracker', () => {
     expect(tracker.hasChanged([server('a', 1, [panel('x'), panel('y')])])).toBe(true)
   })
 
-  test('a known app that gains an installation config signals a rebuild', () => {
+  test('a known app that gains an config signals a rebuild', () => {
     const tracker = createExposesTracker()
     tracker.hasChanged([server('a', 1, [panel('x')])])
-    expect(tracker.hasChanged([server('a', 1, [panel('x')], installationConfig)])).toBe(true)
+    expect(tracker.hasChanged([server('a', 1, [panel('x')], config)])).toBe(true)
   })
 
   test('a newly appearing app is not a rebuild — it reconciles softly', () => {

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
@@ -163,7 +163,7 @@ describe('startDevServerRegistration', () => {
     const {extract} = mockStartDevManifestWatcher.mock.calls[0][0]
     const params = {configPath: '/tmp/sanity-project/sanity.cli.ts', workDir: '/tmp/sanity-project'}
     await expect(extract(params)).resolves.toEqual({
-      installationConfigs: [],
+      configs: [],
       interfaces: [{entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'}],
       manifest,
     })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -623,6 +623,7 @@ describe('startWorkbenchDevServer', () => {
         applications: [expect.objectContaining({id: 'app-1', type: 'studio'})],
         configs: [
           {
+            appType: 'media-library',
             config: {
               fields: [
                 {
@@ -635,7 +636,6 @@ describe('startWorkbenchDevServer', () => {
             },
             moduleName: 'media-library',
             remoteURL: 'http://localhost:3337',
-            type: 'media-library',
           },
         ],
       })
@@ -666,7 +666,7 @@ describe('startWorkbenchDevServer', () => {
         expect.objectContaining({id: 'app-1', type: 'coreApp'}),
       ])
       expect(payload.configs).toEqual([
-        expect.objectContaining({moduleName: 'media-library', type: 'media-library'}),
+        expect.objectContaining({appType: 'media-library', moduleName: 'media-library'}),
       ])
     })
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -531,7 +531,7 @@ describe('startWorkbenchDevServer', () => {
             type: 'coreApp',
           },
         ],
-        installationConfigs: [],
+        configs: [],
       })
     })
 
@@ -555,7 +555,7 @@ describe('startWorkbenchDevServer', () => {
             type: 'studio',
           },
         ],
-        installationConfigs: [],
+        configs: [],
       })
     })
 
@@ -590,18 +590,18 @@ describe('startWorkbenchDevServer', () => {
             type: 'studio',
           }),
         ],
-        installationConfigs: [],
+        configs: [],
       })
     })
 
-    test('routes a config-only server (no interfaces) to installationConfigs, not applications', async () => {
+    test('routes a config-only server (no interfaces) to configs, not applications', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
       const mockServer = createMockServer()
       mockCreateServer.mockResolvedValue(mockServer)
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
-      const installationConfig = {
+      const config = {
         appType: 'media-library',
         fields: [
           {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
@@ -611,8 +611,8 @@ describe('startWorkbenchDevServer', () => {
       watchCallback([
         {host: 'localhost', id: 'app-1', pid: 2, port: 3334, type: 'studio'},
         {
+          configs: [{...config, moduleName: 'media-library'}],
           host: 'localhost',
-          installationConfigs: [{...installationConfig, moduleName: 'media-library'}],
           pid: 3,
           port: 3337,
           type: 'coreApp',
@@ -621,7 +621,7 @@ describe('startWorkbenchDevServer', () => {
 
       expect(mockServer.ws.send).toHaveBeenCalledWith('sanity:workbench:local-applications', {
         applications: [expect.objectContaining({id: 'app-1', type: 'studio'})],
-        installationConfigs: [
+        configs: [
           {
             config: {
               fields: [
@@ -651,11 +651,9 @@ describe('startWorkbenchDevServer', () => {
       const watchCallback = mockWatchRegistry.mock.calls[0][0]
       watchCallback([
         {
+          configs: [{appType: 'media-library', fields: [], moduleName: 'media-library'}],
           host: 'localhost',
           id: 'app-1',
-          installationConfigs: [
-            {appType: 'media-library', fields: [], moduleName: 'media-library'},
-          ],
           interfaces: [{entry_point: './src/Feed.tsx', interface_type: 'panel', name: 'feed'}],
           pid: 3,
           port: 3337,
@@ -667,7 +665,7 @@ describe('startWorkbenchDevServer', () => {
       expect(payload.applications).toEqual([
         expect.objectContaining({id: 'app-1', type: 'coreApp'}),
       ])
-      expect(payload.installationConfigs).toEqual([
+      expect(payload.configs).toEqual([
         expect.objectContaining({moduleName: 'media-library', type: 'media-library'}),
       ])
     })
@@ -758,7 +756,7 @@ describe('startWorkbenchDevServer', () => {
             type: 'coreApp',
           },
         ],
-        installationConfigs: [],
+        configs: [],
       })
     })
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -1,21 +1,21 @@
 import {type CliConfig} from '@sanity/cli-core'
 
-import {isWorkbenchApp, readInstallationConfig} from '../../defineApp.js'
+import {isWorkbenchApp, readConfig} from '../../defineApp.js'
 import {type DevServerManifest} from './registry.js'
 
 /** One forwarded interface record on the dev-server registry entry. */
 export type DevServerInterface = NonNullable<DevServerManifest['interfaces']>[number]
 
-/** One forwarded installation config on the dev-server registry entry. */
-export type DevServerConfig = NonNullable<DevServerManifest['installationConfigs']>[number]
+/** One forwarded config on the dev-server registry entry. */
+export type DevServerConfig = NonNullable<DevServerManifest['configs']>[number]
 
 /**
  * Map a workbench app's declarations to the interface records forwarded on its
  * registry entry: `views` → panels, `services` → workers, `entry` → the
  * navigable `app` view (`entry_point` is the raw `src`, not a resolved URL).
  * `undefined` for a non-branded app; a studio that declares `entry` is rejected
- * (studio app views are not implemented yet). The installation config is not an
- * interface — see {@link deriveInstallationConfigs}.
+ * (studio app views are not implemented yet). The config is not an
+ * interface — see {@link deriveConfigs}.
  */
 export function deriveInterfaces(
   app: CliConfig['app'],
@@ -50,17 +50,13 @@ export function deriveInterfaces(
  * tracker owns none of the per-type shape. Throws on an app type it can't
  * handle, so a new config family has to register its shape here.
  */
-export function deriveInstallationConfigEntries(
-  config: DevServerConfig,
-): {name: string; src: string}[] {
+export function deriveConfigEntries(config: DevServerConfig): {name: string; src: string}[] {
   switch (config.appType) {
     case 'media-library': {
       return config.fields.map((field) => ({name: field.name, src: field.src}))
     }
     default: {
-      throw new Error(
-        `Cannot derive entries for unknown installation config appType: ${config.appType}`,
-      )
+      throw new Error(`Cannot derive entries for unknown config appType: ${config.appType}`)
     }
   }
 }
@@ -71,14 +67,14 @@ export function deriveInstallationConfigEntries(
  * repoint rebuilds. `appType` routes the config to the singleton (no app id to
  * key on).
  */
-export function deriveInstallationConfigs(app: CliConfig['app']): DevServerConfig[] {
+export function deriveConfigs(app: CliConfig['app']): DevServerConfig[] {
   if (!isWorkbenchApp(app)) return []
-  const installationConfig = readInstallationConfig(app)
-  if (!installationConfig) return []
+  const config = readConfig(app)
+  if (!config) return []
   return [
     {
-      appType: installationConfig.appType,
-      fields: installationConfig.fields.map((field) => ({
+      appType: config.appType,
+      fields: config.fields.map((field) => ({
         name: field.name,
         public: field.public,
         src: field.src,

--- a/packages/@sanity/workbench-cli/src/actions/dev/exposesSetId.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/exposesSetId.ts
@@ -1,30 +1,30 @@
 import {
-  deriveInstallationConfigEntries,
+  deriveConfigEntries,
   type DevServerConfig,
   type DevServerInterface,
 } from './deriveInterfaces.js'
 import {type DevServerManifest} from './registry.js'
 
 interface ExposeSet {
-  installationConfigs?: readonly DevServerConfig[] | undefined
+  configs?: readonly DevServerConfig[] | undefined
   interfaces?: readonly DevServerInterface[] | undefined
 }
 
 /**
  * Order-independent id of an app's exposed-module set. Keys each interface by
- * its type, name, and source file, and each installation config by its module
+ * its type, name, and source file, and each config by its module
  * identity plus one key per entry (a named source file), so the id changes on
  * any rebuild-worthy edit — add, remove, rename, repoint, or gaining/losing the
  * config module — while reordering and HMR content edits keep it stable.
  */
-export function exposesSetId({installationConfigs, interfaces}: ExposeSet): string {
+export function exposesSetId({configs, interfaces}: ExposeSet): string {
   const keys = [
     ...(interfaces ?? []).map((iface) =>
       [iface.interface_type, iface.name, iface.entry_point].join('::'),
     ),
-    ...(installationConfigs ?? []).flatMap((config) => [
+    ...(configs ?? []).flatMap((config) => [
       ['config', config.appType].join('::'),
-      ...deriveInstallationConfigEntries(config).map((entry) =>
+      ...deriveConfigEntries(config).map((entry) =>
         ['config', config.appType, entry.name, entry.src].join('::'),
       ),
     ]),
@@ -54,7 +54,7 @@ const serverKey = (server: DevServerManifest): string =>
   `${server.id ?? ''}@${server.host ?? ''}:${server.port}`
 
 const serverExposesId = (server: DevServerManifest): string =>
-  exposesSetId({installationConfigs: server.installationConfigs, interfaces: server.interfaces})
+  exposesSetId({configs: server.configs, interfaces: server.interfaces})
 
 /**
  * Multi-app counterpart to {@link trackExposesSet}: true when a *known* app's

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -36,14 +36,12 @@ function ownStartedAt(): string {
 }
 
 const devServerManifestSchema = z.object({
-  host: z.string(),
-  id: z.optional(z.string()),
   /**
    * Field schema *values* load from the federation module; each field's `src`
    * rides along so a repoint bumps the exposes-set id and forces a rebuild.
    * Lenient — the workbench is the authority.
    */
-  installationConfigs: z.optional(
+  configs: z.optional(
     z.array(
       z.object({
         // Identifies the owning app when it has no app id (singletons).
@@ -62,6 +60,8 @@ const devServerManifestSchema = z.object({
       }),
     ),
   ),
+  host: z.string(),
+  id: z.optional(z.string()),
   /**
    * Interfaces the app exposes, mapped from the declared `views` (dock panels,
    * `interface_type: "panel"`) and `services` (background workers,

--- a/packages/@sanity/workbench-cli/src/actions/dev/startDevManifestWatcher.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startDevManifestWatcher.ts
@@ -25,7 +25,7 @@ interface ManifestPatch<T> {
   manifestUpdatedAt: string
 
   /** Same re-derive-don't-omit contract as `interfaces`. */
-  installationConfigs?: DevServerConfig[] | undefined
+  configs?: DevServerConfig[] | undefined
   /**
    * Workbench interfaces (views/services/app view) re-derived from the config
    * on each change, so editing `views`/`services`/`entry` in `sanity.cli.ts`
@@ -101,10 +101,10 @@ export async function startDevManifestWatcher<T>({
     }
     running = true
     try {
-      const {installationConfigs, interfaces, manifest} = await extract({configPath, workDir})
+      const {configs, interfaces, manifest} = await extract({configPath, workDir})
       if (closed) return
       await update({
-        installationConfigs,
+        configs,
         interfaces,
         manifest,
         manifestUpdatedAt: new Date().toISOString(),

--- a/packages/@sanity/workbench-cli/src/actions/dev/startDevServerRegistration.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startDevServerRegistration.ts
@@ -1,7 +1,7 @@
 import {type CliConfig, getCliConfigUncached, type Output} from '@sanity/cli-core'
 import {type ViteDevServer} from 'vite'
 
-import {deriveInstallationConfigs, deriveInterfaces} from './deriveInterfaces.js'
+import {deriveConfigs, deriveInterfaces} from './deriveInterfaces.js'
 import {trackExposesSet} from './exposesSetId.js'
 import {type DevServerManifest, registerDevServer} from './registry.js'
 import {startDevManifestWatcher} from './startDevManifestWatcher.js'
@@ -65,12 +65,12 @@ export async function startDevServerRegistration(
   // Forwarded alongside (not inside) the manifest so the workbench renders local
   // panels/workers and reads the configs without a deploy.
   const interfaces = deriveInterfaces(cliConfig.app, {isApp})
-  const installationConfigs = deriveInstallationConfigs(cliConfig.app)
+  const configs = deriveConfigs(cliConfig.app)
 
   const registration = registerDevServer({
+    configs,
     host: appHost,
     id: appId,
-    installationConfigs,
     interfaces,
     port: appPort,
     projectId: cliConfig?.api?.projectId,
@@ -78,7 +78,7 @@ export async function startDevServerRegistration(
     workDir,
   })
 
-  const exposesSet = trackExposesSet({installationConfigs, interfaces})
+  const exposesSet = trackExposesSet({configs, interfaces})
 
   const watcher = await startDevManifestWatcher({
     // Re-derive every pass (don't omit): the registry patch is a shallow merge,
@@ -86,7 +86,7 @@ export async function startDevServerRegistration(
     extract: async (params) => {
       const app = (await getCliConfigUncached(params.workDir)).app
       return {
-        installationConfigs: deriveInstallationConfigs(app),
+        configs: deriveConfigs(app),
         interfaces: deriveInterfaces(app, {isApp}),
         manifest: await extractManifest(params),
       }
@@ -98,7 +98,7 @@ export async function startDevServerRegistration(
     update: async (patch) => {
       if (
         !exposesSet.changed({
-          installationConfigs: patch.installationConfigs,
+          configs: patch.configs,
           interfaces: patch.interfaces,
         })
       ) {
@@ -110,7 +110,7 @@ export async function startDevServerRegistration(
       const rebuiltServer = await onInterfaceSetChange?.()
       // Commit only after a successful rebuild, so a thrown one retries next pass.
       exposesSet.commit({
-        installationConfigs: patch.installationConfigs,
+        configs: patch.configs,
         interfaces: patch.interfaces,
       })
       // The recreated server can bind a different port (non-strict ports).

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -18,10 +18,10 @@ const devDebug = subdebug('dev')
 
 const noop = async () => {}
 
-// Every server is a local app except a config-only one — an installation config
+// Every server is a local app except a config-only one — an config
 // with no interfaces (the media library). A server with both lands in both channels.
 const isLocalApp = (server: DevServerManifest): boolean => {
-  const configOnly = Boolean(server.installationConfigs?.length) && !server.interfaces?.length
+  const configOnly = Boolean(server.configs?.length) && !server.interfaces?.length
   return !configOnly
 }
 
@@ -37,10 +37,10 @@ const toApplicationsPayload = (servers: DevServerManifest[]) => ({
       projectId,
       type,
     })),
-  installationConfigs: servers.flatMap(({host, installationConfigs, port}) =>
+  configs: servers.flatMap(({configs, host, port}) =>
     // Pass through the app-type-specific payload (`fields` for a media library)
     // once the discriminator and transport coordinates are peeled off.
-    (installationConfigs ?? []).map(({appType, moduleName, ...config}) => ({
+    (configs ?? []).map(({appType, moduleName, ...config}) => ({
       config,
       moduleName,
       remoteURL: `http://${host}:${port}`,

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -38,13 +38,14 @@ const toApplicationsPayload = (servers: DevServerManifest[]) => ({
       type,
     })),
   configs: servers.flatMap(({configs, host, port}) =>
-    // Pass through the app-type-specific payload (`fields` for a media library)
-    // once the discriminator and transport coordinates are peeled off.
+    // The registry stores the config flat; the workbench wire shape nests the
+    // type-specific payload (`fields` for a media library) under `config`, keyed
+    // by the `appType` discriminator.
     (configs ?? []).map(({appType, moduleName, ...config}) => ({
+      appType,
       config,
       moduleName,
       remoteURL: `http://${host}:${port}`,
-      type: appType,
     })),
   ),
 })

--- a/packages/@sanity/workbench-cli/src/contract.ts
+++ b/packages/@sanity/workbench-cli/src/contract.ts
@@ -1,7 +1,7 @@
 import {z} from 'zod/mini'
 
 // Shared module-federation extension contract: interface (view/service) and
-// installation-config declaration schemas, plus the versions the build stamps.
+// config declaration schemas, plus the versions the build stamps.
 // `zod/mini` keeps the bundle small.
 
 /** @internal */
@@ -11,7 +11,7 @@ export const VIEW_CONTRACT_VERSION = 1
 export const SERVICE_CONTRACT_VERSION = 1
 
 /** @internal */
-export const MEDIA_LIBRARY_INSTALLATION_CONFIG_CONTRACT_VERSION = 1
+export const MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION = 1
 
 /**
  * A view component. The return is opaque so the runtime helpers carry no React
@@ -84,7 +84,7 @@ const MediaLibraryFieldSchema = z.object({
 export const INSTALLATION_CONFIG_TYPE = 'installation_config'
 
 // `appType` is stamped by `unstable_defineMediaLibrary`, never authored.
-const MediaLibraryInstallationConfigSchema = z.object({
+const MediaLibraryConfigSchema = z.object({
   appType: z.literal('media-library'),
   fields: z
     .array(MediaLibraryFieldSchema)
@@ -97,9 +97,7 @@ const MediaLibraryInstallationConfigSchema = z.object({
 })
 
 /**
- * An app's optional installation config, keyed by `appType`; deploys as a versioned snapshot, not an interface.
+ * An app's optional config, keyed by `appType`; deploys as a versioned snapshot, not an interface.
  * @internal
  */
-export const InstallationConfigSchema = z.discriminatedUnion('appType', [
-  MediaLibraryInstallationConfigSchema,
-])
+export const ConfigSchema = z.discriminatedUnion('appType', [MediaLibraryConfigSchema])

--- a/packages/@sanity/workbench-cli/src/defineApp.ts
+++ b/packages/@sanity/workbench-cli/src/defineApp.ts
@@ -1,10 +1,6 @@
 import {z} from 'zod/mini'
 
-import {
-  InstallationConfigSchema,
-  InterfaceDeclarationSchema,
-  ServiceDeclarationSchema,
-} from './contract.js'
+import {ConfigSchema, InterfaceDeclarationSchema, ServiceDeclarationSchema} from './contract.js'
 
 /** Allowed characters for an app `name`. */
 const APP_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/
@@ -41,6 +37,13 @@ export const DefineAppInputSchema = z
      */
     applicationType: z.optional(ApplicationType),
     /**
+     * Deployed as a versioned snapshot on the app's org installation, not the
+     * application service. Singletons only. Internal, so excluded from the public
+     * `DefineAppInput` and set via `@ts-expect-error` like `applicationType`.
+     * @internal
+     */
+    config: z.optional(ConfigSchema),
+    /**
      * App entrypoint module. Defaults to `./src/App.tsx` when omitted. The build
      * derives the app's navigable `app` view from it. SDK apps only — setting it
      * on a studio is rejected (studio app views are not yet implemented).
@@ -50,13 +53,6 @@ export const DefineAppInputSchema = z
     group: z.optional(DockGroupSchema),
     /** Optional icon override (path to an SVG). Wins over manifest/studio icon. */
     icon: z.optional(z.string()),
-    /**
-     * Deployed as a versioned snapshot on the app's org installation, not the
-     * application service. Singletons only. Internal, so excluded from the public
-     * `DefineAppInput` and set via `@ts-expect-error` like `applicationType`.
-     * @internal
-     */
-    installationConfig: z.optional(InstallationConfigSchema),
     /**
      * Sanity-owned app deployed once, installed per org; excluded from the public `DefineAppInput`.
      * @internal
@@ -114,25 +110,25 @@ export const DefineAppInputSchema = z
     }),
   )
   .check(
-    // An installation config belongs to a Sanity-owned singleton (the Media
+    // An config belongs to a Sanity-owned singleton (the Media
     // Library). A non-singleton declaring one is rejected — see
-    // {@link readInstallationConfig} for the runtime guard.
-    z.refine((input) => !(input.installationConfig && !input.isSingleton), {
-      error: '`installationConfig` is only supported for singleton apps',
-      path: ['installationConfig'],
+    // {@link readConfig} for the runtime guard.
+    z.refine((input) => !(input.config && !input.isSingleton), {
+      error: '`config` is only supported for singleton apps',
+      path: ['config'],
     }),
   )
 
 /**
  * User-facing input for `unstable_defineApp`. Excludes the internal
- * `applicationType`, `isSingleton`, and `installationConfig` — validated by the
+ * `applicationType`, `isSingleton`, and `config` — validated by the
  * schema but not part of the public surface (Sanity-owned apps set them via
  * `@ts-expect-error`).
  * @public
  */
 export type DefineAppInput = Omit<
   z.output<typeof DefineAppInputSchema>,
-  'applicationType' | 'installationConfig' | 'isSingleton'
+  'applicationType' | 'config' | 'isSingleton'
 >
 
 /**
@@ -170,19 +166,17 @@ export function isWorkbenchApp(app: unknown): app is WorkbenchApp {
 }
 
 /**
- * The app's installation config, or `undefined` when it declares none. Throws
+ * The app's config, or `undefined` when it declares none. Throws
  * when a non-singleton declares one — configs belong to Sanity-owned singletons,
  * so build/dev/deploy all read it through here to reject the combination
  * consistently.
  * @internal
  */
-export function readInstallationConfig(
-  app: WorkbenchApp,
-): WorkbenchApp['installationConfig'] | undefined {
-  if (app.installationConfig && !app.isSingleton) {
-    throw new Error('`installationConfig` is only supported for singleton apps')
+export function readConfig(app: WorkbenchApp): WorkbenchApp['config'] | undefined {
+  if (app.config && !app.isSingleton) {
+    throw new Error('`config` is only supported for singleton apps')
   }
-  return app.installationConfig
+  return app.config
 }
 
 /**
@@ -227,16 +221,14 @@ export interface DefineMediaLibraryInput {
 }
 
 /**
- * Declare the Sanity Media Library as a workbench app — a singleton whose `fields` become its installation config.
+ * Declare the Sanity Media Library as a workbench app — a singleton whose `fields` become its config.
  * @public
  */
 export function unstable_defineMediaLibrary(input: DefineMediaLibraryInput): DefineAppResult {
   return unstable_defineApp({
-    // @ts-expect-error -- `applicationType`/`isSingleton`/`installationConfig` are internal, excluded from `DefineAppInput`; Sanity-owned apps set them
+    // @ts-expect-error -- `applicationType`/`isSingleton`/`config` are internal, excluded from `DefineAppInput`; Sanity-owned apps set them
     applicationType: 'media-library',
-    installationConfig: input.fields?.length
-      ? {appType: 'media-library', fields: input.fields}
-      : undefined,
+    config: input.fields?.length ? {appType: 'media-library', fields: input.fields} : undefined,
     isSingleton: true,
     name: 'media-library',
     organizationId: input.organizationId,

--- a/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
@@ -6,12 +6,7 @@
 
 import {type CliConfig} from '@sanity/cli-core'
 
-import {
-  type DefineAppInput,
-  isWorkbenchApp,
-  readInstallationConfig,
-  type WorkbenchApp,
-} from './defineApp.js'
+import {type DefineAppInput, isWorkbenchApp, readConfig, type WorkbenchApp} from './defineApp.js'
 
 /**
  * Bundled so adding a declaration family touches this type and the artifact
@@ -19,7 +14,7 @@ import {
  * @internal
  */
 export interface WorkbenchExposes {
-  installationConfig?: WorkbenchApp['installationConfig']
+  config?: WorkbenchApp['config']
   services?: DefineAppInput['services']
   views?: DefineAppInput['views']
 }
@@ -36,10 +31,10 @@ export interface ResolvedWorkbenchApp {
 
   /** Resolved app kind — `studio` or one of the SDK app types. */
   readonly applicationType?: string
+  /** Deploys on its own path, separate from the interfaces. */
+  readonly config?: WorkbenchApp['config']
   /** SDK app-view entrypoint, when declared. */
   readonly entry?: string
-  /** Deploys on its own path, separate from the interfaces. */
-  readonly installationConfig?: WorkbenchApp['installationConfig']
   /** Explicit singleton flag (a Sanity-owned app); `undefined` when the app doesn't set it. */
   readonly isSingleton?: boolean
 }
@@ -56,8 +51,8 @@ export function resolveWorkbenchApp(
 
   return {
     applicationType: app.applicationType,
+    config: readConfig(app),
     entry: app.entry,
-    installationConfig: readInstallationConfig(app),
     isSingleton: app.isSingleton,
     name: app.name,
     services: app.services ?? [],


### PR DESCRIPTION
### Description

`installationConfig` carries a redundant qualifier: in a workbench app a config always refers to an installation. This renames the internal `installationConfig` field, its zod schemas, the `read`/`deploy`/`summarize` helpers, and the `deployConfig` module (was `deployInstallationConfig.ts`) to `config`, across the app model, deploy, and dev-registry code.

Non-breaking, so it's a patch: the `installation_config` module-federation type (the expose path + the runtime `type` discriminant) and the `/installations` API — including `installationId`/`resolveInstallationId` and the `installation-config.tar.gz` part filename — are untouched.

Touches deploy files also changed by #1453 and #1455; whichever lands first, the others rebase.

### What to review

- The rename boundary: everything CLI-side becomes `config`; the wire stays — `INSTALLATION_CONFIG_TYPE`/`'installation_config'`, the `/installations` entity, and the tarball filename.
- `deployInstallationConfig.ts` → `deployConfig.ts` (git rename).

### Testing

Pure rename — the existing unit suites were updated with it and stay green (types, lint, unit).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename with tests updated; no auth, API contract, or runtime behavior changes beyond naming and JSON field keys on CLI deploy plans.
> 
> **Overview**
> Renames the internal workbench **`installationConfig`** surface to **`config`** across `@sanity/workbench-cli` and `@sanity/cli`: app schema (`DefineAppInputSchema`), **`readConfig`**, **`deploySingletonConfig`**, **`configArtifacts`**, and deploy/dry-run JSON fields that previously used **`installationConfig`**.
> 
> Deploy exports move from **`deployInstallationConfig`** / **`summarizeInstallationConfig`** to **`deployConfig`** / **`summarizeConfig`** (module **`deployConfig.ts`**). Dev registry and workbench HMR payloads use **`configs`** instead of **`installationConfigs`**, with **`deriveConfigs`** / **`deriveConfigEntries`** replacing the installation-named helpers.
> 
> **Unchanged (intentional boundary):** module-federation **`installation_config`** expose/type, **`INSTALLATION_CONFIG_TYPE`**, **`resolveInstallationId`**, **`/installations/.../configs`**, and tarball filename **`installation-config.tar.gz`**. Patched as non-breaking in the changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b694a58cedffa938b0e679308120aaca18632b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->