### PR TITLE
fix(project): Ensure no dataset listing/create operations during `project create` in unattended mode with no dataset specified

### DIFF
--- a/.changeset/pr-1495.md
+++ b/.changeset/pr-1495.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(project): Ensure no dataset listing/create operations during `project create` in unattended mode with no dataset specified

--- a/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
@@ -165,13 +165,10 @@ describe('#projects:create', () => {
     })
 
     test('creates project without dataset in unattended mode if no dataset name provided as flag', async () => {
-      mockCreateDataset.mockResolvedValue({
-        aclMode: 'private',
-        datasetName: 'staging',
-      })
-
       await CreateProjectCommand.run(['--yes', '--organization=org-1'])
 
+      expect(mockListDatasets).not.toHaveBeenCalled()
+      expect(mockCreateDataset).not.toHaveBeenCalled()
       expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
       expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(
         expect.stringContaining('Project created successfully'),

--- a/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
@@ -134,7 +134,7 @@ describe('#projects:create', () => {
     beforeEach(() => {
       mocks.SanityCmdIsUnattended.mockReturnValue(true)
     })
-    test('creates project with dataset in unattended mode when dataset name provided as flag', async () => {
+    test('creates project with dataset when dataset name provided as flag', async () => {
       mockCreateDataset.mockResolvedValue({
         aclMode: 'private',
         datasetName: 'staging',
@@ -164,7 +164,7 @@ describe('#projects:create', () => {
       expect(mocks.SanityCmdOutput.log).toHaveBeenCalledWith(expect.stringMatching(mockManageUrl))
     })
 
-    test('creates project without dataset in unattended mode if no dataset name provided as flag', async () => {
+    test('creates project without dataset if no dataset name provided as flag', async () => {
       await CreateProjectCommand.run(['--yes', '--organization=org-1'])
 
       expect(mockListDatasets).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/projects/create.ts
+++ b/packages/@sanity/cli/src/commands/projects/create.ts
@@ -141,11 +141,15 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
       return this.output.error(`Failed to create project: ${error}`, {exit: 1})
     }
 
-    const newDataset = await this.handleDatasetCreation(
-      newProject.projectId,
-      dataset,
-      datasetVisibility,
-    )
+    let newDataset: DatasetResponse | undefined
+    // If dataset name specified, or in attended mode (to prompt for dataset name), create a dataset.
+    if (dataset || !this.isUnattended()) {
+      newDataset = await this.handleDatasetCreation(
+        newProject.projectId,
+        dataset,
+        datasetVisibility,
+      )
+    }
 
     this.printProjectCreationSuccess(chosenOrganization, newProject, newDataset)
   }


### PR DESCRIPTION
### Description

The logic of `handleDatasetCreation` is weird. Guard against entering it in the case where we don't want to create a dataset at all.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI behavior change for unattended project creation; reduces unintended API calls without altering interactive flows or explicit `--dataset` usage.
> 
> **Overview**
> **`sanity project create` in unattended mode without `--dataset` no longer touches datasets.**
> 
> After a project is created, `handleDatasetCreation` runs only when a dataset name was passed on the CLI **or** the command is in attended mode (so prompts can run). Unattended runs with no `--dataset` skip that path entirely, so **`listDatasets` and `createDataset` are not invoked** and success output omits dataset details.
> 
> Tests for unattended mode were tightened to assert those mocks stay unused when no dataset flag is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37dce86a158ab0ece9995c1c582d0580a9988a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->