### PR TITLE
fix(test): fix default `getProjectRoot()` mock return value

### DIFF
--- a/.changeset/pr-1464.md
+++ b/.changeset/pr-1464.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-test': patch
+---
+
+fix(test): fix default `getProjectRoot()` mock return value

--- a/packages/@sanity/cli-test/src/mocks/cli-core/SanityCommand.ts
+++ b/packages/@sanity/cli-test/src/mocks/cli-core/SanityCommand.ts
@@ -1,27 +1,35 @@
 import {Command} from '@oclif/core'
-import {type Output, type SanityCommandInterface} from '@sanity/cli-core/types'
+import {type Output, ProjectRootResult, type SanityCommandInterface} from '@sanity/cli-core/types'
 import {Mock, vi} from 'vitest'
 
 interface MockCollection {
+  DefaultProjectRoot: ProjectRootResult
   OclifCmdExit: Mock<Command['exit']>
   SanityCmdGetCliConfig: Mock
   SanityCmdGetProjectId: Mock
-  SanityCmdGetProjectRoot: Mock
+  SanityCmdGetProjectRoot: Mock<() => ProjectRootResult>
   SanityCmdIsUnattended: Mock
   SanityCmdOutput: Output
   SanityCmdResolveIsInteractive: Mock
+}
+
+const DefaultProjectRoot = {
+  directory: '/some/path/to/cli-test/mocks',
+  path: '/some/path/to/cli-test/mocks/sanity.studio.ts',
+  type: 'studio' as const,
 }
 
 /**
  * @internal
  */
 export const mocks: MockCollection = {
+  DefaultProjectRoot,
   // Mock OCLIF Command methods
   OclifCmdExit: vi.fn((_code?: number) => undefined as never),
   // Mock SanityCommand methods
   SanityCmdGetCliConfig: vi.fn(),
   SanityCmdGetProjectId: vi.fn(() => 'cli-test-mock-project-id'),
-  SanityCmdGetProjectRoot: vi.fn(() => '/some/path/to/cli-test/mocks'),
+  SanityCmdGetProjectRoot: vi.fn(() => DefaultProjectRoot),
   SanityCmdIsUnattended: vi.fn(),
   SanityCmdOutput: createMockOutput(),
   SanityCmdResolveIsInteractive: vi.fn(),


### PR DESCRIPTION
### Description

Mocks for `getProjectRoot()` currently return the wrong shape. This PR fixes that, and exposes a `DefaultProjectRoot` that is by default returned on the `mocks` export.

Came across this issue converting the cli `debug` command tests - needed to customize this mock.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock changes in `@sanity/cli-test` with no production runtime impact.
> 
> **Overview**
> The `@sanity/cli-test` **`SanityCommand`** mock now returns a **`ProjectRootResult`** from **`getProjectRoot()`** instead of a bare directory string, matching **`SanityCommandInterface`** and real **`findProjectRoot`** behavior.
> 
> A shared **`DefaultProjectRoot`** object (`directory`, `path`, `type: 'studio'`) is added and exported on **`mocks`** so tests can reuse or override the default when stubbing **`SanityCmdGetProjectRoot`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb09d3d98a5a9d950bf9685789d09684a644c4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->