### PR TITLE
test: Deprecate createMockSpinner

### DIFF
--- a/packages/@sanity/cli-test/src/index.ts
+++ b/packages/@sanity/cli-test/src/index.ts
@@ -1,6 +1,5 @@
 export * from './test/constants.js'
 export * from './test/createMockHttpServer.js'
-export {createMockSpinner} from './test/createMockSpinner.js'
 export * from './test/createMockWatcher.js'
 export * from './test/createTestClient.js'
 export * from './test/createTestToken.js'
@@ -12,3 +11,6 @@ export * from './test/testCommand.js'
 export * from './test/testFixture.js'
 export * from './test/testHook.js'
 export * from './utils/paths.js'
+
+/** DEPRECATED */
+export {createMockSpinner} from './test/createMockSpinner.js'

--- a/packages/@sanity/cli-test/src/mocks/cli-core/ux.ts
+++ b/packages/@sanity/cli-test/src/mocks/cli-core/ux.ts
@@ -30,13 +30,23 @@ export const select: Mock = vi.fn()
  * @internal
  */
 export const spinnerText: Mock = vi.fn()
+/**
+ * Spy for asserting on spinner start.
+ * @internal
+ */
+export const spinnerStart: Mock = vi.fn().mockReturnThis()
+/**
+ * Spy for asserting on spinner succeed.
+ * @internal
+ */
+export const spinnerSucceed: Mock = vi.fn()
 /** @internal */
 export const spinner: Mock = vi.fn(() => {
   const mockSpin = {
     fail: vi.fn(),
     render: vi.fn(),
-    start: vi.fn().mockReturnThis(),
-    succeed: vi.fn(),
+    start: spinnerStart,
+    succeed: spinnerSucceed,
   }
   Object.defineProperty(mockSpin, 'text', {
     configurable: true,

--- a/packages/@sanity/cli-test/src/mocks/cli-core/ux.ts
+++ b/packages/@sanity/cli-test/src/mocks/cli-core/ux.ts
@@ -62,3 +62,5 @@ export const spinnerPromise: Mock = vi.fn()
 export const getTimer: Mock = vi
   .fn()
   .mockReturnValue({end: vi.fn().mockReturnValue(0), start: vi.fn()})
+/** @internal */
+export class Separator {}

--- a/packages/@sanity/cli-test/src/mocks/cli-core/ux.ts
+++ b/packages/@sanity/cli-test/src/mocks/cli-core/ux.ts
@@ -43,7 +43,9 @@ export const spinnerSucceed: Mock = vi.fn()
 /** @internal */
 export const spinner: Mock = vi.fn(() => {
   const mockSpin = {
+    clear: vi.fn(),
     fail: vi.fn(),
+    info: vi.fn(),
     render: vi.fn(),
     start: spinnerStart,
     succeed: spinnerSucceed,

--- a/packages/@sanity/cli-test/src/test/createMockSpinner.ts
+++ b/packages/@sanity/cli-test/src/test/createMockSpinner.ts
@@ -6,7 +6,7 @@ import {Mock, vi} from 'vitest'
  * Creates a mock spinner function to avoid writing output to stdout.
  * @param overrides - Pass any mocks or stubs for test expectations
  * @internal
- * @deprecated Use mocks/ux/spinner instead
+ * @deprecated Use mocks/cli-core/ux/spinner instead
  */
 export function createMockSpinner(
   overrides?: Partial<SpinnerInstance>,

--- a/packages/@sanity/cli-test/src/test/createMockSpinner.ts
+++ b/packages/@sanity/cli-test/src/test/createMockSpinner.ts
@@ -6,6 +6,7 @@ import {Mock, vi} from 'vitest'
  * Creates a mock spinner function to avoid writing output to stdout.
  * @param overrides - Pass any mocks or stubs for test expectations
  * @internal
+ * @deprecated Use mocks/ux/spinner instead
  */
 export function createMockSpinner(
   overrides?: Partial<SpinnerInstance>,

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/createUserApplication.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/createUserApplication.test.ts
@@ -11,18 +11,7 @@ vi.mock('../../../services/userApplications.js', () => ({
   createUserApplication: vi.fn(),
 }))
 
-vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
-  const {createMockSpinner} = await import('@sanity/cli-test')
-  return {
-    ...(await importOriginal<typeof import('@sanity/cli-core/ux')>()),
-    input: vi.fn(),
-    spinner: createMockSpinner({
-      fail: vi.fn().mockReturnThis(),
-      start: vi.fn().mockReturnThis(),
-      succeed: vi.fn().mockReturnThis(),
-    }),
-  }
-})
+vi.mock('@sanity/cli-core/ux', async () => import('@sanity/cli-test/mocks/cli-core/ux'))
 
 const mockRequest = vi.mocked(createUserApplicationRequest)
 const mockInput = vi.mocked(input)

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/findUserApplication.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/findUserApplication.test.ts
@@ -14,19 +14,7 @@ vi.mock('../../../services/userApplications.js', () => ({
   createUserApplication: vi.fn(),
 }))
 
-vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
-  const {createMockSpinner} = await import('@sanity/cli-test')
-  return {
-    ...(await importOriginal<typeof import('@sanity/cli-core/ux')>()),
-    spinner: createMockSpinner({
-      clear: vi.fn().mockReturnThis(),
-      fail: vi.fn().mockReturnThis(),
-      info: vi.fn().mockReturnThis(),
-      start: vi.fn().mockReturnThis(),
-      succeed: vi.fn().mockReturnThis(),
-    }),
-  }
-})
+vi.mock('@sanity/cli-core/ux', async () => import('@sanity/cli-test/mocks/cli-core/ux'))
 
 const mockResolveApp = vi.mocked(resolveAppDeployTarget)
 const mockResolveStudio = vi.mocked(resolveStudioDeployTarget)

--- a/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
@@ -3,17 +3,10 @@ import {tmpdir} from 'node:os'
 import path from 'node:path'
 
 import {type Output} from '@sanity/cli-core'
-import {createMockSpinner} from '@sanity/cli-test'
+import {spinner, spinnerStart, spinnerSucceed} from '@sanity/cli-test/mocks/cli-core/ux'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {resolveLatestVersions} from '../../../../src/util/resolveLatestVersions.js'
-
-const mockedSpinnerStart = vi.fn().mockReturnThis()
-const mockedSpinnerSucceed = vi.fn().mockReturnThis()
-const mockedSpinner = createMockSpinner({
-  start: mockedSpinnerStart,
-  succeed: mockedSpinnerSucceed,
-})
 
 vi.mock('../../../../src/util/resolveLatestVersions.js', () => ({
   resolveLatestVersions: vi.fn().mockImplementation(async (deps: Record<string, string>) => {
@@ -27,9 +20,7 @@ vi.mock('../../../../src/actions/init/updateInitialTemplateMetadata.js', () => (
   updateInitialTemplateMetadata: vi.fn().mockResolvedValue(undefined),
 }))
 
-vi.mock('@sanity/cli-core/ux', async () => ({
-  spinner: mockedSpinner,
-}))
+vi.mock('@sanity/cli-core/ux', async () => import('@sanity/cli-test/mocks/cli-core/ux'))
 
 const {bootstrapLocalTemplate} =
   await import('../../../../src/actions/init/bootstrapLocalTemplate.js')
@@ -69,9 +60,10 @@ describe('bootstrapLocalTemplate (app templates)', () => {
       },
     })
 
-    expect(mockedSpinner).toHaveBeenCalledWith('Bootstrapping files from template')
-    expect(mockedSpinnerStart).toHaveBeenCalledTimes(3)
-    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+    expect(spinner).toHaveBeenCalledWith('Bootstrapping files from template')
+
+    expect(spinnerStart).toHaveBeenCalledTimes(3)
+    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
 
     const appTsx = await readFile(path.join(tmp, 'src', 'App.tsx'), 'utf8')
     expect(appTsx).toContain(`projectId: 'abc123'`)
@@ -97,7 +89,7 @@ describe('bootstrapLocalTemplate (app templates)', () => {
       },
     })
 
-    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
 
     const appTsx = await readFile(path.join(tmp, 'src', 'App.tsx'), 'utf8')
     expect(appTsx).toContain(`projectId: ''`)
@@ -134,7 +126,7 @@ describe('bootstrapLocalTemplate (workbench)', () => {
       },
     })
 
-    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
 
     expect(resolveLatestVersions).toHaveBeenCalledOnce()
     const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
@@ -161,7 +153,7 @@ describe('bootstrapLocalTemplate (workbench)', () => {
       },
     })
 
-    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
 
     expect(resolveLatestVersions).toHaveBeenCalledOnce()
     const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
@@ -185,7 +177,7 @@ describe('bootstrapLocalTemplate (workbench)', () => {
       },
     })
 
-    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
 
     expect(resolveLatestVersions).toHaveBeenCalledOnce()
     const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
@@ -209,7 +201,7 @@ describe('bootstrapLocalTemplate (workbench)', () => {
       },
     })
 
-    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
 
     const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
     expect(cliConfig).toContain(`import {defineCliConfig, unstable_defineApp} from 'sanity/cli'`)
@@ -238,7 +230,7 @@ describe('bootstrapLocalTemplate (workbench)', () => {
       },
     })
 
-    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
 
     const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
     expect(cliConfig).toContain(`import {defineCliConfig, unstable_defineApp} from 'sanity/cli'`)
@@ -267,7 +259,7 @@ describe('bootstrapLocalTemplate (workbench)', () => {
       },
     })
 
-    expect(mockedSpinnerSucceed).toHaveBeenCalledTimes(3)
+    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
 
     const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
     expect(cliConfig).not.toContain('unstable_defineApp')


### PR DESCRIPTION
### Description

Deprecates and removes all uses of createMockSpinner in favour of the mocks just added in cli-test.

### Testing

Updated tests to use the new mocks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors to mocking helpers; no production CLI or runtime behavior changes.
> 
> **Overview**
> **Deprecates `createMockSpinner`** and steers tests toward the shared `@sanity/cli-test/mocks/cli-core/ux` module. The package entry still re-exports the helper at the bottom with a **DEPRECATED** marker; the function is tagged `@deprecated` in favor of the centralized spinner mocks.
> 
> The **shared ux mock** gains **`spinnerStart`** and **`spinnerSucceed`** spies wired into the mock spinner instance, plus **`clear`**, **`info`**, and a stub **`Separator`** class so mocks better match real `@sanity/cli-core/ux` usage.
> 
> **CLI deploy and init tests** drop per-file `createMockSpinner` / partial ux mocks and instead `vi.mock('@sanity/cli-core/ux', () => import('@sanity/cli-test/mocks/cli-core/ux'))`. The bootstrap integration suite asserts spinner behavior via the exported **`spinner`**, **`spinnerStart`**, and **`spinnerSucceed`** mocks rather than local stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5499a4abc8f1b331bd51ea103c40ed6b098513ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->