### PR TITLE
feat(cli): share the --json flag definition across commands

### DIFF
--- a/.changeset/pr-1494.md
+++ b/.changeset/pr-1494.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): share the --json flag definition across commands

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -9,6 +9,7 @@ import {deployDebug} from '../actions/deploy/deployDebug.js'
 import {deployStudio} from '../actions/deploy/deployStudio.js'
 import {determineIsApp} from '../util/determineIsApp.js'
 import {dirIsEmptyOrNonExistent} from '../util/dirIsEmptyOrNonExistent.js'
+import {getJsonFlag} from '../util/sharedFlags.js'
 
 export class DeployCommand extends SanityCommand<typeof DeployCommand> {
   static override args = {
@@ -60,11 +61,7 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
       description: 'Register an externally hosted studio',
       exclusive: ['source-maps', 'minify', 'build'],
     }),
-    json: Flags.boolean({
-      char: 'j',
-      default: false,
-      description: 'Output the result as JSON',
-    }),
+    ...getJsonFlag(),
     minify: Flags.boolean({
       allowNo: true,
       default: true,

--- a/packages/@sanity/cli/src/commands/doctor.ts
+++ b/packages/@sanity/cli/src/commands/doctor.ts
@@ -1,6 +1,6 @@
 import {styleText} from 'node:util'
 
-import {Args, Flags} from '@oclif/core'
+import {Args} from '@oclif/core'
 import {SanityCommand} from '@sanity/cli-core'
 import {logSymbols} from '@sanity/cli-core/ux'
 
@@ -14,6 +14,7 @@ import {
   type DoctorResults,
   type MessageType,
 } from '../actions/doctor/types.js'
+import {getJsonFlag} from '../util/sharedFlags.js'
 
 const STATUS_SYMBOLS: Record<CheckResultStatus, string> = {
   error: logSymbols.error,
@@ -52,11 +53,7 @@ export class DoctorCommand extends SanityCommand<typeof DoctorCommand> {
   ]
 
   static override flags = {
-    json: Flags.boolean({
-      char: 'j',
-      default: false,
-      description: 'Output results as JSON',
-    }),
+    ...getJsonFlag(),
   }
 
   // Needed for variable argument count

--- a/packages/@sanity/cli/src/commands/openapi/list.ts
+++ b/packages/@sanity/cli/src/commands/openapi/list.ts
@@ -2,6 +2,8 @@ import {Flags} from '@oclif/core'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 import open from 'open'
 
+import {getJsonFlag} from '../../util/sharedFlags.js'
+
 interface OpenAPISpec {
   description: string
   slug: string
@@ -29,9 +31,7 @@ export class ListOpenApiCommand extends SanityCommand<typeof ListOpenApiCommand>
   ]
 
   static override flags = {
-    json: Flags.boolean({
-      description: 'Output JSON',
-    }),
+    ...getJsonFlag(),
     web: Flags.boolean({
       char: 'w',
       description: 'Open HTTP Reference in web browser',

--- a/packages/@sanity/cli/src/commands/projects/create.ts
+++ b/packages/@sanity/cli/src/commands/projects/create.ts
@@ -20,6 +20,7 @@ import {
 } from '../../services/organizations.js'
 import {createProject, type CreateProjectResult} from '../../services/projects.js'
 import {getCliUser} from '../../services/user.js'
+import {getJsonFlag} from '../../util/sharedFlags.js'
 
 const debug = subdebug('projects:create')
 
@@ -73,10 +74,7 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
       description: 'Dataset visibility: public or private',
       options: ['private', 'public'],
     }),
-    json: Flags.boolean({
-      default: false,
-      description: 'Output in JSON format',
-    }),
+    ...getJsonFlag(),
     organization: Flags.string({
       description: 'Organization to create the project in',
       helpValue: '<slug|id>',

--- a/packages/@sanity/cli/src/commands/schemas/list.ts
+++ b/packages/@sanity/cli/src/commands/schemas/list.ts
@@ -4,6 +4,7 @@ import {SanityCommand} from '@sanity/cli-core'
 import {listSchemas} from '../../actions/schema/listSchemas.js'
 import {schemasListDebug} from '../../actions/schema/utils/debug.js'
 import {parseWorkspaceSchemaId} from '../../actions/schema/utils/schemaStoreValidation.js'
+import {getJsonFlag} from '../../util/sharedFlags.js'
 
 const description = `
 List all schemas in the current dataset.
@@ -46,9 +47,7 @@ export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
       description: 'Fetch a single schema by id',
       helpValue: '<schema_id>',
     }),
-    json: Flags.boolean({
-      description: 'Get schema as json',
-    }),
+    ...getJsonFlag(),
     'manifest-dir': Flags.directory({
       default: './dist/static',
       description: 'Directory containing manifest file',

--- a/packages/@sanity/cli/src/commands/tokens/add.ts
+++ b/packages/@sanity/cli/src/commands/tokens/add.ts
@@ -5,7 +5,7 @@ import {input, select} from '@sanity/cli-core/ux'
 import {validateRole} from '../../actions/tokens/validateRole.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {createToken, getTokenRoles} from '../../services/tokens.js'
-import {getProjectIdFlag} from '../../util/sharedFlags.js'
+import {getJsonFlag, getProjectIdFlag} from '../../util/sharedFlags.js'
 
 const tokensAddDebug = subdebug('tokens:add')
 
@@ -44,10 +44,7 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
 
   static override flags = {
     ...getProjectIdFlag({description: 'Project ID to add token to', semantics: 'override'}),
-    json: Flags.boolean({
-      default: false,
-      description: 'Output as JSON',
-    }),
+    ...getJsonFlag(),
     role: Flags.string({
       description: 'Role to assign to the token',
       helpValue: 'viewer',

--- a/packages/@sanity/cli/src/commands/tokens/list.ts
+++ b/packages/@sanity/cli/src/commands/tokens/list.ts
@@ -1,4 +1,3 @@
-import {Flags} from '@oclif/core'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {Table} from 'console-table-printer'
@@ -6,7 +5,7 @@ import {Table} from 'console-table-printer'
 import {type Token} from '../../actions/tokens/types.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {getTokens} from '../../services/tokens.js'
-import {getProjectIdFlag} from '../../util/sharedFlags.js'
+import {getJsonFlag, getProjectIdFlag} from '../../util/sharedFlags.js'
 
 const listTokenDebug = subdebug('tokens:list')
 
@@ -31,18 +30,14 @@ export class TokensListCommand extends SanityCommand<typeof TokensListCommand> {
       description: 'Project ID to list tokens for',
       semantics: 'override',
     }),
-    json: Flags.boolean({
-      default: false,
-      description: 'Output tokens in JSON format',
-    }),
+    ...getJsonFlag(),
   }
 
   static override hiddenAliases: string[] = ['token:list']
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(TokensListCommand)
-    const {json} = flags
-    const outputJson = json ?? false
+    const {json: outputJson} = flags
 
     // Ensure we have project context
     const projectId = await this.getProjectId({

--- a/packages/@sanity/cli/src/commands/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/undeploy.ts
@@ -7,6 +7,7 @@ import {
 } from '../actions/undeploy/adapters.js'
 import {runUndeploy} from '../actions/undeploy/runUndeploy.js'
 import {determineIsApp} from '../util/determineIsApp.js'
+import {getJsonFlag} from '../util/sharedFlags.js'
 
 export class UndeployCommand extends SanityCommand<typeof UndeployCommand> {
   static override description = 'Removes the deployed Sanity Studio/App from Sanity hosting'
@@ -31,11 +32,7 @@ export class UndeployCommand extends SanityCommand<typeof UndeployCommand> {
       default: false,
       description: 'Report what would be undeployed without deleting anything',
     }),
-    json: Flags.boolean({
-      char: 'j',
-      default: false,
-      description: 'Output the result as JSON',
-    }),
+    ...getJsonFlag(),
     yes: Flags.boolean({
       char: 'y',
       default: false,

--- a/packages/@sanity/cli/src/util/__tests__/sharedFlags.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/sharedFlags.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, test} from 'vitest'
 
-import {getDatasetFlag, getProjectIdFlag} from '../sharedFlags.js'
+import {getDatasetFlag, getJsonFlag, getProjectIdFlag} from '../sharedFlags.js'
 
 describe('getProjectIdFlag', () => {
   test('override semantics: appends suffix and sets OVERRIDE helpGroup', () => {
@@ -97,5 +97,14 @@ describe('getDatasetFlag', () => {
     const invoke = (input: string) => parse(input, {} as any, {} as any)
     await expect(invoke('  staging  ')).resolves.toBe('staging')
     await expect(invoke('  ')).rejects.toThrow('cannot be empty')
+  })
+})
+
+describe('getJsonFlag', () => {
+  test('locks char, default, and description', () => {
+    const flag = getJsonFlag().json
+    expect(flag.char).toBe('j')
+    expect(flag.default).toBe(false)
+    expect(flag.description).toBe('Output the result as JSON')
   })
 })

--- a/packages/@sanity/cli/src/util/sharedFlags.ts
+++ b/packages/@sanity/cli/src/util/sharedFlags.ts
@@ -90,3 +90,20 @@ export function getDatasetFlag(options: SharedFlagOptions) {
     }),
   }
 }
+
+/**
+ * Returns a `--json` / `-j` flag definition.
+ *
+ * Locked: flag name (`json`), char (`j`), description, and `default` (false).
+ * Output format never falls back to CLI configuration, so there is no
+ * `semantics` option.
+ */
+export function getJsonFlag() {
+  return {
+    json: Flags.boolean({
+      char: 'j',
+      default: false,
+      description: 'Output the result as JSON',
+    }),
+  }
+}


### PR DESCRIPTION
### Description

Follow-up to #1471, where review feedback asked for `--json` to live in the shared flags module. Closes [SDK-1895](https://linear.app/sanity/issue/SDK-1895/make-json-a-shared-flag-across-cli-commands).

8 commands defined their own `--json` flag inline, with 7 different description strings, and only `deploy`, `undeploy`, and `doctor` accepted `-j`. This adds `getJsonFlag()` to `sharedFlags.ts` (locked: name, `-j`, description, `default: false`) and points all 8 commands at it.

Two small user-visible side effects:

- `openapi list`, `projects create`, `schemas list`, `tokens add`, and `tokens list` now accept `-j`.
- Help text is unified to "Output the result as JSON".

I looked at doing the same for `--dry-run` but left it inline: only 3 commands define it, and the description is where the per-command meaning lives (`deploy` vs `undeploy` vs `graphql deploy`), so a shared getter would only lock the name.

Why a getter instead of oclif's built-ins: `Flags.custom()` only produces option flags (it hard-codes `type: 'option'`), so it can't declare a shared boolean. And `enableJsonFlag` is a semantics package, not just a flag — hard-coded description/help group, no `-j`, suppresses `this.log()` and JSON-formats errors when `--json` is passed. Adopting it would be a real behavior change, out of scope here.

### What to review

That locking char/description/default in `getJsonFlag()` is right for every consumer — none of the 8 commands seemed to need a per-command description.

### Testing

Added a `getJsonFlag` case to `sharedFlags.test.ts`. Existing command tests already exercise `--json` behavior.

### Notes for release

All JSON-capable commands (`deploy`, `undeploy`, `doctor`, `openapi list`, `projects create`, `schemas list`, `tokens add`, `tokens list`) now accept `-j` as shorthand for `--json`, with unified help text.
