### PR TITLE
fix(create-sanity): only spawn the CLI when executed directly

### DIFF
--- a/.changeset/pr-1492.md
+++ b/.changeset/pr-1492.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'create-sanity': patch
+---
+
+fix(create-sanity): only spawn the CLI when executed directly

--- a/packages/create-sanity/index.js
+++ b/packages/create-sanity/index.js
@@ -1,30 +1,39 @@
 #!/usr/bin/env node
 import {spawn} from 'node:child_process'
+import {realpathSync} from 'node:fs'
 import {readFile} from 'node:fs/promises'
 import {dirname, resolve} from 'node:path'
 import {fileURLToPath} from 'node:url'
 
-const args = process.argv.slice(2)
+// Spawn only when executed directly, so importing this module has no side
+// effects. npm runs the bin through a symlink, hence the realpath comparison.
+const isMain =
+  Boolean(process.argv[1]) &&
+  realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))
 
-let cliBin
-try {
-  const cliPkgDir = fileURLToPath(import.meta.resolve('@sanity/cli/package.json'))
-  const cliDir = dirname(cliPkgDir)
+if (isMain) {
+  const args = process.argv.slice(2)
 
-  // Read the package.json file and extract the bin path
-  const pJson = await readFile(cliPkgDir, 'utf8')
-  const pkgJson = JSON.parse(pJson)
-  const binPath = pkgJson.bin?.['sanity']
-  if (!binPath) {
-    throw new Error('Failed to resolve `@sanity/cli` package')
+  let cliBin
+  try {
+    const cliPkgDir = fileURLToPath(import.meta.resolve('@sanity/cli/package.json'))
+    const cliDir = dirname(cliPkgDir)
+
+    // Read the package.json file and extract the bin path
+    const pJson = await readFile(cliPkgDir, 'utf8')
+    const pkgJson = JSON.parse(pJson)
+    const binPath = pkgJson.bin?.['sanity']
+    if (!binPath) {
+      throw new Error('Failed to resolve `@sanity/cli` package')
+    }
+
+    cliBin = resolve(cliDir, binPath)
+  } catch (err) {
+    throw new Error('Failed to resolve `@sanity/cli` package', {cause: err})
   }
 
-  cliBin = resolve(cliDir, binPath)
-} catch (err) {
-  throw new Error('Failed to resolve `@sanity/cli` package', {cause: err})
+  const proc = spawn('node', [cliBin, 'init', ...args, '--from-create'], {stdio: 'inherit'})
+  proc.on('exit', (code) => {
+    process.exitCode = code
+  })
 }
-
-const proc = spawn('node', [cliBin, 'init', ...args, '--from-create'], {stdio: 'inherit'})
-proc.on('exit', (code) => {
-  process.exitCode = code
-})


### PR DESCRIPTION
### Description

The bundle-stats comment shows `❌ ChildProcess denied: node` for `create-sanity`'s import-time cell (see #1490). The benchmark imports the bin entry in a sandbox that blocks child processes, and `create-sanity/index.js` spawns `sanity init` as a top-level side effect of being imported.

The spawn-on-import is the actual problem, not the sandbox: importing a module shouldn't execute it. This guards the bin body behind a main-module check (realpath comparison, since npm executes bins through symlinks), so importing the file is inert and only direct execution spawns the CLI.

The alternative, `allow-bin-child-process: true` on the action, would have the benchmark actually run `sanity init` in CI 10 times per job.

### What to review

- Direct execution paths still work: `node index.js`, npm's `.bin` symlink, `npm create sanity`. All three spawn via `process.argv[1]`, which the realpath comparison handles.
- The import benchmark on this PR's bundle-stats comment should now show a timing for `bin:create-sanity` instead of the ❌.

### Testing

Verified import is side-effect free (`await import(...)` spawns nothing), direct and symlinked execution both still delegate to `sanity init --help`, and the existing create-sanity tests pass (they spawn `node index.js`, so `argv[1]` is set and the guard holds).

### Notes for release

`npm create sanity` no longer runs the CLI when its entry module is imported rather than executed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix to bin entry loading; direct CLI invocation paths are preserved and risk is limited to edge cases around main-module detection.
> 
> **Overview**
> **`create-sanity/index.js` no longer spawns `sanity init` on import.** The CLI delegation (resolve `@sanity/cli`, `spawn` with `--from-create`) now runs only when the entry file is the main module, using a `realpathSync` comparison between `process.argv[1]` and `import.meta.url` so npm `.bin` symlinks still count as direct execution.
> 
> This removes import-time child-process side effects that broke bundle-stats import benchmarks and could surprise any code that `import`s the bin entry. **`npm create sanity` / `node index.js` behavior is unchanged** when run as intended.
> 
> A patch changeset is included for `create-sanity`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d145bcb08d73d584f21c568c1eb4ccd5a1a0b89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->