### PR TITLE
feat(undeploy): add --json flag

### DIFF
--- a/.changeset/pr-1471.md
+++ b/.changeset/pr-1471.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(undeploy): add --json flag

--- a/.changeset/pr-1471.md
+++ b/.changeset/pr-1471.md
@@ -1,5 +1,6 @@
 <!-- auto-generated -->
 ---
+'@sanity/cli-core': minor
 '@sanity/cli': minor
 ---
 

--- a/.changeset/pr-1471.md
+++ b/.changeset/pr-1471.md
@@ -1,6 +1,5 @@
 <!-- auto-generated -->
 ---
-'@sanity/cli-core': minor
 '@sanity/cli': minor
 ---
 

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -1,11 +1,10 @@
-import {format} from 'node:util'
-
 import {CLIError} from '@oclif/core/errors'
 import {type Output} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {type DeployedExpose} from '@sanity/workbench-cli/deploy'
 
 import {createCollectingReporter, createFailFastReporter} from '../../util/checks.js'
+import {toStderrOutput} from '../../util/toStderrOutput.js'
 import {type DeployCheck, type DeployCheckReporter, type DeployTarget} from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
 import {
@@ -62,17 +61,8 @@ export async function runDeploy(options: DeployAppOptions, spec: DeploySpec): Pr
   const emitJson = (payload: unknown) => output.log(JSON.stringify(payload, null, 2))
 
   // The JSON payload owns stdout, so the run's progress logs go to stderr; only
-  // the final JSON.stringify writes to stdout. Spinners are already on stderr.
-  const runOptions = json
-    ? {
-        ...options,
-        output: {
-          ...output,
-          log: (message = '', ...args: unknown[]) =>
-            void process.stderr.write(`${format(message, ...args)}\n`),
-        },
-      }
-    : options
+  // the final JSON.stringify writes to stdout.
+  const runOptions = json ? {...options, output: toStderrOutput(output)} : options
 
   try {
     if (options.flags['dry-run']) {

--- a/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
@@ -8,6 +8,7 @@ import {
   describeUndeployTarget,
   renderUndeployPlan,
   type UndeployPlan,
+  undeployPlanToJson,
   type UndeployTarget,
 } from '../undeployPlan.js'
 
@@ -183,6 +184,67 @@ describe('runUndeploy real run', () => {
   })
 })
 
+describe('runUndeploy --json', () => {
+  test('a dry run emits the plan as JSON on stdout only', async () => {
+    const output = mockOutput()
+    await runUndeploy(options(output, {'dry-run': true, json: true}), adapter())
+
+    const logged = vi.mocked(output.log).mock.calls.map((call) => String(call[0]))
+    expect(logged).toHaveLength(1)
+    const payload = JSON.parse(logged[0]!)
+    expect(payload.canUndeploy).toBe(true)
+    expect(payload.target.applicationId).toBe('app-1')
+    expect(payload.applicationType).toBe('studio')
+  })
+
+  test('a real run emits an {undeployed: true} envelope with the target', async () => {
+    const output = mockOutput()
+    await runUndeploy(options(output, {json: true, yes: true}), adapter())
+
+    const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
+    expect(payload.undeployed).toBe(true)
+    expect(payload.target.applicationId).toBe('app-1')
+  })
+
+  test('a real run without --yes is a usage error, never an implicit consent', async () => {
+    const output = mockOutput()
+    const undeploy = vi.fn()
+    await runUndeploy(options(output, {json: true}), adapter({undeploy}))
+
+    expect(undeploy).not.toHaveBeenCalled()
+    expect(confirm).not.toHaveBeenCalled()
+    expect(output.error).toHaveBeenCalledWith(expect.stringContaining('Pass --yes'), {exit: 2})
+  })
+
+  test('nothing to undeploy emits {undeployed: false} with the reason', async () => {
+    const output = mockOutput()
+    await runUndeploy(
+      options(output, {json: true, yes: true}),
+      adapter({resolveTarget: async () => ({message: 'No application ID provided', type: 'none'})}),
+    )
+
+    const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
+    expect(payload).toEqual({reason: 'No application ID provided', undeployed: false})
+  })
+
+  test('a failed deletion emits a {undeployed: false} error envelope and still errors on stderr', async () => {
+    const output = mockOutput()
+    await runUndeploy(
+      options(output, {json: true, yes: true}),
+      adapter({
+        undeploy: async () => {
+          throw new Error('boom')
+        },
+      }),
+    )
+
+    const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
+    expect(payload.undeployed).toBe(false)
+    expect(payload.error.message).toContain('boom')
+    expect(output.error).toHaveBeenCalledWith(payload.error.message, {exit: 1})
+  })
+})
+
 describe('describeUndeployTarget', () => {
   test('a found studio → pass check naming its URL', () => {
     expect(describeUndeployTarget({target: target(), type: 'found'})).toEqual({
@@ -222,6 +284,7 @@ describe('canUndeploy', () => {
   test('true with a target and no failing checks', () => {
     const plan: UndeployPlan = {
       checks: [{message: 'ok', status: 'pass'}],
+      reason: null,
       target: target(),
       type: 'studio',
     }
@@ -229,16 +292,61 @@ describe('canUndeploy', () => {
   })
 
   test('false without a target', () => {
-    expect(canUndeploy({checks: [], target: null, type: 'studio'})).toBe(false)
+    expect(canUndeploy({checks: [], reason: null, target: null, type: 'studio'})).toBe(false)
   })
 
   test('false with a failing check', () => {
     const plan: UndeployPlan = {
       checks: [{message: 'boom', status: 'fail'}],
+      reason: null,
       target: target(),
       type: 'studio',
     }
     expect(canUndeploy(plan)).toBe(false)
+  })
+})
+
+describe('undeployPlanToJson', () => {
+  test('derives errors and warnings from the same checks the human report renders', () => {
+    const json = undeployPlanToJson({
+      checks: [
+        {message: 'ok', status: 'pass'},
+        {message: 'heads up', status: 'warn'},
+        {message: 'boom', solution: 'do X', status: 'fail'},
+      ],
+      reason: null,
+      target: target(),
+      type: 'studio',
+    })
+
+    expect(json).toEqual({
+      applicationType: 'studio',
+      canUndeploy: false,
+      errors: {boom: 'do X'},
+      reason: null,
+      target: target(),
+      warnings: ['heads up'],
+    })
+  })
+
+  test('nothing to undeploy carries the reason for agents', () => {
+    const json = undeployPlanToJson({
+      checks: [{message: 'No application ID provided', status: 'skip'}],
+      reason: 'No application ID provided',
+      target: null,
+      type: 'coreApp',
+    })
+
+    expect(json.canUndeploy).toBe(false)
+    expect(json.errors).toEqual({})
+    expect(json.reason).toBe('No application ID provided')
+    expect(json.target).toBeNull()
+  })
+
+  test('an undeployable plan reports the full target', () => {
+    const json = undeployPlanToJson({checks: [], reason: null, target: target(), type: 'studio'})
+    expect(json.canUndeploy).toBe(true)
+    expect(json.target).toEqual(target())
   })
 })
 
@@ -248,6 +356,7 @@ describe('renderUndeployPlan', () => {
     renderUndeployPlan(
       {
         checks: [{message: 'Undeploys studio https://my-studio.sanity.studio', status: 'pass'}],
+        reason: null,
         target: target(),
         type: 'studio',
       },
@@ -265,6 +374,7 @@ describe('renderUndeployPlan', () => {
     renderUndeployPlan(
       {
         checks: [],
+        reason: null,
         target: target({
           activeDeployment: {
             deployedAt: '2024-01-02T00:00:00Z',
@@ -294,6 +404,7 @@ describe('renderUndeployPlan', () => {
     renderUndeployPlan(
       {
         checks: [{message: 'No application ID provided', status: 'skip'}],
+        reason: 'No application ID provided',
         target: null,
         type: 'coreApp',
       },
@@ -310,6 +421,7 @@ describe('renderUndeployPlan', () => {
     renderUndeployPlan(
       {
         checks: [{message: 'boom', solution: 'do X', status: 'fail'}],
+        reason: null,
         target: null,
         type: 'coreApp',
       },

--- a/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
@@ -193,8 +193,7 @@ describe('runUndeploy --json', () => {
     expect(logged).toHaveLength(1)
     const payload = JSON.parse(logged[0]!)
     expect(payload.canUndeploy).toBe(true)
-    expect(payload.target.applicationId).toBe('app-1')
-    expect(payload.applicationType).toBe('studio')
+    expect(payload.application.id).toBe('app-1')
   })
 
   test('a real run emits an {undeployed: true} envelope with the target', async () => {
@@ -203,17 +202,18 @@ describe('runUndeploy --json', () => {
 
     const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
     expect(payload.undeployed).toBe(true)
-    expect(payload.target.applicationId).toBe('app-1')
+    expect(payload.application.id).toBe('app-1')
   })
 
-  test('a real run without --yes is a usage error, never an implicit consent', async () => {
+  test('a real run without --yes proceeds unattended, never prompting', async () => {
     const output = mockOutput()
     const undeploy = vi.fn()
     await runUndeploy(options(output, {json: true}), adapter({undeploy}))
 
-    expect(undeploy).not.toHaveBeenCalled()
     expect(confirm).not.toHaveBeenCalled()
-    expect(output.error).toHaveBeenCalledWith(expect.stringContaining('Pass --yes'), {exit: 2})
+    expect(undeploy).toHaveBeenCalled()
+    const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
+    expect(payload.undeployed).toBe(true)
   })
 
   test('nothing to undeploy emits {undeployed: false} with the reason', async () => {
@@ -320,11 +320,10 @@ describe('undeployPlanToJson', () => {
     })
 
     expect(json).toEqual({
-      applicationType: 'studio',
+      application: target(),
       canUndeploy: false,
       errors: {boom: 'do X'},
       reason: null,
-      target: target(),
       warnings: ['heads up'],
     })
   })
@@ -340,13 +339,13 @@ describe('undeployPlanToJson', () => {
     expect(json.canUndeploy).toBe(false)
     expect(json.errors).toEqual({})
     expect(json.reason).toBe('No application ID provided')
-    expect(json.target).toBeNull()
+    expect(json.application).toBeNull()
   })
 
   test('an undeployable plan reports the full target', () => {
     const json = undeployPlanToJson({checks: [], reason: null, target: target(), type: 'studio'})
     expect(json.canUndeploy).toBe(true)
-    expect(json.target).toEqual(target())
+    expect(json.application).toEqual(target())
   })
 })
 

--- a/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
@@ -205,15 +205,14 @@ describe('runUndeploy --json', () => {
     expect(payload.application.id).toBe('app-1')
   })
 
-  test('a real run without --yes proceeds unattended, never prompting', async () => {
+  test("without `yes` the runner still confirms — unattended consent is the command's job", async () => {
     const output = mockOutput()
     const undeploy = vi.fn()
+    vi.mocked(confirm).mockResolvedValueOnce(false)
     await runUndeploy(options(output, {json: true}), adapter({undeploy}))
 
-    expect(confirm).not.toHaveBeenCalled()
-    expect(undeploy).toHaveBeenCalled()
-    const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
-    expect(payload.undeployed).toBe(true)
+    expect(confirm).toHaveBeenCalled()
+    expect(undeploy).not.toHaveBeenCalled()
   })
 
   test('nothing to undeploy emits {undeployed: false} with the reason', async () => {

--- a/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
@@ -1,7 +1,7 @@
-import {styleText} from 'node:util'
+import {format, styleText} from 'node:util'
 
 import {CLIError} from '@oclif/core/errors'
-import {type Output, subdebug} from '@sanity/cli-core'
+import {exitCodes, type Output, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {confirm, spinner} from '@sanity/cli-core/ux'
 
@@ -15,6 +15,7 @@ import {
   describeUndeployTarget,
   renderUndeployPlan,
   type UndeployPlan,
+  undeployPlanToJson,
   type UndeployTarget,
   type UndeployTargetResolution,
 } from './undeployPlan.js'
@@ -41,16 +42,37 @@ export interface UndeployAdapter {
   undeploy(target: UndeployTarget): Promise<void>
 }
 
+/** What a real undeploy produced — the payload `--json` reports. */
+type UndeployResult =
+  | {applicationType: 'coreApp' | 'studio'; target: UndeployTarget; undeployed: true}
+  | {reason: string; undeployed: false}
+
 /**
  * Runs an undeploy in the mode the flags select: a real undeploy fails fast,
  * confirms, and deletes; `--dry-run` drives the same target resolution
- * read-only and renders a plan instead.
+ * read-only and renders a plan instead. `--json` emits the same information as
+ * machine-readable JSON.
  */
 export async function runUndeploy(
   options: UndeployOptions,
   adapter: UndeployAdapter,
 ): Promise<void> {
   const {flags, output} = options
+  const json = !!flags.json
+  const emitJson = (payload: unknown) => output.log(JSON.stringify(payload, null, 2))
+
+  // The JSON payload owns stdout, so the run's progress logs go to stderr; only
+  // the final JSON.stringify writes to stdout. Spinners are already on stderr.
+  const runOptions = json
+    ? {
+        ...options,
+        output: {
+          ...output,
+          log: (message = '', ...args: unknown[]) =>
+            void process.stderr.write(`${format(message, ...args)}\n`),
+        },
+      }
+    : options
 
   try {
     if (flags['dry-run']) {
@@ -58,44 +80,63 @@ export async function runUndeploy(
       const resolution = await resolveTarget(adapter, reporter)
       const plan: UndeployPlan = {
         checks: reporter.results,
+        reason: resolution?.type === 'none' ? resolution.message : null,
         target: resolution?.type === 'found' ? resolution.target : null,
         type: adapter.type,
       }
-      renderUndeployPlan(plan, output)
+      if (json) emitJson(undeployPlanToJson(plan))
+      else renderUndeployPlan(plan, output)
       // A blocked plan exits like a real (fail-fast) undeploy would.
       const failed = plan.checks.find((check) => check.status === 'fail')
       if (failed) output.error('Undeploy blocked by failing checks.', {exit: failed.exitCode ?? 1})
       return
     }
 
-    await undeployApp(options, adapter)
+    const result = await undeployApp(runOptions, adapter)
+    if (json && result) emitJson(result)
   } catch (error) {
     const failure = normalizeFailure(error, adapter.type)
+    // A blocked dry run reaches this catch too (its exit throws) and already
+    // printed its plan, so only a real undeploy adds the {undeployed: false} envelope.
+    if (json && !flags['dry-run']) {
+      emitJson({error: {message: failure.message}, undeployed: false})
+    }
     output.error(failure.message, {exit: failure.exit})
   }
 }
 
 /** The real run: resolve the target, confirm, delete, report. */
-async function undeployApp(options: UndeployOptions, adapter: UndeployAdapter): Promise<void> {
+async function undeployApp(
+  options: UndeployOptions,
+  adapter: UndeployAdapter,
+): Promise<UndeployResult | undefined> {
   const {flags, output} = options
 
   const resolution = await resolveTarget(adapter, createFailFastReporter(output))
   // A resolve failure never lands here: the fail-fast reporter already exited.
-  if (!resolution) return
+  if (!resolution) return undefined
   if (resolution.type === 'none') {
     output.log(`${resolution.message}.`)
     if (resolution.solution) output.log(`${resolution.solution}.`)
     output.log('Nothing to undeploy.')
-    return
+    return {reason: resolution.message, undeployed: false}
   }
 
   const {target} = resolution
   if (!flags.yes) {
+    // Deleting is destructive, so --json never implies consent the way it does
+    // for deploy — an unattended undeploy must pass --yes explicitly.
+    if (flags.json) {
+      output.error('Cannot confirm the undeploy with --json. Pass --yes (-y) to run unattended.', {
+        exit: exitCodes.USAGE_ERROR,
+      })
+      return undefined
+    }
     const shouldUndeploy = await confirm({
       default: false,
       message: confirmUndeployMessage(target),
     })
-    if (!shouldUndeploy) return
+    if (!shouldUndeploy) return undefined
   }
 
   const spin = spinner(
@@ -110,6 +151,7 @@ async function undeployApp(options: UndeployOptions, adapter: UndeployAdapter): 
   spin.succeed()
 
   printUndeployScheduled(target, output)
+  return {applicationType: target.applicationType, target, undeployed: true}
 }
 
 /**
@@ -174,7 +216,7 @@ function printUndeployScheduled(target: UndeployTarget, output: Output): void {
   )
 }
 
-/** The one failure diagnosis the stderr message reads. */
+/** The one failure diagnosis both the stderr message and the `--json` envelope read. */
 function normalizeFailure(
   error: unknown,
   type: UndeployAdapter['type'],

--- a/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
@@ -1,7 +1,7 @@
 import {format, styleText} from 'node:util'
 
 import {CLIError} from '@oclif/core/errors'
-import {exitCodes, type Output, subdebug} from '@sanity/cli-core'
+import {type Output, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {confirm, spinner} from '@sanity/cli-core/ux'
 
@@ -44,7 +44,7 @@ export interface UndeployAdapter {
 
 /** What a real undeploy produced — the payload `--json` reports. */
 type UndeployResult =
-  | {applicationType: 'coreApp' | 'studio'; target: UndeployTarget; undeployed: true}
+  | {application: UndeployTarget; undeployed: true}
   | {reason: string; undeployed: false}
 
 /**
@@ -123,15 +123,9 @@ async function undeployApp(
   }
 
   const {target} = resolution
-  if (!flags.yes) {
-    // Deleting is destructive, so --json never implies consent the way it does
-    // for deploy — an unattended undeploy must pass --yes explicitly.
-    if (flags.json) {
-      output.error('Cannot confirm the undeploy with --json. Pass --yes (-y) to run unattended.', {
-        exit: exitCodes.USAGE_ERROR,
-      })
-      return undefined
-    }
+  // --json runs unattended: confirmation prompts are for humans, and machine
+  // callers preview with --dry-run.
+  if (!flags.yes && !flags.json) {
     const shouldUndeploy = await confirm({
       default: false,
       message: confirmUndeployMessage(target),
@@ -151,7 +145,7 @@ async function undeployApp(
   spin.succeed()
 
   printUndeployScheduled(target, output)
-  return {applicationType: target.applicationType, target, undeployed: true}
+  return {application: target, undeployed: true}
 }
 
 /**

--- a/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
@@ -1,4 +1,4 @@
-import {format, styleText} from 'node:util'
+import {styleText} from 'node:util'
 
 import {CLIError} from '@oclif/core/errors'
 import {type Output, subdebug} from '@sanity/cli-core'
@@ -11,6 +11,7 @@ import {
   createCollectingReporter,
   createFailFastReporter,
 } from '../../util/checks.js'
+import {toStderrOutput} from '../../util/toStderrOutput.js'
 import {
   describeUndeployTarget,
   renderUndeployPlan,
@@ -62,17 +63,8 @@ export async function runUndeploy(
   const emitJson = (payload: unknown) => output.log(JSON.stringify(payload, null, 2))
 
   // The JSON payload owns stdout, so the run's progress logs go to stderr; only
-  // the final JSON.stringify writes to stdout. Spinners are already on stderr.
-  const runOptions = json
-    ? {
-        ...options,
-        output: {
-          ...output,
-          log: (message = '', ...args: unknown[]) =>
-            void process.stderr.write(`${format(message, ...args)}\n`),
-        },
-      }
-    : options
+  // the final JSON.stringify writes to stdout.
+  const runOptions = json ? {...options, output: toStderrOutput(output)} : options
 
   try {
     if (flags['dry-run']) {
@@ -123,9 +115,7 @@ async function undeployApp(
   }
 
   const {target} = resolution
-  // --json runs unattended: confirmation prompts are for humans, and machine
-  // callers preview with --dry-run.
-  if (!flags.yes && !flags.json) {
+  if (!flags.yes) {
     const shouldUndeploy = await confirm({
       default: false,
       message: confirmUndeployMessage(target),

--- a/packages/@sanity/cli/src/actions/undeploy/undeployPlan.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/undeployPlan.ts
@@ -49,11 +49,10 @@ export function canUndeploy(plan: UndeployPlan): boolean {
  * report renders, so the two can't drift.
  */
 export function undeployPlanToJson(plan: UndeployPlan): {
-  applicationType: UndeployPlan['type']
+  application: UndeployTarget | null
   canUndeploy: boolean
   errors: Record<string, string | null>
   reason: string | null
-  target: UndeployTarget | null
   warnings: string[]
 } {
   const errors: Record<string, string | null> = {}
@@ -64,11 +63,10 @@ export function undeployPlanToJson(plan: UndeployPlan): {
   }
 
   return {
-    applicationType: plan.type,
+    application: plan.target,
     canUndeploy: canUndeploy(plan),
     errors,
     reason: plan.reason,
-    target: plan.target,
     warnings,
   }
 }

--- a/packages/@sanity/cli/src/actions/undeploy/undeployPlan.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/undeployPlan.ts
@@ -6,8 +6,8 @@ import {type Check, checkStatusIcon, renderIssues} from '../../util/checks.js'
 
 /**
  * What an undeploy deletes, resolved once and read by every report — the
- * dry-run plan and the real run's confirmation prompt — so the human and
- * machine outputs can't drift.
+ * dry-run plan, the `--json` payloads, and the real run's confirmation prompt —
+ * so the human and machine outputs can't drift.
  */
 export interface UndeployTarget {
   /** Details of the deployment currently being served; `null` when none is live. */
@@ -32,6 +32,8 @@ export type UndeployTargetResolution =
 /** What a `--dry-run` undeploy would do: the real undeploy sequence with the deletion gated off. */
 export interface UndeployPlan {
   checks: Check[]
+  /** Why there is nothing to undeploy; `null` when a target resolved. */
+  reason: string | null
   /** What would be deleted; `null` when there is nothing to undeploy. */
   target: UndeployTarget | null
   type: 'coreApp' | 'studio'
@@ -39,6 +41,36 @@ export interface UndeployPlan {
 
 export function canUndeploy(plan: UndeployPlan): boolean {
   return plan.target !== null && plan.checks.every((check) => check.status !== 'fail')
+}
+
+/**
+ * A machine-readable projection of the plan: blocking problems mapped to their
+ * fix, warnings as messages. Derived from the same checks and target the human
+ * report renders, so the two can't drift.
+ */
+export function undeployPlanToJson(plan: UndeployPlan): {
+  applicationType: UndeployPlan['type']
+  canUndeploy: boolean
+  errors: Record<string, string | null>
+  reason: string | null
+  target: UndeployTarget | null
+  warnings: string[]
+} {
+  const errors: Record<string, string | null> = {}
+  const warnings: string[] = []
+  for (const check of plan.checks) {
+    if (check.status === 'fail') errors[check.message] = check.solution ?? null
+    else if (check.status === 'warn') warnings.push(check.message)
+  }
+
+  return {
+    applicationType: plan.type,
+    canUndeploy: canUndeploy(plan),
+    errors,
+    reason: plan.reason,
+    target: plan.target,
+    warnings,
+  }
 }
 
 /**

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -467,6 +467,93 @@ describe('#undeploy', () => {
     expect(error?.message).toContain('Undeploy blocked by failing checks.')
   })
 
+  test('dry run with --json emits the plan as JSON', async () => {
+    mockApi({
+      apiVersion: 'v2024-08-01',
+      query: {appHost: 'my-host', appType: 'studio'},
+      uri: '/projects/test/user-applications',
+    }).reply(200, {
+      appHost: 'my-host',
+      id: 'app-id',
+    })
+
+    const {stdout} = await testCommand(UndeployCommand, ['--dry-run', '--json'], {
+      mocks: {
+        cliConfig: {
+          api: {projectId: 'test'},
+          studioHost: 'my-host',
+        },
+        token: 'test-token',
+      },
+    })
+
+    const payload = JSON.parse(stdout)
+    expect(payload.canUndeploy).toBe(true)
+    expect(payload.applicationType).toBe('studio')
+    expect(payload.target).toMatchObject({
+      applicationId: 'app-id',
+      url: 'https://my-host.sanity.studio',
+    })
+  })
+
+  test('--json with --yes undeploys and emits the result envelope', async () => {
+    mockApi({
+      apiVersion: 'v2024-08-01',
+      query: {appHost: 'my-host', appType: 'studio'},
+      uri: '/projects/test/user-applications',
+    }).reply(200, {
+      appHost: 'my-host',
+      id: 'app-id',
+    })
+
+    mockApi({
+      apiVersion: 'v2024-08-01',
+      method: 'delete',
+      query: {appType: 'studio'},
+      uri: '/user-applications/app-id',
+    }).reply(200)
+
+    const {stdout} = await testCommand(UndeployCommand, ['--json', '--yes'], {
+      mocks: {
+        cliConfig: {
+          api: {projectId: 'test'},
+          studioHost: 'my-host',
+        },
+        token: 'test-token',
+      },
+    })
+
+    const payload = JSON.parse(stdout)
+    expect(payload.undeployed).toBe(true)
+    expect(payload.target.applicationId).toBe('app-id')
+  })
+
+  test('--json without --yes refuses to undeploy', async () => {
+    mockApi({
+      apiVersion: 'v2024-08-01',
+      query: {appHost: 'my-host', appType: 'studio'},
+      uri: '/projects/test/user-applications',
+    }).reply(200, {
+      appHost: 'my-host',
+      id: 'app-id',
+    })
+
+    const {error, stdout} = await testCommand(UndeployCommand, ['--json'], {
+      mocks: {
+        cliConfig: {
+          api: {projectId: 'test'},
+          studioHost: 'my-host',
+        },
+        token: 'test-token',
+      },
+    })
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(error?.message).toContain('Pass --yes')
+    const payload = JSON.parse(stdout)
+    expect(payload.undeployed).toBe(false)
+  })
+
   test('handles error when deployment.appId does not exist for the org', async () => {
     mockApi({
       apiVersion: 'v2024-08-01',

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -489,9 +489,8 @@ describe('#undeploy', () => {
 
     const payload = JSON.parse(stdout)
     expect(payload.canUndeploy).toBe(true)
-    expect(payload.applicationType).toBe('studio')
-    expect(payload.target).toMatchObject({
-      applicationId: 'app-id',
+    expect(payload.application).toMatchObject({
+      id: 'app-id',
       url: 'https://my-host.sanity.studio',
     })
   })
@@ -525,10 +524,10 @@ describe('#undeploy', () => {
 
     const payload = JSON.parse(stdout)
     expect(payload.undeployed).toBe(true)
-    expect(payload.target.applicationId).toBe('app-id')
+    expect(payload.application.id).toBe('app-id')
   })
 
-  test('--json without --yes refuses to undeploy', async () => {
+  test('--json without --yes undeploys unattended, never prompting', async () => {
     mockApi({
       apiVersion: 'v2024-08-01',
       query: {appHost: 'my-host', appType: 'studio'},
@@ -538,7 +537,14 @@ describe('#undeploy', () => {
       id: 'app-id',
     })
 
-    const {error, stdout} = await testCommand(UndeployCommand, ['--json'], {
+    mockApi({
+      apiVersion: 'v2024-08-01',
+      method: 'delete',
+      query: {appType: 'studio'},
+      uri: '/user-applications/app-id',
+    }).reply(200)
+
+    const {stdout} = await testCommand(UndeployCommand, ['--json'], {
       mocks: {
         cliConfig: {
           api: {projectId: 'test'},
@@ -549,9 +555,8 @@ describe('#undeploy', () => {
     })
 
     expect(confirm).not.toHaveBeenCalled()
-    expect(error?.message).toContain('Pass --yes')
     const payload = JSON.parse(stdout)
-    expect(payload.undeployed).toBe(false)
+    expect(payload.undeployed).toBe(true)
   })
 
   test('handles error when deployment.appId does not exist for the org', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -168,6 +168,7 @@ describe('#undeploy', () => {
           api: {projectId: 'test'},
           studioHost: 'my-host',
         },
+        isInteractive: true,
         token: 'test-token',
       },
     })
@@ -200,6 +201,7 @@ describe('#undeploy', () => {
           api: {projectId: 'test'},
           studioHost: 'my-host',
         },
+        isInteractive: true,
         token: 'test-token',
       },
     })
@@ -233,6 +235,7 @@ describe('#undeploy', () => {
           app: {},
           deployment: {appId: 'core-id'},
         },
+        isInteractive: true,
         token: 'test-token',
       },
     })
@@ -273,6 +276,7 @@ describe('#undeploy', () => {
           app: {},
           deployment: {appId: 'core-id'},
         },
+        isInteractive: true,
         token: 'test-token',
       },
     })

--- a/packages/@sanity/cli/src/commands/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/undeploy.ts
@@ -52,6 +52,9 @@ export class UndeployCommand extends SanityCommand<typeof UndeployCommand> {
       ? createAppUndeployAdapter(cliConfig)
       : createStudioUndeployAdapter(cliConfig)
 
-    await runUndeploy({flags, output: this.output}, adapter)
+    // An unattended run (--yes, --json, non-TTY) can't answer the confirmation
+    // prompt, so it consents up front; machine callers preview with --dry-run.
+    const undeployFlags = this.isUnattended() ? {...flags, yes: true} : flags
+    await runUndeploy({flags: undeployFlags, output: this.output}, adapter)
   }
 }

--- a/packages/@sanity/cli/src/commands/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/undeploy.ts
@@ -20,12 +20,21 @@ export class UndeployCommand extends SanityCommand<typeof UndeployCommand> {
       command: '<%= config.bin %> <%= command.id %> --dry-run',
       description: 'Report what would be undeployed without deleting anything',
     },
+    {
+      command: '<%= config.bin %> <%= command.id %> --json --yes',
+      description: 'Undeploy without prompting and report the result as JSON',
+    },
   ]
 
   static override flags = {
     'dry-run': Flags.boolean({
       default: false,
       description: 'Report what would be undeployed without deleting anything',
+    }),
+    json: Flags.boolean({
+      char: 'j',
+      default: false,
+      description: 'Output the result as JSON',
     }),
     yes: Flags.boolean({
       char: 'y',

--- a/packages/@sanity/cli/src/util/toStderrOutput.ts
+++ b/packages/@sanity/cli/src/util/toStderrOutput.ts
@@ -1,0 +1,16 @@
+import {format} from 'node:util'
+
+import {type Output} from '@sanity/cli-core'
+
+/**
+ * An `Output` whose `log` writes to stderr, for `--json` runs where the payload
+ * owns stdout and progress logs must not corrupt it. Spinners are already on
+ * stderr.
+ */
+export function toStderrOutput(output: Output): Output {
+  return {
+    ...output,
+    log: (message = '', ...args: unknown[]) =>
+      void process.stderr.write(`${format(message, ...args)}\n`),
+  }
+}


### PR DESCRIPTION
### Description

Agents and scripts can't consume undeploy output (SDK-1860).

This adds `--json`: the dry-run payload is a projection of the same plan the human report renders, and a real run emits an `{undeployed: true|false}` envelope. Every terminal path writes exactly one JSON document to stdout; progress goes to stderr.

Like deploy, `--json` runs unattended — confirmation prompts are for humans, and machine callers preview with `--dry-run` first.

### What to review

- `undeployPlanToJson` in `runUndeploy.ts` — derived from the same checks and application as the human render.
- The stdout/stderr split and the error envelope.

### Example output

```
$ sanity undeploy --dry-run --json
{
  "application": {
    "activeDeployment": {
      "deployedAt": "2026-07-01T09:12:00Z",
      "deployedBy": "gustav@sanity.io",
      "version": "4.10.2"
    },
    "appHost": "my-studio",
    "createdAt": "2025-11-20T08:00:00Z",
    "deletes": "application",
    "id": "ah1x2y3z",
    "organizationId": null,
    "projectId": "ppsg7ml5",
    "title": "My Studio",
    "type": "studio",
    "url": "https://my-studio.sanity.studio"
  },
  "canUndeploy": true,
  "errors": {},
  "reason": null,
  "warnings": []
}
```

With nothing to undeploy (exit 0):

```
$ sanity undeploy --dry-run --json
{
  "application": null,
  "canUndeploy": false,
  "errors": {},
  "reason": "No studio hostname configured",
  "warnings": []
}
```

A real run emits `{"undeployed": true, "application": …}` on success, `{"undeployed": false, "reason": …}` when there is nothing to undeploy, and `{"undeployed": false, "error": {"message": …}}` on failure.

### Testing

Runner unit tests trace every terminal path of a `--json` run to exactly one JSON document; command tests parse stdout for the dry-run, success, and unattended paths.

### Notes for release

`sanity undeploy` supports `--json` for machine-readable dry-run and result output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends a destructive hosting delete with an unattended JSON path that auto-confirms (mirroring deploy), though behavior is heavily tested and stdout stays parseable.
> 
> **Overview**
> Adds **`--json` / `-j`** to `sanity undeploy` so agents and scripts get machine-readable output aligned with the human dry-run plan and real-run results.
> 
> **Dry-run + `--json`** emits a single JSON document via `undeployPlanToJson` (`canUndeploy`, `application`, `errors`, `warnings`, `reason`). **Real runs** emit `{undeployed: true, application: …}`, `{undeployed: false, reason: …}` when there is nothing to delete, or `{undeployed: false, error: {message}}` on failure. Progress and human-oriented logs are redirected off stdout through shared **`toStderrOutput`** (also replaces inline stderr wiring in **`deployRunner`**).
> 
> **`UndeployCommand`** treats unattended runs (including **`--json`**) like deploy: it sets **`yes: true`** so confirmation is skipped; interactive TTY runs still prompt. **`UndeployPlan`** gains an optional **`reason`** field for empty-target cases. Coverage adds runner and command tests for every JSON terminal path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d11b4a54cc2460a4704a6406c8fe0c043cbdd99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->