### PR TITLE
feat(workbench): forward contract versions on the dev wire

### DIFF
--- a/.changeset/dev-contract-versions.md
+++ b/.changeset/dev-contract-versions.md
@@ -1,0 +1,5 @@
+---
+'@sanity/workbench-cli': patch
+---
+
+feat(workbench): forward config and interface contract versions on the dev wire

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -13,7 +13,7 @@ describe('deriveInterfaces', () => {
   test('maps views to panel interfaces', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed', version: 1},
     ])
   })
 
@@ -22,7 +22,7 @@ describe('deriveInterfaces', () => {
       services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread'},
+      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread', version: 1},
     ])
   })
 
@@ -47,8 +47,8 @@ describe('deriveInterfaces', () => {
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
-      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread'},
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed', version: 1},
+      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread', version: 1},
       {entry_point: './src/App.tsx', interface_type: 'app', name: 'my-app'},
     ])
   })
@@ -63,7 +63,7 @@ describe('deriveInterfaces', () => {
     })
     // only the panel — the config rides deriveConfigs, not interfaces
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed', version: 1},
     ])
   })
 
@@ -77,7 +77,7 @@ describe('deriveInterfaces', () => {
   test('a studio without entry still derives its panels/workers', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     expect(deriveInterfaces(app, {isApp: false})).toEqual([
-      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
+      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed', version: 1},
     ])
   })
 })
@@ -114,6 +114,7 @@ describe('deriveConfigs', () => {
         ],
         id: expect.any(String),
         moduleName: 'test-app',
+        version: 1,
       },
     ])
   })
@@ -165,6 +166,7 @@ describe('deriveConfigEntries', () => {
           {name: 'language', src: './src/language.ts', title: 'Language'},
         ],
         id: 'cfg-hash',
+        version: 1,
       }),
     ).toEqual([
       {name: 'description', src: './src/description.ts'},
@@ -173,12 +175,14 @@ describe('deriveConfigEntries', () => {
   })
 
   test('an empty field set yields no entries', () => {
-    expect(deriveConfigEntries({appType: 'media-library', fields: [], id: 'cfg-hash'})).toEqual([])
+    expect(
+      deriveConfigEntries({appType: 'media-library', fields: [], id: 'cfg-hash', version: 1}),
+    ).toEqual([])
   })
 
   test('throws on an app type it cannot handle', () => {
-    expect(() => deriveConfigEntries({appType: 'core-app', fields: [], id: 'cfg-hash'})).toThrow(
-      /unknown config appType: core-app/i,
-    )
+    expect(() =>
+      deriveConfigEntries({appType: 'core-app', fields: [], id: 'cfg-hash', version: 1}),
+    ).toThrow(/unknown config appType: core-app/i)
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
@@ -18,6 +18,7 @@ const mlConfig = (fields: DevServerConfig['fields']): DevServerConfig => ({
   appType: 'media-library',
   fields,
   id: 'cfg-hash',
+  version: 1,
 })
 const config = mlConfig([{name: 'd', src: './src/d.ts', title: 'D'}])
 const server = (

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
@@ -164,7 +164,9 @@ describe('startDevServerRegistration', () => {
     const params = {configPath: '/tmp/sanity-project/sanity.cli.ts', workDir: '/tmp/sanity-project'}
     await expect(extract(params)).resolves.toEqual({
       configs: [],
-      interfaces: [{entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'}],
+      interfaces: [
+        {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed', version: 1},
+      ],
       manifest,
     })
     expect(mockExtractManifest).toHaveBeenCalledWith(params)

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -611,7 +611,7 @@ describe('startWorkbenchDevServer', () => {
       watchCallback([
         {host: 'localhost', id: 'app-1', pid: 2, port: 3334, type: 'studio'},
         {
-          configs: [{...config, id: 'cfg-hash', moduleName: 'media-library'}],
+          configs: [{...config, id: 'cfg-hash', moduleName: 'media-library', version: 1}],
           host: 'localhost',
           pid: 3,
           port: 3337,
@@ -637,6 +637,7 @@ describe('startWorkbenchDevServer', () => {
             id: 'cfg-hash',
             moduleName: 'media-library',
             remoteURL: 'http://localhost:3337',
+            version: 1,
           },
         ],
       })

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -2,6 +2,11 @@ import {hash} from 'node:crypto'
 
 import {type CliConfig} from '@sanity/cli-core'
 
+import {
+  MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION,
+  SERVICE_CONTRACT_VERSION,
+  VIEW_CONTRACT_VERSION,
+} from '../../contract.js'
 import {isWorkbenchApp, readConfig} from '../../defineApp.js'
 import {type DevServerManifest} from './registry.js'
 
@@ -17,7 +22,9 @@ export type DevServerConfig = NonNullable<DevServerManifest['configs']>[number]
  * navigable `app` view (`entry_point` is the raw `src`, not a resolved URL).
  * `undefined` for a non-branded app; a studio that declares `entry` is rejected
  * (studio app views are not implemented yet). The config is not an
- * interface — see {@link deriveConfigs}.
+ * interface — see {@link deriveConfigs}. `version` is the contract version the
+ * interface's generated module exports, known before the module runs; the app
+ * view has no versioned contract, so it carries none.
  */
 export function deriveInterfaces(
   app: CliConfig['app'],
@@ -34,11 +41,13 @@ export function deriveInterfaces(
       entry_point: view.src,
       interface_type: view.type,
       name: view.name,
+      version: VIEW_CONTRACT_VERSION,
     })) ?? []),
     ...(app.services?.map((service) => ({
       entry_point: service.src,
       interface_type: service.type,
       name: service.name,
+      version: SERVICE_CONTRACT_VERSION,
     })) ?? []),
     ...(app.entry === undefined
       ? []
@@ -69,7 +78,8 @@ export function deriveConfigEntries(config: DevServerConfig): {name: string; src
  * repoint rebuilds. `appType` routes the config to the singleton (no app id to
  * key on). `id` is a content hash of the entry — it fills the
  * installation-config id slot deployed apps get from the applications API,
- * and the workbench keys change detection on it.
+ * and the workbench keys change detection on it. `version` is the config
+ * contract version the generated module exports, known before the module runs.
  */
 export function deriveConfigs(app: CliConfig['app']): DevServerConfig[] {
   if (!isWorkbenchApp(app)) return []
@@ -84,6 +94,7 @@ export function deriveConfigs(app: CliConfig['app']): DevServerConfig[] {
       title: field.title,
     })),
     moduleName: app.name,
+    version: MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION,
   }
   return [{...entry, id: hash('sha1', JSON.stringify(entry))}]
 }

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -60,6 +60,9 @@ const devServerManifestSchema = z.object({
         // The app's `unstable_defineApp` name — the module-federation alias the
         // workbench loads this config's live values from.
         moduleName: z.optional(z.string()),
+        // Config contract version the generated module exports, so the
+        // workbench knows what it can resolve before loading the module.
+        version: z.number(),
       }),
     ),
   ),
@@ -76,7 +79,16 @@ const devServerManifestSchema = z.object({
    * interface shape.
    */
   interfaces: z.optional(
-    z.array(z.object({entry_point: z.string(), interface_type: z.string(), name: z.string()})),
+    z.array(
+      z.object({
+        entry_point: z.string(),
+        interface_type: z.string(),
+        name: z.string(),
+        // Contract version the interface's generated module exports; the app
+        // view has no versioned contract and carries none.
+        version: z.optional(z.number()),
+      }),
+    ),
   ),
   /**
    * Inlined manifest — either a {@link StudioManifest} or {@link CoreAppManifest},

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -41,12 +41,13 @@ const toApplicationsPayload = (servers: DevServerManifest[]) => ({
     // The registry stores the config flat; the workbench wire shape nests the
     // type-specific payload (`fields` for a media library) under `config`, keyed
     // by the `appType` discriminator.
-    (configs ?? []).map(({appType, id, moduleName, ...config}) => ({
+    (configs ?? []).map(({appType, id, moduleName, version, ...config}) => ({
       appType,
       config,
       id,
       moduleName,
       remoteURL: `http://${host}:${port}`,
+      version,
     })),
   ),
 })


### PR DESCRIPTION
### Description

Brett surfaces a `version` for installation configs and interfaces, but it's the package release version — it says nothing about whether a consumer can parse the module behind it. Locally the situation was worse: the contract versions live only inside the generated federation modules (`export const version`), so the workbench had to load and run a module to learn its contract.

The CLI knows these versions statically (it stamps them into the modules it generates), so forward them on the dev wire: `version` on each config entry (required, `MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION`) and on view/worker interface records (`VIEW_CONTRACT_VERSION` / `SERVICE_CONTRACT_VERSION`). The `app` view has no versioned contract and carries none. The version is part of the hashed config entry, so a contract bump also produces a new config `id`.

Stacked on #1468. Part of [SDK-1877](https://linear.app/sanity/issue/SDK-1877/hash-config-instead-of-stringifying-for-change-detection); workbench consumer: sanity-io/workbench#289.

### What to review

- `deriveConfigs` / `deriveInterfaces` stamp the same constants the build writes into the generated modules, so wire and module can't drift.
- Registry schema: config `version` required (unreleased wire, no legacy), interface `version` optional (the `app` record never has one).

### Testing

Unit tests pin the stamped versions on derived configs and interfaces and the top-level forwarding on the wire payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only wire and registry shape changes with matching unit tests; no auth or production deploy path touched.
> 
> **Overview**
> The workbench CLI now stamps **contract versions** onto local dev registry entries and HMR payloads so the workbench can tell what module shape to expect **without loading federation remotes first**.
> 
> `deriveInterfaces` adds `version` to panel and worker records from `VIEW_CONTRACT_VERSION` / `SERVICE_CONTRACT_VERSION`; the navigable **`app`** interface still has no version. `deriveConfigs` includes `MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION` on each config, and that field is part of the hashed entry so a contract bump yields a new config **`id`**.
> 
> The dev-server registry schema requires config `version` and treats interface `version` as optional; `startWorkbenchDevServer` forwards `version` on the `sanity:workbench:local-applications` config wire shape. Tests assert the stamped values end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b978f10a760693d039672299b4ebde097a9c0547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->