### PR TITLE
test(chore): convert `cli` project-create tests

### DIFF
--- a/packages/@sanity/cli/src/actions/organizations/__tests__/getOrganization.test.ts
+++ b/packages/@sanity/cli/src/actions/organizations/__tests__/getOrganization.test.ts
@@ -1,0 +1,107 @@
+import {createMockOutput} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
+import * as uxMocks from '@sanity/cli-test/mocks/cli-core/ux'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {getOrganization} from '../getOrganization.js'
+
+const mockPromptForOrgName = vi.hoisted(() => vi.fn())
+const mockCreateOrg = vi.hoisted(() => vi.fn())
+const mockListOrgs = vi.hoisted(() => vi.fn())
+const mockFindOrgByUserName = vi.hoisted(() => vi.fn())
+const mockGetOrgChoices = vi.hoisted(() => vi.fn())
+const mockGetOrgsWithGrantInfo = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/cli-core/ux', () => import('@sanity/cli-test/mocks/cli-core/ux'))
+vi.mock('../../../prompts/promptForOrganizationName.js', () => ({
+  promptForOrganizationName: mockPromptForOrgName,
+}))
+vi.mock('../../../services/organizations.js', () => ({
+  createOrganization: mockCreateOrg,
+  listOrganizations: mockListOrgs,
+}))
+vi.mock('../findOrganizationByUserName.js', () => ({
+  findOrganizationByUserName: mockFindOrgByUserName,
+}))
+vi.mock('../getOrganizationChoices.js', () => ({
+  getOrganizationChoices: mockGetOrgChoices,
+}))
+vi.mock('../getOrganizationsWithAttachGrantInfo.js', () => ({
+  getOrganizationsWithAttachGrantInfo: mockGetOrgsWithGrantInfo,
+}))
+
+const output = createMockOutput()
+const user = {
+  email: 'test@example.com',
+  id: 'user-123',
+  name: 'TestUser',
+  provider: 'sanity' as const,
+}
+const org = {id: 'org-1', name: 'Org 1', slug: 'org-1'}
+const baseFlags = {isUnattended: true, output, requestedId: undefined, user}
+const orgWithGrantInfo = {hasAttachGrant: true, organization: org}
+
+describe('actions/organizations/getOrganization', () => {
+  beforeEach(() => {
+    mockListOrgs.mockResolvedValue([org])
+    mockPromptForOrgName.mockResolvedValue(org.name)
+    mockCreateOrg.mockResolvedValue(org)
+    mockGetOrgsWithGrantInfo.mockResolvedValue([orgWithGrantInfo])
+    mockGetOrgChoices.mockReturnValue([])
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('throws if listing orgs fails', async () => {
+    const err = new Error('boom')
+    mockListOrgs.mockRejectedValue(err)
+    await expect(getOrganization(baseFlags)).rejects.toThrow(err)
+  })
+
+  test('throws if requestedId does not match returned listed orgs', async () => {
+    await expect(
+      getOrganization({isUnattended: true, output, requestedId: 'nope', user}),
+    ).rejects.toThrow(`Organization "nope" not found or you don't have access to it`)
+  })
+
+  test('prompts to create an org if none returned by list orgs', async () => {
+    mockListOrgs.mockResolvedValue([])
+    await getOrganization(baseFlags)
+    expect(output.log).toHaveBeenCalledWith(
+      'You need to create an organization to create projects.',
+    )
+    expect(mockGetOrgsWithGrantInfo).not.toHaveBeenCalled()
+  })
+
+  describe('unattended mode', () => {
+    test('should return first attached-grant-info orgs if at least one exists', async () => {
+      const result = await getOrganization(baseFlags)
+      expect(result).toEqual(org)
+    })
+    test('should return undefined if no attached-grant-info orgs exist', async () => {
+      mockGetOrgsWithGrantInfo.mockResolvedValue([])
+      const result = await getOrganization(baseFlags)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('interactive mode', () => {
+    const attendedFlags = {...baseFlags, isUnattended: false}
+    test('should prompt user to select an org and create if "-new-" selected', async () => {
+      uxMocks.select.mockResolvedValue('-new-')
+      await getOrganization(attendedFlags)
+      expect(mockPromptForOrgName).toHaveBeenCalled()
+      expect(mockCreateOrg).toHaveBeenCalled()
+    })
+
+    test('should prompt user to select an org and return selected org', async () => {
+      uxMocks.select.mockResolvedValue(org.id)
+
+      const result = await getOrganization(attendedFlags)
+
+      expect(mockPromptForOrgName).not.toHaveBeenCalled()
+      expect(mockCreateOrg).not.toHaveBeenCalled()
+      expect(result).toEqual(org)
+    })
+  })
+})

--- a/packages/@sanity/cli/src/actions/organizations/getOrganization.ts
+++ b/packages/@sanity/cli/src/actions/organizations/getOrganization.ts
@@ -1,4 +1,5 @@
-import {Output, type SanityOrgUser, subdebug} from '@sanity/cli-core'
+import {subdebug} from '@sanity/cli-core/debug'
+import {type Output, type SanityOrgUser} from '@sanity/cli-core/types'
 import {select, spinner} from '@sanity/cli-core/ux'
 
 import {promptForOrganizationName} from '../../prompts/promptForOrganizationName.js'

--- a/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
@@ -1,570 +1,240 @@
-import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
-import {cleanAll, pendingMocks} from 'nock'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
+import * as uxMocks from '@sanity/cli-test/mocks/cli-core/ux'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
-import {ORGANIZATIONS_API_VERSION} from '../../../services/organizations.js'
-import {CREATE_PROJECT_API_VERSION} from '../../../services/projects.js'
 import {CreateProjectCommand} from '../create.js'
 
-const mockConfirm = vi.hoisted(() => vi.fn())
-const mockInput = vi.hoisted(() => vi.fn())
-const mockSelect = vi.hoisted(() => vi.fn())
 const mockCreateDataset = vi.hoisted(() => vi.fn())
+const mockValidateDatasetName = vi.hoisted(() => vi.fn())
+const mockGetOrganization = vi.hoisted(() => vi.fn())
+const mockCreateProject = vi.hoisted(() => vi.fn())
+const mockGetProjectFeatures = vi.hoisted(() => vi.fn())
+const mockListDatasets = vi.hoisted(() => vi.fn())
+const mockGetManageUrl = vi.hoisted(() => vi.fn())
+const mockPromptForProjectName = vi.hoisted(() => vi.fn())
 
-vi.mock('@sanity/cli-core/ux', async () => {
-  const actual = await vi.importActual<typeof import('@sanity/cli-core/ux')>('@sanity/cli-core/ux')
-  return {
-    ...actual,
-    confirm: mockConfirm,
-    input: mockInput,
-    select: mockSelect,
-  }
-})
+vi.mock(
+  '@sanity/cli-core/SanityCommand',
+  () => import('@sanity/cli-test/mocks/cli-core/SanityCommand'),
+)
+vi.mock('@sanity/cli-core/ux', () => import('@sanity/cli-test/mocks/cli-core/ux'))
+vi.mock('../../../actions/dataset/create.js', () => ({
+  createDataset: mockCreateDataset,
+}))
+vi.mock('../../../actions/dataset/validateDatasetName.js', () => ({
+  validateDatasetName: mockValidateDatasetName,
+}))
+vi.mock('../../../actions/organizations/getOrganization.js', () => ({
+  getOrganization: mockGetOrganization,
+}))
+vi.mock('../../../actions/projects/getManageUrl.js', () => ({
+  getManageUrl: mockGetManageUrl,
+}))
+vi.mock('../../../prompts/promptForDatasetName.js', () => ({
+  promptForDatasetName: vi.fn(),
+}))
+vi.mock('../../../prompts/promptForDefaultConfig.js', () => ({
+  promptForDefaultConfig: vi.fn(),
+}))
+vi.mock('../../../prompts/promptForProjectName.js', () => ({
+  promptForProjectName: mockPromptForProjectName,
+}))
+vi.mock('../../../services/datasets.js', () => ({
+  listDatasets: mockListDatasets,
+}))
+vi.mock('../../../services/organizations.js', () => ({})) // prevent loading of the types
+vi.mock('../../../services/getProjectFeatures.js', () => ({
+  getProjectFeatures: mockGetProjectFeatures,
+}))
+vi.mock('../../../services/projects.js', () => ({
+  createProject: mockCreateProject,
+}))
+vi.mock('../../../services/user.js', () => ({
+  getCliUser: vi.fn(),
+}))
 
-vi.mock('@sanity/cli-core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@sanity/cli-core')>()
-
-  return {
-    ...actual,
-    getGlobalCliClient: vi.fn().mockImplementation(async (options) => {
-      const testClient = createTestClient({
-        apiVersion: options.apiVersion,
-        token: 'test-token',
-      })
-
-      return {
-        config: vi.fn().mockReturnValue({apiHost: 'https://api.sanity.io'}),
-        projects: {
-          list: vi.fn().mockResolvedValue([]),
-        },
-        request: testClient.request,
-        users: {
-          getById: vi.fn().mockResolvedValue({
-            email: 'test@example.com',
-            id: 'user-123',
-            name: 'Test User',
-          }),
-        } as never,
-      }
-    }),
-    getProjectCliClient: vi.fn().mockImplementation(async (options) => {
-      const testClient = createTestClient({
-        apiVersion: options.apiVersion,
-        token: 'test-token',
-      })
-
-      return {
-        datasets: {
-          create: mockCreateDataset,
-          list: vi.fn().mockResolvedValue([]),
-        },
-        request: testClient.request,
-      }
-    }),
-  }
-})
-
-const defaultMocks = {
-  projectRoot: {
-    directory: '/test/path',
-    path: '/test/path',
-    type: 'studio' as const,
-  },
-  token: 'test-token',
+const mockOrg = {id: 'org-1', name: 'Org 1', slug: 'org-1'}
+const mockProject = {
+  displayName: 'My Project',
+  id: 'proj-123',
+  projectId: 'proj-123',
 }
+const mockDataset = {aclMode: 'private', datasetName: 'dataset'}
+const mockManageUrl = 'sanity.lol'
 
 describe('#projects:create', () => {
+  beforeEach(() => {
+    mockValidateDatasetName.mockReturnValue(null) // returns error if invalid
+    mockGetOrganization.mockResolvedValue(mockOrg)
+    mockCreateProject.mockResolvedValue(mockProject)
+    mockGetProjectFeatures.mockResolvedValue(['privateDataset'])
+    mockListDatasets.mockResolvedValue([])
+    mockCreateDataset.mockImplementation((opts) => ({
+      ...mockDataset,
+      ...(opts.datasetName ? {datasetName: opts.datasetName} : {}),
+    }))
+    mockGetManageUrl.mockReturnValue(mockManageUrl)
+  })
   afterEach(() => {
     vi.clearAllMocks()
-    const pending = pendingMocks()
-    cleanAll()
-    expect(pending, 'pending mocks').toEqual([])
   })
 
   test('throws error if provided invalid dataset flag', async () => {
-    const {error} = await testCommand(CreateProjectCommand, ['--dataset=~~invalid-name'])
-
-    expect(error?.message).toContain('Dataset name must start with a letter or a number')
+    const datasetError = 'terrible name'
+    mockValidateDatasetName.mockReturnValue(datasetError) // returns error if invalid
+    await expect(CreateProjectCommand.run(['--dataset=~~invalid-name'])).rejects.toThrow(
+      datasetError,
+    )
   })
 
   test('errors when retrieving organization fails', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(500, {message: 'Internal server error'})
+    const err = new Error('boom')
+    mockGetOrganization.mockRejectedValue(err)
+    await CreateProjectCommand.run(['My Project'])
 
-    const {error} = await testCommand(CreateProjectCommand, ['My Project'], {
-      mocks: {
-        ...defaultMocks,
-        isInteractive: true,
-      },
-    })
-
-    expect(error?.message).toContain('Failed to retrieve an organization')
-    expect(error?.oclif?.exit).toBe(1)
-  })
-
-  test('errors when requested organization id is not found', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-    const {error} = await testCommand(
-      CreateProjectCommand,
-      ['My Project', '--organization=invalid'],
+    expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
+      expect.stringMatching(/Failed to retrieve an organization.*boom/i),
       {
-        mocks: {
-          ...defaultMocks,
-          isInteractive: true,
-        },
+        exit: 1,
       },
     )
-
-    expect(error?.message).toContain('Failed to retrieve organization invalid')
-    expect(error?.message).toContain(
-      `Organization "invalid" not found or you don't have access to it`,
-    )
-    expect(error?.oclif?.exit).toBe(1)
   })
 
   test('errors when create project fails', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
+    const err = new Error('boom')
+    mockCreateProject.mockRejectedValue(err)
+    await CreateProjectCommand.run(['My Project', '--organization=org-1'])
 
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(400, {message: 'Bad request'})
-
-    const {error} = await testCommand(
-      CreateProjectCommand,
-      ['My Project', '--organization=org-1'],
+    expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
+      expect.stringMatching(/Failed to create project.*boom/i),
       {
-        mocks: {
-          ...defaultMocks,
-          isInteractive: true,
-        },
+        exit: 1,
       },
     )
-
-    expect(error?.message).toContain('Failed to create project')
-    expect(error?.message).toContain('Bad request')
-    expect(error?.oclif?.exit).toBe(1)
   })
 
-  test('prompts user and creates organization when user has no organizations', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [])
+  test('prompts for project name when not provided', async () => {
+    const customProjName = 'My Custom Project'
+    mocks.SanityCmdIsUnattended.mockReturnValue(false)
+    mockPromptForProjectName.mockResolvedValue(customProjName)
 
-    mockInput.mockResolvedValue('Test Organization')
+    await CreateProjectCommand.run(['--organization=org-1'])
 
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'post',
-      uri: '/organizations',
-    }).reply(201, {
-      id: 'new-org-id',
-      name: 'Test Organization',
-      slug: 'test-organization',
-    })
-
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(201, {
-      displayName: 'My Project',
-      id: 'proj-123',
-      projectId: 'proj-123',
-    })
-
-    const {error, stdout} = await testCommand(CreateProjectCommand, ['My Project'], {
-      mocks: {
-        ...defaultMocks,
-        isInteractive: true,
-      },
-    })
-
-    if (error) throw error
-    expect(mockInput).toHaveBeenCalledWith({
-      default: 'Test User',
-      message: 'Organization name:',
-      validate: expect.any(Function),
-    })
-    expect(stdout).toContain('Project created successfully')
-    expect(stdout).toContain('Organization: Test Organization')
+    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+    expect(mockPromptForProjectName).toHaveBeenCalled()
+    expect(mockCreateProject).toHaveBeenCalledWith(
+      expect.objectContaining({displayName: customProjName}),
+    )
   })
 
-  test('prompts user and creates organization when user selects new organization', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Existing Org', slug: 'existing-org'}])
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations/org-1/grants',
-    }).reply(200, [
-      {
-        grants: [{grantId: 'attach', permission: true}],
-        memberId: 'user-123',
-      },
-    ])
-
-    mockSelect.mockResolvedValue('-new-')
-    mockInput.mockResolvedValue('New Organization')
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'post',
-      uri: '/organizations',
-    }).reply(201, {
-      id: 'new-org-id',
-      name: 'New Organization',
-      slug: 'new-organization',
-    })
-
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(201, {
-      displayName: 'My Project',
-      id: 'proj-123',
-      projectId: 'proj-123',
-    })
-
-    const {error, stdout} = await testCommand(CreateProjectCommand, ['My Project'], {
-      mocks: {...defaultMocks, isInteractive: true},
-    })
-
-    if (error) throw error
-    expect(mockSelect).toHaveBeenCalledWith({
-      choices: expect.arrayContaining([expect.objectContaining({value: '-new-'})]),
-      default: undefined,
-      message: 'Select organization:',
-    })
-    expect(stdout).toContain('Project created successfully')
-    expect(stdout).toContain('Organization: New Organization')
-  })
-
-  test('creates project with dataset in unattended mode', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(201, {
-      displayName: 'My Sanity Project',
-      id: 'proj-123',
-      projectId: 'proj-123',
-    })
-
-    mockApi({
-      apiVersion: PROJECT_FEATURES_API_VERSION,
-      method: 'get',
-      uri: '/features',
-    }).reply(200, ['privateDataset'])
-
-    mockCreateDataset.mockResolvedValueOnce({
+  test('creates project with dataset in unattended mode when dataset name provided as flag', async () => {
+    mockCreateDataset.mockResolvedValue({
       aclMode: 'private',
       datasetName: 'staging',
     })
 
-    const {error, stdout} = await testCommand(
-      CreateProjectCommand,
-      ['--yes', '--dataset=staging', '--dataset-visibility=private', '--organization=org-1'],
-      {
-        mocks: defaultMocks,
-      },
-    )
-
-    if (error) throw error
-    expect(stdout).toContain('Project created successfully')
-    expect(stdout).toContain('My Sanity Project')
-    expect(stdout).toContain('Dataset: staging (private)')
-  })
-
-  test('creates project without dataset in unattended mode', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(201, {
-      displayName: 'My Sanity Project',
-      id: 'proj-123',
-      projectId: 'proj-123',
-    })
-
-    const {error, stdout} = await testCommand(
-      CreateProjectCommand,
-      ['--yes', '--organization=org-1'],
-      {
-        mocks: defaultMocks,
-      },
-    )
-
-    if (error) throw error
-    expect(stdout).toContain('Project created successfully')
-    expect(stdout).toContain('My Sanity Project')
-    expect(stdout).not.toContain('Dataset:')
-  })
-
-  test('creates project with `production` dataset when user chooses default config', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations/org-1/grants',
-    }).reply(200, [
-      {
-        grants: [{grantId: 'attach', permission: true}],
-        memberId: 'user-123',
-      },
+    await CreateProjectCommand.run([
+      '--yes',
+      '--dataset=staging',
+      '--dataset-visibility=private',
+      '--organization=org-1',
     ])
 
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(201, {
-      displayName: 'My Project',
-      id: 'proj-123',
-      projectId: 'proj-123',
-    })
-
-    mockSelect.mockResolvedValueOnce('org-1') // Select organization
-    mockConfirm.mockResolvedValueOnce(true) // Would you like to create a dataset?
-    mockConfirm.mockResolvedValueOnce(true) // Use default config?
-
-    mockApi({
-      apiVersion: PROJECT_FEATURES_API_VERSION,
-      method: 'get',
-      uri: '/features',
-    }).reply(200, [])
-
-    mockCreateDataset.mockResolvedValueOnce({
-      aclMode: 'public',
-      datasetName: 'production',
-    })
-
-    const {error, stdout} = await testCommand(CreateProjectCommand, ['My Project'], {
-      mocks: {...defaultMocks, isInteractive: true},
-    })
-
-    if (error) throw error
-    expect(stdout).toContain('Project created successfully')
-    expect(stdout).toContain('Dataset: production (public)')
+    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining('Project created successfully'),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining(mockProject.displayName),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining(mockProject.projectId),
+    )
+    expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringMatching(/Dataset: staging/i),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(expect.stringMatching(mockManageUrl))
   })
 
-  test('creates project with named dataset when user chooses custom name', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(201, {
-      displayName: 'My Project',
-      id: 'proj-123',
-      projectId: 'proj-123',
-    })
-
-    mockConfirm.mockResolvedValueOnce(true) // Would you like to create a dataset?
-    mockConfirm.mockResolvedValueOnce(false) // Use default config?
-
-    mockInput.mockResolvedValue('staging')
-
-    mockApi({
-      apiVersion: PROJECT_FEATURES_API_VERSION,
-      method: 'get',
-      uri: '/features',
-    }).reply(200, [])
-
-    mockCreateDataset.mockResolvedValueOnce({
-      aclMode: 'public',
+  test('creates project without dataset in unattended mode if no dataset name provided as flag', async () => {
+    mockCreateDataset.mockResolvedValue({
+      aclMode: 'private',
       datasetName: 'staging',
     })
 
-    const {error, stdout} = await testCommand(
-      CreateProjectCommand,
-      ['My Project', '--organization=org-1'],
-      {
-        mocks: {...defaultMocks, isInteractive: true},
-      },
-    )
+    await CreateProjectCommand.run(['--yes', '--organization=org-1'])
 
-    if (error) throw error
-    expect(mockInput).toHaveBeenCalledWith({
-      message: 'Dataset name:',
-      validate: expect.any(Function),
+    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining('Project created successfully'),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining(mockProject.displayName),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining(mockProject.projectId),
+    )
+    expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).not.toHaveBeenCalledWith(expect.stringMatching(/Dataset:/i))
+  })
+
+  test('creates project with dataset when user confirms and chooses default config', async () => {
+    mockCreateDataset.mockResolvedValue({
+      aclMode: 'private',
+      datasetName: 'staging',
     })
-    expect(stdout).toContain('Project created successfully')
-    expect(stdout).toContain('Dataset: staging (public)')
+    uxMocks.confirm.mockResolvedValue(true) // Would you like to create a dataset?
+    uxMocks.confirm.mockResolvedValue(true) // Use default config?
+
+    await CreateProjectCommand.run(['New Project'])
+
+    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining('Project created successfully'),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining(mockProject.displayName),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining(mockProject.projectId),
+    )
+    expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).not.toHaveBeenCalledWith(
+      expect.stringMatching(/Dataset: staging/i),
+    )
   })
 
   test('warns user when dataset creation fails', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
+    mockCreateDataset.mockRejectedValue(new Error('Failed to create Dataset'))
 
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(201, {
-      displayName: 'My Project',
-      id: 'proj-123',
-      projectId: 'proj-123',
-    })
+    await CreateProjectCommand.run(['My Project', '--dataset=production', '--organization=org-1'])
 
-    mockApi({
-      apiVersion: PROJECT_FEATURES_API_VERSION,
-      method: 'get',
-      uri: '/features',
-    }).reply(200, [])
-
-    mockCreateDataset.mockRejectedValueOnce(new Error('Failed to create Dataset'))
-
-    const {error, stderr, stdout} = await testCommand(
-      CreateProjectCommand,
-      ['My Project', '--dataset=production', '--organization=org-1'],
-      {
-        mocks: {...defaultMocks, isInteractive: true},
-      },
+    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining('Project created successfully'),
     )
-
-    if (error) throw error
-    expect(stdout).toContain('Project created successfully')
-    expect(stderr).toContain('Project created but dataset creation failed')
+    expect(mocks.SanityCmdOutput.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Project created but dataset creation failed'),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining(mockProject.displayName),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining(mockProject.projectId),
+    )
+    expect(mocks.SanityCmdOutput.log).not.toHaveBeenCalledWith(
+      expect.stringMatching(/Dataset: staging/i),
+    )
   })
 
   test('creates project with JSON output', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
+    await CreateProjectCommand.run(['My Project', '--organization=org-1', '--json'])
 
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(201, {
-      displayName: 'My Project',
-      id: 'proj-123',
-      projectId: 'proj-123',
-    })
-
-    const {error, stdout} = await testCommand(
-      CreateProjectCommand,
-      ['My Project', '--organization=org-1', '--json'],
-      {
-        mocks: defaultMocks,
-      },
+    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(JSON.stringify(mockProject, null, 2))
+    expect(mocks.SanityCmdOutput.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('Project created successfully'),
     )
-
-    if (error) throw error
-    const json = JSON.parse(stdout)
-    expect(json).toEqual({
-      displayName: 'My Project',
-      projectId: 'proj-123',
-    })
-  })
-
-  test('prompts for project name when not provided', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-    mockInput.mockResolvedValue('My Custom Project')
-
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(201, {
-      displayName: 'My Custom Project',
-      id: 'proj-123',
-      projectId: 'proj-123',
-    })
-
-    const {error, stdout} = await testCommand(CreateProjectCommand, ['--organization=org-1'], {
-      mocks: {...defaultMocks, isInteractive: true},
-    })
-
-    if (error) throw error
-    expect(mockInput).toHaveBeenCalledWith({
-      default: 'My Sanity Project',
-      message: 'Project name:',
-      validate: expect.any(Function),
-    })
-    expect(stdout).toContain('My Custom Project')
-  })
-
-  test('includes manage URL in output', async () => {
-    mockApi({
-      apiVersion: ORGANIZATIONS_API_VERSION,
-      method: 'get',
-      uri: '/organizations',
-    }).reply(200, [{id: 'org-1', name: 'Org 1', slug: 'org-1'}])
-
-    mockApi({
-      apiVersion: CREATE_PROJECT_API_VERSION,
-      method: 'post',
-      uri: '/projects',
-    }).reply(201, {
-      displayName: 'My Project',
-      id: 'proj-123',
-      projectId: 'proj-123',
-    })
-
-    const {error, stdout} = await testCommand(
-      CreateProjectCommand,
-      ['My Project', '--organization=org-1'],
-      {
-        mocks: defaultMocks,
-      },
-    )
-
-    if (error) throw error
-    expect(stdout).toContain('Manage your project: https://www.sanity.io/manage/project/proj-123')
   })
 })

--- a/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
@@ -12,6 +12,8 @@ const mockGetProjectFeatures = vi.hoisted(() => vi.fn())
 const mockListDatasets = vi.hoisted(() => vi.fn())
 const mockGetManageUrl = vi.hoisted(() => vi.fn())
 const mockPromptForProjectName = vi.hoisted(() => vi.fn())
+const mockPromptForDefaultConfig = vi.hoisted(() => vi.fn())
+const mockPromptForDatasetName = vi.hoisted(() => vi.fn())
 
 vi.mock(
   '@sanity/cli-core/SanityCommand',
@@ -31,10 +33,10 @@ vi.mock('../../../actions/projects/getManageUrl.js', () => ({
   getManageUrl: mockGetManageUrl,
 }))
 vi.mock('../../../prompts/promptForDatasetName.js', () => ({
-  promptForDatasetName: vi.fn(),
+  promptForDatasetName: mockPromptForDatasetName,
 }))
 vi.mock('../../../prompts/promptForDefaultConfig.js', () => ({
-  promptForDefaultConfig: vi.fn(),
+  promptForDefaultConfig: mockPromptForDefaultConfig,
 }))
 vi.mock('../../../prompts/promptForProjectName.js', () => ({
   promptForProjectName: mockPromptForProjectName,
@@ -64,6 +66,7 @@ const mockManageUrl = 'sanity.lol'
 
 describe('#projects:create', () => {
   beforeEach(() => {
+    mocks.SanityCmdIsUnattended.mockReturnValue(false)
     mockValidateDatasetName.mockReturnValue(null) // returns error if invalid
     mockGetOrganization.mockResolvedValue(mockOrg)
     mockCreateProject.mockResolvedValue(mockProject)
@@ -127,65 +130,70 @@ describe('#projects:create', () => {
     )
   })
 
-  test('creates project with dataset in unattended mode when dataset name provided as flag', async () => {
-    mockCreateDataset.mockResolvedValue({
-      aclMode: 'private',
-      datasetName: 'staging',
+  describe('in unattended mode', () => {
+    beforeEach(() => {
+      mocks.SanityCmdIsUnattended.mockReturnValue(true)
+    })
+    test('creates project with dataset in unattended mode when dataset name provided as flag', async () => {
+      mockCreateDataset.mockResolvedValue({
+        aclMode: 'private',
+        datasetName: 'staging',
+      })
+
+      await CreateProjectCommand.run([
+        '--yes',
+        '--dataset=staging',
+        '--dataset-visibility=private',
+        '--organization=org-1',
+      ])
+
+      expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+      expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining('Project created successfully'),
+      )
+      expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining(mockProject.displayName),
+      )
+      expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining(mockProject.projectId),
+      )
+      expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalled()
+      expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+        expect.stringMatching(/Dataset: staging/i),
+      )
+      expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(expect.stringMatching(mockManageUrl))
     })
 
-    await CreateProjectCommand.run([
-      '--yes',
-      '--dataset=staging',
-      '--dataset-visibility=private',
-      '--organization=org-1',
-    ])
+    test('creates project without dataset in unattended mode if no dataset name provided as flag', async () => {
+      mockCreateDataset.mockResolvedValue({
+        aclMode: 'private',
+        datasetName: 'staging',
+      })
 
-    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
-    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
-      expect.stringContaining('Project created successfully'),
-    )
-    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
-      expect.stringContaining(mockProject.displayName),
-    )
-    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
-      expect.stringContaining(mockProject.projectId),
-    )
-    expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalled()
-    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
-      expect.stringMatching(/Dataset: staging/i),
-    )
-    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(expect.stringMatching(mockManageUrl))
-  })
+      await CreateProjectCommand.run(['--yes', '--organization=org-1'])
 
-  test('creates project without dataset in unattended mode if no dataset name provided as flag', async () => {
-    mockCreateDataset.mockResolvedValue({
-      aclMode: 'private',
-      datasetName: 'staging',
+      expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+      expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining('Project created successfully'),
+      )
+      expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining(mockProject.displayName),
+      )
+      expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+        expect.stringContaining(mockProject.projectId),
+      )
+      expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalled()
+      expect(mocks.SanityCmdOutput.log).not.toHaveBeenCalledWith(expect.stringMatching(/Dataset:/i))
     })
-
-    await CreateProjectCommand.run(['--yes', '--organization=org-1'])
-
-    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
-    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
-      expect.stringContaining('Project created successfully'),
-    )
-    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
-      expect.stringContaining(mockProject.displayName),
-    )
-    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
-      expect.stringContaining(mockProject.projectId),
-    )
-    expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalled()
-    expect(mocks.SanityCmdOutput.log).not.toHaveBeenCalledWith(expect.stringMatching(/Dataset:/i))
   })
 
   test('creates project with dataset when user confirms and chooses default config', async () => {
     mockCreateDataset.mockResolvedValue({
       aclMode: 'private',
-      datasetName: 'staging',
+      datasetName: 'production',
     })
     uxMocks.confirm.mockResolvedValue(true) // Would you like to create a dataset?
-    uxMocks.confirm.mockResolvedValue(true) // Use default config?
+    mockPromptForDefaultConfig.mockResolvedValue(true) // sets dataset name to production
 
     await CreateProjectCommand.run(['New Project'])
 
@@ -200,8 +208,37 @@ describe('#projects:create', () => {
       expect.stringContaining(mockProject.projectId),
     )
     expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalled()
-    expect(mocks.SanityCmdOutput.log).not.toHaveBeenCalledWith(
-      expect.stringMatching(/Dataset: staging/i),
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(expect.stringMatching(/Dataset:/i))
+    expect(mockCreateDataset).toHaveBeenCalledWith(
+      expect.objectContaining({datasetName: 'production'}),
+    )
+  })
+
+  test('creates project with dataset when user confirms but chooses not default config and is prompted for dataset name', async () => {
+    mockCreateDataset.mockResolvedValue({
+      aclMode: 'private',
+      datasetName: 'staging',
+    })
+    uxMocks.confirm.mockResolvedValue(true) // Would you like to create a dataset?
+    mockPromptForDefaultConfig.mockResolvedValue(false)
+    mockPromptForDatasetName.mockResolvedValue('staging')
+
+    await CreateProjectCommand.run(['New Project'])
+
+    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining('Project created successfully'),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining(mockProject.displayName),
+    )
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
+      expect.stringContaining(mockProject.projectId),
+    )
+    expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(expect.stringMatching(/Dataset:/i))
+    expect(mockCreateDataset).toHaveBeenCalledWith(
+      expect.objectContaining({datasetName: 'staging'}),
     )
   })
 

--- a/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
@@ -261,7 +261,7 @@ describe('#projects:create', () => {
       expect.stringContaining(mockProject.projectId),
     )
     expect(mocks.SanityCmdOutput.log).not.toHaveBeenCalledWith(
-      expect.stringMatching(/Dataset: staging/i),
+      expect.stringMatching(/Dataset: production/i),
     )
   })
 

--- a/packages/@sanity/cli/src/commands/projects/create.ts
+++ b/packages/@sanity/cli/src/commands/projects/create.ts
@@ -1,8 +1,9 @@
 import {Args, Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {subdebug} from '@sanity/cli-core/debug'
+import {SanityCommand} from '@sanity/cli-core/SanityCommand'
 import {confirm, spinner} from '@sanity/cli-core/ux'
-import {DatasetResponse} from '@sanity/client'
+import {type DatasetResponse} from '@sanity/client'
 
 import {createDataset} from '../../actions/dataset/create.js'
 import {validateDatasetName} from '../../actions/dataset/validateDatasetName.js'
@@ -13,8 +14,11 @@ import {promptForDefaultConfig} from '../../prompts/promptForDefaultConfig.js'
 import {promptForProjectName} from '../../prompts/promptForProjectName.js'
 import {listDatasets} from '../../services/datasets.js'
 import {getProjectFeatures} from '../../services/getProjectFeatures.js'
-import {OrganizationCreateResponse, ProjectOrganization} from '../../services/organizations.js'
-import {createProject, CreateProjectResult} from '../../services/projects.js'
+import {
+  type OrganizationCreateResponse,
+  type ProjectOrganization,
+} from '../../services/organizations.js'
+import {createProject, type CreateProjectResult} from '../../services/projects.js'
 import {getCliUser} from '../../services/user.js'
 
 const debug = subdebug('projects:create')
@@ -117,7 +121,7 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
       const errorText = organization
         ? `Failed to retrieve organization ${organization}`
         : 'Failed to retrieve an organization'
-      this.error(`${errorText}: ${error}`, {exit: 1})
+      return this.output.error(`${errorText}: ${error}`, {exit: 1})
     }
 
     const spin = spinner('Creating project').start()
@@ -134,7 +138,7 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
     } catch (error) {
       spin.fail()
       debug(`Failed to create project: ${error}`)
-      this.error(`Failed to create project: ${error}`, {exit: 1})
+      return this.output.error(`Failed to create project: ${error}`, {exit: 1})
     }
 
     const newDataset = await this.handleDatasetCreation(
@@ -188,7 +192,7 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
       return
     } catch (error) {
       debug(`Error creating dataset: ${error}`)
-      this.warn(`Project created but dataset creation failed: ${error}`)
+      this.output.warn(`Project created but dataset creation failed: ${error}`)
       return
     }
   }
@@ -199,20 +203,20 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
     dataset: DatasetResponse | undefined,
   ) {
     if (this.flags.json) {
-      this.log(JSON.stringify(project, null, 2))
+      this.output.log(JSON.stringify(project, null, 2))
       return
     }
 
-    this.log(`Project created successfully!`)
-    this.log(`ID: ${project.projectId}`)
-    this.log(`Name: ${project.displayName}`)
-    this.log(`Organization: ${organization?.name || 'Personal'}`)
+    this.output.log(`Project created successfully!`)
+    this.output.log(`ID: ${project.projectId}`)
+    this.output.log(`Name: ${project.displayName}`)
+    this.output.log(`Organization: ${organization?.name || 'Personal'}`)
 
     if (dataset) {
-      this.log(`Dataset: ${dataset.datasetName} (${dataset.aclMode})`)
+      this.output.log(`Dataset: ${dataset.datasetName} (${dataset.aclMode})`)
     }
 
-    this.log(``)
-    this.log(`Manage your project: ${getManageUrl(project.projectId)}`)
+    this.output.log(``)
+    this.output.log(`Manage your project: ${getManageUrl(project.projectId)}`)
   }
 }

--- a/packages/@sanity/cli/src/prompts/__tests__/promptForDatasetName.test.ts
+++ b/packages/@sanity/cli/src/prompts/__tests__/promptForDatasetName.test.ts
@@ -32,7 +32,7 @@ describe('promptForDatasetName', () => {
       })
       promptForDatasetName({}, ['robin'])
     })
-    test('should prevent duplicate dataset names', () => {
+    test('should prevent invalid dataset names', () => {
       expect.assertions(1)
       const err = 'laughable name'
       mockValidate.mockReturnValue(err)

--- a/packages/@sanity/cli/src/prompts/__tests__/promptForDatasetName.test.ts
+++ b/packages/@sanity/cli/src/prompts/__tests__/promptForDatasetName.test.ts
@@ -1,0 +1,57 @@
+import * as uxMocks from '@sanity/cli-test/mocks/cli-core/ux'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {promptForDatasetName} from '../promptForDatasetName.js'
+
+const mockValidate = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/cli-core/ux', () => import('@sanity/cli-test/mocks/cli-core/ux'))
+vi.mock('../../actions/dataset/validateDatasetName.js', () => ({
+  validateDatasetName: mockValidate,
+}))
+
+describe('promptForDatasetName', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+  test('should default to message "Dataset name:" if none provided', () => {
+    promptForDatasetName()
+    expect(uxMocks.input).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Dataset name:',
+      }),
+    )
+  })
+  describe('validation', () => {
+    test('should prevent duplicate dataset names', () => {
+      expect.assertions(1)
+      const userSelection = 'robin'
+      uxMocks.input.mockImplementation((opts) => {
+        const validationResult = opts.validate(userSelection)
+        expect(validationResult).toEqual('Dataset name already exists')
+      })
+      promptForDatasetName({}, ['robin'])
+    })
+    test('should prevent duplicate dataset names', () => {
+      expect.assertions(1)
+      const err = 'laughable name'
+      mockValidate.mockReturnValue(err)
+      const userSelection = 'robin'
+      uxMocks.input.mockImplementation((opts) => {
+        const validationResult = opts.validate(userSelection)
+        expect(validationResult).toEqual(err)
+      })
+      promptForDatasetName({}, ['batman'])
+    })
+    test('should be ok with non-duplicate name that passes name validation', () => {
+      expect.assertions(1)
+      mockValidate.mockReturnValue(null)
+      const userSelection = 'robin'
+      uxMocks.input.mockImplementation((opts) => {
+        const validationResult = opts.validate(userSelection)
+        expect(validationResult).toEqual(true)
+      })
+      promptForDatasetName({}, ['batman'])
+    })
+  })
+})


### PR DESCRIPTION
### Description

Adds unit tests for `getOrganization.ts` and `promptForDatasetName.ts`, ensuring tests that previously existed under the `project/create.test.ts` test exist at the relevant abstraction level (next to the source they are testing). Converts project-create command tests to the new faster way. Also uses unbarreled imports for the sibling packages and the proper `SanityCommand` class methods for CLI output.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly test structure and CLI output wiring; production behavior should be equivalent aside from how errors are emitted through `this.output`.
> 
> **Overview**
> Refactors **`projects:create`** tests from **nock/API integration** to **mocked collaborators** (`getOrganization`, `createProject`, prompts, dataset actions) via **`@sanity/cli-test`** mocks, shrinking the command test file while keeping coverage for errors, unattended mode, dataset flows, JSON output, and dataset-creation warnings.
> 
> Adds **focused unit tests** next to **`getOrganization`** (list failures, invalid `--organization`, empty org list, unattended vs interactive selection/create) and **`promptForDatasetName`** (default prompt text and validate: duplicates, invalid names).
> 
> Updates **`CreateProjectCommand`** and **`getOrganization`** to use **unbarreled `@sanity/cli-core` imports** and routes user-facing output through **`this.output.log` / `error` / `warn`** (with **`return this.output.error(...)`** on failures) instead of inherited **`this.log` / `this.error`** helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3601ea6d91e5b522c0b0081b809e1631e027753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->