### PR TITLE
fix(deploy): nest expose and config summaries in the dry-run report

### DIFF
--- a/.changeset/pr-1475.md
+++ b/.changeset/pr-1475.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+'@sanity/workbench-cli': patch
+---
+
+fix(deploy): nest expose and config summaries in the dry-run report

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -124,12 +124,12 @@ describe('deploymentPlanToJson', () => {
 
   test('surfaces the registered exposes and config summary', () => {
     const plan = studioPlan([{message: 'ok', status: 'pass'}])
-    plan.exposes = [{name: 'edit', title: 'Edit', type: 'panel'}]
+    plan.exposes = [{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}]
     plan.config = 'Media Library fields:\n  Title (title)'
 
     const json = deploymentPlanToJson(plan)
 
-    expect(json.exposes).toEqual([{name: 'edit', title: 'Edit', type: 'panel'}])
+    expect(json.exposes).toEqual([{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}])
     expect(json.config).toBe('Media Library fields:\n  Title (title)')
   })
 
@@ -157,8 +157,8 @@ describe('reportExposes', () => {
     })
 
     expect(exposes).toEqual([
-      {name: 'edit', title: 'Edit', type: 'panel'},
-      {name: 'sync', title: 'sync', type: 'worker'},
+      {name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'},
+      {name: 'sync', src: './sync.ts', title: 'sync', type: 'worker'},
     ])
     expect(reporter.results.every((check) => check.status === 'pass')).toBe(true)
     // The structured list rides on the first check so a dry run's collector reads it back.
@@ -223,6 +223,22 @@ describe('renderDeploymentPlan', () => {
     )
 
     expect(lines.join('\n')).not.toContain('Files to deploy')
+  })
+
+  test('nests multi-line check messages under their heading', () => {
+    renderDeploymentPlan(
+      studioPlan([
+        {message: 'Views:\n  Feed (feed): ./src/feed.tsx', status: 'pass'},
+        {message: 'Services:\n  sync: ./src/sync.ts', status: 'pass'},
+        {message: 'Media library fields:\n  Author (author)', status: 'pass'},
+      ]),
+      output,
+    )
+
+    const text = lines.join('\n')
+    expect(text).toContain('Views:\n      Feed (feed): ./src/feed.tsx')
+    expect(text).toContain('Services:\n      sync: ./src/sync.ts')
+    expect(text).toContain('Media library fields:\n      Author (author)')
   })
 
   test('surfaces warnings in their own section', () => {

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -144,7 +144,7 @@ export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void
   // Only pass/skip here; problems and warnings render below with their fixes.
   for (const check of plan.checks) {
     if (check.status === 'pass' || check.status === 'skip') {
-      output.log(`  ${statusIcon(check.status)} ${check.message}`)
+      output.log(nestLines(`  ${statusIcon(check.status)} ${check.message}`))
     }
   }
 
@@ -168,13 +168,19 @@ export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void
   }
 }
 
+// Continuation lines of multi-line messages (expose and config summaries)
+// indent past the icon so their items nest under the heading.
+function nestLines(text: string): string {
+  return text.replaceAll('\n', '\n    ')
+}
+
 function renderIssues(output: Output, title: string, checks: DeployCheck[]): void {
   if (checks.length === 0) return
 
   output.log(`\n${title}`)
   for (const check of checks) {
     const fix = check.solution ? `: ${check.solution}` : ''
-    output.log(`  ${statusIcon(check.status)} ${check.message}${fix}`)
+    output.log(nestLines(`  ${statusIcon(check.status)} ${check.message}${fix}`))
   }
 }
 

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
@@ -73,10 +73,13 @@ describe('summarizeExposes', () => {
     })
 
     expect(exposes).toEqual([
-      {name: 'feed', title: 'Feed', type: 'panel'},
-      {name: 'sync', title: 'sync', type: 'worker'},
+      {name: 'feed', src: './src/feed.tsx', title: 'Feed', type: 'panel'},
+      {name: 'sync', src: './src/sync.ts', title: 'sync', type: 'worker'},
     ])
-    expect(lines).toEqual(['Views:\n  Feed (feed)', 'Services:\n  sync (sync)'])
+    expect(lines).toEqual([
+      'Views:\n  Feed (feed): ./src/feed.tsx',
+      'Services:\n  sync: ./src/sync.ts',
+    ])
   })
 
   test('is empty when nothing is exposed', () => {

--- a/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
@@ -54,12 +54,15 @@ export function buildExposes(
 /** A view or service as the deploy report and `--json` output surface it. */
 export interface DeployedExpose {
   name: string
+  src: string
   title: string
   type: string
 }
 
 function summarizeExposeGroup(heading: string, items: readonly DeployedExpose[]): string {
-  return `${heading}:\n${items.map((item) => `  ${item.title} (${item.name})`).join('\n')}`
+  const label = (item: DeployedExpose) =>
+    item.title === item.name ? item.name : `${item.title} (${item.name})`
+  return `${heading}:\n${items.map((item) => `  ${label(item)}: ${item.src}`).join('\n')}`
 }
 
 /**
@@ -71,8 +74,14 @@ export function summarizeExposes({services, views}: WorkbenchExposes): {
   exposes: DeployedExpose[]
   lines: string[]
 } {
-  const toExpose = (decl: {name: string; title?: string; type: string}): DeployedExpose => ({
+  const toExpose = (decl: {
+    name: string
+    src: string
+    title?: string
+    type: string
+  }): DeployedExpose => ({
     name: decl.name,
+    src: decl.src,
     title: decl.title ?? decl.name,
     type: decl.type,
   })


### PR DESCRIPTION
### Description

The dry-run deploy report renders multi-line check messages with an icon prefix on the first line only, so the items under `Views:`, `Services:`, and `Media library fields:` ended up flush left of their heading:

```
  ✔ Views:
  agent-panel (agent-panel)
```

The `agent-panel (agent-panel)` duplication comes from the title defaulting to the name.

This nests continuation lines under their heading (one fix in the renderer covers exposes and installation configs alike), shows each view/service's entry module, and drops the `(name)` suffix when no title is declared:

```
  ✔ Views:
      agent-panel: ./src/views/AgentPanel.tsx
```

`DeployedExpose` now carries `src`, so the `--json` payload includes the entry too.

### What to review

- `renderDeploymentPlan` in `deploymentPlan.ts` — continuation-line indentation for pass/skip checks.
- `summarizeExposes` in `buildExposes.ts` — the new line format and the `src` field.

### Testing

Unit tests cover the nesting (views, services, and config fields) and the new expose format.

### Notes for release

Fix indentation of views, services, and media library fields in the `sanity deploy --dry-run` report, and show each view/service's entry module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output and JSON shape extension only; no deploy execution or server behavior changes.
> 
> **Overview**
> Improves **`sanity deploy --dry-run`** readability by indenting continuation lines under multi-line check messages (Views, Services, media library config) via a shared **`nestLines`** helper in **`renderDeploymentPlan`**, applied to pass/skip checks and problem/warning lines.
> 
> Expose summaries now include each view/service **entry module (`src`)** in human report lines and in **`DeployedExpose`** for **`--json`**. When title equals name, the redundant **`(name)`** suffix is omitted (e.g. `sync: ./src/sync.ts` instead of `sync (sync)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0722437701057e13fd5779461618e769bdfdbc77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->