### PR TITLE
ci: reinstall dependencies per ref in bundle stats

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -30,7 +30,11 @@ jobs:
       - uses: rexxars/bundle-stats@d3671d09a4973b4b2b09c4fe8b1c07c360683397 # v1.11.3
         with:
           packages: packages/@sanity/cli, packages/@sanity/cli-core, packages/@sanity/cli-build, packages/create-sanity
-          build-command: pnpm build:cli
+          # Reset state per checked-out ref: node_modules otherwise stays at the
+          # head ref's dependency tree (dependency bumps measure as zero delta),
+          # and turbo restores cached outputs without pruning files the other
+          # ref's build left in dist.
+          build-command: pnpm clean && pnpm install --frozen-lockfile && pnpm build:cli
           # _internal/** covers cli-build, which has no root export; with a
           # bare '.' the action fails with "No exports or bin entries matched"
           only: '., _internal/**'


### PR DESCRIPTION
### Description

Follow-up to #1490. That PR fixed which exports get measured; this one fixes a second reason dependency-bump PRs never show size deltas.

The bundle-stats action installs `node_modules` once (from the PR merge ref) and then measures both refs: it checks out the baseline, builds, measures, checks out head, builds, measures. `git checkout` reverts `package.json` and `pnpm-lock.yaml`, but not `node_modules` — and the action's bundler (`@rollup/plugin-node-resolve`) and import benchmark both resolve dependencies from the filesystem. So the baseline gets bundled against the head's dependency tree, and on a version bump both sides measure the new version: bundled-size delta is structurally 0 and the import-time delta is noise.

Turbo is not the problem here. The task hashes differ per ref and each build restores the correct dist from remote cache; only dependency resolution at measure time is contaminated.

The action `eval`s `build-command` after each checkout, so prepending `pnpm install --frozen-lockfile` installs whichever lockfile is checked out. With the warm pnpm store from setup this costs roughly 15-30s per ref. `pnpm clean` is in there too: turbo restores cached outputs without pruning files the other ref's build left in `dist`, so each measurement should start from an empty output dir.

### What to review

The bundle-stats comment on this PR, and that the job's runtime stays reasonable with the two extra installs.

### Testing

Verified against the run for #1485: the baseline and head turbo hashes were disjoint (builds were correct per ref), while the measured sizes were byte-identical — consistent with both measurements resolving the same `node_modules`.

### Notes for release

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with no runtime or application code impact; main tradeoff is longer bundle-stats job time from two extra installs.
> 
> **Overview**
> The **bundle-stats** workflow now runs **`pnpm clean && pnpm install --frozen-lockfile && pnpm build:cli`** on each ref checkout instead of only **`pnpm build:cli`**.
> 
> That resets **`node_modules`** to match each ref’s lockfile so baseline and head aren’t both measured against the PR’s dependency tree (which made dependency-bump PRs show **zero** size delta). **`pnpm clean`** clears **`dist`** so turbo cache restores don’t leave artifacts from the other ref’s build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e621a564852d56ba8528470923c620912db8874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




---

Resubmitted from #1491, which GitHub auto-closed when its base branch merged.