### PR TITLE
test(ci): try pnpm-documented approach to managing Github CI pnpm cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,30 +9,18 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ inputs.node-version }}
-
     - name: Set NODE_VERSION for Turbo cache
       run: echo "NODE_VERSION=${{ inputs.node-version }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@v6
 
-    - name: Get pnpm store directory
-      run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      shell: bash
-
-    - name: Cache pnpm store
-      uses: actions/cache@v5
+    - name: Setup Node.js ${{ inputs.node-version }}
+      uses: actions/setup-node@v6
       with:
-        path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-node-${{ inputs.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-node-${{ inputs.node-version }}-
-          ${{ runner.os }}-pnpm-store-
+        node-version: ${{ inputs.node-version }}
+        cache: 'pnpm'
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v6
 
-    - name: Setup Node.js ${{ inputs.node-version }}
+    - name: Setup Node ${{ inputs.node-version }}
       uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Restore Vitest cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: packages/@sanity/cli-e2e/node_modules/.vite/vitest
           key: vitest-e2e-scheduled-cache-${{ matrix.os }}-node${{ matrix.node-version }}-${{ github.run_id }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,7 +59,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Restore Vitest cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: packages/@sanity/cli-e2e/node_modules/.vite/vitest
           key: vitest-e2e-cache-${{ matrix.os }}-node${{ matrix.node-version }}-shard${{ matrix.shardIndex }}-${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         run: echo "TURBO_FORCE=true" >> $GITHUB_ENV
 
       - name: Restore Vitest cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: node_modules/.vite/vitest
           key: vitest-cache-unit-${{ matrix.os }}-node${{ matrix.node-version }}-${{ github.run_id }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Save coverage baseline to cache
         if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: coverage/baseline
           key: coverage-main-${{ github.sha }}
@@ -140,7 +140,7 @@ jobs:
       # The exact key won't match on PRs (PR SHA ≠ main SHA); restore-keys picks up the latest main entry.
       - name: Restore main branch coverage baseline
         if: github.event_name == 'pull_request'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: coverage/baseline
           key: coverage-main-${{ github.sha }}
@@ -207,7 +207,7 @@ jobs:
         run: echo "TURBO_FORCE=true" >> $GITHUB_ENV
 
       - name: Restore Vitest cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: node_modules/.vite/vitest
           key: vitest-cache-integration-${{ matrix.os }}-node${{ matrix.node-version }}-shard${{ matrix.shardIndex }}-${{ github.run_id }}


### PR DESCRIPTION
### Description

As documented on https://pnpm.io/continuous-integration#github-actions - letting the `setup-node` action manage the pnpm cache, rather than doing it ourselves. How is it different?

#### Before

Approximate base setup action timings from [a recent `main` CI run](https://github.com/sanity-io/cli/actions/runs/29118897688)'s logs and comparing between Ubuntu and Windows, on the `integration-test` job, shard 3, node v22:

Step | Ubuntu | Windows | Delta
-- | -- | -- | --
setup-node | ~0.5s | ~4.5s | +4s
pnpm/action-setup | ~1.2s | ~2.6s | +1.4s
pnpm store path | ~0.7s | ~1.6s | +0.9s
actions/cache restore | ~5.3s | ~33.8s | +28.5s
pnpm install --frozen-lockfile | ~5.8s | ~42.0s | +36.2s
total | 14s | 86s | N/A

The above is for a cache _hit_ run.

#### After

Results from CI timings in this PR. The first CI run, since it uses a `setup-node`-managed cache, had a cache miss. This is comparing `integration-test` job, shard 3, node v22, [Ubuntu](https://github.com/sanity-io/cli/actions/runs/29156330756/job/86553943353?pr=1480) vs. [Windows](https://github.com/sanity-io/cli/actions/runs/29156330756/job/86553943342?pr=1480). Those timings are: