### PR TITLE
feat(workbench): thread the media-library application type through deploy and dev

### DIFF
--- a/.changeset/pr-1489.md
+++ b/.changeset/pr-1489.md
@@ -1,0 +1,8 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+'@sanity/workbench-cli': minor
+---
+
+feat(workbench): thread the media-library application type through deploy and dev

--- a/packages/@sanity/cli-core/src/config/cli/workbenchApp.ts
+++ b/packages/@sanity/cli-core/src/config/cli/workbenchApp.ts
@@ -30,7 +30,7 @@ const STUDIO_CONFIG_FILES = [
 // Mirrors the `ApplicationType` enum in `@sanity/workbench-cli`'s `defineApp`
 // schema — `unstable_defineApp` doesn't validate, so the loader is the first
 // place `applicationType` can be checked. Kept in sync by a test there.
-const APPLICATION_TYPES = ['coreApp', 'studio', 'canvas', 'dashboard', 'media-library'] as const
+const APPLICATION_TYPES = ['coreApp', 'studio', 'dashboard', 'media-library'] as const
 
 /** The resolved kind of a workbench app — `studio` or one of the SDK app types. */
 export type ApplicationType = (typeof APPLICATION_TYPES)[number]

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -231,6 +231,9 @@ async function runAppDeployment(
     const slug = workbench.slug ?? generateAppSlug()
     const {applicationId} = await deployWorkbenchCoreApp({
       appId,
+      // Brett only knows media-library besides coreApp; other kinds (e.g.
+      // dashboard) deploy as plain coreApps.
+      applicationType: workbench.applicationType === 'media-library' ? 'media-library' : 'coreApp',
       interfaces: buildExposes(workbench, {
         appName: workbench.name,
         appTitle,

--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -91,12 +91,12 @@ describe('DefineAppInputSchema (build-time validation)', () => {
 
   test('validates the internal applicationType when present', () => {
     const parsed = DefineAppInputSchema.parse({
-      applicationType: 'canvas',
+      applicationType: 'media-library',
       name: 'media',
       organizationId: 'org-1',
       title: 'Media',
     })
-    expect(parsed.applicationType).toBe('canvas')
+    expect(parsed.applicationType).toBe('media-library')
     expect(
       DefineAppInputSchema.safeParse({
         applicationType: 'not-a-type',

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -184,6 +184,7 @@ describe('createDeployment', () => {
 })
 
 const coreAppOptions = {
+  applicationType: 'coreApp' as const,
   interfaces,
   isAutoUpdating: false,
   isSingleton: false,
@@ -218,6 +219,15 @@ describe('deployCoreApp', () => {
       uri: '/applications',
     })
     expect(appendedFields()).toContainEqual(['slug', 'abc123'])
+    expect(appendedFields()).toContainEqual(['type', 'coreApp'])
+  })
+
+  test('creates a media-library app with its own type', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'app_new'})
+
+    await deployCoreApp({...coreAppOptions, appId: undefined, applicationType: 'media-library'})
+
+    expect(appendedFields()).toContainEqual(['type', 'media-library'])
   })
 
   test('forwards isSingleton when creating a singleton core app', async () => {

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
@@ -10,7 +10,7 @@ import {pack} from 'tar-fs'
 import {APP_WORKBENCH_API_VERSION} from './apiVersion.js'
 import {type BrettInterface} from './buildExposes.js'
 
-export type ApplicationType = 'coreApp' | 'studio'
+export type ApplicationType = 'coreApp' | 'media-library' | 'studio'
 
 export interface Application {
   id: string
@@ -145,6 +145,7 @@ async function request<T>(uri: string, formData: FormData): Promise<T> {
  */
 export async function deployCoreApp(options: {
   appId: string | undefined
+  applicationType: Exclude<ApplicationType, 'studio'>
   interfaces: readonly BrettInterface[]
   isAutoUpdating: boolean
   isSingleton?: boolean
@@ -156,6 +157,7 @@ export async function deployCoreApp(options: {
 }): Promise<{applicationId: string}> {
   const {
     appId,
+    applicationType,
     interfaces,
     isAutoUpdating,
     isSingleton,
@@ -182,7 +184,7 @@ export async function deployCoreApp(options: {
       slug,
       tarball,
       title,
-      type: 'coreApp',
+      type: applicationType,
       version,
     })
     spin.succeed()

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
@@ -66,7 +66,7 @@ describe('startDevServerRegistration', () => {
     )
   })
 
-  test('registers a media-library app as a coreApp', async () => {
+  test('registers a media-library app with its own type', async () => {
     await register({
       cliConfig: workbenchCliConfig({
         app: workbenchApp({applicationType: 'media-library', isSingleton: true}),
@@ -74,7 +74,9 @@ describe('startDevServerRegistration', () => {
       isApp: true,
     })
 
-    expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({type: 'coreApp'}))
+    expect(mockRegisterDevServer).toHaveBeenCalledWith(
+      expect.objectContaining({type: 'media-library'}),
+    )
   })
 
   test('records the caller-resolved appId on the registry entry', async () => {

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -106,7 +106,7 @@ const devServerManifestSchema = z.object({
   port: z.number(),
   projectId: z.optional(z.string()),
   startedAt: z.string(),
-  type: z.enum(['coreApp', 'studio']),
+  type: z.enum(['coreApp', 'studio', 'media-library']),
   version: z.literal(REGISTRY_VERSION),
   workDir: z.string(),
 })

--- a/packages/@sanity/workbench-cli/src/actions/dev/startDevServerRegistration.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startDevServerRegistration.ts
@@ -1,6 +1,7 @@
 import {type CliConfig, getCliConfigUncached, type Output} from '@sanity/cli-core'
 import {type ViteDevServer} from 'vite'
 
+import {resolveWorkbenchApp} from '../../resolveWorkbenchApp.js'
 import {deriveConfigs, deriveInterfaces} from './deriveInterfaces.js'
 import {trackExposesSet} from './exposesSetId.js'
 import {type DevServerManifest, registerDevServer} from './registry.js'
@@ -67,6 +68,7 @@ export async function startDevServerRegistration(
   const interfaces = deriveInterfaces(cliConfig.app, {isApp})
   const configs = deriveConfigs(cliConfig.app)
 
+  const applicationType = resolveWorkbenchApp(cliConfig)?.applicationType
   const registration = registerDevServer({
     configs,
     host: appHost,
@@ -74,7 +76,7 @@ export async function startDevServerRegistration(
     interfaces,
     port: appPort,
     projectId: cliConfig?.api?.projectId,
-    type: isApp ? 'coreApp' : 'studio',
+    type: applicationType === 'media-library' ? 'media-library' : isApp ? 'coreApp' : 'studio',
     workDir,
   })
 

--- a/packages/@sanity/workbench-cli/src/defineApp.ts
+++ b/packages/@sanity/workbench-cli/src/defineApp.ts
@@ -9,7 +9,7 @@ const APP_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/
  * Internal application discriminator. Sanity-owned singleton apps only;
  * validated by the schema but excluded from the public `DefineAppInput` type.
  */
-const ApplicationType = z.enum(['coreApp', 'studio', 'canvas', 'dashboard', 'media-library'])
+const ApplicationType = z.enum(['coreApp', 'studio', 'dashboard', 'media-library'])
 
 /** Dock groups an app can place itself into. */
 const DockGroupSchema = z.enum(['dock.system', 'dock.applications', 'dock.user'])


### PR DESCRIPTION
### Description

Brett's applications API now accepts `type: media-library` for singleton applications (sanity-io/brett#531). The CLI collapsed every non-studio workbench app to `coreApp` — both on deploy and in the dev registry — so the Media Library couldn't identify itself to Brett or to a local workbench.

- Deploy: `deployCoreApp` takes a strict `applicationType` (`'coreApp' | 'media-library'`) and threads it to Brett untouched; the call site in `deployApp.ts` decides that non-media-library kinds (e.g. `dashboard`) deploy as plain coreApps.
- Dev: the registry entry (and the `sanity:workbench:local-applications` payload) carries `media-library` for apps that declare it — including `unstable_defineMediaLibrary`, which already stamps that type.
- `unstable_defineApp` accepts the internal `applicationType: 'media-library'` as before; the property stays invisible in the public `DefineAppInput`.
- Drops `canvas` from the internal enum; Brett dropped it in sanity-io/brett#524.

Legacy (non-workbench) app and studio deploys are untouched.

### What to review

- The strict `applicationType` contract on `deployCoreApp` and the collapse at its call site in `deployApp.ts`.
- The registry `type` derivation in `startDevServerRegistration.ts`.

### Testing

Unit tests cover the deploy pass-through, dev registration for media-library apps, and the widened registry schema.

### Notes for release

Workbench apps that declare the internal `media-library` application type now deploy and register with that type instead of `coreApp`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how workbench apps are classified when talking to Brett and the dev registry; mis-mapping could break Media Library deploy or local workbench discovery, but the logic is narrow and covered by unit tests.
> 
> **Overview**
> Workbench apps that declare **`media-library`** now identify themselves to Brett on deploy and in the local dev registry instead of being folded into **`coreApp`**.
> 
> **Deploy:** `deployCoreApp` requires an explicit `applicationType` (`coreApp` | `media-library`) and sends it as Brett’s `type` on create; `deployApp.ts` only passes `media-library` when the workbench app declares it—other internal kinds (e.g. `dashboard`) still deploy as `coreApp`.
> 
> **Dev:** The dev-server registry schema and `startDevServerRegistration` register `type: media-library` when `resolveWorkbenchApp` reports that `applicationType`, so the workbench and `sanity:workbench:local-applications` can treat Media Library like a first-class app locally.
> 
> **Cleanup:** **`canvas`** is removed from the internal `applicationType` enums in `@sanity/cli-core` and `defineApp` to match Brett. Legacy non-workbench app/studio deploy paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d164cece69956a0cefc30577c61bfc07927fa3a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->