### PR TITLE
test(chore): drop including snapshot serializer in `cli` unit tests

### DIFF
--- a/packages/@sanity/cli/vitest.config.ts
+++ b/packages/@sanity/cli/vitest.config.ts
@@ -15,6 +15,5 @@ export default defineConfig({
     globals: false,
     name: '@sanity/cli/unit',
     setupFiles: ['test/setup.ts'],
-    snapshotSerializers: ['test/snapshotSerializer.ts'],
   },
 })


### PR DESCRIPTION
### Description

Small change: snapshot serializer pulls in a non-trivial `cli-test` import graph. For unit tests this should not be needed.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Vitest configuration change with no production or runtime behavior impact.
> 
> **Overview**
> Removes `snapshotSerializers: ['test/snapshotSerializer.ts']` from the `@sanity/cli` **unit** Vitest config so those runs no longer load the `@sanity/cli-test/vitest` serializer (and its heavier import graph).
> 
> Integration tests still register the same serializer in `vitest.config.integration.ts`; unit tests rely on inline snapshots and do not need the custom serializer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cba345d5d46902fadbff7f16c822d46032d8bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->