### PR TITLE
feat(test): granular exports for `cli-test`

### DIFF
--- a/.changeset/frank-garlics-kick.md
+++ b/.changeset/frank-garlics-kick.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli-test": minor
+---
+
+Expose test `@sanity/client` client as new isolated export

--- a/.changeset/frank-garlics-kick.md
+++ b/.changeset/frank-garlics-kick.md
@@ -2,4 +2,4 @@
 "@sanity/cli-test": minor
 ---
 
-Expose test `@sanity/client` client as new isolated export
+Expose test utilities as granular exports.

--- a/packages/@sanity/cli-build/tsconfig.json
+++ b/packages/@sanity/cli-build/tsconfig.json
@@ -9,6 +9,8 @@
       "@sanity/cli-core/*": ["./node_modules/@sanity/cli-core/src/_exports/*"],
       "@sanity/cli-test": ["./node_modules/@sanity/cli-test/src/index.ts"],
       "@sanity/cli-test/vitest": ["./node_modules/@sanity/cli-test/src/vitest.ts"],
+      "@sanity/cli-test/mocks/*": ["./node_modules/@sanity/cli-test/src/mocks/*"],
+      "@sanity/cli-test/test/*": ["./node_modules/@sanity/cli-test/src/test/*"],
       "@sanity/workbench-cli": ["./node_modules/@sanity/workbench-cli/src/_exports/index.ts"],
       "@sanity/workbench-cli/*": ["./node_modules/@sanity/workbench-cli/src/_exports/*"]
     }

--- a/packages/@sanity/cli-e2e/tsconfig.json
+++ b/packages/@sanity/cli-e2e/tsconfig.json
@@ -6,6 +6,8 @@
     "paths": {
       "@sanity/cli-test": ["./node_modules/@sanity/cli-test/src/index.ts"],
       "@sanity/cli-test/vitest": ["./node_modules/@sanity/cli-test/src/vitest.ts"],
+      "@sanity/cli-test/mocks/*": ["./node_modules/@sanity/cli-test/src/mocks/*"],
+      "@sanity/cli-test/test/*": ["./node_modules/@sanity/cli-test/src/test/*"],
       "@sanity/cli-build/*": ["./node_modules/@sanity/cli-build/src/_exports/*"],
       "@sanity/cli-core": ["./node_modules/@sanity/cli-core/src/_exports/index.ts"]
     }

--- a/packages/@sanity/cli-test/package.json
+++ b/packages/@sanity/cli-test/package.json
@@ -82,8 +82,8 @@
       "default": "./dist/test/mockApi.js"
     },
     "./test/oclif": {
-      "source": "./src/test/testCommand.ts",
-      "default": "./dist/test/testCommand.js"
+      "source": "./src/test/oclif.ts",
+      "default": "./dist/test/oclif.js"
     },
     "./test/setupFixtures": {
       "source": "./src/test/setupFixtures.ts",

--- a/packages/@sanity/cli-test/package.json
+++ b/packages/@sanity/cli-test/package.json
@@ -73,6 +73,26 @@
       "source": "./src/utils/paths.ts",
       "default": "./dist/utils/paths.js"
     },
+    "./test/createTestClient": {
+      "source": "./src/test/createTestClient.ts",
+      "default": "./dist/test/createTestToken.js"
+    },
+    "./test/mockApi": {
+      "source": "./src/test/mockApi.ts",
+      "default": "./dist/test/mockApi.js"
+    },
+    "./test/oclif": {
+      "source": "./src/test/testCommand.ts",
+      "default": "./dist/test/testCommand.js"
+    },
+    "./test/setupFixtures": {
+      "source": "./src/test/setupFixtures.ts",
+      "default": "./dist/test/setupFixtures.js"
+    },
+    "./test/util": {
+      "source": "./src/test/util.ts",
+      "default": "./dist/test/util.js"
+    },
     "./vitest": {
       "source": "./src/vitest.ts",
       "default": "./dist/vitest.js"
@@ -104,7 +124,6 @@
     "ansis": "^4.2.0",
     "esbuild": "^0.28.1",
     "nock": "catalog:",
-    "ora": "catalog:",
     "tinyglobby": "catalog:"
   },
   "devDependencies": {

--- a/packages/@sanity/cli-test/package.json
+++ b/packages/@sanity/cli-test/package.json
@@ -75,7 +75,7 @@
     },
     "./test/createTestClient": {
       "source": "./src/test/createTestClient.ts",
-      "default": "./dist/test/createTestToken.js"
+      "default": "./dist/test/createTestClient.js"
     },
     "./test/mockApi": {
       "source": "./src/test/mockApi.ts",

--- a/packages/@sanity/cli-test/src/index.ts
+++ b/packages/@sanity/cli-test/src/index.ts
@@ -1,3 +1,5 @@
+// DO NOT ADD NEW EXPORTS HERE!
+// Instead, add them to the relevant granular export files laid out in package.json exports.
 export * from './test/constants.js'
 export * from './test/createMockHttpServer.js'
 export {createMockSpinner} from './test/createMockSpinner.js'

--- a/packages/@sanity/cli-test/src/test/captureOutput.ts
+++ b/packages/@sanity/cli-test/src/test/captureOutput.ts
@@ -1,6 +1,7 @@
 import {type Errors} from '@oclif/core'
 import ansis from 'ansis'
 
+/** @public */
 export interface CaptureOptions {
   /**
    * Whether to print the output to the console
@@ -13,6 +14,7 @@ export interface CaptureOptions {
   testNodeEnv?: string
 }
 
+/** @public */
 export interface CaptureResult<T = unknown> {
   stderr: string
   stdout: string
@@ -27,7 +29,7 @@ export interface CaptureResult<T = unknown> {
  * @param fn - The function to capture the output of
  * @param opts - The options for the capture
  * @returns The result of the command
- * @internal
+ * @public
  *
  * Credits to oclif for the original implementation:
  * https://github.com/oclif/test/blob/2a5407e6fc80d388043d10f6b7b8eaa586483015/src/index.ts

--- a/packages/@sanity/cli-test/src/test/createMockSpinner.ts
+++ b/packages/@sanity/cli-test/src/test/createMockSpinner.ts
@@ -1,5 +1,4 @@
 import {type SpinnerInstance} from '@sanity/cli-core/ux'
-import {type PersistOptions} from 'ora'
 import {Mock, vi} from 'vitest'
 
 /**
@@ -42,7 +41,7 @@ export function createMockSpinner(
       stop: function (): SpinnerInstance {
         throw new Error('Function not implemented.')
       },
-      stopAndPersist: function (_options?: PersistOptions): SpinnerInstance {
+      stopAndPersist: function (_options?: any): SpinnerInstance {
         throw new Error('Function not implemented.')
       },
       succeed: function (_text?: string): SpinnerInstance {

--- a/packages/@sanity/cli-test/src/test/oclif.ts
+++ b/packages/@sanity/cli-test/src/test/oclif.ts
@@ -1,0 +1,5 @@
+// Heavy integration test tooling goes here. OCLIF is a transient dependency. Do not rely on this tooling - instead write unit tests!
+export * from './captureOutput.js'
+export * from './mockSanityCommand.js'
+export * from './testCommand.js'
+export * from './testHook.js'

--- a/packages/@sanity/cli-test/src/test/setupFixtures.ts
+++ b/packages/@sanity/cli-test/src/test/setupFixtures.ts
@@ -3,7 +3,6 @@ import {readFile, rm, writeFile} from 'node:fs/promises'
 import {basename, join} from 'node:path'
 import {promisify} from 'node:util'
 
-import ora from 'ora'
 import {glob} from 'tinyglobby'
 import {type TestProject} from 'vitest/node'
 
@@ -101,12 +100,7 @@ interface FixtureDetails {
  */
 export async function setup(_: TestProject, options: SetupTestFixturesOptions = {}): Promise<void> {
   const {additionalFixtures, ignoreWorkspace, tempDir} = options
-
-  const spinner = ora({
-    // Without this, the watch mode input is discarded
-    discardStdin: false,
-    text: 'Initializing test environment...',
-  }).start()
+  console.log('Initializing test environment...')
 
   try {
     const fixturesDir = getFixturesPath()
@@ -130,7 +124,7 @@ export async function setup(_: TestProject, options: SetupTestFixturesOptions = 
       if (additionalFixturePaths.length > 0) {
         allFixturePaths.push(...additionalFixturePaths)
       } else {
-        spinner.warn(
+        console.warn(
           `No additional fixtures found, check the glob pattern: ${additionalFixtures.join(', ')}`,
         )
       }
@@ -161,7 +155,7 @@ export async function setup(_: TestProject, options: SetupTestFixturesOptions = 
         )
       } catch (error) {
         const execError = error as {message: string; stderr?: string; stdout?: string}
-        spinner.fail('Failed to install dependencies')
+        console.error('Failed to install dependencies')
         console.error(execError.stderr || execError.stdout || execError.message)
         throw new Error(
           `Error installing dependencies in ${toPath}: ${execError.stderr || execError.stdout || execError.message}`,
@@ -170,9 +164,9 @@ export async function setup(_: TestProject, options: SetupTestFixturesOptions = 
       }
     }
 
-    spinner.succeed('Test environment initialized')
+    console.log('Test environment initialized')
   } catch (error) {
-    spinner.fail('Failed to initialize test environment')
+    console.error('Failed to initialize test environment')
     throw error
   }
 }

--- a/packages/@sanity/cli-test/src/test/util.ts
+++ b/packages/@sanity/cli-test/src/test/util.ts
@@ -1,0 +1,8 @@
+// Fast, in-memory export of utilities provided by cli-test. Limit transient dependencies (no OCLIF, no nock, etc.). Dedicated exports for test utilities relying on heavy exports already exist (e.g. test/createTestClient, test/mockApi, test/oclif, test/setupFixtures, etc.)
+export * from './constants.js'
+export * from './createMockHttpServer.js'
+export * from './createMockSpinner.js'
+export * from './createTestToken.js'
+export * from './mockTelemetry.js'
+export * from './snapshotSerializer.js'
+export * from './testFixture.js'

--- a/packages/@sanity/cli/tsconfig.json
+++ b/packages/@sanity/cli/tsconfig.json
@@ -13,9 +13,10 @@
       "@sanity/cli-core/ExitCodes": ["./node_modules/@sanity/cli-core/src/exitCodes.ts"],
       "@sanity/cli-core/SanityCommand": ["./node_modules/@sanity/cli-core/src/SanityCommand.ts"],
       "@sanity/cli-test": ["./node_modules/@sanity/cli-test/src/index.ts"],
-      "@sanity/cli-test/vitest": ["./node_modules/@sanity/cli-test/src/vitest.ts"],
-      "@sanity/cli-test/mocks/cli-core/*": ["./node_modules/@sanity/cli-test/src/mocks/cli-core/*"],
+      "@sanity/cli-test/mocks/*": ["./node_modules/@sanity/cli-test/src/mocks/*"],
       "@sanity/cli-test/paths": ["./node_modules/@sanity/cli-test/src/utils/paths.ts"],
+      "@sanity/cli-test/test/*": ["./node_modules/@sanity/cli-test/src/test/*"],
+      "@sanity/cli-test/vitest": ["./node_modules/@sanity/cli-test/src/vitest.ts"],
       "@sanity/workbench-cli": ["./node_modules/@sanity/workbench-cli/src/_exports/index.ts"],
       "@sanity/workbench-cli/*": ["./node_modules/@sanity/workbench-cli/src/_exports/*"]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1176,9 +1176,6 @@ importers:
       nock:
         specifier: 'catalog:'
         version: 14.0.15
-      ora:
-        specifier: 'catalog:'
-        version: 9.4.0
       tinyglobby:
         specifier: 'catalog:'
         version: 0.2.17


### PR DESCRIPTION
### Description

Adds granular exports for the `cli-test` package.

Transient dependencies in this package, too, impact vitest import and transpilation times (`@sanity/client` (11MB), OCLIF (4MB) and nock (2MB) in particular) - every dependency pulled in forces `vitest` to import the entire graph and transpile the entire bundle. It is through this sort of thoughtless dependency usage that we end up with import and transpilation taking 90%+ of the time it takes to run the tests. Only use them when super necessary!

Also removes `ora` as a dependency from `cli-test`. We don't need another 300kb to show a fancy spinner during integration test setup.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-helper packaging and dependency trimming only; the root export remains, so behavior risk is limited to consumers that adopt new import paths.
> 
> **Overview**
> **`@sanity/cli-test`** now exposes **granular subpath exports** so tests can import only what they need (`test/util`, `test/oclif`, `test/setupFixtures`, `test/mockApi`, `test/createTestClient`, plus broader `mocks/*` and `test/*` TS paths in consuming packages). New barrels split **light helpers** (`test/util`) from **OCLIF-heavy integration tooling** (`test/oclif`), and the main `index` is documented as **frozen**—new surface should go through `package.json` exports.
> 
> **`ora` is removed** from runtime dependencies: fixture global setup uses plain `console` logging instead of a spinner, and the mock spinner no longer depends on `ora` types.
> 
> `captureOutput` and its types are marked **`@public`** (was internal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd8c4e9cdfdbfb1b1324a9af334e08bba83b621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->