### PR TITLE
feat(deploy): add --debug flag to print debug logging

### DIFF
--- a/.changeset/deploy-debug-flag.md
+++ b/.changeset/deploy-debug-flag.md
@@ -1,0 +1,6 @@
+---
+'@sanity/cli': minor
+'@sanity/cli-core': minor
+---
+
+feat(deploy): add a `--debug` flag that turns on `sanity:*` debug logging (HTTP requests, resolution steps) without having to set the `DEBUG` environment variable

--- a/packages/@sanity/cli-core/src/_exports/__tests__/debug.test.ts
+++ b/packages/@sanity/cli-core/src/_exports/__tests__/debug.test.ts
@@ -1,0 +1,22 @@
+import createDebug from 'debug'
+import {afterEach, describe, expect, test} from 'vitest'
+
+import {enableDebug} from '../debug.js'
+
+afterEach(() => createDebug.disable())
+
+describe('enableDebug', () => {
+  test('enables the CLI and @sanity/client namespaces', () => {
+    createDebug.disable()
+    enableDebug()
+    expect(createDebug.enabled('sanity:cli:deploy')).toBe(true)
+    expect(createDebug.enabled('sanity:client')).toBe(true)
+  })
+
+  test('keeps namespaces already enabled via DEBUG', () => {
+    createDebug.enable('other:ns')
+    enableDebug()
+    expect(createDebug.enabled('other:ns')).toBe(true)
+    expect(createDebug.enabled('sanity:cli')).toBe(true)
+  })
+})

--- a/packages/@sanity/cli-core/src/_exports/debug.ts
+++ b/packages/@sanity/cli-core/src/_exports/debug.ts
@@ -15,3 +15,13 @@ export const debug = debugIt('sanity:cli')
  * @returns The extended `debug` instance
  */
 export const subdebug = (namespace: string) => debug.extend(namespace)
+
+/**
+ * Runtime equivalent of `DEBUG=sanity*`, for a `--debug` flag. Uses `sanity*`
+ * (not `sanity:cli*`) so `@sanity/client` request logs show too, and keeps any
+ * namespaces already enabled via `DEBUG`.
+ * @internal
+ */
+export function enableDebug(): void {
+  debugIt.enable([debugIt.disable(), 'sanity*'].filter(Boolean).join(','))
+}

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -79,7 +79,7 @@ export {
 export {safeStructuredClone} from '../util/safeStructuredClone.js'
 export {colorizeJson} from '../ux/colorizeJson.js'
 export {getTimer} from '../ux/timer.js'
-export {debug, subdebug} from './debug.js'
+export {debug, enableDebug, subdebug} from './debug.js'
 export {
   type CoreAppManifest,
   coreAppManifestSchema,

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {enableDebug, SanityCommand} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 
 import {deployApp} from '../actions/deploy/deployApp.js'
@@ -50,6 +50,10 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
       default: true,
       description:
         'Build the studio before deploying (use --no-build to deploy existing `dist/` output)',
+    }),
+    debug: Flags.boolean({
+      default: false,
+      description: 'Print debug logging (HTTP requests, resolution steps); like DEBUG=sanity*',
     }),
     'dry-run': Flags.boolean({
       default: false,
@@ -100,6 +104,8 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(DeployCommand)
+
+    if (flags.debug) enableDebug()
 
     const cliConfig = await this.getCliConfig()
     const projectRoot = await this.getProjectRoot()


### PR DESCRIPTION
### Description

Debugging a deploy required setting `DEBUG=sanity*` in the environment — and `sanity deploy --debug` failed with `Nonexistent flag: --debug`.

This adds a `--debug` flag to `sanity deploy` that enables the `sanity:*` debug namespaces at runtime, so HTTP requests and deploy-resolution steps print without touching the environment. The work happens in a new `enableDebug` helper in `@sanity/cli-core`; it uses `sanity*` (not just `sanity:cli*`) so `@sanity/client`'s request logs show too, and preserves any namespaces already set via `DEBUG`.

Scoped to `deploy` for now (that's where it bit); it could be promoted to a global flag later.

### What to review

- `enableDebug` in `@sanity/cli-core` (`_exports/debug.ts`) — the namespace choice and DEBUG-preservation.
- The flag wiring in `commands/deploy.ts` — `enableDebug()` runs first thing in `run()`.

### Testing

Unit tests in `cli-core` cover `enableDebug` enabling the CLI + `@sanity/client` namespaces and preserving existing `DEBUG` namespaces. Deploy integration tests still pass with the added flag.