### PR TITLE
feat(deploy): create workbench apps at a configured slug

### DIFF
--- a/.changeset/pr-1473.md
+++ b/.changeset/pr-1473.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+'@sanity/workbench-cli': minor
+---
+
+feat(deploy): create workbench apps at a configured slug

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -407,6 +407,27 @@ describe('checkAppTarget (workbench backend)', () => {
     expect(reporter.results[0]?.message).toContain('Would create a new application "New App"')
     expect(mockGetApplication).not.toHaveBeenCalled()
   })
+
+  test('no appId with a configured slug → check and target name the slug', async () => {
+    const reporter = createCollectingReporter()
+
+    await checkAppTarget(reporter, {
+      appId: undefined,
+      isWorkbenchApp: true,
+      slug: 'drop-desk',
+      title: 'New App',
+    })
+
+    expect(reporter.results[0]?.message).toContain(
+      'Would create a new application "New App" with slug "drop-desk"',
+    )
+    expect(reporter.results[0]?.target).toEqual({
+      applicationId: null,
+      slug: 'drop-desk',
+      title: 'New App',
+      url: null,
+    })
+  })
 })
 
 describe('checkStudioTarget (workbench backend)', () => {

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -123,6 +123,7 @@ async function runAppDeployment(
     await checkAppTarget(reporter, {
       appId: getAppId(cliConfig),
       isWorkbenchApp: true,
+      slug: workbench.slug,
       title: appTitle,
     })
   } else if (deployApplication) {
@@ -224,8 +225,10 @@ async function runAppDeployment(
 
   // Workbench apps deploy to Brett; plain coreApps use user-applications.
   if (workbench && organizationId) {
+    const appId = getAppId(cliConfig)
+    const slug = workbench.slug ?? generateAppSlug()
     const {applicationId} = await deployWorkbenchCoreApp({
-      appId: getAppId(cliConfig),
+      appId,
       interfaces: buildExposes(workbench, {
         appName: workbench.name,
         appTitle,
@@ -235,7 +238,7 @@ async function runAppDeployment(
       isAutoUpdating,
       isSingleton: workbench.isSingleton,
       organizationId,
-      slug: generateAppSlug(),
+      slug,
       sourceDir,
       title: appTitle,
       version,
@@ -246,7 +249,13 @@ async function runAppDeployment(
       applicationVersion: version,
       ...(exposes.length > 0 ? {exposes} : {}),
       ...(workbench.isSingleton === undefined ? {} : {isSingleton: workbench.isSingleton}),
-      target: {applicationId, title: appTitle, url: getCoreAppUrl(organizationId, applicationId)},
+      target: {
+        applicationId,
+        // A redeploy ignores the slug, so only a create reports the one it used.
+        ...(appId ? {} : {slug}),
+        title: appTitle,
+        url: getCoreAppUrl(organizationId, applicationId),
+      },
     }
   }
 

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -37,6 +37,12 @@ export interface DeployTarget {
   title: string | null
   /** Where the deployed studio/app is reachable; `null` when it can't be resolved yet. */
   url: string | null
+
+  /**
+   * Slug the deploy creates the application at. Omitted on redeploys, and in a
+   * dry run when no slug is configured (it's generated on deploy).
+   */
+  slug?: string
 }
 
 export interface DeployCheck {
@@ -242,7 +248,7 @@ export async function verifyOutputDir({
  */
 export function describeAppTarget(
   resolution: AppDeployTargetResolution,
-  {title}: {title?: string} = {},
+  {slug, title}: {slug?: string; title?: string} = {},
 ): DeployCheck {
   switch (resolution.type) {
     case 'blocked': {
@@ -277,9 +283,9 @@ export function describeAppTarget(
     case 'would-create': {
       if (title) {
         return {
-          message: `Would create a new application "${title}"`,
+          message: `Would create a new application "${title}"${slug ? ` with slug "${slug}"` : ''}`,
           status: 'pass',
-          target: {applicationId: null, title, url: null},
+          target: {applicationId: null, ...(slug ? {slug} : {}), title, url: null},
         }
       }
       return {
@@ -307,7 +313,7 @@ export function describeAppTargetError(err: unknown, organizationId: string | un
 export async function checkAppTarget(
   reporter: CheckReporter,
   options:
-    | {appId: string | undefined; isWorkbenchApp: true; title?: string}
+    | {appId: string | undefined; isWorkbenchApp: true; slug?: string; title?: string}
     | {
         appId: string | undefined
         isWorkbenchApp?: false
@@ -317,9 +323,9 @@ export async function checkAppTarget(
 ): Promise<DeployTarget | null> {
   const {title} = options
   if (options.isWorkbenchApp) {
-    const {appId} = options
+    const {appId, slug} = options
     return runStep(reporter, 'target', async () => {
-      const check = describeAppTarget(await resolveWorkbenchApp({appId}), {title})
+      const check = describeAppTarget(await resolveWorkbenchApp({appId}), {slug, title})
       reporter.report(check)
       return check.target ?? null
     })

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -16,6 +16,7 @@ import {dirIsEmptyOrNonExistent} from '../../../src/util/dirIsEmptyOrNonExistent
 
 const mockGetLocalPackageVersion = vi.hoisted(() => vi.fn())
 const mockCheckBuiltOutput = vi.hoisted(() => vi.fn())
+const mockDeployCoreApp = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
@@ -33,11 +34,10 @@ vi.mock('../../../src/actions/deploy/checkDir.js', () => ({
   checkDir: vi.fn(),
 }))
 
-// `getWorkbench`/`assertDeployable` stay real — pure config the no-interfaces
-// test exercises; only the fs-touching `checkBuiltOutput` is stubbed.
 vi.mock(import('@sanity/workbench-cli/deploy'), async (importOriginal) => ({
   ...(await importOriginal()),
   checkBuiltOutput: mockCheckBuiltOutput,
+  deployCoreApp: mockDeployCoreApp,
 }))
 
 vi.mock(
@@ -323,6 +323,87 @@ describe('#deploy app', () => {
     // fails before any directory check or API call
     expect(mockCheckBuiltOutput).not.toHaveBeenCalled()
     expect(mockCheckDir).not.toHaveBeenCalled()
+  })
+
+  test('creates a workbench app at the configured slug and reports it in --json', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    mockDeployCoreApp.mockResolvedValue({applicationId: 'app_new'})
+
+    const app = unstable_defineApp({
+      entry: './src/App.tsx',
+      name: 'workbench-app',
+      organizationId,
+      slug: 'drop-desk-host',
+      title: 'Workbench App',
+    })
+
+    const {error, stdout} = await testCommand(DeployCommand, ['--json'], {
+      config: {root: cwd},
+      mocks: {cliConfig: {app}},
+    })
+
+    if (error) throw error
+    expect(mockDeployCoreApp).toHaveBeenCalledWith(
+      expect.objectContaining({slug: 'drop-desk-host'}),
+    )
+    const result = JSON.parse(stdout)
+    expect(result.deployed).toBe(true)
+    expect(result.target).toMatchObject({applicationId: 'app_new', slug: 'drop-desk-host'})
+  })
+
+  test('a dry run surfaces the configured slug in the report and --json target', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    const app = unstable_defineApp({
+      entry: './src/App.tsx',
+      name: 'workbench-app',
+      organizationId,
+      slug: 'drop-desk-host',
+      title: 'Workbench App',
+    })
+
+    const {error, stdout} = await testCommand(DeployCommand, ['--dry-run', '--json'], {
+      config: {root: cwd},
+      mocks: {cliConfig: {app}},
+    })
+
+    if (error) throw error
+    const plan = JSON.parse(stdout)
+    expect(plan.isDeployable).toBe(true)
+    expect(plan.target).toEqual({
+      applicationId: null,
+      slug: 'drop-desk-host',
+      title: 'Workbench App',
+      url: null,
+    })
+    expect(mockDeployCoreApp).not.toHaveBeenCalled()
+  })
+
+  test('creates a workbench app at a generated slug when none is set', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    mockDeployCoreApp.mockResolvedValue({applicationId: 'app_new'})
+
+    const app = unstable_defineApp({
+      entry: './src/App.tsx',
+      name: 'workbench-app',
+      organizationId,
+      title: 'Workbench App',
+    })
+
+    const {error} = await testCommand(DeployCommand, [], {
+      config: {root: cwd},
+      mocks: {cliConfig: {app}},
+    })
+
+    if (error) throw error
+    expect(mockDeployCoreApp).toHaveBeenCalledWith(
+      expect.objectContaining({slug: expect.stringMatching(/^[a-z][a-z0-9]{11}$/)}),
+    )
   })
 
   test('should PATCH user-application when manifest title differs from existing app title', async () => {

--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -261,6 +261,16 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     expect(result.error?.issues[0]?.path).toEqual(['entry'])
   })
 
+  test('accepts `slug` for an SDK app', () => {
+    const parsed = DefineAppInputSchema.parse({
+      name: 'drop-desk',
+      organizationId: 'org-1',
+      slug: 'drop-desk',
+      title: 'Drop',
+    })
+    expect(parsed.slug).toBe('drop-desk')
+  })
+
   test('accepts `entry` for an SDK app (no applicationType / coreApp)', () => {
     expect(
       DefineAppInputSchema.safeParse({

--- a/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
@@ -32,13 +32,14 @@ describe('resolveWorkbenchApp', () => {
     })
   })
 
-  test('passes through declared views, services, and entry', () => {
+  test('passes through declared views, services, entry, and slug', () => {
     const config = asConfig(
       unstable_defineApp({
         entry: './src/App.tsx',
         name: 'my-app',
         organizationId: 'org-123',
         services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
+        slug: 'my-app-host',
         title: 'My App',
         views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],
       }),
@@ -48,6 +49,7 @@ describe('resolveWorkbenchApp', () => {
     expect(resolved).toMatchObject({
       entry: './src/App.tsx',
       services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
+      slug: 'my-app-host',
       views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],
     })
   })

--- a/packages/@sanity/workbench-cli/src/defineApp.ts
+++ b/packages/@sanity/workbench-cli/src/defineApp.ts
@@ -82,6 +82,12 @@ export const DefineAppInputSchema = z
           ),
         ),
     ),
+    /**
+     * Hostname the application is created at on first deploy. Generated when
+     * omitted; redeploys target `deployment.appId` and ignore it. SDK apps
+     * only — studios use `studioHost` in sanity.cli.ts.
+     */
+    slug: z.optional(z.string()),
     /** User-facing app title. Wins over studio.config.ts title on merge. */
     title: z.string(),
     /**

--- a/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
@@ -37,6 +37,8 @@ export interface ResolvedWorkbenchApp {
   readonly entry?: string
   /** Explicit singleton flag (a Sanity-owned app); `undefined` when the app doesn't set it. */
   readonly isSingleton?: boolean
+  /** Hostname the application is created at on first deploy. */
+  readonly slug?: string
 }
 
 /**
@@ -56,6 +58,7 @@ export function resolveWorkbenchApp(
     isSingleton: app.isSingleton,
     name: app.name,
     services: app.services ?? [],
+    slug: app.slug,
     views: app.views ?? [],
   }
 }


### PR DESCRIPTION
### Description

Studios can pick their hostname (`studioHost`), but workbench core apps always deploy under a random generated slug.

This adds an optional `slug` to `unstable_defineApp`, which deploy sends as the application's slug on create. Redeploys (`deployment.appId` set) ignore it, same as studios. Plain SDK app deploys through user-applications are unchanged — they keep generating a slug.

The slug also surfaces in the deploy reports:

- Dry run: `Would create a new application "Title" with slug "xyz"`, and `target.slug` in `--json` (omitted when it would be generated on deploy).
- Real deploy with `--json`: `target.slug` carries the slug the application was created with, configured or generated. Redeploys omit it since the slug isn't sent.

### What to review

- `defineApp.ts` — the new schema field.
- `deployApp.ts` — `slug: workbench.slug ?? generateAppSlug()` is the whole threading.
- `deployChecks.ts` — `DeployTarget.slug` and the would-create verdict, shared by the dry-run report and `--json` so they can't drift.

### Testing

Schema and resolver tests cover the new field; deployChecks tests cover the would-create message and target; integration tests on the deploy command assert the slug reaches `deployCoreApp` and both `--json` payloads (dry-run plan and deploy result).

### Notes for release

Workbench apps can set `slug` in `unstable_defineApp` to pick the hostname their application is created at

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to workbench first-create deploy and reporting; existing redeploy and user-applications flows are unchanged, with tests covering slug threading and JSON output.
> 
> **Overview**
> Workbench SDK apps can now set an optional **`slug`** on `unstable_defineApp` so the **first** deploy creates the application at that hostname instead of always using a random slug. **Redeploys** with `deployment.appId` still ignore `slug`, matching studio `studioHost` behavior; the **user-applications** deploy path is unchanged and keeps auto-generating slugs.
> 
> Deploy wiring uses `workbench.slug ?? generateAppSlug()` when calling `deployCoreApp`, passes `slug` into workbench `checkAppTarget`, and extends **`DeployTarget`** so dry-run text (`Would create… with slug "…"`) and **`--json`** `target.slug` stay aligned. Slug is included on create (configured or generated); omitted on redeploy and on dry-run when no slug is configured (since it would be generated at deploy time).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817427b3fb27b30e16b34320165145cfb604597a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->