### PR TITLE
fix(test): add missing ux.spinner and telemetry mocks to `cli-test`

### DIFF
--- a/.changeset/pr-1477.md
+++ b/.changeset/pr-1477.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-test': patch
+---
+
+fix(test): add missing ux.spinner and telemetry mocks to `cli-test`

--- a/packages/@sanity/cli-test/src/mocks/cli-core/telemetry.ts
+++ b/packages/@sanity/cli-test/src/mocks/cli-core/telemetry.ts
@@ -1,4 +1,5 @@
-import {type Mock, vi} from 'vitest'
+import {type CLITelemetryStore} from '@sanity/cli-core/types'
+import {type Mock, MockedObject, vi} from 'vitest'
 /** @internal */
 export const clearCliTelemetry: Mock = vi.fn()
 /** @internal */
@@ -9,3 +10,21 @@ export const reportCliTraceError: Mock = vi.fn()
 export const setCliTelemetry: Mock = vi.fn()
 /** @internal */
 export const getTelemetryBaseInfo: Mock = vi.fn()
+/** @internal */
+export const MockTrace: Record<'await' | 'complete' | 'error' | 'log' | 'start', Mock> & {
+  newContext: () => MockedObject<CLITelemetryStore>
+} = {
+  await: vi.fn(),
+  complete: vi.fn(),
+  error: vi.fn(),
+  log: vi.fn(),
+  newContext: () => MockTelemetry,
+  start: vi.fn(),
+}
+/** @internal */
+export const MockTelemetry: MockedObject<CLITelemetryStore> = {
+  log: vi.fn(),
+  resume: vi.fn(),
+  trace: vi.fn(() => MockTrace),
+  updateUserProperties: vi.fn(),
+}

--- a/packages/@sanity/cli-test/src/mocks/cli-core/ux.ts
+++ b/packages/@sanity/cli-test/src/mocks/cli-core/ux.ts
@@ -48,6 +48,7 @@ export const spinner: Mock = vi.fn(() => {
     info: vi.fn(),
     render: vi.fn(),
     start: spinnerStart,
+    stop: vi.fn(),
     succeed: spinnerSucceed,
   }
   Object.defineProperty(mockSpin, 'text', {


### PR DESCRIPTION
### Description

As I continue working away on improved testing, a few missing mocks that would be helpful for some tests in the CLI. Particularly, these would be helpful for `cli/src/commands/login.ts` and `cli/src/actions/auth/login/login.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock additions in `@sanity/cli-test` with no changes to production CLI or runtime telemetry/UX code.
> 
> **Overview**
> Extends **`@sanity/cli-test`** mocks so CLI tests (e.g. login flows) can stub telemetry and spinners without runtime gaps.
> 
> In **`telemetry.ts`**, adds **`MockTelemetry`** and **`MockTrace`** typed against **`CLITelemetryStore`**, including trace helpers (`await`, `complete`, `error`, `log`, `start`) and **`newContext`** wiring back to the store mock.
> 
> In **`ux.ts`**, the **`spinner`** factory mock now exposes **`stop`**, matching real spinner usage alongside existing start/succeed/clear behavior.
> 
> Ships as a **patch** changeset for **`@sanity/cli-test`** only; no production CLI behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006d725ec1cedd1a8c049420daa377d2d86e10f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->