### PR TITLE
fix: make projects list SANITY_INTERNAL_ENV-aware

### DIFF
--- a/.changeset/odd-moles-take.md
+++ b/.changeset/odd-moles-take.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+sanity projects list no longer assumes it's for sanity.io URLs

--- a/packages/@sanity/cli/src/commands/projects/list.ts
+++ b/packages/@sanity/cli/src/commands/projects/list.ts
@@ -5,6 +5,7 @@ import {SanityCommand, subdebug} from '@sanity/cli-core'
 import size from 'lodash-es/size.js'
 import sortBy from 'lodash-es/sortBy.js'
 
+import {getManageUrl} from '../../actions/projects/getManageUrl.js'
 import {listProjects} from '../../services/projects.js'
 
 const sortFields = ['id', 'members', 'name', 'url', 'created']
@@ -46,7 +47,7 @@ export class List extends SanityCommand<typeof List> {
       const projects = await listProjects()
       const ordered = sortBy(
         projects.map(({createdAt, displayName, id, members = []}) => {
-          const manage = `https://www.sanity.io/manage/project/${id}`
+          const manage = getManageUrl(id)
           return [id, members.length, displayName, manage, createdAt].map(String)
         }),
         [sortFields.indexOf(sort)],


### PR DESCRIPTION
`sanity projects list` will now output correct URLs when `SANITY_INTERNAL_ENV` is set to something other than production

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line URL construction change in a CLI display command; reuses an existing helper already used elsewhere in the CLI.
> 
> **Overview**
> **`sanity projects list`** now prints manage URLs via **`getManageUrl`** instead of hardcoded `https://www.sanity.io/manage/project/...`, matching **`sanity manage`** and **`projects create`**.
> 
> When **`SANITY_INTERNAL_ENV`** points at a non-production Sanity environment, the **url** column reflects the correct host instead of always showing production sanity.io links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c09eda343fdd5dafbedec67d608ec5fabe49e942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->