### PR TITLE
ci: add cli-build to bundle stats, drop dead ignore

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -29,7 +29,8 @@ jobs:
 
       - uses: rexxars/bundle-stats@d3671d09a4973b4b2b09c4fe8b1c07c360683397 # v1.11.3
         with:
-          packages: packages/@sanity/cli, packages/@sanity/cli-core, packages/create-sanity
+          packages: packages/@sanity/cli, packages/@sanity/cli-core, packages/@sanity/cli-build, packages/create-sanity
           build-command: pnpm build:cli
-          only: '.'
-          ignore: 'bin/**'
+          # _internal/** covers cli-build, which has no root export; with a
+          # bare '.' the action fails with "No exports or bin entries matched"
+          only: '., _internal/**'


### PR DESCRIPTION
### Description

Two cleanups to the bundle-stats workflow:

- Add `packages/@sanity/cli-build` to the measured packages (the TODO from #1062; the package is published now at 3.0.0). It exposes only `_internal/*` exports, so the `only` filter gains `_internal/**` — with a bare `only: '.'` the action hard-fails for it ("No exports or bin entries matched the active filters"). The pattern doesn't leak into the other packages: `@sanity/cli`'s `./_internal` key has no slash, so `_internal/**` doesn't match it.
- Drop `ignore: 'bin/**'`. It has been a no-op since #858: bin entries are keyed `bin:sanity` and the glob needs a slash, so it never matched anything (which is why `bin:sanity` still shows up in every comment).

### What to review

The bundle-stats comment on this PR: `@sanity/cli-build`'s three `_internal` exports should appear, everything else stays at root exports + bins as before.

### Testing

Ran the action's CLI locally: `--only '.'` against cli-build exits 1 with the "no exports" error, `--only '.' --only '_internal/**'` measures its three exports, and the combined patterns still resolve `@sanity/cli` to just `.` + `bin:sanity`.

### Notes for release

N/A