### PR TITLE
fix(workbench): set the staging runtime flag in the dev shell

### DIFF
--- a/.changeset/dev-staging-runtime-flag.md
+++ b/.changeset/dev-staging-runtime-flag.md
@@ -1,0 +1,5 @@
+---
+'@sanity/workbench-cli': patch
+---
+
+fix(workbench): set the `__SANITY_STAGING__` runtime flag in the dev shell so staging environments resolve the staging API

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/writeWorkbenchRuntime.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/writeWorkbenchRuntime.test.ts
@@ -26,6 +26,7 @@ describe('writeWorkbenchRuntime', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
   })
 
   test('creates the workbench directory, writes both entry files, and returns the dir', async () => {
@@ -67,6 +68,21 @@ describe('writeWorkbenchRuntime', () => {
     expect(html).toContain('<meta charset="UTF-8" />')
     expect(html).toContain('<div id="workbench">')
     expect(html).toContain('<script type="module" src="./workbench.js">')
+  })
+
+  describe('staging runtime flag', () => {
+    test.each([
+      ['staging', true],
+      ['production', false],
+      [undefined, false],
+    ])('with SANITY_INTERNAL_ENV=%s the shell sets the flag to %s', async (env, expected) => {
+      vi.stubEnv('SANITY_INTERNAL_ENV', env)
+
+      await writeWorkbenchRuntime({cwd: CWD, reactStrictMode: false})
+
+      const html = written('index.html')
+      expect(html).toContain(`<script>globalThis.__SANITY_STAGING__ = ${expected}</script>`)
+    })
   })
 
   describe('prefetch hints', () => {

--- a/packages/@sanity/workbench-cli/src/actions/dev/writeWorkbenchRuntime.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/writeWorkbenchRuntime.ts
@@ -28,6 +28,7 @@ const indexHtmlTemplate = `\
   </head>
   <body>
     <div id="workbench"></div>
+    <script>globalThis.__SANITY_STAGING__ = %SANITY_WORKBENCH_STAGING%</script>
     <script type="module" src="./workbench.js"></script>
   </body>
 </html>
@@ -59,7 +60,14 @@ export async function writeWorkbenchRuntime(options: {
 
   const prefetchHints = buildPrefetchHints(remoteUrl)
 
-  const indexHtml = indexHtmlTemplate.replace(/%SANITY_WORKBENCH_PREFETCH_HINTS%/, prefetchHints)
+  // The runtime flag builds get via decorateIndexWithStagingScript — a vite
+  // `define` never reaches pre-bundled dependencies like the SDK.
+  const indexHtml = indexHtmlTemplate
+    .replace(/%SANITY_WORKBENCH_PREFETCH_HINTS%/, prefetchHints)
+    .replace(
+      /%SANITY_WORKBENCH_STAGING%/,
+      JSON.stringify(process.env.SANITY_INTERNAL_ENV === 'staging'),
+    )
 
   devDebug('Making workbench runtime directory')
   await fs.mkdir(workbenchDir, {recursive: true})


### PR DESCRIPTION
### Description

On staging (`SANITY_INTERNAL_ENV=staging`), a workbench dev session resolved auth, users and organizations against the production API. The SDK's staging detection (sanity-io/sdk#793) reads the `__SANITY_STAGING__` global at runtime — builds provide it via `decorateIndexWithStagingScript`, but the dev shell only passed it as a vite `define`, which never reaches pre-bundled dependencies like the SDK.

This injects the same runtime flag into the generated `index.html`, before the module script so it's set ahead of any module evaluation.

Note: this makes the host and views env-aware in dev. The federated workbench remote is still a production build (`workbench-remote.sanity.dev`) with the flag inlined `false` — staging dev additionally needs `SANITY_INTERNAL_WORKBENCH_REMOTE_URL` pointed at a staging-built remote until sanity-io/workbench deploys one (issue to follow there).

### What to review

`writeWorkbenchRuntime.ts` — the new `%SANITY_WORKBENCH_STAGING%` token follows the existing token-replacement pattern. Affects the dev shell only; builds already have the equivalent script.

### Testing

Unit tests cover the flag for staging, production and unset envs. Verified end to end against a staging org: with the flag set, login redirects to `www.sanity.work` and API calls target `api.sanity.work`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-shell HTML generation only; no auth or production build path changes, with behavior covered by new unit tests.
> 
> **Overview**
> **Workbench dev** now writes `globalThis.__SANITY_STAGING__` into the generated `index.html` (before the module entry), driven by whether `SANITY_INTERNAL_ENV` is `staging`. That mirrors production builds’ `decorateIndexWithStagingScript` behavior so the SDK can pick staging APIs at runtime instead of relying on Vite `define`, which does not apply to pre-bundled deps.
> 
> Unit tests assert the injected script for staging, production, and unset env, with `vi.unstubAllEnvs()` in teardown. A patch changeset documents the `@sanity/workbench-cli` fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c51fd9227039f6fb4d93dc74e864d664b790c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->