### PR TITLE
fix(test): one more cli-test export

### DIFF
--- a/.changeset/pr-1460.md
+++ b/.changeset/pr-1460.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-test': patch
+---
+
+fix(test): one more cli-test export

--- a/packages/@sanity/cli-test/src/test/util.ts
+++ b/packages/@sanity/cli-test/src/test/util.ts
@@ -2,6 +2,7 @@
 export * from './constants.js'
 export * from './createMockHttpServer.js'
 export * from './createMockSpinner.js'
+export * from './createMockWatcher.js'
 export * from './createTestToken.js'
 export * from './mockTelemetry.js'
 export * from './snapshotSerializer.js'


### PR DESCRIPTION
### Description

Quick follow-up to get one more granular export out that I missed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single barrel re-export and changeset only; no runtime or test-helper behavior changes.
> 
> **Overview**
> Follow-up to the granular `@sanity/cli-test` export split: **`createMockWatcher`** is now re-exported from the **`@sanity/cli-test/test/util`** entry (via `util.ts`), alongside other lightweight in-memory test helpers.
> 
> Consumers can import the Vite watcher mock from **`test/util`** without pulling the full package surface. A **patch** changeset records the `@sanity/cli-test` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9009c4196c10b81960a1623564a38fa0ea0083b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->