### PR TITLE
feat(cli): support unattended mode for admin commands

### DIFF
--- a/.changeset/pr-1496.md
+++ b/.changeset/pr-1496.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): support unattended mode for admin commands

--- a/.changeset/pr-1496.md
+++ b/.changeset/pr-1496.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-feat(cli): support unattended mode for admin commands

--- a/.changeset/unattended-admin-commands.md
+++ b/.changeset/unattended-admin-commands.md
@@ -1,0 +1,11 @@
+---
+'@sanity/cli': minor
+---
+
+Improve admin commands for unattended environments:
+
+- Default `cors add` to disallow credentials and require `--yes` for wildcard origins.
+- Require an explicit origin for `cors delete`.
+- Validate `tokens add` labels before project lookup and report invalid labels or roles as usage errors.
+- Require a token ID and `--yes` for `tokens delete`.
+- Require an email address and `--role` for `users invite`.

--- a/.changeset/unattended-admin-commands.md
+++ b/.changeset/unattended-admin-commands.md
@@ -2,10 +2,7 @@
 '@sanity/cli': minor
 ---
 
-Improve admin commands for unattended environments:
+feat(cli): support unattended mode for admin commands
 
-- Default `cors add` to disallow credentials and require `--yes` for wildcard origins.
-- Require an explicit origin for `cors delete`.
-- Validate `tokens add` labels before project lookup and report invalid labels or roles as usage errors.
-- Require a token ID and `--yes` for `tokens delete`.
-- Require an email address and `--role` for `users invite`.
+Add deterministic defaults and required flags for CORS, token, and user commands that previously
+prompted.

--- a/packages/@sanity/cli/src/actions/tokens/validateRole.ts
+++ b/packages/@sanity/cli/src/actions/tokens/validateRole.ts
@@ -1,4 +1,4 @@
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 
 import {getTokenRoles} from '../../services/tokens.js'
 
@@ -25,5 +25,7 @@ export async function validateRole(
   }
 
   const availableRoles = robotRoles.map((r) => r.name).join(', ')
-  return output.error(`Invalid role "${roleName}". Available roles: ${availableRoles}`, {exit: 2})
+  return output.error(`Invalid role "${roleName}". Available roles: ${availableRoles}`, {
+    exit: exitCodes.USAGE_ERROR,
+  })
 }

--- a/packages/@sanity/cli/src/actions/tokens/validateRole.ts
+++ b/packages/@sanity/cli/src/actions/tokens/validateRole.ts
@@ -25,5 +25,5 @@ export async function validateRole(
   }
 
   const availableRoles = robotRoles.map((r) => r.name).join(', ')
-  return output.error(`Invalid role "${roleName}". Available roles: ${availableRoles}`, {exit: 1})
+  return output.error(`Invalid role "${roleName}". Available roles: ${availableRoles}`, {exit: 2})
 }

--- a/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
@@ -1,4 +1,5 @@
 import {type Output} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {type UndeployAdapter, type UndeployApplicationTarget} from '@sanity/cli-core/undeploy'
 import {confirm} from '@sanity/cli-test/mocks/cli-core/ux'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
@@ -114,7 +115,9 @@ describe('runUndeploy real run', () => {
     await runUndeploy(options(output), adapter({undeploy}))
 
     expect(undeploy).not.toHaveBeenCalled()
-    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled', {exit: 3})
+    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled', {
+      exit: exitCodes.USER_ABORT,
+    })
   })
 
   test('an unattended run requires explicit confirmation', async () => {
@@ -127,7 +130,7 @@ describe('runUndeploy real run', () => {
     expect(undeploy).not.toHaveBeenCalled()
     expect(output.error).toHaveBeenCalledWith(
       'Undeploy requires confirmation. Pass --yes to continue.',
-      {exit: 2},
+      {exit: exitCodes.USAGE_ERROR},
     )
   })
 
@@ -220,7 +223,9 @@ describe('runUndeploy real run', () => {
 
     await runUndeploy(options(output), adapter())
 
-    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled', {exit: 3})
+    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled', {
+      exit: exitCodes.USER_ABORT,
+    })
   })
 })
 

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {convertToSystemPath, createTestClient, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -439,7 +440,7 @@ describe('#init: bootstrap-app-initialization', () => {
     )
 
     expect(error).toBeInstanceOf(Error)
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(error?.message).toBe(
       'Project or organization is required for app templates in unattended mode. ' +
         'Pass `--project <id>` or `--organization <id>`. To create a project, pass ' +
@@ -512,7 +513,7 @@ describe('#init: bootstrap-app-initialization', () => {
     )
 
     expect(error).toBeInstanceOf(Error)
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(error?.message).toBe(
       'Project or organization is required for app templates in unattended mode. ' +
         'Pass `--project <id>` or `--organization <id>`. To create a project, pass ' +
@@ -533,7 +534,7 @@ describe('#init: bootstrap-app-initialization', () => {
       },
     )
 
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(error?.message).toBe(
       'Output path is required in unattended mode. Pass it with `--output-path <path>`.\n' +
         'Error: Project or organization is required for app templates in unattended mode. ' +

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -1308,6 +1309,6 @@ describe('#init: promptForAppTemplateSetup', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('--organization')
     expect(error?.message).toContain('--project')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 })

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -87,7 +88,7 @@ describe('#init: oclif command setup', () => {
     expect(error?.message).toContain(
       `--${name2}=${value2} cannot also be provided when using --${name1}`,
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test.each([
@@ -115,7 +116,7 @@ describe('#init: oclif command setup', () => {
     })
 
     expect(error?.message).toContain(message)
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('throws error when type argument is passed', async () => {
@@ -214,7 +215,7 @@ describe('#init: oclif command setup', () => {
     expect(error?.message).toBe(
       'Output path is required in unattended mode. Pass it with `--output-path <path>`.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('does not require `output-path` in unattended mode when `bare` is used', async () => {
@@ -261,7 +262,7 @@ describe('#init: oclif command setup', () => {
         'Error: Organization is required when creating a project in unattended mode. ' +
         'Pass it with `--organization <id>`.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('throws error when in unattended mode and `project-name` set without `organization`', async () => {
@@ -284,7 +285,7 @@ describe('#init: oclif command setup', () => {
       'Organization is required when creating a project in unattended mode. ' +
         'Pass it with `--organization <id>`.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('reports all missing unattended options before authentication', async () => {
@@ -303,7 +304,7 @@ describe('#init: oclif command setup', () => {
         'Error: Organization is required when creating a project in unattended mode. ' +
         'Pass it with `--organization <id>`.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mocks.getById).not.toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {confirm} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {unstable_defineApp, unstable_defineMediaLibrary} from '@sanity/workbench-cli'
@@ -177,7 +178,7 @@ describe('#undeploy', () => {
       },
     })
 
-    expect(error?.oclif?.exit).toBe(3)
+    expect(error?.oclif?.exit).toBe(exitCodes.USER_ABORT)
   })
 
   test('requires --yes before prompting in unattended mode', async () => {
@@ -196,7 +197,7 @@ describe('#undeploy', () => {
     })
 
     expect(error?.message).toContain('Pass --yes to continue')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(confirm).not.toHaveBeenCalled()
   })
 
@@ -584,7 +585,7 @@ describe('#undeploy', () => {
       },
       undeployed: false,
     })
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('workbench app dry run resolves the Brett application', async () => {

--- a/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {confirm} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -158,7 +159,7 @@ describe('#cors:add', () => {
     })
 
     expect(error?.message).toContain('Pass `--yes` to continue')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockConfirm).not.toHaveBeenCalled()
   })
 
@@ -262,7 +263,7 @@ describe('#cors:add', () => {
       {
         confirmWildcard: false,
         description: 'cancels operation when wildcard confirmation is denied',
-        expectedExit: 3,
+        expectedExit: exitCodes.USER_ABORT,
         expectedOutput: 'CORS origin not added',
         setupMocks: () => mockConfirm.mockResolvedValueOnce(false),
       },

--- a/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
@@ -89,7 +89,9 @@ describe('#cors:add', () => {
       }
     })
 
-    const {stdout} = await testCommand(Add, [origin, '--credentials'], {mocks: defaultMocks})
+    const {stdout} = await testCommand(Add, [origin, '--credentials'], {
+      mocks: defaultMocks,
+    })
 
     expect(stdout).toContain('CORS origin added')
   })
@@ -119,7 +121,9 @@ describe('#cors:add', () => {
       }
     })
 
-    const {stdout} = await testCommand(Add, [origin, '--no-credentials'], {mocks: defaultMocks})
+    const {stdout} = await testCommand(Add, [origin, '--no-credentials'], {
+      mocks: defaultMocks,
+    })
 
     expect(stdout).toContain('CORS origin added')
   })
@@ -153,7 +157,7 @@ describe('#cors:add', () => {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toContain('Pass --yes to continue')
+    expect(error?.message).toContain('Pass `--yes` to continue')
     expect(error?.oclif?.exit).toBe(2)
     expect(mockConfirm).not.toHaveBeenCalled()
   })
@@ -166,7 +170,12 @@ describe('#cors:add', () => {
       uri: '/projects/test-project/cors',
     }).reply(201, function (_, requestBody) {
       expect(requestBody).toEqual({allowCredentials: false, origin})
-      return {allowCredentials: false, id: 1, origin, projectId: 'test-project'}
+      return {
+        allowCredentials: false,
+        id: 1,
+        origin,
+        projectId: 'test-project',
+      }
     })
 
     const {error, stdout} = await testCommand(Add, [origin, '--yes'], {
@@ -264,7 +273,9 @@ describe('#cors:add', () => {
       async ({expectedExit, expectedOutput, setupMocks}) => {
         setupMocks()
 
-        const result = await testCommand(Add, ['https://*.example.com'], {mocks: defaultMocks})
+        const result = await testCommand(Add, ['https://*.example.com'], {
+          mocks: defaultMocks,
+        })
 
         expect(confirm).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -298,7 +309,9 @@ describe('#cors:add', () => {
       mockConfirm.mockResolvedValueOnce(true)
       setupSuccessfulApiMock()
 
-      const {stdout} = await testCommand(Add, ['https://example.com'], {mocks: defaultMocks})
+      const {stdout} = await testCommand(Add, ['https://example.com'], {
+        mocks: defaultMocks,
+      })
 
       expect(confirm).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -315,7 +328,9 @@ describe('#cors:add', () => {
         .mockResolvedValueOnce(false) // Deny credentials
       setupSuccessfulApiMock()
 
-      const {stdout} = await testCommand(Add, ['https://*.example.com'], {mocks: defaultMocks})
+      const {stdout} = await testCommand(Add, ['https://*.example.com'], {
+        mocks: defaultMocks,
+      })
 
       expect(stdout).toContain('HIGHLY')
       expect(stdout).toContain('recommend NOT allowing credentials')
@@ -362,7 +377,9 @@ describe('#cors:add', () => {
     ]
 
     test.each(invalidOrigins)('rejects invalid origin: %s', async (origin) => {
-      const {error} = await testCommand(Add, [origin, '--credentials'], {mocks: defaultMocks})
+      const {error} = await testCommand(Add, [origin, '--credentials'], {
+        mocks: defaultMocks,
+      })
 
       expect(error).toBeDefined()
       expect(error?.message).toContain('Invalid origin')
@@ -405,7 +422,9 @@ describe('#cors:add', () => {
       async ({expectedOutput, input, shouldNormalize}) => {
         setupSuccessfulApiMock()
 
-        const {stdout} = await testCommand(Add, [input, '--credentials'], {mocks: defaultMocks})
+        const {stdout} = await testCommand(Add, [input, '--credentials'], {
+          mocks: defaultMocks,
+        })
 
         if (shouldNormalize) {
           expect(stdout).toContain(expectedOutput)

--- a/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
@@ -88,8 +88,11 @@ describe('#cors:add', () => {
       }
     })
 
-    const {stdout} = await testCommand(Add, [origin, '--credentials'], {mocks: defaultMocks})
+    const {error, stdout} = await testCommand(Add, [origin, '--credentials'], {
+      mocks: defaultMocks,
+    })
 
+    if (error) throw error
     expect(stdout).toContain('CORS origin added successfully')
   })
 
@@ -118,9 +121,45 @@ describe('#cors:add', () => {
       }
     })
 
-    const {stdout} = await testCommand(Add, [origin, '--no-credentials'], {mocks: defaultMocks})
+    const {stdout} = await testCommand(Add, [origin, '--no-credentials'], {
+      mocks: defaultMocks,
+    })
 
     expect(stdout).toContain('CORS origin added successfully')
+  })
+
+  test('defaults credentials to false without prompting in unattended mode', async () => {
+    const origin = 'https://example.com'
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      method: 'post',
+      uri: '/projects/test-project/cors',
+    }).reply(201, function (_, requestBody) {
+      expect(requestBody).toEqual({allowCredentials: false, origin})
+      return {
+        allowCredentials: false,
+        id: 1,
+        origin,
+        projectId: 'test-project',
+      }
+    })
+
+    const {error} = await testCommand(Add, [origin], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    if (error) throw error
+    expect(mockConfirm).not.toHaveBeenCalled()
+  })
+
+  test('requires --yes for wildcard origins in unattended mode', async () => {
+    const {error} = await testCommand(Add, ['https://*.example.com', '--no-credentials'], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toContain('Pass --yes to continue')
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockConfirm).not.toHaveBeenCalled()
   })
 
   test('fails when no project ID is available', async () => {
@@ -209,7 +248,9 @@ describe('#cors:add', () => {
       async ({expectedError, expectedOutput, setupMocks}) => {
         setupMocks()
 
-        const result = await testCommand(Add, ['https://*.example.com'], {mocks: defaultMocks})
+        const result = await testCommand(Add, ['https://*.example.com'], {
+          mocks: defaultMocks,
+        })
 
         expect(confirm).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -244,7 +285,9 @@ describe('#cors:add', () => {
       mockConfirm.mockResolvedValueOnce(true)
       setupSuccessfulApiMock()
 
-      const {stdout} = await testCommand(Add, ['https://example.com'], {mocks: defaultMocks})
+      const {stdout} = await testCommand(Add, ['https://example.com'], {
+        mocks: defaultMocks,
+      })
 
       expect(confirm).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -261,7 +304,9 @@ describe('#cors:add', () => {
         .mockResolvedValueOnce(false) // Deny credentials
       setupSuccessfulApiMock()
 
-      const {stdout} = await testCommand(Add, ['https://*.example.com'], {mocks: defaultMocks})
+      const {stdout} = await testCommand(Add, ['https://*.example.com'], {
+        mocks: defaultMocks,
+      })
 
       expect(stdout).toContain('HIGHLY')
       expect(stdout).toContain('recommend NOT allowing credentials')
@@ -308,7 +353,9 @@ describe('#cors:add', () => {
     ]
 
     test.each(invalidOrigins)('rejects invalid origin: %s', async (origin) => {
-      const {error} = await testCommand(Add, [origin, '--credentials'], {mocks: defaultMocks})
+      const {error} = await testCommand(Add, [origin, '--credentials'], {
+        mocks: defaultMocks,
+      })
 
       expect(error).toBeDefined()
       expect(error?.message).toContain('Invalid origin')
@@ -351,7 +398,9 @@ describe('#cors:add', () => {
       async ({expectedOutput, input, shouldNormalize}) => {
         setupSuccessfulApiMock()
 
-        const {stdout} = await testCommand(Add, [input, '--credentials'], {mocks: defaultMocks})
+        const {stdout} = await testCommand(Add, [input, '--credentials'], {
+          mocks: defaultMocks,
+        })
 
         if (shouldNormalize) {
           expect(stdout).toContain(expectedOutput)

--- a/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/add.test.ts
@@ -24,6 +24,7 @@ vi.mock('node:fs', () => ({
 
 const defaultMocks = {
   cliConfig: {api: {projectId: 'test-project'}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -88,12 +89,9 @@ describe('#cors:add', () => {
       }
     })
 
-    const {error, stdout} = await testCommand(Add, [origin, '--credentials'], {
-      mocks: defaultMocks,
-    })
+    const {stdout} = await testCommand(Add, [origin, '--credentials'], {mocks: defaultMocks})
 
-    if (error) throw error
-    expect(stdout).toContain('CORS origin added successfully')
+    expect(stdout).toContain('CORS origin added')
   })
 
   test('adds CORS origin with no-credentials flag', async () => {
@@ -121,11 +119,9 @@ describe('#cors:add', () => {
       }
     })
 
-    const {stdout} = await testCommand(Add, [origin, '--no-credentials'], {
-      mocks: defaultMocks,
-    })
+    const {stdout} = await testCommand(Add, [origin, '--no-credentials'], {mocks: defaultMocks})
 
-    expect(stdout).toContain('CORS origin added successfully')
+    expect(stdout).toContain('CORS origin added')
   })
 
   test('defaults credentials to false without prompting in unattended mode', async () => {
@@ -159,6 +155,26 @@ describe('#cors:add', () => {
 
     expect(error?.message).toContain('Pass --yes to continue')
     expect(error?.oclif?.exit).toBe(2)
+    expect(mockConfirm).not.toHaveBeenCalled()
+  })
+
+  test('accepts --yes for wildcard origins in unattended mode', async () => {
+    const origin = 'https://*.example.com'
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      method: 'post',
+      uri: '/projects/test-project/cors',
+    }).reply(201, function (_, requestBody) {
+      expect(requestBody).toEqual({allowCredentials: false, origin})
+      return {allowCredentials: false, id: 1, origin, projectId: 'test-project'}
+    })
+
+    const {error, stdout} = await testCommand(Add, [origin, '--yes'], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    if (error) throw error
+    expect(stdout).toContain('CORS origin added')
     expect(mockConfirm).not.toHaveBeenCalled()
   })
 
@@ -227,8 +243,8 @@ describe('#cors:add', () => {
       {
         confirmWildcard: true,
         description: 'prompts for confirmation with wildcard origins and proceeds',
-        expectedError: undefined,
-        expectedOutput: 'CORS origin added successfully',
+        expectedExit: undefined,
+        expectedOutput: 'CORS origin added',
         setupMocks: () => {
           mockConfirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
           setupSuccessfulApiMock()
@@ -237,20 +253,18 @@ describe('#cors:add', () => {
       {
         confirmWildcard: false,
         description: 'cancels operation when wildcard confirmation is denied',
-        expectedError: 'Operation cancelled',
-        expectedOutput: undefined,
+        expectedExit: 3,
+        expectedOutput: 'CORS origin not added',
         setupMocks: () => mockConfirm.mockResolvedValueOnce(false),
       },
     ]
 
     test.each(wildcardConfirmationCases)(
       '$description',
-      async ({expectedError, expectedOutput, setupMocks}) => {
+      async ({expectedExit, expectedOutput, setupMocks}) => {
         setupMocks()
 
-        const result = await testCommand(Add, ['https://*.example.com'], {
-          mocks: defaultMocks,
-        })
+        const result = await testCommand(Add, ['https://*.example.com'], {mocks: defaultMocks})
 
         expect(confirm).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -262,9 +276,8 @@ describe('#cors:add', () => {
         if (expectedOutput) {
           expect(result.stdout).toContain(expectedOutput)
         }
-        if (expectedError) {
-          expect(result.error?.message).toContain(expectedError)
-          expect(result.error?.oclif?.exit).toBe(1)
+        if (expectedExit) {
+          expect(result.error?.oclif?.exit).toBe(expectedExit)
         }
       },
     )
@@ -285,9 +298,7 @@ describe('#cors:add', () => {
       mockConfirm.mockResolvedValueOnce(true)
       setupSuccessfulApiMock()
 
-      const {stdout} = await testCommand(Add, ['https://example.com'], {
-        mocks: defaultMocks,
-      })
+      const {stdout} = await testCommand(Add, ['https://example.com'], {mocks: defaultMocks})
 
       expect(confirm).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -295,7 +306,7 @@ describe('#cors:add', () => {
           message: expect.stringContaining('Allow credentials'),
         }),
       )
-      expect(stdout).toContain('CORS origin added successfully')
+      expect(stdout).toContain('CORS origin added')
     })
 
     test('shows warning about wildcard credentials', async () => {
@@ -304,9 +315,7 @@ describe('#cors:add', () => {
         .mockResolvedValueOnce(false) // Deny credentials
       setupSuccessfulApiMock()
 
-      const {stdout} = await testCommand(Add, ['https://*.example.com'], {
-        mocks: defaultMocks,
-      })
+      const {stdout} = await testCommand(Add, ['https://*.example.com'], {mocks: defaultMocks})
 
       expect(stdout).toContain('HIGHLY')
       expect(stdout).toContain('recommend NOT allowing credentials')
@@ -332,7 +341,7 @@ describe('#cors:add', () => {
       })
 
       if (error) throw error
-      expect(stdout).toContain('CORS origin added successfully')
+      expect(stdout).toContain('CORS origin added')
     })
 
     test.each(validWildcardOrigins)('accepts valid wildcard origin: %s', async (origin) => {
@@ -344,7 +353,7 @@ describe('#cors:add', () => {
       })
 
       if (error) throw error
-      expect(stdout).toContain('CORS origin added successfully')
+      expect(stdout).toContain('CORS origin added')
     })
 
     const invalidOrigins = [
@@ -353,9 +362,7 @@ describe('#cors:add', () => {
     ]
 
     test.each(invalidOrigins)('rejects invalid origin: %s', async (origin) => {
-      const {error} = await testCommand(Add, [origin, '--credentials'], {
-        mocks: defaultMocks,
-      })
+      const {error} = await testCommand(Add, [origin, '--credentials'], {mocks: defaultMocks})
 
       expect(error).toBeDefined()
       expect(error?.message).toContain('Invalid origin')
@@ -387,7 +394,7 @@ describe('#cors:add', () => {
       },
       {
         description: 'preserves non-default ports',
-        expectedOutput: 'CORS origin added successfully',
+        expectedOutput: 'CORS origin added',
         input: 'https://example.com:8080',
         shouldNormalize: false,
       },
@@ -398,9 +405,7 @@ describe('#cors:add', () => {
       async ({expectedOutput, input, shouldNormalize}) => {
         setupSuccessfulApiMock()
 
-        const {stdout} = await testCommand(Add, [input, '--credentials'], {
-          mocks: defaultMocks,
-        })
+        const {stdout} = await testCommand(Add, [input, '--credentials'], {mocks: defaultMocks})
 
         if (shouldNormalize) {
           expect(stdout).toContain(expectedOutput)
@@ -423,7 +428,7 @@ describe('#cors:add', () => {
         mocks: defaultMocks,
       })
 
-      expect(stdout).toContain('CORS origin added successfully')
+      expect(stdout).toContain('CORS origin added')
     })
   })
 })

--- a/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
@@ -25,16 +25,14 @@ const TEST_ORIGINS = {
   CASE_MIXED: createCorsOrigin({id: 1, origin: 'https://Example.Com'}),
   EXAMPLE: createCorsOrigin({id: 1, origin: 'https://example.com'}),
   LOCALHOST: createCorsOrigin({id: 1, origin: 'http://localhost:3000'}),
-  SPECIAL_CHARS: createCorsOrigin({
-    id: 1,
-    origin: 'https://café.example.com',
-  }),
+  SPECIAL_CHARS: createCorsOrigin({id: 1, origin: 'https://café.example.com'}),
 } as const
 
 const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -71,9 +69,7 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors/1',
     }).reply(204)
 
-    const {stdout} = await testCommand(Delete, ['https://example.com'], {
-      mocks: defaultMocks,
-    })
+    const {stdout} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
     expect(stdout).toBe('Origin deleted\n')
   })
 
@@ -103,6 +99,19 @@ describe('#cors:delete', () => {
     })
   })
 
+  test('requires an origin before project lookup in unattended mode', async () => {
+    const {error} = await testCommand(Delete, [], {
+      mocks: {
+        ...defaultMocks,
+        cliConfig: {api: {projectId: undefined}},
+        isInteractive: false,
+      },
+    })
+
+    expect(error?.message).toContain('<origin>')
+    expect(error?.oclif?.exit).toBe(2)
+  })
+
   test('handles case-insensitive origin matching', async () => {
     mockApi({
       apiVersion: CORS_API_VERSION,
@@ -115,9 +124,7 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors/1',
     }).reply(204)
 
-    const {stdout} = await testCommand(Delete, ['https://example.com'], {
-      mocks: defaultMocks,
-    })
+    const {stdout} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
     expect(stdout).toBe('Origin deleted\n')
   })
 
@@ -127,9 +134,7 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors',
     }).reply(200, [TEST_ORIGINS.EXAMPLE])
 
-    const {error} = await testCommand(Delete, ['https://nonexistent.com'], {
-      mocks: defaultMocks,
-    })
+    const {error} = await testCommand(Delete, ['https://nonexistent.com'], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toEqual('Origin "https://nonexistent.com" not found')
     expect(error?.oclif?.exit).toBe(1)
@@ -141,34 +146,22 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors',
     }).reply(200, [])
 
-    const {error} = await testCommand(Delete, ['https://example.com'], {
-      mocks: defaultMocks,
-    })
+    const {error} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toEqual('No CORS origins configured for this project.')
     expect(error?.oclif?.exit).toBe(1)
   })
 
   test.each([
-    {
-      desc: 'when fetching origins',
-      message: 'Internal Server Error',
-      statusCode: 500,
-    },
-    {
-      desc: 'with 404 error when fetching origins',
-      message: 'Project not found',
-      statusCode: 404,
-    },
+    {desc: 'when fetching origins', message: 'Internal Server Error', statusCode: 500},
+    {desc: 'with 404 error when fetching origins', message: 'Project not found', statusCode: 404},
   ])('handles API error $desc', async ({message, statusCode}) => {
     mockApi({
       apiVersion: CORS_API_VERSION,
       uri: '/projects/test-project/cors',
     }).reply(statusCode, {message})
 
-    const {error} = await testCommand(Delete, ['https://example.com'], {
-      mocks: defaultMocks,
-    })
+    const {error} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Failed to fetch CORS origins')
     expect(error?.message).toContain(message)
@@ -176,16 +169,8 @@ describe('#cors:delete', () => {
   })
 
   test.each([
-    {
-      desc: 'when deleting origin',
-      message: 'Failed to delete',
-      statusCode: 500,
-    },
-    {
-      desc: 'with 404 error when deleting origin',
-      message: 'Origin not found',
-      statusCode: 404,
-    },
+    {desc: 'when deleting origin', message: 'Failed to delete', statusCode: 500},
+    {desc: 'with 404 error when deleting origin', message: 'Origin not found', statusCode: 404},
   ])('handles API error $desc', async ({message, statusCode}) => {
     mockApi({
       apiVersion: CORS_API_VERSION,
@@ -198,9 +183,7 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors/1',
     }).reply(statusCode, {message})
 
-    const {error} = await testCommand(Delete, ['https://example.com'], {
-      mocks: defaultMocks,
-    })
+    const {error} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Origin deletion failed')
     expect(error?.message).toContain(message)
@@ -224,9 +207,7 @@ describe('#cors:delete', () => {
 
   test('handles network errors when fetching origins', async () => {
     // Don't set up any mock to simulate network failure
-    const {error} = await testCommand(Delete, ['https://example.com'], {
-      mocks: defaultMocks,
-    })
+    const {error} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Failed to fetch CORS origins')
     expect(error?.oclif?.exit).toBe(1)
@@ -238,11 +219,7 @@ describe('#cors:delete', () => {
       input: 'https://café.example.com',
       origin: TEST_ORIGINS.SPECIAL_CHARS,
     },
-    {
-      desc: 'ports',
-      input: 'http://localhost:3000',
-      origin: TEST_ORIGINS.LOCALHOST,
-    },
+    {desc: 'ports', input: 'http://localhost:3000', origin: TEST_ORIGINS.LOCALHOST},
   ])('handles $desc in origin names', async ({input, origin}) => {
     mockApi({
       apiVersion: CORS_API_VERSION,
@@ -255,9 +232,7 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors/1',
     }).reply(204)
 
-    const {stdout} = await testCommand(Delete, [input], {
-      mocks: defaultMocks,
-    })
+    const {stdout} = await testCommand(Delete, [input], {mocks: defaultMocks})
     expect(stdout).toBe('Origin deleted\n')
   })
 })

--- a/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -109,7 +110,7 @@ describe('#cors:delete', () => {
     })
 
     expect(error?.message).toContain('<origin>')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('handles case-insensitive origin matching', async () => {

--- a/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/cors/__tests__/delete.test.ts
@@ -25,7 +25,10 @@ const TEST_ORIGINS = {
   CASE_MIXED: createCorsOrigin({id: 1, origin: 'https://Example.Com'}),
   EXAMPLE: createCorsOrigin({id: 1, origin: 'https://example.com'}),
   LOCALHOST: createCorsOrigin({id: 1, origin: 'http://localhost:3000'}),
-  SPECIAL_CHARS: createCorsOrigin({id: 1, origin: 'https://café.example.com'}),
+  SPECIAL_CHARS: createCorsOrigin({
+    id: 1,
+    origin: 'https://café.example.com',
+  }),
 } as const
 
 const testProjectId = 'test-project'
@@ -68,7 +71,9 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors/1',
     }).reply(204)
 
-    const {stdout} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
+    const {stdout} = await testCommand(Delete, ['https://example.com'], {
+      mocks: defaultMocks,
+    })
     expect(stdout).toBe('Origin deleted\n')
   })
 
@@ -110,7 +115,9 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors/1',
     }).reply(204)
 
-    const {stdout} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
+    const {stdout} = await testCommand(Delete, ['https://example.com'], {
+      mocks: defaultMocks,
+    })
     expect(stdout).toBe('Origin deleted\n')
   })
 
@@ -120,7 +127,9 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors',
     }).reply(200, [TEST_ORIGINS.EXAMPLE])
 
-    const {error} = await testCommand(Delete, ['https://nonexistent.com'], {mocks: defaultMocks})
+    const {error} = await testCommand(Delete, ['https://nonexistent.com'], {
+      mocks: defaultMocks,
+    })
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toEqual('Origin "https://nonexistent.com" not found')
     expect(error?.oclif?.exit).toBe(1)
@@ -132,22 +141,34 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors',
     }).reply(200, [])
 
-    const {error} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
+    const {error} = await testCommand(Delete, ['https://example.com'], {
+      mocks: defaultMocks,
+    })
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toEqual('No CORS origins configured for this project.')
     expect(error?.oclif?.exit).toBe(1)
   })
 
   test.each([
-    {desc: 'when fetching origins', message: 'Internal Server Error', statusCode: 500},
-    {desc: 'with 404 error when fetching origins', message: 'Project not found', statusCode: 404},
+    {
+      desc: 'when fetching origins',
+      message: 'Internal Server Error',
+      statusCode: 500,
+    },
+    {
+      desc: 'with 404 error when fetching origins',
+      message: 'Project not found',
+      statusCode: 404,
+    },
   ])('handles API error $desc', async ({message, statusCode}) => {
     mockApi({
       apiVersion: CORS_API_VERSION,
       uri: '/projects/test-project/cors',
     }).reply(statusCode, {message})
 
-    const {error} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
+    const {error} = await testCommand(Delete, ['https://example.com'], {
+      mocks: defaultMocks,
+    })
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Failed to fetch CORS origins')
     expect(error?.message).toContain(message)
@@ -155,8 +176,16 @@ describe('#cors:delete', () => {
   })
 
   test.each([
-    {desc: 'when deleting origin', message: 'Failed to delete', statusCode: 500},
-    {desc: 'with 404 error when deleting origin', message: 'Origin not found', statusCode: 404},
+    {
+      desc: 'when deleting origin',
+      message: 'Failed to delete',
+      statusCode: 500,
+    },
+    {
+      desc: 'with 404 error when deleting origin',
+      message: 'Origin not found',
+      statusCode: 404,
+    },
   ])('handles API error $desc', async ({message, statusCode}) => {
     mockApi({
       apiVersion: CORS_API_VERSION,
@@ -169,7 +198,9 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors/1',
     }).reply(statusCode, {message})
 
-    const {error} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
+    const {error} = await testCommand(Delete, ['https://example.com'], {
+      mocks: defaultMocks,
+    })
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Origin deletion failed')
     expect(error?.message).toContain(message)
@@ -193,7 +224,9 @@ describe('#cors:delete', () => {
 
   test('handles network errors when fetching origins', async () => {
     // Don't set up any mock to simulate network failure
-    const {error} = await testCommand(Delete, ['https://example.com'], {mocks: defaultMocks})
+    const {error} = await testCommand(Delete, ['https://example.com'], {
+      mocks: defaultMocks,
+    })
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Failed to fetch CORS origins')
     expect(error?.oclif?.exit).toBe(1)
@@ -205,7 +238,11 @@ describe('#cors:delete', () => {
       input: 'https://café.example.com',
       origin: TEST_ORIGINS.SPECIAL_CHARS,
     },
-    {desc: 'ports', input: 'http://localhost:3000', origin: TEST_ORIGINS.LOCALHOST},
+    {
+      desc: 'ports',
+      input: 'http://localhost:3000',
+      origin: TEST_ORIGINS.LOCALHOST,
+    },
   ])('handles $desc in origin names', async ({input, origin}) => {
     mockApi({
       apiVersion: CORS_API_VERSION,
@@ -218,7 +255,9 @@ describe('#cors:delete', () => {
       uri: '/projects/test-project/cors/1',
     }).reply(204)
 
-    const {stdout} = await testCommand(Delete, [input], {mocks: defaultMocks})
+    const {stdout} = await testCommand(Delete, [input], {
+      mocks: defaultMocks,
+    })
     expect(stdout).toBe('Origin deleted\n')
   })
 })

--- a/packages/@sanity/cli/src/commands/cors/add.ts
+++ b/packages/@sanity/cli/src/commands/cors/add.ts
@@ -87,7 +87,9 @@ export class Add extends SanityCommand<typeof Add> {
 
     if (hasWildcard) {
       if (this.isUnattended() && !flags.yes) {
-        this.error('Wildcard origins require confirmation. Pass --yes to continue.', {exit: 2})
+        this.error('Wildcard origins require confirmation. Pass `--yes` to continue.', {
+          exit: exitCodes.USAGE_ERROR,
+        })
       }
       const confirmed = flags.yes || (await this.promptForWildcardConfirmation(origin))
       if (!confirmed) {

--- a/packages/@sanity/cli/src/commands/cors/add.ts
+++ b/packages/@sanity/cli/src/commands/cors/add.ts
@@ -54,6 +54,10 @@ export class Add extends SanityCommand<typeof Add> {
       description: 'Allow credentials (token/cookie) to be sent from this origin',
       required: false,
     }),
+    yes: Flags.boolean({
+      char: 'y',
+      description: 'Confirm risky wildcard origins without prompting',
+    }),
   }
 
   public async run(): Promise<void> {
@@ -82,15 +86,20 @@ export class Add extends SanityCommand<typeof Add> {
     const hasWildcard = origin.includes('*')
 
     if (hasWildcard) {
-      const confirmed = await this.promptForWildcardConfirmation(origin)
+      if (this.isUnattended() && !flags.yes) {
+        this.error('Wildcard origins require confirmation. Pass --yes to continue.', {exit: 2})
+      }
+      const confirmed = flags.yes || (await this.promptForWildcardConfirmation(origin))
       if (!confirmed) {
-        this.error('Operation cancelled', {exit: 1})
+        this.error('Operation cancelled', {exit: 3})
       }
     }
 
     const allowCredentials =
       flags.credentials === undefined
-        ? await this.promptForCredentials(hasWildcard)
+        ? this.isUnattended()
+          ? false
+          : await this.promptForCredentials(hasWildcard)
         : Boolean(flags.credentials)
 
     if (filteredOrigin !== origin) {

--- a/packages/@sanity/cli/src/commands/cors/add.ts
+++ b/packages/@sanity/cli/src/commands/cors/add.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {confirm, logSymbols} from '@sanity/cli-core/ux'
 import {oneline} from 'oneline'
 
@@ -91,7 +91,8 @@ export class Add extends SanityCommand<typeof Add> {
       }
       const confirmed = flags.yes || (await this.promptForWildcardConfirmation(origin))
       if (!confirmed) {
-        this.error('Operation cancelled', {exit: 3})
+        this.log('CORS origin not added')
+        this.exit(exitCodes.USER_ABORT)
       }
     }
 
@@ -115,7 +116,7 @@ export class Add extends SanityCommand<typeof Add> {
 
       addCorsDebug(`CORS origin added successfully`, response)
 
-      this.log('CORS origin added successfully')
+      this.log('CORS origin added')
     } catch (error) {
       const err = error as Error
 

--- a/packages/@sanity/cli/src/commands/cors/delete.ts
+++ b/packages/@sanity/cli/src/commands/cors/delete.ts
@@ -1,5 +1,5 @@
 import {Args} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 
 import {promptForProject} from '../../prompts/promptForProject.js'
@@ -44,7 +44,9 @@ export class Delete extends SanityCommand<typeof Delete> {
     const {args} = await this.parse(Delete)
 
     if (!args.origin && this.isUnattended()) {
-      this.error('Origin is required. Pass it as the `<origin>` argument.', {exit: 2})
+      this.error('Origin is required. Pass it as the `<origin>` argument.', {
+        exit: exitCodes.USAGE_ERROR,
+      })
     }
 
     // Ensure we have project context

--- a/packages/@sanity/cli/src/commands/cors/delete.ts
+++ b/packages/@sanity/cli/src/commands/cors/delete.ts
@@ -69,6 +69,11 @@ export class Delete extends SanityCommand<typeof Delete> {
     specifiedOrigin: string | undefined,
     projectId: string,
   ): Promise<number> {
+    if (!specifiedOrigin && this.isUnattended()) {
+      this.error('Origin is required in unattended mode. Pass the origin as an argument.', {
+        exit: 2,
+      })
+    }
     let origins: CorsOrigin[]
     try {
       origins = await listCorsOrigins(projectId)

--- a/packages/@sanity/cli/src/commands/cors/delete.ts
+++ b/packages/@sanity/cli/src/commands/cors/delete.ts
@@ -43,6 +43,10 @@ export class Delete extends SanityCommand<typeof Delete> {
   public async run(): Promise<void> {
     const {args} = await this.parse(Delete)
 
+    if (!args.origin && this.isUnattended()) {
+      this.error('Origin is required. Pass it as the `<origin>` argument.', {exit: 2})
+    }
+
     // Ensure we have project context
     const projectId = await this.getProjectId({
       fallback: () =>
@@ -69,11 +73,6 @@ export class Delete extends SanityCommand<typeof Delete> {
     specifiedOrigin: string | undefined,
     projectId: string,
   ): Promise<number> {
-    if (!specifiedOrigin && this.isUnattended()) {
-      this.error('Origin is required in unattended mode. Pass the origin as an argument.', {
-        exit: 2,
-      })
-    }
     let origins: CorsOrigin[]
     try {
       origins = await listCorsOrigins(projectId)

--- a/packages/@sanity/cli/src/commands/hooks/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/hooks/__tests__/delete.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -144,7 +145,7 @@ describe('#delete', () => {
     })
 
     expect(error?.message).toBe('Webhook name is required. Pass the name as an argument.')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockSelect).not.toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/commands/hooks/__tests__/logs.test.ts
+++ b/packages/@sanity/cli/src/commands/hooks/__tests__/logs.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -309,7 +310,7 @@ describe('#hook:logs', () => {
     expect(error?.message).toBe(
       'Webhook name is required when multiple webhooks exist. Pass the name as an argument.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockedSelect).not.toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/commands/hooks/delete.ts
+++ b/packages/@sanity/cli/src/commands/hooks/delete.ts
@@ -1,5 +1,5 @@
 import {Args} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 
 import {type Hook} from '../../actions/hook/types'
@@ -47,7 +47,9 @@ export class Delete extends SanityCommand<typeof Delete> {
     const {args} = await this.parse(Delete)
 
     if (!args.name && this.isUnattended()) {
-      this.error('Webhook name is required. Pass the name as an argument.', {exit: 2})
+      this.error('Webhook name is required. Pass the name as an argument.', {
+        exit: exitCodes.USAGE_ERROR,
+      })
     }
 
     const projectId = await this.getProjectId({

--- a/packages/@sanity/cli/src/commands/hooks/logs.ts
+++ b/packages/@sanity/cli/src/commands/hooks/logs.ts
@@ -1,7 +1,7 @@
 import {inspect, styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 import groupBy from 'lodash-es/groupBy.js'
 
@@ -96,7 +96,7 @@ export class LogsHookCommand extends SanityCommand<typeof LogsHookCommand> {
         this.error(
           'Webhook name is required when multiple webhooks exist. Pass the name as an argument.',
           {
-            exit: 2,
+            exit: exitCodes.USAGE_ERROR,
           },
         )
       }

--- a/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
 import * as uxMocks from '@sanity/cli-test/mocks/cli-core/ux'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
@@ -87,7 +88,7 @@ describe('#projects:create', () => {
     mockValidateDatasetName.mockReturnValue(datasetError) // returns error if invalid
     await expect(CreateProjectCommand.run(['--dataset=~~invalid-name'])).rejects.toMatchObject({
       message: expect.stringContaining(datasetError),
-      oclif: {exit: 2},
+      oclif: {exit: exitCodes.USAGE_ERROR},
     })
   })
 

--- a/packages/@sanity/cli/src/commands/projects/create.ts
+++ b/packages/@sanity/cli/src/commands/projects/create.ts
@@ -1,5 +1,6 @@
 import {Args, Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
+import {exitCodes} from '@sanity/cli-core'
 import {subdebug} from '@sanity/cli-core/debug'
 import {SanityCommand} from '@sanity/cli-core/SanityCommand'
 import {confirm, spinner} from '@sanity/cli-core/ux'
@@ -63,7 +64,7 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
       parse: async (input) => {
         const datasetNameError = validateDatasetName(input)
         if (datasetNameError) {
-          throw new CLIError(datasetNameError, {exit: 2})
+          throw new CLIError(datasetNameError, {exit: exitCodes.USAGE_ERROR})
         }
 
         return input

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
@@ -85,8 +85,11 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/tokens',
     }).reply(200, mockToken)
 
-    const {stdout} = await testCommand(AddTokenCommand, ['My Test Token'], {mocks: defaultMocks})
+    const {error, stdout} = await testCommand(AddTokenCommand, ['My Test Token'], {
+      mocks: defaultMocks,
+    })
 
+    expect(error).toBeUndefined()
     expect(stdout).toContain('Token created successfully!')
     expect(stdout).toContain('Label: My Test Token')
     expect(stdout).toContain('ID: token-123')
@@ -421,8 +424,8 @@ describe('#tokens:add', () => {
     const {error} = await testCommand(AddTokenCommand, ['--yes'], {mocks: defaultMocks})
 
     expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toContain('Token label is required in non-interactive mode')
-    expect(error?.message).toContain('Provide a label as an argument')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.message).toContain('Token label is required')
+    expect(error?.message).toContain('<label>')
+    expect(error?.oclif?.exit).toBe(2)
   })
 })

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
@@ -85,17 +85,14 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/tokens',
     }).reply(200, mockToken)
 
-    const {error, stdout} = await testCommand(AddTokenCommand, ['My Test Token'], {
-      mocks: defaultMocks,
-    })
+    const {stdout} = await testCommand(AddTokenCommand, ['My Test Token'], {mocks: defaultMocks})
 
-    expect(error).toBeUndefined()
-    expect(stdout).toContain('Token created successfully!')
+    expect(stdout).toContain('API token created')
     expect(stdout).toContain('Label: My Test Token')
     expect(stdout).toContain('ID: token-123')
     expect(stdout).toContain('Role: Viewer')
     expect(stdout).toContain('Token: sk_test_abcd1234')
-    expect(stdout).toContain('Copy the token above')
+    expect(stdout).toContain("Copy the token now. It won't be shown again.")
   })
 
   test('creates token with specific role', async () => {
@@ -148,7 +145,7 @@ describe('#tokens:add', () => {
       mocks: defaultMocks,
     })
 
-    expect(stdout).toContain('Token created successfully!')
+    expect(stdout).toContain('API token created')
     expect(stdout).toContain('Label: Editor Token')
     expect(stdout).toContain('Role: Editor')
     expect(stdout).toContain('Token: sk_test_editor1234')
@@ -210,7 +207,7 @@ describe('#tokens:add', () => {
       mocks: defaultMocks,
     })
 
-    expect(stdout).toContain('Token created successfully!')
+    expect(stdout).toContain('API token created')
     expect(stdout).toContain('Label: Unattended Token')
     expect(mockedSelect).not.toHaveBeenCalled()
     expect(mockedInput).not.toHaveBeenCalled()
@@ -241,7 +238,7 @@ describe('#tokens:add', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Invalid role "invalid"')
     expect(error?.message).toContain('Available roles: viewer')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('handles API error during token creation', async () => {
@@ -360,7 +357,7 @@ describe('#tokens:add', () => {
       message: 'Token label:',
       validate: expect.any(Function),
     })
-    expect(stdout).toContain('Token created successfully!')
+    expect(stdout).toContain('API token created')
     expect(stdout).toContain('Label: Prompted Label')
   })
 
@@ -420,12 +417,30 @@ describe('#tokens:add', () => {
     }
   })
 
-  test('throws error when no label provided in non-interactive mode with --yes flag', async () => {
-    const {error} = await testCommand(AddTokenCommand, ['--yes'], {mocks: defaultMocks})
+  test.each([
+    {args: ['--yes'], description: 'with --yes', isInteractive: true},
+    {args: [], description: 'without an interactive terminal', isInteractive: false},
+  ])('requires a label in unattended mode $description', async ({args, isInteractive}) => {
+    const {error} = await testCommand(AddTokenCommand, args, {
+      mocks: {
+        ...defaultMocks,
+        cliConfig: {api: {projectId: undefined}},
+        isInteractive,
+      },
+    })
 
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Token label is required')
     expect(error?.message).toContain('<label>')
+    expect(error?.oclif?.exit).toBe(2)
+  })
+
+  test('rejects an empty label argument before project lookup', async () => {
+    const {error} = await testCommand(AddTokenCommand, ['   ', '--yes'], {
+      mocks: {...defaultMocks, cliConfig: {api: {projectId: undefined}}},
+    })
+
+    expect(error?.message).toContain('Token label cannot be empty')
     expect(error?.oclif?.exit).toBe(2)
   })
 })

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/add.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -238,7 +239,7 @@ describe('#tokens:add', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Invalid role "invalid"')
     expect(error?.message).toContain('Available roles: viewer')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('handles API error during token creation', async () => {
@@ -432,7 +433,7 @@ describe('#tokens:add', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Token label is required')
     expect(error?.message).toContain('<label>')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('rejects an empty label argument before project lookup', async () => {
@@ -441,6 +442,6 @@ describe('#tokens:add', () => {
     })
 
     expect(error?.message).toContain('Token label cannot be empty')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 })

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
@@ -80,14 +80,15 @@ describe('#tokens:delete', () => {
     const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123'], {
       mocks: defaultMocks,
     })
-    expect(stdout).toBe('Token deleted successfully\n')
+    expect(stdout).toBe('API token deleted\n')
     expect(confirm).toHaveBeenCalledWith({
       default: false,
-      message: 'Are you sure you want to delete the token with ID "token-api-123"?',
+      message: 'Delete API token "token-api-123"?',
     })
   })
 
   test('deletes a specific token by ID with --yes flag (skips confirmation)', async () => {
+    const {confirm} = await import('@sanity/cli-core/ux')
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'delete',
@@ -97,7 +98,8 @@ describe('#tokens:delete', () => {
     const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {
       mocks: defaultMocks,
     })
-    expect(stdout).toBe('Token deleted successfully\n')
+    expect(stdout).toBe('API token deleted\n')
+    expect(confirm).not.toHaveBeenCalled()
   })
 
   test('deletes a specific token by ID with -y flag (skips confirmation)', async () => {
@@ -110,19 +112,23 @@ describe('#tokens:delete', () => {
     const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123', '-y'], {
       mocks: defaultMocks,
     })
-    expect(stdout).toBe('Token deleted successfully\n')
+    expect(stdout).toBe('API token deleted\n')
   })
 
   test('cancels deletion when user declines confirmation', async () => {
     const {confirm} = await import('@sanity/cli-core/ux')
     vi.mocked(confirm).mockResolvedValue(false)
 
-    const {error} = await testCommand(DeleteTokensCommand, ['token-api-123'], {mocks: defaultMocks})
+    const {error, stdout} = await testCommand(DeleteTokensCommand, ['token-api-123'], {
+      mocks: defaultMocks,
+    })
     expect(error).toBeInstanceOf(Error)
     expect(error?.oclif?.exit).toBe(3)
+    expect(stdout).toBe('API token not deleted\n')
   })
 
   test('requires a token ID and --yes in unattended mode', async () => {
+    const {confirm, select} = await import('@sanity/cli-core/ux')
     const missingId = await testCommand(DeleteTokensCommand, [], {
       mocks: {...defaultMocks, isInteractive: false},
     })
@@ -134,6 +140,8 @@ describe('#tokens:delete', () => {
     })
     expect(missingConfirmation.error?.message).toContain('--yes')
     expect(missingConfirmation.error?.oclif?.exit).toBe(2)
+    expect(confirm).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
   })
 
   test('prompts user to select token when none specified', async () => {
@@ -153,7 +161,7 @@ describe('#tokens:delete', () => {
     }).reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
-    expect(stdout).toBe('Token deleted successfully\n')
+    expect(stdout).toBe('API token deleted\n')
     expect(select).toHaveBeenCalledWith({
       choices: [
         {name: 'API Token (Editor)', value: 'token-api-123'},
@@ -188,7 +196,7 @@ describe('#tokens:delete', () => {
     }).reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
-    expect(stdout).toBe('Token deleted successfully\n')
+    expect(stdout).toBe('API token deleted\n')
     expect(select).toHaveBeenCalledWith({
       choices: [{name: 'Multi Role Token (Editor, Viewer)', value: 'token-multi-123'}],
       message: 'Select token to delete:',
@@ -217,7 +225,7 @@ describe('#tokens:delete', () => {
     }).reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
-    expect(stdout).toBe('Token deleted successfully\n')
+    expect(stdout).toBe('API token deleted\n')
     expect(select).toHaveBeenCalledWith({
       choices: [{name: 'No Role Token ()', value: 'token-no-role-123'}],
       message: 'Select token to delete:',
@@ -247,8 +255,7 @@ describe('#tokens:delete', () => {
 
     const {error} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toContain('Token deletion failed')
-    expect(error?.message).toContain('No tokens found')
+    expect(error?.message).toBe('No API tokens found for this project.')
     expect(error?.oclif?.exit).toBe(1)
   })
 
@@ -279,7 +286,9 @@ describe('#tokens:delete', () => {
 
     const {error} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toContain('Token with ID "undefined" not found')
+    expect(error?.message).toContain('Could not list API tokens')
+    expect(error?.message).toContain('Project not found')
+    expect(error?.message).toContain('Check the project ID and your access permissions')
     expect(error?.oclif?.exit).toBe(1)
   })
 
@@ -291,7 +300,7 @@ describe('#tokens:delete', () => {
 
     const {error} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toContain('Token deletion failed')
+    expect(error?.message).toContain('Could not list API tokens')
     expect(error?.message).toContain('Internal Server Error')
     expect(error?.oclif?.exit).toBe(1)
   })
@@ -315,7 +324,7 @@ describe('#tokens:delete', () => {
     // Don't set up any mock to simulate network failure
     const {error} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toContain('Token deletion failed')
+    expect(error?.message).toContain('Could not list API tokens')
     expect(error?.oclif?.exit).toBe(1)
   })
 

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
@@ -130,9 +130,16 @@ describe('#tokens:delete', () => {
   test('requires a token ID and --yes in unattended mode', async () => {
     const {confirm, select} = await import('@sanity/cli-core/ux')
     const missingId = await testCommand(DeleteTokensCommand, [], {
-      mocks: {...defaultMocks, isInteractive: false},
+      mocks: {
+        ...defaultMocks,
+        cliConfig: {api: {projectId: undefined}},
+        isInteractive: false,
+      },
     })
-    expect(missingId.error?.message).toContain('<tokenId>')
+    expect(missingId.error?.message).toBe(
+      'Token ID is required. Pass it as the `<tokenId>` argument.\n' +
+        'Error: Deletion requires confirmation. Pass `--yes` to delete the token.',
+    )
     expect(missingId.error?.oclif?.exit).toBe(2)
 
     const missingConfirmation = await testCommand(DeleteTokensCommand, ['token-api-123'], {

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
@@ -41,6 +41,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -118,8 +119,21 @@ describe('#tokens:delete', () => {
 
     const {error} = await testCommand(DeleteTokensCommand, ['token-api-123'], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toContain('Operation cancelled')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(3)
+  })
+
+  test('requires a token ID and --yes in unattended mode', async () => {
+    const missingId = await testCommand(DeleteTokensCommand, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+    expect(missingId.error?.message).toContain('<tokenId>')
+    expect(missingId.error?.oclif?.exit).toBe(2)
+
+    const missingConfirmation = await testCommand(DeleteTokensCommand, ['token-api-123'], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+    expect(missingConfirmation.error?.message).toContain('--yes')
+    expect(missingConfirmation.error?.oclif?.exit).toBe(2)
   })
 
   test('prompts user to select token when none specified', async () => {

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -123,7 +124,7 @@ describe('#tokens:delete', () => {
       mocks: defaultMocks,
     })
     expect(error).toBeInstanceOf(Error)
-    expect(error?.oclif?.exit).toBe(3)
+    expect(error?.oclif?.exit).toBe(exitCodes.USER_ABORT)
     expect(stdout).toBe('API token not deleted\n')
   })
 
@@ -140,13 +141,13 @@ describe('#tokens:delete', () => {
       'Token ID is required. Pass it as the `<tokenId>` argument.\n' +
         'Error: Deletion requires confirmation. Pass `--yes` to delete the token.',
     )
-    expect(missingId.error?.oclif?.exit).toBe(2)
+    expect(missingId.error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
 
     const missingConfirmation = await testCommand(DeleteTokensCommand, ['token-api-123'], {
       mocks: {...defaultMocks, isInteractive: false},
     })
     expect(missingConfirmation.error?.message).toContain('--yes')
-    expect(missingConfirmation.error?.oclif?.exit).toBe(2)
+    expect(missingConfirmation.error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(confirm).not.toHaveBeenCalled()
     expect(select).not.toHaveBeenCalled()
   })

--- a/packages/@sanity/cli/src/commands/tokens/add.ts
+++ b/packages/@sanity/cli/src/commands/tokens/add.ts
@@ -49,7 +49,7 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
       description: 'Output as JSON',
     }),
     role: Flags.string({
-      description: 'Role to assign to the token',
+      description: 'Role to assign to the token (defaults to viewer in unattended mode)',
       helpValue: 'viewer',
     }),
     yes: Flags.boolean({
@@ -76,8 +76,9 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
         }),
     })
 
+    const label = givenLabel || (await this.promptForLabel())
+
     try {
-      const label = givenLabel || (await this.promptForLabel())
       const roleName = await (role
         ? validateRole(role, projectId, this.output)
         : this.promptForRole(projectId))
@@ -111,12 +112,9 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
 
   private async promptForLabel(): Promise<string> {
     if (this.isUnattended()) {
-      this.error(
-        'Token label is required in non-interactive mode. Provide a label as an argument.',
-        {
-          exit: 1,
-        },
-      )
+      this.error('Token label is required. Pass it as the `<label>` argument.', {
+        exit: 2,
+      })
     }
 
     const label = await input({

--- a/packages/@sanity/cli/src/commands/tokens/add.ts
+++ b/packages/@sanity/cli/src/commands/tokens/add.ts
@@ -66,6 +66,11 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
     const {label: givenLabel} = args
     const {json, role} = flags
 
+    const label = givenLabel === undefined ? await this.promptForLabel() : givenLabel.trim()
+    if (!label) {
+      this.error('Token label cannot be empty. Pass a non-empty `<label>` argument.', {exit: 2})
+    }
+
     const projectId = await this.getProjectId({
       fallback: () =>
         promptForProject({
@@ -76,13 +81,11 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
         }),
     })
 
-    const label = givenLabel || (await this.promptForLabel())
+    const roleName = await (role
+      ? validateRole(role, projectId, this.output)
+      : this.promptForRole(projectId))
 
     try {
-      const roleName = await (role
-        ? validateRole(role, projectId, this.output)
-        : this.promptForRole(projectId))
-
       tokensAddDebug(`Creating token for project ${projectId}`, {label, roleName})
       const token = await createToken({
         label,
@@ -95,13 +98,13 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
         return
       }
 
-      this.log('Token created successfully!')
+      this.log('API token created')
       this.log(`Label: ${token.label}`)
       this.log(`ID: ${token.id}`)
       this.log(`Role: ${token.roles.map((r) => r.title).join(', ')}`)
       this.log(`Token: ${token.key}`)
       this.log('')
-      this.log('Copy the token above – this is your only chance to do so!')
+      this.log("Copy the token now. It won't be shown again.")
     } catch (error) {
       const err = error as Error
 
@@ -127,7 +130,7 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
       },
     })
 
-    return label
+    return label.trim()
   }
 
   private async promptForRole(projectId: string): Promise<string> {

--- a/packages/@sanity/cli/src/commands/tokens/add.ts
+++ b/packages/@sanity/cli/src/commands/tokens/add.ts
@@ -1,5 +1,5 @@
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 
 import {validateRole} from '../../actions/tokens/validateRole.js'
@@ -43,7 +43,10 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
   ]
 
   static override flags = {
-    ...getProjectIdFlag({description: 'Project ID to add token to', semantics: 'override'}),
+    ...getProjectIdFlag({
+      description: 'Project ID to add token to',
+      semantics: 'override',
+    }),
     json: Flags.boolean({
       default: false,
       description: 'Output as JSON',
@@ -68,7 +71,9 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
 
     const label = givenLabel === undefined ? await this.promptForLabel() : givenLabel.trim()
     if (!label) {
-      this.error('Token label cannot be empty. Pass a non-empty `<label>` argument.', {exit: 2})
+      this.error('Token label cannot be empty. Pass a non-empty value as the `<label>` argument.', {
+        exit: exitCodes.USAGE_ERROR,
+      })
     }
 
     const projectId = await this.getProjectId({
@@ -86,7 +91,10 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
       : this.promptForRole(projectId))
 
     try {
-      tokensAddDebug(`Creating token for project ${projectId}`, {label, roleName})
+      tokensAddDebug(`Creating token for project ${projectId}`, {
+        label,
+        roleName,
+      })
       const token = await createToken({
         label,
         projectId,
@@ -116,7 +124,7 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
   private async promptForLabel(): Promise<string> {
     if (this.isUnattended()) {
       this.error('Token label is required. Pass it as the `<label>` argument.', {
-        exit: 2,
+        exit: exitCodes.USAGE_ERROR,
       })
     }
 

--- a/packages/@sanity/cli/src/commands/tokens/delete.ts
+++ b/packages/@sanity/cli/src/commands/tokens/delete.ts
@@ -73,7 +73,9 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
       }
 
       if (errors.length > 0) {
-        this.error(formatCliErrorMessages(errors), {exit: 2})
+        this.error(formatCliErrorMessages(errors), {
+          exit: exitCodes.USAGE_ERROR,
+        })
       }
     }
 
@@ -128,12 +130,14 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
       deleteTokenDebug(`Error fetching tokens for project ${this.projectId}`, err)
       this.error(
         `Could not list API tokens:\n${err.message}\nCheck the project ID and your access permissions, then try again.`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
 
     if (tokens.length === 0) {
-      this.error('No API tokens found for this project.', {exit: 1})
+      this.error('No API tokens found for this project.', {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     const choices = tokens.map((token) => ({

--- a/packages/@sanity/cli/src/commands/tokens/delete.ts
+++ b/packages/@sanity/cli/src/commands/tokens/delete.ts
@@ -1,5 +1,5 @@
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {confirm, select} from '@sanity/cli-core/ux'
 import {ClientError} from '@sanity/client'
 
@@ -57,14 +57,16 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
   public async run(): Promise<void> {
     const {args, flags} = await this.parse(DeleteTokensCommand)
 
-    const unattended = flags.yes
+    const skipConfirmation = flags.yes
+    const unattended = this.isUnattended()
     const {tokenId: givenTokenId} = args
 
     if (unattended && !givenTokenId) {
-      this.error(
-        'Token ID is required in non-interactive mode. Provide a token ID as an argument.',
-        {exit: 1},
-      )
+      this.error('Token ID is required. Pass it as the `<tokenId>` argument.', {exit: 2})
+    }
+
+    if (unattended && !skipConfirmation) {
+      this.error('Deletion requires confirmation. Pass `--yes` to delete the token.', {exit: 2})
     }
 
     // Ensure we have project context
@@ -77,22 +79,21 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
 
     this.projectId = projectId
 
-    let tokenId: string | undefined
+    const tokenId = givenTokenId || (await this.getTokenIdFromList())
+
+    if (!skipConfirmation) {
+      const confirmed = await confirm({
+        default: false,
+        message: `Are you sure you want to delete the token with ID "${tokenId}"?`,
+      })
+
+      if (!confirmed) {
+        this.log('Operation cancelled')
+        this.exit(exitCodes.USER_ABORT)
+      }
+    }
 
     try {
-      tokenId = givenTokenId || (await this.getTokenIdFromList())
-
-      if (!unattended) {
-        const confirmed = await confirm({
-          default: false,
-          message: `Are you sure you want to delete the token with ID "${tokenId}"?`,
-        })
-
-        if (!confirmed) {
-          this.error('Operation cancelled', {exit: 1})
-        }
-      }
-
       await deleteToken({
         projectId: this.projectId,
         tokenId,

--- a/packages/@sanity/cli/src/commands/tokens/delete.ts
+++ b/packages/@sanity/cli/src/commands/tokens/delete.ts
@@ -5,6 +5,7 @@ import {ClientError} from '@sanity/client'
 
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {deleteToken, getTokens} from '../../services/tokens.js'
+import {formatCliErrorMessages} from '../../util/formatCliErrorMessages.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
 
 const deleteTokenDebug = subdebug('tokens:delete')
@@ -61,12 +62,19 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
     const unattended = this.isUnattended()
     const {tokenId: givenTokenId} = args
 
-    if (unattended && !givenTokenId) {
-      this.error('Token ID is required. Pass it as the `<tokenId>` argument.', {exit: 2})
-    }
+    if (unattended) {
+      const errors: string[] = []
 
-    if (unattended && !skipConfirmation) {
-      this.error('Deletion requires confirmation. Pass `--yes` to delete the token.', {exit: 2})
+      if (!givenTokenId) {
+        errors.push('Token ID is required. Pass it as the `<tokenId>` argument.')
+      }
+      if (!skipConfirmation) {
+        errors.push('Deletion requires confirmation. Pass `--yes` to delete the token.')
+      }
+
+      if (errors.length > 0) {
+        this.error(formatCliErrorMessages(errors), {exit: 2})
+      }
     }
 
     // Ensure we have project context

--- a/packages/@sanity/cli/src/commands/tokens/delete.ts
+++ b/packages/@sanity/cli/src/commands/tokens/delete.ts
@@ -84,11 +84,11 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
     if (!skipConfirmation) {
       const confirmed = await confirm({
         default: false,
-        message: `Are you sure you want to delete the token with ID "${tokenId}"?`,
+        message: `Delete API token "${tokenId}"?`,
       })
 
       if (!confirmed) {
-        this.log('Operation cancelled')
+        this.log('API token not deleted')
         this.exit(exitCodes.USER_ABORT)
       }
     }
@@ -99,7 +99,7 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
         tokenId,
       })
 
-      this.log('Token deleted successfully')
+      this.log('API token deleted')
     } catch (error) {
       if (error instanceof ClientError && error.response.statusCode === 404) {
         this.error(`Token with ID "${tokenId}" not found`, {exit: 1})
@@ -112,10 +112,20 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
   }
 
   private async getTokenIdFromList() {
-    const tokens = await getTokens(this.projectId)
+    let tokens: Awaited<ReturnType<typeof getTokens>>
+    try {
+      tokens = await getTokens(this.projectId)
+    } catch (error) {
+      const err = error as Error
+      deleteTokenDebug(`Error fetching tokens for project ${this.projectId}`, err)
+      this.error(
+        `Could not list API tokens:\n${err.message}\nCheck the project ID and your access permissions, then try again.`,
+        {exit: 1},
+      )
+    }
 
     if (tokens.length === 0) {
-      this.error('No tokens found', {exit: 1})
+      this.error('No API tokens found for this project.', {exit: 1})
     }
 
     const choices = tokens.map((token) => ({

--- a/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -112,19 +113,19 @@ describe('#invite', () => {
       'Email address is required. Pass it as the `<email>` argument.\n' +
         'Error: User role is required. Pass it with `--role <role>`.',
     )
-    expect(missingBoth.error?.oclif?.exit).toBe(2)
+    expect(missingBoth.error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
 
     const missingEmail = await testCommand(UsersInviteCommand, ['--role', 'developer'], {
       mocks: {...defaultMocks, isInteractive: false},
     })
     expect(missingEmail.error?.message).toContain('<email>')
-    expect(missingEmail.error?.oclif?.exit).toBe(2)
+    expect(missingEmail.error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
 
     const missingRole = await testCommand(UsersInviteCommand, ['test@example.com'], {
       mocks: {...defaultMocks, isInteractive: false},
     })
     expect(missingRole.error?.message).toContain('--role <role>')
-    expect(missingRole.error?.oclif?.exit).toBe(2)
+    expect(missingRole.error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(input).not.toHaveBeenCalled()
     expect(select).not.toHaveBeenCalled()
   })
@@ -162,7 +163,7 @@ describe('#invite', () => {
     })
 
     expect(error?.message).toContain('valid email address')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('invites user with email provided via args and role as flag', async () => {
@@ -201,7 +202,7 @@ describe('#invite', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Role name "invalid-role" not found')
     expect(error?.message).toContain('Available roles:')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('exits when project ID is not found', async () => {
@@ -305,7 +306,7 @@ describe('#invite', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Role name "robot" not found')
     expect(error?.message).toContain('Available roles:')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('role names are case insensitive', async () => {

--- a/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
@@ -116,6 +116,33 @@ describe('#invite', () => {
     expect(select).not.toHaveBeenCalled()
   })
 
+  test('uses provided values without prompting in unattended mode', async () => {
+    mockApi({
+      apiVersion: PROJECTS_API_VERSION,
+      uri: `/projects/${testProjectId}/roles`,
+    }).reply(200, mockRoles)
+
+    mockApi({
+      apiVersion: PROJECTS_API_VERSION,
+      method: 'post',
+      uri: `/invitations/project/${testProjectId}`,
+    }).reply(200, function (_, requestBody) {
+      expect(requestBody).toEqual({email: 'test@example.com', role: 'developer'})
+      return {}
+    })
+
+    const {error, stdout} = await testCommand(
+      UsersInviteCommand,
+      [' test@example.com ', '--role', 'developer'],
+      {mocks: {...defaultMocks, isInteractive: false}},
+    )
+
+    if (error) throw error
+    expect(stdout).toContain('Invitation sent to test@example.com')
+    expect(input).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
+  })
+
   test('validates an email argument before fetching roles', async () => {
     const {error} = await testCommand(UsersInviteCommand, ['not-an-email', '--role', 'developer'], {
       mocks: defaultMocks,

--- a/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
@@ -19,6 +19,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -99,6 +100,31 @@ describe('#invite', () => {
     expect(stdout).toContain('Invitation sent to test@example.com')
   })
 
+  test('requires email and role in unattended mode', async () => {
+    const missingEmail = await testCommand(UsersInviteCommand, ['--role', 'developer'], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+    expect(missingEmail.error?.message).toContain('<email>')
+    expect(missingEmail.error?.oclif?.exit).toBe(2)
+
+    const missingRole = await testCommand(UsersInviteCommand, ['test@example.com'], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+    expect(missingRole.error?.message).toContain('--role <role>')
+    expect(missingRole.error?.oclif?.exit).toBe(2)
+    expect(input).not.toHaveBeenCalled()
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  test('validates an email argument before fetching roles', async () => {
+    const {error} = await testCommand(UsersInviteCommand, ['not-an-email', '--role', 'developer'], {
+      mocks: defaultMocks,
+    })
+
+    expect(error?.message).toContain('valid email address')
+    expect(error?.oclif?.exit).toBe(2)
+  })
+
   test('invites user with email provided via args and role as flag', async () => {
     mockApi({
       apiVersion: PROJECTS_API_VERSION,
@@ -135,7 +161,7 @@ describe('#invite', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Role name "invalid-role" not found')
     expect(error?.message).toContain('Available roles:')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('exits when project ID is not found', async () => {
@@ -239,7 +265,7 @@ describe('#invite', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Role name "robot" not found')
     expect(error?.message).toContain('Available roles:')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('role names are case insensitive', async () => {

--- a/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
+++ b/packages/@sanity/cli/src/commands/users/__tests__/invite.test.ts
@@ -101,6 +101,19 @@ describe('#invite', () => {
   })
 
   test('requires email and role in unattended mode', async () => {
+    const missingBoth = await testCommand(UsersInviteCommand, [], {
+      mocks: {
+        ...defaultMocks,
+        cliConfig: {api: {projectId: undefined}},
+        isInteractive: false,
+      },
+    })
+    expect(missingBoth.error?.message).toBe(
+      'Email address is required. Pass it as the `<email>` argument.\n' +
+        'Error: User role is required. Pass it with `--role <role>`.',
+    )
+    expect(missingBoth.error?.oclif?.exit).toBe(2)
+
     const missingEmail = await testCommand(UsersInviteCommand, ['--role', 'developer'], {
       mocks: {...defaultMocks, isInteractive: false},
     })

--- a/packages/@sanity/cli/src/commands/users/invite.ts
+++ b/packages/@sanity/cli/src/commands/users/invite.ts
@@ -59,6 +59,18 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
     const {email: selectedEmail} = this.args
     const {role: selectedRole} = this.flags
 
+    if (this.isUnattended() && !selectedEmail) {
+      this.error('Email address is required. Pass it as the `<email>` argument.', {exit: 2})
+    }
+    if (this.isUnattended() && !selectedRole) {
+      this.error('User role is required. Pass it with `--role <role>`.', {exit: 2})
+    }
+
+    if (selectedEmail) {
+      const validation = validateEmail(selectedEmail)
+      if (validation !== true) this.error(`${validation}. Pass a valid email address.`, {exit: 2})
+    }
+
     const projectId = await this.getProjectId({
       fallback: () =>
         promptForProject({
@@ -84,7 +96,7 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
     if (!role) {
       this.error(
         `Role name "${roleSelection}" not found. Available roles: ${roles.map((r) => r.name).join(', ')}`,
-        {exit: 1},
+        {exit: 2},
       )
     }
 

--- a/packages/@sanity/cli/src/commands/users/invite.ts
+++ b/packages/@sanity/cli/src/commands/users/invite.ts
@@ -58,17 +58,18 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
   public async run(): Promise<void> {
     const {email: selectedEmail} = this.args
     const {role: selectedRole} = this.flags
+    const normalizedEmail = selectedEmail?.trim()
 
-    if (this.isUnattended() && !selectedEmail) {
+    if (this.isUnattended() && !normalizedEmail) {
       this.error('Email address is required. Pass it as the `<email>` argument.', {exit: 2})
     }
     if (this.isUnattended() && !selectedRole) {
       this.error('User role is required. Pass it with `--role <role>`.', {exit: 2})
     }
 
-    if (selectedEmail) {
-      const validation = validateEmail(selectedEmail)
-      if (validation !== true) this.error(`${validation}. Pass a valid email address.`, {exit: 2})
+    if (selectedEmail !== undefined) {
+      const validation = validateEmail(normalizedEmail ?? '')
+      if (validation !== true) this.error(validation, {exit: 2})
     }
 
     const projectId = await this.getProjectId({
@@ -89,7 +90,7 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
       this.error('Error fetching roles', {exit: 1})
     }
 
-    const email = selectedEmail || (await this.promptForEmail())
+    const email = normalizedEmail || (await this.promptForEmail())
     const roleSelection = selectedRole || (await this.promptForRole(roles))
     const role = roles.find(({name}) => name.toLowerCase() === roleSelection.toLowerCase())
 

--- a/packages/@sanity/cli/src/commands/users/invite.ts
+++ b/packages/@sanity/cli/src/commands/users/invite.ts
@@ -6,6 +6,7 @@ import {type Role} from '../../actions/users/types.js'
 import {validateEmail} from '../../actions/users/validateEmail.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {getProjectRoles, inviteUser} from '../../services/projects.js'
+import {formatCliErrorMessages} from '../../util/formatCliErrorMessages.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
 
 const QUOTA_ERROR_MESSAGE =
@@ -60,11 +61,19 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
     const {role: selectedRole} = this.flags
     const normalizedEmail = selectedEmail?.trim()
 
-    if (this.isUnattended() && !normalizedEmail) {
-      this.error('Email address is required. Pass it as the `<email>` argument.', {exit: 2})
-    }
-    if (this.isUnattended() && !selectedRole) {
-      this.error('User role is required. Pass it with `--role <role>`.', {exit: 2})
+    if (this.isUnattended()) {
+      const errors: string[] = []
+
+      if (!normalizedEmail) {
+        errors.push('Email address is required. Pass it as the `<email>` argument.')
+      }
+      if (!selectedRole) {
+        errors.push('User role is required. Pass it with `--role <role>`.')
+      }
+
+      if (errors.length > 0) {
+        this.error(formatCliErrorMessages(errors), {exit: 2})
+      }
     }
 
     if (selectedEmail !== undefined) {

--- a/packages/@sanity/cli/src/commands/users/invite.ts
+++ b/packages/@sanity/cli/src/commands/users/invite.ts
@@ -1,5 +1,5 @@
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 
 import {type Role} from '../../actions/users/types.js'
@@ -72,13 +72,15 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
       }
 
       if (errors.length > 0) {
-        this.error(formatCliErrorMessages(errors), {exit: 2})
+        this.error(formatCliErrorMessages(errors), {
+          exit: exitCodes.USAGE_ERROR,
+        })
       }
     }
 
     if (selectedEmail !== undefined) {
       const validation = validateEmail(normalizedEmail ?? '')
-      if (validation !== true) this.error(validation, {exit: 2})
+      if (validation !== true) this.error(validation, {exit: exitCodes.USAGE_ERROR})
     }
 
     const projectId = await this.getProjectId({
@@ -106,7 +108,7 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
     if (!role) {
       this.error(
         `Role name "${roleSelection}" not found. Available roles: ${roles.map((r) => r.name).join(', ')}`,
-        {exit: 2},
+        {exit: exitCodes.USAGE_ERROR},
       )
     }
 


### PR DESCRIPTION
### Description

Adds unattended-mode support for admin commands.

### What to review

Review the flags, prompt handling, and automated coverage.

### Testing

<!-- To be completed before marking ready. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CORS credentials and wildcard origins are applied in unattended mode and tightens token/user admin inputs; behavior is deliberate but affects security-sensitive project settings in automation.
> 
> **Overview**
> Adds **unattended (non-interactive) behavior** for project admin CLI commands so CI and scripts can run without prompts, with explicit flags where confirmation used to be interactive.
> 
> **CORS:** `cors add` gains `--yes` for wildcard origins; unattended runs default **allow credentials to false** unless `--credentials` / `--no-credentials` is set, and wildcards fail unless `--yes` is passed. Denied wildcard confirmation now logs and exits with **user abort** instead of a generic error. `cors delete` requires the `<origin>` argument when unattended.
> 
> **Tokens:** `tokens add` validates the label up front (required in unattended, rejects empty), defaults role to **viewer** when unattended and `--role` is omitted, and uses clearer success copy. `tokens delete` in unattended mode requires both **token ID** and **`--yes`** (aggregated error messages); list failures and cancel paths are improved. Invalid token roles use **`USAGE_ERROR`**.
> 
> **Users:** `users invite` requires `<email>` and `--role` in unattended mode (batched errors), validates email before API calls, and maps invalid roles to **`USAGE_ERROR`**.
> 
> **Hooks:** `hooks delete` and `hooks logs` error in unattended mode when a webhook name is required but missing (including the multi-hook logs case).
> 
> Across these areas (plus related **init**, **undeploy**, and **projects create** tests), hard-coded exit codes are replaced with shared **`exitCodes`** (`USAGE_ERROR`, `USER_ABORT`, `RUNTIME_ERROR`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe3aba81c41ae7a26fe7185b2844a5edd78118b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->