### PR TITLE
chore(test): cli-build test tweaks

### DIFF
--- a/packages/@sanity/cli-build/package.json
+++ b/packages/@sanity/cli-build/package.json
@@ -91,7 +91,6 @@
     "@swc/cli": "catalog:",
     "@swc/core": "catalog:",
     "@types/debug": "catalog:",
-    "@types/jsdom": "catalog:",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "@types/picomatch": "^4.0.3",

--- a/packages/@sanity/cli-build/package.json
+++ b/packages/@sanity/cli-build/package.json
@@ -101,7 +101,6 @@
     "@vitest/coverage-istanbul": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
     "eslint": "catalog:",
-    "jsdom": "catalog:",
     "magic-string": "^0.30.21",
     "publint": "catalog:",
     "sanity": "catalog:",

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/buildApp.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/buildApp.test.ts
@@ -49,8 +49,8 @@ vi.mock(import('../resolveVendorBuildConfig.js'), () => ({
   resolveVendorBuildConfig: vi.fn(),
 }))
 
-vi.mock(import('../buildDebug'), () => ({
-  buildDebug: vi.fn() as unknown as (typeof import('../buildDebug'))['buildDebug'],
+vi.mock('../buildDebug', () => ({
+  buildDebug: vi.fn(),
 }))
 
 vi.mock(import('../getEnvironmentVariables.js'), () => ({

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/writeSanityRuntime.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/writeSanityRuntime.test.ts
@@ -10,17 +10,10 @@ const mockWatch = vi.hoisted(() => vi.fn())
 const mockRenderDocument = vi.hoisted(() => vi.fn())
 const mockWriteFile = vi.hoisted(() => vi.fn())
 
-vi.mock(import('node:fs/promises'), async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...actual,
-    default: {
-      ...actual.default,
-      mkdir: vi.fn(),
-      writeFile: mockWriteFile,
-    },
-  }
-})
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+  writeFile: mockWriteFile,
+}))
 vi.mock('@sanity/cli-core/config', () => import('@sanity/cli-test/mocks/cli-core/config'))
 vi.mock('chokidar', () => ({watch: mockWatch}))
 vi.mock('../renderDocument.js', () => ({renderDocument: mockRenderDocument}))

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, test, vi} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {addTimestampedImportMapScriptToHtml} from '../addTimestampImportMapScriptToHtml.js'
 
@@ -21,6 +21,9 @@ const importMap = {
 }
 
 describe('addTimestampedImportMapScriptToHtml', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
   test('does not modify html when no importMap is provided', () => {
     addTimestampedImportMapScriptToHtml(baseHtml)
     expect(mockAppend).not.toHaveBeenCalled()
@@ -67,6 +70,7 @@ describe('addTimestampedImportMapScriptToHtml', () => {
     mockQuerySelector.mockReturnValueOnce(null as unknown as typeof fakeDom)
     addTimestampedImportMapScriptToHtml('<head></head><body></body>', importMap)
 
+    expect(mockAppend).toHaveBeenCalled()
     expect(mockInsert).toHaveBeenCalledWith(
       'beforeend',
       expect.stringContaining('<script type="application/json" id="__imports">'),
@@ -88,6 +92,7 @@ describe('addTimestampedImportMapScriptToHtml', () => {
       .mockReturnValueOnce(null as unknown as typeof fakeDom)
     addTimestampedImportMapScriptToHtml('<html><body></body></html>', importMap)
 
+    expect(mockInsert).toHaveBeenCalledWith('afterbegin', '<head></head>')
     expect(mockInsert).toHaveBeenCalledWith(
       'beforeend',
       expect.stringContaining('<script type="application/json" id="__imports">'),

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
@@ -83,7 +83,9 @@ describe('addTimestampedImportMapScriptToHtml', () => {
 
   test('handles html string with no <head>', () => {
     // Make second call to querySelector return falsy, triggering lack-of-head-el conditional
-    mockQuerySelector.mockReturnThis().mockReturnValueOnce(null as unknown as typeof fakeDom)
+    mockQuerySelector
+      .mockReturnValueOnce(fakeDom)
+      .mockReturnValueOnce(null as unknown as typeof fakeDom)
     addTimestampedImportMapScriptToHtml('<html><body></body></html>', importMap)
 
     expect(mockInsert).toHaveBeenCalledWith(

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/__tests__/addTimestampImportMapScriptToHtml.test.ts
@@ -1,328 +1,102 @@
-import {JSDOM} from 'jsdom'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {describe, expect, test, vi} from 'vitest'
 
-import {addTimestampedImportMapScriptToHtml} from '../addTimestampImportMapScriptToHtml'
+import {addTimestampedImportMapScriptToHtml} from '../addTimestampImportMapScriptToHtml.js'
+
+const mockInsert = vi.hoisted(() => vi.fn())
+const mockAppend = vi.hoisted(() => vi.fn())
+const mockQuerySelector = vi.hoisted(() => vi.fn().mockReturnThis())
+const fakeDom = vi.hoisted(() => ({
+  append: mockAppend,
+  insertAdjacentHTML: mockInsert,
+  querySelector: mockQuerySelector,
+}))
+const mockParse = vi.hoisted(() => vi.fn(() => fakeDom))
+vi.mock('node-html-parser', () => ({
+  parse: mockParse,
+}))
 
 const baseHtml = '<html><head></head><body></body></html>'
+const importMap = {
+  imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
+}
 
 describe('addTimestampedImportMapScriptToHtml', () => {
-  test('returns html unchanged when no importMap is provided', () => {
-    const result = addTimestampedImportMapScriptToHtml(baseHtml)
-    expect(result).toBe(baseHtml)
+  test('does not modify html when no importMap is provided', () => {
+    addTimestampedImportMapScriptToHtml(baseHtml)
+    expect(mockAppend).not.toHaveBeenCalled()
+    expect(mockInsert).not.toHaveBeenCalled()
   })
 
-  test('injects import map JSON into the head', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
+  test('injects import map JSON and timestamped import map injector script into the head', () => {
+    addTimestampedImportMapScriptToHtml(baseHtml, importMap)
 
-    expect(result).toContain('id="__imports"')
-    expect(result).toContain('"sanity"')
-    expect(result).toContain('sanity-cdn.com')
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining('<script type="application/json" id="__imports">'),
+    )
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining(JSON.stringify(importMap)),
+    )
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining('auto-generated script to add import map with timestamp'),
+    )
   })
 
-  test('injects the timestamped import map injector script', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
-
-    expect(result).toContain('importmap')
-    expect(result).toContain('__imports')
-  })
-
-  test('includes CSS URLs as a css array in the __imports JSON', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
+  test('includes CSS URLs as a css array in the __imports JSON if provided', () => {
     const cssUrls = [
       'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890/index.css',
       'https://sanity-cdn.com/v1/modules/@sanity__vision/default/%5E3.2.0/t1234567890/index.css',
     ]
 
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap, cssUrls)
+    addTimestampedImportMapScriptToHtml(baseHtml, importMap, cssUrls)
 
-    const match = result.match(/id="__imports">([^<]+)</)
-    expect(match).toBeTruthy()
-    const importsData = JSON.parse(match![1])
-    expect(importsData.css).toEqual(cssUrls)
-    expect(importsData.imports).toEqual(importMap.imports)
-  })
-
-  test('omits the css array when no CSS URLs are provided', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
-
-    const match = result.match(/id="__imports">([^<]+)</)
-    const importsData = JSON.parse(match![1])
-    expect(importsData.css).toBeUndefined()
-  })
-
-  test('does not emit static <link> tags — CSS is created by the runtime script', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const cssUrls = [
-      'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890/index.css',
-    ]
-
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap, cssUrls)
-
-    // The provided CSS URL should not be emitted as a static stylesheet tag in the HTML.
-    expect(result).not.toContain(`<link rel="stylesheet" href="${cssUrls[0]}"`)
-  })
-
-  test('runtime script creates link tags synchronously with fresh timestamps', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
-
-    // Script reads the css array from __imports
-    expect(result).toContain('css = []')
-    // Script creates <link> elements
-    expect(result).toContain("createElement('link')")
-    // Script sets rel="stylesheet"
-    expect(result).toContain("linkEl.rel = 'stylesheet'")
-    // Script applies the fresh timestamp via replaceTimestamp
-    expect(result).toContain('replaceTimestamp(cssUrl)')
-    // Appended to head
-    expect(result).toContain('document.head.appendChild(linkEl)')
-  })
-
-  test('runtime script uses shared replaceTimestamp for both imports and CSS', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
-
-    expect(result).toContain('function replaceTimestamp')
-    // Used for import map entries
-    expect(result).toContain('[specifier, replaceTimestamp(path)]')
-    // Used for CSS URLs
-    expect(result).toContain('replaceTimestamp(cssUrl)')
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining('<script type="application/json" id="__imports">'),
+    )
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining(JSON.stringify({...importMap, css: cssUrls})),
+    )
   })
 
   test('handles html string with no <html> wrapper', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const result = addTimestampedImportMapScriptToHtml('<head></head><body></body>', importMap)
+    // Make first call to querySelector return falsy, triggering lack-of-html-el conditional
+    mockQuerySelector.mockReturnValueOnce(null as unknown as typeof fakeDom)
+    addTimestampedImportMapScriptToHtml('<head></head><body></body>', importMap)
 
-    expect(result).toContain('id="__imports"')
-    expect(result).toContain('<html>')
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining('<script type="application/json" id="__imports">'),
+    )
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining(JSON.stringify(importMap)),
+    )
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining('auto-generated script to add import map with timestamp'),
+    )
   })
 
   test('handles html string with no <head>', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const result = addTimestampedImportMapScriptToHtml('<html><body></body></html>', importMap)
+    // Make second call to querySelector return falsy, triggering lack-of-head-el conditional
+    mockQuerySelector.mockReturnThis().mockReturnValueOnce(null as unknown as typeof fakeDom)
+    addTimestampedImportMapScriptToHtml('<html><body></body></html>', importMap)
 
-    expect(result).toContain('id="__imports"')
-    expect(result).toContain('<head>')
-  })
-})
-
-const fixedTimestamp = 1_700_000_000_000
-
-// A current desktop Chrome UA: a known-safe engine on the modulepreload
-// allowlist, so it gets the modulepreload as well as the preconnect.
-const chromeUserAgent =
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-
-// Desktop Safari and iOS Safari: WebKit engines that blank the studio when the
-// modulepreload follows the CDN's cross-origin redirect, so the modulepreload
-// must be withheld from both (the safe preconnect still runs).
-const desktopSafariUserAgent =
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15'
-const iosSafariUserAgent =
-  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1'
-
-// An iOS UA carrying a `Chrome` token (an in-app webview or spoof): WebKit
-// under the hood, so it must be withheld. The allowlist's engine token would
-// match it — the iOS device-name exclusion is the only thing keeping the
-// modulepreload off, which proves that guard is load-bearing, not dead code.
-const iosChromeTokenUserAgent =
-  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile/15E148 Safari/604.1'
-
-// An unrecognised engine matching neither the device-name nor the allowlist:
-// default-deny must withhold the modulepreload rather than risk bricking it.
-const unknownEngineUserAgent = 'SomeFutureBrowser/1.0'
-
-function createRuntimeDom(html: string, userAgent: string = chromeUserAgent): JSDOM {
-  return new JSDOM(html, {
-    beforeParse(window) {
-      window.Date.now = () => fixedTimestamp
-      // The injected script branches on navigator.userAgent to gate the hints,
-      // so the UA the in-page script sees must be stubbed before it runs.
-      Object.defineProperty(window.navigator, 'userAgent', {
-        configurable: true,
-        get: () => userAgent,
-      })
-    },
-    runScripts: 'dangerously',
-    url: 'https://example.test/',
-  })
-}
-
-describe('tests the runtime TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT', () => {
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-  test('executes runtime script and injects the expected import map', () => {
-    const importMap = {
-      imports: {
-        external: 'https://example.com/modules/external/index.js',
-        sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890',
-      },
-    }
-
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
-    const dom = createRuntimeDom(result)
-
-    const importMapEl = dom.window.document.querySelector('script[type="importmap"]')
-    expect(importMapEl).toBeTruthy()
-
-    const runtimeImportMap = JSON.parse(importMapEl?.textContent || '{}') as {
-      imports?: Record<string, string>
-    }
-
-    expect(runtimeImportMap.imports?.sanity).toBe(
-      'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000',
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining('<script type="application/json" id="__imports">'),
     )
-    expect(runtimeImportMap.imports?.external).toBe('https://example.com/modules/external/index.js')
-  })
-
-  test('executes runtime script and appends stylesheet links with the expected URLs', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const cssUrls = [
-      'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890/index.css',
-      'https://example.com/styles/external.css',
-    ]
-
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap, cssUrls)
-    const dom = createRuntimeDom(result)
-
-    const stylesheetLinks = [...dom.window.document.querySelectorAll('link[rel="stylesheet"]')].map(
-      (link) => link.getAttribute('href'),
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining(JSON.stringify(importMap)),
     )
-
-    expect(stylesheetLinks).toEqual([
-      'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000/index.css',
-      'https://example.com/styles/external.css',
-    ])
-  })
-
-  describe.each([
-    ['desktop Chrome', chromeUserAgent],
-    ['desktop Safari', desktopSafariUserAgent],
-    ['iOS Safari', iosSafariUserAgent],
-    ['an iOS webview with a Chrome token', iosChromeTokenUserAgent],
-    ['an unrecognised engine', unknownEngineUserAgent],
-  ])('preconnect is safe in every engine (%s)', (_label, userAgent) => {
-    test('warms the CDN connection with a crossorigin preconnect', () => {
-      const importMap = {
-        imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-      }
-      const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
-      const dom = createRuntimeDom(result, userAgent)
-
-      const preconnectLinks = dom.window.document.querySelectorAll('link[rel="preconnect"]')
-      expect(preconnectLinks).toHaveLength(1)
-      expect(preconnectLinks[0].getAttribute('href')).toBe('https://sanity-cdn.com')
-      expect(preconnectLinks[0].getAttribute('crossorigin')).toBe('anonymous')
-    })
-  })
-
-  test('modulepreloads sanity with a timestamp matching the importmap entry (no double fetch)', () => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
-    const dom = createRuntimeDom(result, chromeUserAgent)
-
-    const preloadLinks = dom.window.document.querySelectorAll('link[rel="modulepreload"]')
-    expect(preloadLinks).toHaveLength(1)
-    const preloadHref = preloadLinks[0].getAttribute('href')
-    expect(preloadHref).toBe(
-      'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000',
+    expect(mockInsert).toHaveBeenCalledWith(
+      'beforeend',
+      expect.stringContaining('auto-generated script to add import map with timestamp'),
     )
-    expect(preloadLinks[0].getAttribute('crossorigin')).toBe('anonymous')
-
-    const importMapEl = dom.window.document.querySelector('script[type="importmap"]')
-    const runtimeImportMap = JSON.parse(importMapEl?.textContent || '{}') as {
-      imports?: Record<string, string>
-    }
-    // The preload href must equal what the importmap resolves `sanity` to,
-    // otherwise the browser fetches the largest chunk twice.
-    expect(preloadHref).toBe(runtimeImportMap.imports?.sanity)
-  })
-
-  test('emits no hints when sanity resolves to a non-CDN host', () => {
-    const importMap = {imports: {sanity: 'https://example.com/modules/sanity/index.js'}}
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
-    const dom = createRuntimeDom(result, chromeUserAgent)
-
-    expect(dom.window.document.querySelectorAll('link[rel="preconnect"]')).toHaveLength(0)
-    expect(dom.window.document.querySelectorAll('link[rel="modulepreload"]')).toHaveLength(0)
-  })
-
-  test('emits no hints when no import resolves to a sanity-cdn host', () => {
-    const importMap = {
-      imports: {external: 'https://example.com/modules/external/index.js'},
-    }
-    const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
-    const dom = createRuntimeDom(result, chromeUserAgent)
-
-    expect(dom.window.document.querySelectorAll('link[rel="preconnect"]')).toHaveLength(0)
-    expect(dom.window.document.querySelectorAll('link[rel="modulepreload"]')).toHaveLength(0)
-  })
-
-  describe.each([
-    ['desktop Safari', desktopSafariUserAgent],
-    ['iOS Safari', iosSafariUserAgent],
-    ['an iOS webview with a Chrome token (device guard wins)', iosChromeTokenUserAgent],
-    ['an unrecognised engine', unknownEngineUserAgent],
-  ])('modulepreload is withheld outside the allowlist (%s)', (_label, gatedUserAgent) => {
-    const importMap = {
-      imports: {sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890'},
-    }
-    const cssUrls = [
-      'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1234567890/index.css',
-    ]
-
-    test('withholds the modulepreload while keeping the safe preconnect', () => {
-      const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap)
-      const dom = createRuntimeDom(result, gatedUserAgent)
-
-      expect(dom.window.document.querySelectorAll('link[rel="modulepreload"]')).toHaveLength(0)
-      expect(dom.window.document.querySelectorAll('link[rel="preconnect"]')).toHaveLength(1)
-    })
-
-    test('still rewrites the import map and emits stylesheet links (graceful fallback)', () => {
-      const result = addTimestampedImportMapScriptToHtml(baseHtml, importMap, cssUrls)
-      const dom = createRuntimeDom(result, gatedUserAgent)
-
-      const importMapEl = dom.window.document.querySelector('script[type="importmap"]')
-      const runtimeImportMap = JSON.parse(importMapEl?.textContent || '{}') as {
-        imports?: Record<string, string>
-      }
-      expect(runtimeImportMap.imports?.sanity).toBe(
-        'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000',
-      )
-
-      const stylesheetLinks = [
-        ...dom.window.document.querySelectorAll('link[rel="stylesheet"]'),
-      ].map((link) => link.getAttribute('href'))
-      expect(stylesheetLinks).toEqual([
-        'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1700000000/index.css',
-      ])
-    })
   })
 })

--- a/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
+++ b/packages/@sanity/cli-build/src/actions/build/writeSanityRuntime.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs/promises'
+import {mkdir, writeFile} from 'node:fs/promises'
 import path from 'node:path'
 
 import {tryFindStudioConfigPath} from '@sanity/cli-core/config'
@@ -40,7 +40,7 @@ export async function writeSanityRuntime(options: RuntimeOptions): Promise<{
   const runtimeDir = path.join(cwd, '.sanity', 'runtime')
 
   buildDebug('Making runtime directory')
-  await fs.mkdir(runtimeDir, {recursive: true})
+  await mkdir(runtimeDir, {recursive: true})
 
   async function renderAndWriteDocument() {
     buildDebug('Rendering document template')
@@ -61,7 +61,7 @@ export async function writeSanityRuntime(options: RuntimeOptions): Promise<{
     )
 
     buildDebug('Writing index.html to runtime directory')
-    await fs.writeFile(path.join(runtimeDir, 'index.html'), indexHtml)
+    await writeFile(path.join(runtimeDir, 'index.html'), indexHtml)
   }
 
   let watcher: FSWatcher | undefined
@@ -91,7 +91,7 @@ export async function writeSanityRuntime(options: RuntimeOptions): Promise<{
     reactStrictMode,
     relativeConfigLocation,
   })
-  await fs.writeFile(path.join(runtimeDir, 'app.js'), appJsContent)
+  await writeFile(path.join(runtimeDir, 'app.js'), appJsContent)
 
   return {
     entries: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -944,9 +944,6 @@ importers:
       '@types/debug':
         specifier: 'catalog:'
         version: 4.1.13
-      '@types/jsdom':
-        specifier: 'catalog:'
-        version: 28.0.3
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -974,9 +974,6 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.5.0(jiti@2.7.0)
-      jsdom:
-        specifier: 'catalog:'
-        version: 29.1.1(@noble/hashes@2.2.0)
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21


### PR DESCRIPTION
### Description

A few fast follow-ups from #1465; drops JSDOM from `cli-build` dev deps too.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test setup and a non-behavioral fs import style in `writeSanityRuntime`; production build HTML injection logic is unchanged in this diff, though runtime injector behavior is no longer exercised by tests here.
> 
> **Overview**
> Follow-up test cleanup in `@sanity/cli-build`: **`jsdom` and `@types/jsdom` are removed** from dev dependencies and the lockfile.
> 
> **`addTimestampImportMapScriptToHtml` tests** no longer parse HTML or execute the injected runtime script in JSDOM. They now **mock `node-html-parser`** and assert the expected `insertAdjacentHTML` / `append` calls (import map JSON, injector script, optional CSS, missing `<html>` / `<head>` branches). The large suite that ran the timestamp injector in-browser (timestamps, stylesheets, preconnect/modulepreload, UA gating) is **removed** in favor of these lighter unit tests.
> 
> Other test tweaks: **`buildDebug` and `node:fs/promises` mocks** use simpler string paths and partial mocks; **`writeSanityRuntime`** switches to **named `mkdir` / `writeFile` imports** from `node:fs/promises` to match that mocking style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1411bb83e6172d37e7ffb336c66181e4d45088d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->