### PR TITLE
test(chore): unit test `schema validate` command

### DIFF
--- a/packages/@sanity/cli/src/actions/schema/__tests__/metafile.test.ts
+++ b/packages/@sanity/cli/src/actions/schema/__tests__/metafile.test.ts
@@ -1,0 +1,111 @@
+import {describe, expect, it} from 'vitest'
+
+import {generateMetafile} from '../metafile.js'
+
+describe('generateMetafile', () => {
+  it('handles an empty schema', () => {
+    expect(
+      generateMetafile({
+        hoisted: {},
+        size: 0,
+        types: {},
+      }),
+    ).toEqual({
+      inputs: {},
+      outputs: {
+        root: {
+          bytes: 0,
+          exports: [],
+          imports: [],
+          inputs: {},
+        },
+      },
+    })
+  })
+
+  it('generates entries for root types and hoisted types', () => {
+    const metafile = generateMetafile({
+      hoisted: {
+        slug: {
+          extends: 'string',
+          size: 3,
+        },
+      },
+      size: 0,
+      types: {
+        post: {
+          extends: 'document',
+          size: 5,
+        },
+      },
+    })
+
+    expect(Object.keys(metafile.inputs).toSorted()).toEqual([
+      'hoisted/slug',
+      'schema/document/post',
+    ])
+
+    expect(metafile.inputs['schema/document/post']).toEqual({
+      bytes: 5,
+      format: 'esm',
+      imports: [],
+    })
+
+    expect(metafile.outputs.root.bytes).toBe(8)
+  })
+
+  it('subtracts child sizes and recursively emits field and array entries', () => {
+    const metafile = generateMetafile({
+      hoisted: {},
+      size: 0,
+      types: {
+        post: {
+          extends: 'document',
+          fields: {
+            authors: {
+              extends: 'array',
+              of: {
+                author: {
+                  extends: 'reference',
+                  size: 6,
+                },
+              },
+              size: 10,
+            },
+            title: {
+              extends: 'string',
+              size: 4,
+            },
+          },
+          size: 20,
+        },
+      },
+    })
+
+    expect(Object.keys(metafile.inputs).toSorted()).toEqual([
+      'schema/document/post',
+      'schema/document/post/authors',
+      'schema/document/post/authors/author',
+      'schema/document/post/title',
+    ])
+
+    // self size = 20 - (4 + 10)
+    expect(metafile.inputs['schema/document/post'].bytes).toBe(6)
+
+    // self size = 10 - 6
+    expect(metafile.inputs['schema/document/post/authors'].bytes).toBe(4)
+
+    expect(metafile.inputs['schema/document/post/authors/author'].bytes).toBe(6)
+    expect(metafile.inputs['schema/document/post/title'].bytes).toBe(4)
+
+    // 6 + 4 + 6 + 4
+    expect(metafile.outputs.root.bytes).toBe(20)
+
+    expect(metafile.outputs.root.inputs).toEqual({
+      'schema/document/post': {bytesInOutput: 6},
+      'schema/document/post/authors': {bytesInOutput: 4},
+      'schema/document/post/authors/author': {bytesInOutput: 6},
+      'schema/document/post/title': {bytesInOutput: 4},
+    })
+  })
+})

--- a/packages/@sanity/cli/src/actions/schema/__tests__/validateAction.test.ts
+++ b/packages/@sanity/cli/src/actions/schema/__tests__/validateAction.test.ts
@@ -1,0 +1,155 @@
+import {createMockOutput} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
+import * as taskMocks from '@sanity/cli-test/mocks/cli-core/tasks'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {validateAction} from '../validateAction'
+
+const mockAggregateSev = vi.hoisted(() => vi.fn())
+const mockGenMetafile = vi.hoisted(() => vi.fn())
+const mockWriteFile = vi.hoisted(() => vi.fn())
+const mockFormatValidation = vi.hoisted(() => vi.fn())
+
+vi.mock('node:fs', () => ({
+  writeFileSync: mockWriteFile,
+}))
+vi.mock('@sanity/cli-build/_internal/extract', () => ({
+  formatSchemaValidation: mockFormatValidation,
+  getAggregatedSeverity: mockAggregateSev,
+}))
+vi.mock('@sanity/cli-core/tasks', () => import('@sanity/cli-test/mocks/cli-core/tasks'))
+vi.mock('@sanity/cli-core/ux', () => import('@sanity/cli-test/mocks/cli-core/ux'))
+vi.mock('../metafile.js', () => ({
+  generateMetafile: mockGenMetafile,
+}))
+vi.mock('../validateSchema.worker.js', () => ({}))
+
+const output = createMockOutput()
+const workDir = '/some/dir'
+const baseOptions = {output, workDir}
+const debugMetafileContents = {debug: 'this bug'}
+
+describe('validateAction', () => {
+  beforeEach(() => {
+    taskMocks.studioWorkerTask.mockResolvedValue({serializedDebug: [], validation: []})
+    mockAggregateSev.mockReturnValue('info')
+    mockGenMetafile.mockReturnValue(debugMetafileContents)
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('sad paths', () => {
+    test('should throw if debugMetafilePath provided, did not fail schema validation and did not produce serializedDebug', async () => {
+      mockAggregateSev.mockReturnValue('info')
+      taskMocks.studioWorkerTask.mockResolvedValue({
+        serializedDebug: false,
+        validation: [{problems: [{message: 'uh oh', severity: 'info'}]}],
+      })
+
+      await expect(validateAction({...baseOptions, debugMetafilePath: 'yesplz'})).rejects.toThrow(
+        'serializedDebug should always be produced',
+      )
+    })
+
+    test('should throw if schema validation failed', async () => {
+      mockAggregateSev.mockReturnValue('error')
+      taskMocks.studioWorkerTask.mockResolvedValue({
+        serializedDebug: false,
+        validation: [{problems: [{message: 'uh oh', severity: 'error'}]}],
+      })
+
+      await expect(validateAction({...baseOptions, format: 'json'})).rejects.toThrow(
+        'Schema validation failed',
+      )
+    })
+  })
+
+  describe('happy paths', () => {
+    test('should output validation result in json format', async () => {
+      const validation = [{problems: [{message: 'uh oh', severity: 'error'}]}]
+      taskMocks.studioWorkerTask.mockResolvedValue({
+        serializedDebug: false,
+        validation,
+      })
+
+      await validateAction({...baseOptions, format: 'json'})
+
+      expect(output.log).toHaveBeenCalledWith(JSON.stringify(validation))
+    })
+
+    test('should output validation result in ndjson format, one per validation group', async () => {
+      const validation = [
+        {problems: [{message: 'uh oh', severity: 'error'}]},
+        {problems: [{message: 'yikes', severity: 'warn'}]},
+      ]
+      taskMocks.studioWorkerTask.mockResolvedValue({
+        serializedDebug: false,
+        validation,
+      })
+
+      await validateAction({...baseOptions, format: 'ndjson'})
+
+      for (const group of validation) {
+        expect(output.log).toHaveBeenCalledWith(JSON.stringify(group))
+      }
+    })
+  })
+
+  test('should output both errors and warnings by default', async () => {
+    const validation = [
+      {problems: [{message: 'uh oh', severity: 'error'}]},
+      {problems: [{message: 'yikes', severity: 'warning'}]},
+    ]
+    taskMocks.studioWorkerTask.mockResolvedValue({
+      serializedDebug: false,
+      validation,
+    })
+
+    await validateAction(baseOptions)
+
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('Validation results'))
+    expect(output.log).toHaveBeenCalledWith(expect.stringMatching(/Errors:\s+1 error/))
+    expect(output.log).toHaveBeenCalledWith(expect.stringMatching(/Warnings:\s+1 warning/))
+    expect(mockFormatValidation).toHaveBeenCalledWith(validation)
+  })
+
+  test('should output only errors with level:error', async () => {
+    const validation = [
+      {problems: [{message: 'uh oh', severity: 'error'}]},
+      {problems: [{message: 'yikes', severity: 'warning'}]},
+    ]
+    taskMocks.studioWorkerTask.mockResolvedValue({
+      serializedDebug: false,
+      validation,
+    })
+
+    await validateAction({...baseOptions, level: 'error'})
+
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining('Validation results'))
+    expect(output.log).toHaveBeenCalledWith(expect.stringMatching(/Errors:\s+1 error/))
+    expect(output.log).not.toHaveBeenCalledWith(expect.stringMatching(/Warnings:\s+1 warning/))
+    expect(mockFormatValidation).toHaveBeenCalledWith(validation)
+  })
+
+  test('should create metafile with debugMetafilePath on successful validation', async () => {
+    const validation = [
+      {problems: [{message: 'uh oh', severity: 'warning'}]},
+      {problems: [{message: 'yikes', severity: 'warning'}]},
+    ]
+    const debugMetafilePath = '/some/meta/path'
+    const serializedDebug = 'bugs in a row'
+    taskMocks.studioWorkerTask.mockResolvedValue({
+      serializedDebug,
+      validation,
+    })
+
+    await validateAction({...baseOptions, debugMetafilePath})
+
+    expect(mockGenMetafile).toHaveBeenCalledWith(serializedDebug)
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      debugMetafilePath,
+      JSON.stringify(debugMetafileContents),
+      'utf8',
+    )
+  })
+})

--- a/packages/@sanity/cli/src/actions/schema/validateAction.ts
+++ b/packages/@sanity/cli/src/actions/schema/validateAction.ts
@@ -1,7 +1,8 @@
 import {writeFileSync} from 'node:fs'
 
 import {formatSchemaValidation, getAggregatedSeverity} from '@sanity/cli-build/_internal/extract'
-import {Output, studioWorkerTask} from '@sanity/cli-core'
+import {studioWorkerTask} from '@sanity/cli-core/tasks'
+import {type Output} from '@sanity/cli-core/types'
 import {logSymbols, spinner} from '@sanity/cli-core/ux'
 
 import {generateMetafile} from './metafile.js'

--- a/packages/@sanity/cli/src/commands/schemas/__tests__/validate.test.ts
+++ b/packages/@sanity/cli/src/commands/schemas/__tests__/validate.test.ts
@@ -1,0 +1,31 @@
+import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {SchemaValidate} from '../validate.js'
+
+const mockValidateAction = vi.hoisted(() => vi.fn())
+
+vi.mock(
+  '@sanity/cli-core/SanityCommand',
+  () => import('@sanity/cli-test/mocks/cli-core/SanityCommand'),
+)
+
+vi.mock('../../../actions/schema/validateAction.js', () => ({validateAction: mockValidateAction}))
+
+describe('schema validate command', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('should invoke validateAction action', async () => {
+    await SchemaValidate.run([])
+    expect(mockValidateAction).toHaveBeenCalledOnce()
+  })
+  test('should error if validateAction throws', async () => {
+    mockValidateAction.mockRejectedValue(new Error('boom'))
+    await SchemaValidate.run([])
+    expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith('Error validating schema: boom', {
+      exit: 1,
+    })
+  })
+})

--- a/packages/@sanity/cli/src/commands/schemas/validate.ts
+++ b/packages/@sanity/cli/src/commands/schemas/validate.ts
@@ -1,5 +1,6 @@
 import {Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {subdebug} from '@sanity/cli-core/debug'
+import {SanityCommand} from '@sanity/cli-core/SanityCommand'
 
 import {validateAction} from '../../actions/schema/validateAction.js'
 
@@ -68,7 +69,7 @@ export class SchemaValidate extends SanityCommand<typeof SchemaValidate> {
       await validateAction(options)
     } catch (error) {
       debug('Error validating schema', error)
-      this.error(
+      return this.output.error(
         `Error validating schema: ${error instanceof Error ? error.message : String(error)}`,
         {exit: 1},
       )

--- a/packages/@sanity/cli/test/integration/commands/schemas/validate.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/schemas/validate.test.ts
@@ -1,6 +1,5 @@
-import {existsSync} from 'node:fs'
 import {readFile, writeFile} from 'node:fs/promises'
-import {join, resolve} from 'node:path'
+import {join} from 'node:path'
 
 import {testCommand, testFixture} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -26,68 +25,6 @@ describe('#schema:validate', {timeout: 60 * 1000}, () => {
     expect(stdout).toContain('Warnings:')
   })
 
-  test('should output JSON format with --format json', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    const {error, stderr, stdout} = await testCommand(SchemaValidate, ['--format', 'json'])
-
-    if (error) throw error
-    expect(stderr).not.toContain('Validating schema')
-    const parsed = JSON.parse(stdout)
-    expect(Array.isArray(parsed)).toBe(true)
-  })
-
-  test('should output NDJSON format with --format ndjson', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    const {error, stderr, stdout} = await testCommand(SchemaValidate, ['--format', 'ndjson'])
-
-    if (error) throw error
-    expect(stderr).not.toContain('Validating schema')
-    if (stdout.trim()) {
-      const lines = stdout.trim().split('\n')
-      for (const line of lines) {
-        expect(() => JSON.parse(line)).not.toThrow()
-      }
-    }
-  })
-
-  test.each([
-    {flag: 'format', options: 'pretty, ndjson, json'},
-    {flag: 'level', options: 'error, warning'},
-  ])('shows error when user inputs incorrect --$flag flag', async ({flag, options}) => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    const {error} = await testCommand(SchemaValidate, [`--${flag}`, 'invalid'])
-
-    expect(error?.message).toContain(`Expected --${flag}=invalid to be one of: ${options}`)
-  })
-
-  test('should show both errors and warnings with --level warning (default)', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    const {error, stdout} = await testCommand(SchemaValidate, ['--level', 'warning'])
-
-    if (error) throw error
-    expect(stdout).toContain('Errors:')
-    expect(stdout).toContain('Warnings:')
-  })
-
-  test('should show only errors with --level error', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    const {error, stdout} = await testCommand(SchemaValidate, ['--level', 'error'])
-
-    if (error) throw error
-    expect(stdout).toContain('Errors:')
-    expect(stdout).not.toContain('Warnings:')
-  })
-
   test('should validate schema with workspace flag', async () => {
     const cwd = await testFixture('multi-workspace-studio')
     process.chdir(cwd)
@@ -111,19 +48,6 @@ describe('#schema:validate', {timeout: 60 * 1000}, () => {
     expect(error?.oclif?.exit).toBe(1)
   })
 
-  test('should fail when workspace does not exist', async () => {
-    const cwd = await testFixture('multi-workspace-studio')
-    process.chdir(cwd)
-
-    const {error, stderr} = await testCommand(SchemaValidate, [
-      '--workspace',
-      'non-existent-workspace',
-    ])
-
-    expect(stderr).toContain('Validating schema')
-    expect(error?.oclif?.exit).toBe(1)
-  })
-
   test('should fail with validation errors for invalid schema (duplicate types)', async () => {
     const cwd = await testFixture('basic-studio')
     process.chdir(cwd)
@@ -142,106 +66,5 @@ describe('#schema:validate', {timeout: 60 * 1000}, () => {
     expect(stdout).toContain('[ERROR]')
     expect(stdout).toContain('A type with name "post" is already defined in the schema')
     expect(error?.oclif?.exit).toBe(1)
-  })
-
-  test('should output validation errors in JSON format', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    const schemaIndexPath = join(cwd, 'schemaTypes', 'index.ts')
-    const content = await readFile(schemaIndexPath, 'utf8')
-    const modified = content.replace(
-      'export const schemaTypes = [post, author, category, blockContent]',
-      'export const schemaTypes = [post, post, author, category, blockContent]',
-    )
-    await writeFile(schemaIndexPath, modified)
-
-    const {error, stdout} = await testCommand(SchemaValidate, ['--format', 'json'])
-
-    expect(error?.oclif?.exit).toBe(1)
-    const parsed = JSON.parse(stdout)
-    expect(Array.isArray(parsed)).toBe(true)
-    expect(parsed.length).toBeGreaterThan(0)
-    const hasPostError = parsed.some((group: {problems?: Array<{message?: string}>}) =>
-      group.problems?.some((p: {message?: string}) =>
-        p.message?.includes('A type with name "post" is already defined'),
-      ),
-    )
-    expect(hasPostError).toBe(true)
-  })
-
-  test('should output validation errors in NDJSON format', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    const schemaIndexPath = join(cwd, 'schemaTypes', 'index.ts')
-    const content = await readFile(schemaIndexPath, 'utf8')
-    const modified = content.replace(
-      'export const schemaTypes = [post, author, category, blockContent]',
-      'export const schemaTypes = [post, post, author, category, blockContent]',
-    )
-    await writeFile(schemaIndexPath, modified)
-
-    const {error, stdout} = await testCommand(SchemaValidate, ['--format', 'ndjson'])
-
-    expect(error?.oclif?.exit).toBe(1)
-    const lines = stdout.trim().split('\n')
-    expect(lines.length).toBeGreaterThan(0)
-    for (const line of lines) {
-      expect(() => JSON.parse(line)).not.toThrow()
-    }
-    const hasPostError = lines.some((line) => {
-      const parsed = JSON.parse(line)
-      return parsed.problems?.some((p: {message?: string}) =>
-        p.message?.includes('A type with name "post" is already defined'),
-      )
-    })
-    expect(hasPostError).toBe(true)
-  })
-
-  test('should create metafile with --debug-metafile-path on successful validation', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    const metafilePath = resolve(cwd, 'metafile.json')
-
-    const {error, stdout} = await testCommand(SchemaValidate, [
-      '--debug-metafile-path',
-      metafilePath,
-    ])
-
-    if (error) throw error
-    expect(existsSync(metafilePath)).toBe(true)
-    expect(stdout).toContain('Metafile written to:')
-    expect(stdout).toContain('https://esbuild.github.io/analyze/')
-
-    const metafileContent = await readFile(metafilePath, 'utf8')
-    const metafile = JSON.parse(metafileContent)
-    expect(metafile).toHaveProperty('inputs')
-    expect(metafile).toHaveProperty('outputs')
-  })
-
-  test('should NOT create metafile when validation fails', async () => {
-    const cwd = await testFixture('basic-studio')
-    process.chdir(cwd)
-
-    const schemaIndexPath = join(cwd, 'schemaTypes', 'index.ts')
-    const content = await readFile(schemaIndexPath, 'utf8')
-    const modified = content.replace(
-      'export const schemaTypes = [post, author, category, blockContent]',
-      'export const schemaTypes = [post, post, author, category, blockContent]',
-    )
-    await writeFile(schemaIndexPath, modified)
-
-    const metafilePath = resolve(cwd, 'metafile.json')
-
-    const {error, stdout} = await testCommand(SchemaValidate, [
-      '--debug-metafile-path',
-      metafilePath,
-    ])
-
-    expect(error?.oclif?.exit).toBe(1)
-    expect(existsSync(metafilePath)).toBe(false)
-    expect(stdout).toContain('Metafile not written due to validation errors')
   })
 })


### PR DESCRIPTION
### Description

- Add unit tests to uncovered units related to `schema validate` command: the command itself, the action, and some other supporting smaller modules
- Eliminate a lot of redundant integration tests covering same cases unit tests can easily cover

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly test additions and integration test deletion; minor CLI error-handling and import-path changes with no schema validation logic changes.
> 
> **Overview**
> Adds **unit tests** for `schema validate` at three layers: `generateMetafile`, `validateAction` (formats, severity levels, debug metafile, failure cases), and the `SchemaValidate` command (delegation and error surfacing).
> 
> **Integration tests** for `#schema:validate` are reduced so they only cover end-to-end flows (default pretty output, workspace selection, multi-workspace errors, invalid schema)—cases that are now covered by mocked unit tests (JSON/NDJSON, `--level`, invalid flags, metafile paths, etc.) are removed.
> 
> Small **production tweaks** to support testing and import layout: `validateAction` pulls `studioWorkerTask` and `Output` from narrower `@sanity/cli-core` entry points; the command catches failures via `return this.output.error(...)` instead of `this.error(...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c0da8d11a420261f43ee8b7f4447e54e050aba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->