### PR TITLE
fix(workbench): hash local app configs into an id for change detection

### DIFF
--- a/.changeset/config-hash-id.md
+++ b/.changeset/config-hash-id.md
@@ -1,0 +1,5 @@
+---
+'@sanity/workbench-cli': patch
+---
+
+fix(workbench): hash local app configs into an `id` so the workbench can detect config changes without stringifying

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -112,9 +112,24 @@ describe('deriveConfigs', () => {
           {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
           {name: 'language', public: undefined, src: './src/language.ts', title: 'Language'},
         ],
+        id: expect.any(String),
         moduleName: 'test-app',
       },
     ])
+  })
+
+  test('id is stable for the same config and changes when the config changes', () => {
+    const config = {
+      appType: 'media-library' as const,
+      fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
+    }
+    const app = workbenchApp({config, isSingleton: true})
+    const edited = workbenchApp({
+      config: {...config, fields: [{...config.fields[0]!, title: 'Edited'}]},
+      isSingleton: true,
+    })
+    expect(deriveConfigs(app)[0]?.id).toBe(deriveConfigs(app)[0]?.id)
+    expect(deriveConfigs(edited)[0]?.id).not.toBe(deriveConfigs(app)[0]?.id)
   })
 
   test("forwards the config's appType discriminator (assigns the singleton, no app id)", () => {
@@ -149,6 +164,7 @@ describe('deriveConfigEntries', () => {
           {name: 'description', public: true, src: './src/description.ts', title: 'Description'},
           {name: 'language', src: './src/language.ts', title: 'Language'},
         ],
+        id: 'cfg-hash',
       }),
     ).toEqual([
       {name: 'description', src: './src/description.ts'},
@@ -157,11 +173,11 @@ describe('deriveConfigEntries', () => {
   })
 
   test('an empty field set yields no entries', () => {
-    expect(deriveConfigEntries({appType: 'media-library', fields: []})).toEqual([])
+    expect(deriveConfigEntries({appType: 'media-library', fields: [], id: 'cfg-hash'})).toEqual([])
   })
 
   test('throws on an app type it cannot handle', () => {
-    expect(() => deriveConfigEntries({appType: 'core-app', fields: []})).toThrow(
+    expect(() => deriveConfigEntries({appType: 'core-app', fields: [], id: 'cfg-hash'})).toThrow(
       /unknown config appType: core-app/i,
     )
   })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
@@ -14,10 +14,12 @@ const worker = (name: string, src = `./src/${name}.ts`): DevServerInterface => (
   interface_type: 'worker',
   name,
 })
-const config: DevServerConfig = {
+const mlConfig = (fields: DevServerConfig['fields']): DevServerConfig => ({
   appType: 'media-library',
-  fields: [{name: 'd', src: './src/d.ts', title: 'D'}],
-}
+  fields,
+  id: 'cfg-hash',
+})
+const config = mlConfig([{name: 'd', src: './src/d.ts', title: 'D'}])
 const server = (
   id: string,
   port: number,
@@ -69,71 +71,43 @@ describe('exposesSetId', () => {
   })
 
   test('a zero-field config still toggles the id — its module is an expose on its own', () => {
-    const empty: DevServerConfig = {appType: 'media-library', fields: []}
     expect(exposesSetId({interfaces: [panel('a')]})).not.toBe(
-      exposesSetId({configs: [empty], interfaces: [panel('a')]}),
+      exposesSetId({configs: [mlConfig([])], interfaces: [panel('a')]}),
     )
   })
 
   test('a config field add or rename changes the id (module is build-baked)', () => {
-    const one: DevServerConfig = {
-      appType: 'media-library',
-      fields: [{name: 'description', src: './src/d.ts', title: 'Description'}],
-    }
-    const added: DevServerConfig = {
-      appType: 'media-library',
-      fields: [
-        {name: 'description', src: './src/d.ts', title: 'Description'},
-        {name: 'language', src: './src/l.ts', title: 'Language'},
-      ],
-    }
-    const renamed: DevServerConfig = {
-      appType: 'media-library',
-      fields: [{name: 'locale', src: './src/d.ts', title: 'Description'}],
-    }
+    const one = mlConfig([{name: 'description', src: './src/d.ts', title: 'Description'}])
+    const added = mlConfig([
+      {name: 'description', src: './src/d.ts', title: 'Description'},
+      {name: 'language', src: './src/l.ts', title: 'Language'},
+    ])
+    const renamed = mlConfig([{name: 'locale', src: './src/d.ts', title: 'Description'}])
     expect(exposesSetId({configs: [one]})).not.toBe(exposesSetId({configs: [added]}))
     expect(exposesSetId({configs: [one]})).not.toBe(exposesSetId({configs: [renamed]}))
   })
 
   test('a config field pointed at a different file is a rebuild — the module reimports it', () => {
-    const before: DevServerConfig = {
-      appType: 'media-library',
-      fields: [{name: 'x', src: './src/x.ts', title: 'X'}],
-    }
-    const after: DevServerConfig = {
-      appType: 'media-library',
-      fields: [{name: 'x', src: './src/y.ts', title: 'X'}],
-    }
+    const before = mlConfig([{name: 'x', src: './src/x.ts', title: 'X'}])
+    const after = mlConfig([{name: 'x', src: './src/y.ts', title: 'X'}])
     expect(exposesSetId({configs: [before]})).not.toBe(exposesSetId({configs: [after]}))
   })
 
   test('reordering config fields is not a change', () => {
-    const a: DevServerConfig = {
-      appType: 'media-library',
-      fields: [
-        {name: 'x', src: './src/x.ts', title: 'X'},
-        {name: 'y', src: './src/y.ts', title: 'Y'},
-      ],
-    }
-    const b: DevServerConfig = {
-      appType: 'media-library',
-      fields: [
-        {name: 'y', src: './src/y.ts', title: 'Y'},
-        {name: 'x', src: './src/x.ts', title: 'X'},
-      ],
-    }
+    const a = mlConfig([
+      {name: 'x', src: './src/x.ts', title: 'X'},
+      {name: 'y', src: './src/y.ts', title: 'Y'},
+    ])
+    const b = mlConfig([
+      {name: 'y', src: './src/y.ts', title: 'Y'},
+      {name: 'x', src: './src/x.ts', title: 'X'},
+    ])
     expect(exposesSetId({configs: [a]})).toBe(exposesSetId({configs: [b]}))
   })
 
   test('a field title/public edit is not a rebuild — those ride the wire, not the module', () => {
-    const a: DevServerConfig = {
-      appType: 'media-library',
-      fields: [{name: 'x', public: true, src: './src/x.ts', title: 'X'}],
-    }
-    const b: DevServerConfig = {
-      appType: 'media-library',
-      fields: [{name: 'x', public: false, src: './src/x.ts', title: 'Renamed'}],
-    }
+    const a = mlConfig([{name: 'x', public: true, src: './src/x.ts', title: 'X'}])
+    const b = mlConfig([{name: 'x', public: false, src: './src/x.ts', title: 'Renamed'}])
     expect(exposesSetId({configs: [a]})).toBe(exposesSetId({configs: [b]}))
   })
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -611,7 +611,7 @@ describe('startWorkbenchDevServer', () => {
       watchCallback([
         {host: 'localhost', id: 'app-1', pid: 2, port: 3334, type: 'studio'},
         {
-          configs: [{...config, moduleName: 'media-library'}],
+          configs: [{...config, id: 'cfg-hash', moduleName: 'media-library'}],
           host: 'localhost',
           pid: 3,
           port: 3337,
@@ -634,6 +634,7 @@ describe('startWorkbenchDevServer', () => {
                 },
               ],
             },
+            id: 'cfg-hash',
             moduleName: 'media-library',
             remoteURL: 'http://localhost:3337',
           },

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -1,3 +1,5 @@
+import {hash} from 'node:crypto'
+
 import {type CliConfig} from '@sanity/cli-core'
 
 import {isWorkbenchApp, readConfig} from '../../defineApp.js'
@@ -65,22 +67,23 @@ export function deriveConfigEntries(config: DevServerConfig): {name: string; src
  * The fields' schema *values* can't serialize — the workbench loads them from
  * the federation module. `src` stays on so the exposes-set id keys on it and a
  * repoint rebuilds. `appType` routes the config to the singleton (no app id to
- * key on).
+ * key on). `id` is a content hash of the entry — it fills the
+ * installation-config id slot deployed apps get from the applications API,
+ * and the workbench keys change detection on it.
  */
 export function deriveConfigs(app: CliConfig['app']): DevServerConfig[] {
   if (!isWorkbenchApp(app)) return []
   const config = readConfig(app)
   if (!config) return []
-  return [
-    {
-      appType: config.appType,
-      fields: config.fields.map((field) => ({
-        name: field.name,
-        public: field.public,
-        src: field.src,
-        title: field.title,
-      })),
-      moduleName: app.name,
-    },
-  ]
+  const entry = {
+    appType: config.appType,
+    fields: config.fields.map((field) => ({
+      name: field.name,
+      public: field.public,
+      src: field.src,
+      title: field.title,
+    })),
+    moduleName: app.name,
+  }
+  return [{...entry, id: hash('sha1', JSON.stringify(entry))}]
 }

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -54,6 +54,9 @@ const devServerManifestSchema = z.object({
             title: z.string(),
           }),
         ),
+        // Content hash of the config — the workbench's change-detection key
+        // (see deriveConfigs).
+        id: z.string(),
         // The app's `unstable_defineApp` name — the module-federation alias the
         // workbench loads this config's live values from.
         moduleName: z.optional(z.string()),

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -41,9 +41,10 @@ const toApplicationsPayload = (servers: DevServerManifest[]) => ({
     // The registry stores the config flat; the workbench wire shape nests the
     // type-specific payload (`fields` for a media library) under `config`, keyed
     // by the `appType` discriminator.
-    (configs ?? []).map(({appType, moduleName, ...config}) => ({
+    (configs ?? []).map(({appType, id, moduleName, ...config}) => ({
       appType,
       config,
+      id,
       moduleName,
       remoteURL: `http://${host}:${port}`,
     })),


### PR DESCRIPTION
### Description

The workbench detects local app config changes by stringifying the whole config on every `applications.sync` comparison — potentially expensive, and flagged in review.

The CLI now hashes the derived config once (`node:crypto` sha1 over the serializable entry) and forwards it as `id` on the registry entry and the local-applications wire payload. The hash fills the same slot as the installation config `id` deployed apps get from the applications API, so local and deployed configs share a shape and the workbench can key change detection on the id alone.

Part of [SDK-1877](https://linear.app/sanity/issue/SDK-1877/hash-config-instead-of-stringifying-for-change-detection). Workbench half: sanity-io/workbench#288.

### What to review

- `deriveConfigs` builds the entry with fixed key order and hashes it once, so every registry write carries the id with no extra plumbing.
- `id` is required in the registry schema — config forwarding is unreleased, so there are no legacy entries to tolerate.
- `toApplicationsPayload` forwards `id` top-level, next to `appType`/`config`/`moduleName`/`remoteURL`.

### Testing

Unit tests pin hash stability (same config → same id, edited config → new id) and top-level forwarding on the wire payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only workbench-cli plumbing for unreleased config forwarding; no auth or production runtime paths, with behavior covered by unit tests.
> 
> **Overview**
> Local workbench app configs now get a **content-derived `id`** (SHA-1 over the serializable config entry in `deriveConfigs`) instead of relying on the workbench to stringify the whole config on every sync.
> 
> That `id` is **required** on dev-server registry config entries and is forwarded **top-level** on the `sanity:workbench:local-applications` payload via `toApplicationsPayload`, matching the installation-config `id` slot deployed apps get from the applications API so change detection can compare ids alone.
> 
> Tests cover hash stability, edits changing the id, and wire forwarding; existing exposes-set / rebuild tests were updated to include `id` on mock configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d0c08488b9a6e86ecbe14978aa9434895900b1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->