### PR TITLE
chore(deps): dedupe @module-federation runtime packages to 2.7.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3301,34 +3301,17 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/error-codes@2.6.0':
-    resolution: {integrity: sha512-J9opjWJJZ1JI/9EvNZF8Ps1VMHS9EsH/i0UjCkQQxFVYZxSDBX1CFunvc7awac4cY//LqJUfqBbfoQPhCfKKKw==}
-
   '@module-federation/error-codes@2.7.0':
     resolution: {integrity: sha512-syToF3H77IbBhJ7auGMCIb5ZDmJ5tvaqSeEvncJrOCq7JBT96F4UDlQDyNh6kCVznvYqqHsPeEMrfI9b5/Omlg==}
 
   '@module-federation/managers@2.7.0':
     resolution: {integrity: sha512-cWohiUvSrY6dIfhwsRABmEWfvJiAD5u/gxU7XRk7bx5nYPj7qn5gvYWJtvLNWzenluHZR6sib+03QMlyo+MYKQ==}
 
-  '@module-federation/runtime-core@2.6.0':
-    resolution: {integrity: sha512-9sL7Yj3H3COZI9JpK/J4hmJUBkIJdmowkj6phHuFiy5Hm5bHiE5U+9WBbR9KqTdyNhAVSL9FeprBW5/Io6i59A==}
-
   '@module-federation/runtime-core@2.7.0':
     resolution: {integrity: sha512-5ROZLVIeV9YnWO2RwCwSHcy6sh48yclErO/2GZ2Xe8lFubPrFirgU8pbwBjZw+All0ZzN44BGS4ECRMVFzVcpg==}
 
-  '@module-federation/runtime@2.6.0':
-    resolution: {integrity: sha512-Y8KgL70RDxD8cCtGWGlGkt+TSDleIjdGmS27gnllibQAIgG/vHhPD11r8kd92x44k4dqtMIntzreOphGICl92g==}
-
   '@module-federation/runtime@2.7.0':
     resolution: {integrity: sha512-UtLozKKNvhT0D1+F0MEWsAmddJ39ItKW15E22LVMAwXmYZRSnzIvJQ2Y6kQ4LwhWABsw/GRSpUDex5OfhpSQPw==}
-
-  '@module-federation/sdk@2.6.0':
-    resolution: {integrity: sha512-Z3HT1uDciMrvz2at3sw6TJbAK9Fl7RmoC/8iqO35HDtQMQJ1qSsMIAjnsiCpAC0D4nAm6PIqgSqPWRO/WYgo0Q==}
-    peerDependencies:
-      node-fetch: ^2.7.0 || ^3.3.2
-    peerDependenciesMeta:
-      node-fetch:
-        optional: true
 
   '@module-federation/sdk@2.7.0':
     resolution: {integrity: sha512-piiLEjaIdjbNq8E11Di6vsfryhcdN/+sBCH6NjG7gSU2VHHoHEayZQWWL7VVdS6rVjexF9McLhPTSrl0adUU+A==}
@@ -12304,8 +12287,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/error-codes@2.6.0': {}
-
   '@module-federation/error-codes@2.7.0': {}
 
   '@module-federation/managers@2.7.0':
@@ -12313,33 +12294,16 @@ snapshots:
       '@module-federation/sdk': 2.7.0
       empathic: 2.0.0
 
-  '@module-federation/runtime-core@2.6.0':
-    dependencies:
-      '@module-federation/error-codes': 2.6.0
-      '@module-federation/sdk': 2.6.0
-    transitivePeerDependencies:
-      - node-fetch
-
   '@module-federation/runtime-core@2.7.0':
     dependencies:
       '@module-federation/error-codes': 2.7.0
       '@module-federation/sdk': 2.7.0
-
-  '@module-federation/runtime@2.6.0':
-    dependencies:
-      '@module-federation/error-codes': 2.6.0
-      '@module-federation/runtime-core': 2.6.0
-      '@module-federation/sdk': 2.6.0
-    transitivePeerDependencies:
-      - node-fetch
 
   '@module-federation/runtime@2.7.0':
     dependencies:
       '@module-federation/error-codes': 2.7.0
       '@module-federation/runtime-core': 2.7.0
       '@module-federation/sdk': 2.7.0
-
-  '@module-federation/sdk@2.6.0': {}
 
   '@module-federation/sdk@2.7.0': {}
 
@@ -14070,7 +14034,7 @@ snapshots:
 
   '@sanity/workbench@0.1.0-alpha.23(@sanity/sdk@2.14.1(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.1))(react@19.2.7)(xstate@5.32.1)':
     dependencies:
-      '@module-federation/runtime': 2.6.0
+      '@module-federation/runtime': 2.7.0
       '@sanity/message-protocol': 0.23.0
       '@sanity/sdk': 2.14.1(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.1)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
@@ -14079,7 +14043,6 @@ snapshots:
       xstate: 5.32.1
       zod: 4.4.3
     transitivePeerDependencies:
-      - node-fetch
       - react
 
   '@sanity/worker-channels@2.0.0': {}
@@ -18569,7 +18532,6 @@ snapshots:
       - bufferutil
       - canvas
       - immer
-      - node-fetch
       - prismjs
       - react-native
       - supports-color


### PR DESCRIPTION
### Description

#1484 bumped `@module-federation/vite` to 1.16.14, which pulls `@module-federation/{runtime,runtime-core,sdk,error-codes}` 2.7.0. The lockfile regeneration was minimal, so `@sanity/workbench`'s `^2.6.0` range stayed resolved at 2.6.0 — leaving two copies of each package in the lockfile.

That state isn't a pnpm fixed point: any branch that touches dependencies gets this dedupe as unrelated churn on install (it showed up in #1486). This lands the dedupe on its own so other diffs stay clean.

### What to review

Lockfile only. The 2.6.0 entries are removed and `@sanity/workbench` now resolves its runtime to 2.7.0 — the same version mf-vite already uses since #1484.

### Testing

`pnpm install --frozen-lockfile`, `pnpm build:cli`, and a re-run of `pnpm install` (no lockfile drift) all pass locally.

### Notes for release

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency lockfile deduplication only; no application source changes, with workbench already semver-compatible with 2.7.0.
> 
> **Overview**
> **Lockfile-only** change that removes duplicate `@module-federation/{runtime,runtime-core,sdk,error-codes}` **2.6.0** entries and pins everything to **2.7.0**, matching what `@module-federation/vite` already pulled in after #1484.
> 
> `@sanity/workbench`’s runtime dependency moves from **2.6.0** to **2.7.0**, so the tree no longer carries two versions and `pnpm install` stops rewriting the lockfile on unrelated dependency work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ff4d7cbac1b6e4bdd023a8db24bb6e2dbd1c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->