### PR TITLE
fix(cli): support unattended mode in dataset lifecycle commands

### DIFF
--- a/.changeset/calm-datasets-automate.md
+++ b/.changeset/calm-datasets-automate.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+Make dataset create, copy, delete, import, export, and backup commands safe to run unattended by using deterministic output paths and returning actionable usage errors instead of prompting for required input or overwrite confirmation.

--- a/.changeset/calm-datasets-automate.md
+++ b/.changeset/calm-datasets-automate.md
@@ -2,4 +2,7 @@
 '@sanity/cli': patch
 ---
 
-Make dataset create, copy, delete, import, export, and backup commands safe to run unattended by using deterministic output paths and returning actionable usage errors instead of prompting for required input or overwrite confirmation.
+fix(cli): support unattended mode in dataset lifecycle commands
+
+Use deterministic export and backup paths, and return usage errors instead of prompting for missing
+input or overwrite confirmation.

--- a/.changeset/pr-1497.md
+++ b/.changeset/pr-1497.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(cli): support unattended mode in dataset lifecycle commands

--- a/.changeset/pr-1497.md
+++ b/.changeset/pr-1497.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(cli): support unattended mode in dataset lifecycle commands

--- a/packages/@sanity/cli/src/commands/backups/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/disable.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -102,7 +103,7 @@ describe('#backup:disable', () => {
     expect(error?.message).toBe(
       'Dataset is required in unattended mode. Pass it as the `<dataset>` argument.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockSelect).not.toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/commands/backups/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/disable.test.ts
@@ -32,6 +32,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -89,6 +90,20 @@ describe('#backup:disable', () => {
       ],
       message: 'Select the dataset name:',
     })
+  })
+
+  test('should require a dataset in unattended mode', async () => {
+    mockListDatasets.mockResolvedValue([{name: 'production'}])
+
+    const {error} = await testCommand(DisableBackupCommand, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe(
+      'Dataset is required in unattended mode. Pass the dataset name as an argument.',
+    )
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockSelect).not.toHaveBeenCalled()
   })
 
   test('should fail when no project ID is available', async () => {

--- a/packages/@sanity/cli/src/commands/backups/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/disable.test.ts
@@ -100,7 +100,7 @@ describe('#backup:disable', () => {
     })
 
     expect(error?.message).toBe(
-      'Dataset is required in unattended mode. Pass the dataset name as an argument.',
+      'Dataset is required in unattended mode. Pass it as the `<dataset>` argument.',
     )
     expect(error?.oclif?.exit).toBe(2)
     expect(mockSelect).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
@@ -116,12 +116,12 @@ describe('#backup:download', () => {
       [
         'concurrency value below minimum',
         ['--backup-id', 'test', '--concurrency', '0'],
-        '--concurrency must be between 1 and 24.',
+        '`--concurrency` must be between 1 and 24.',
       ],
       [
         'concurrency value above maximum',
         ['--backup-id', 'test', '--concurrency', '25'],
-        '--concurrency must be between 1 and 24.',
+        '`--concurrency` must be between 1 and 24.',
       ],
     ])('should reject %s', async (_, flags, expectedError) => {
       setupTempDir()
@@ -180,8 +180,8 @@ describe('#backup:download', () => {
       })
 
       expect(error?.message).toBe(
-        'Dataset is required in unattended mode. Pass the dataset name as an argument.\n' +
-          'Error: Backup ID is required in unattended mode. Pass it with --backup-id <id>.',
+        'Dataset is required in unattended mode. Pass it as the `<dataset>` argument.\n' +
+          'Error: Backup ID is required in unattended mode. Pass it with `--backup-id <id>`.',
       )
       expect(error?.oclif?.exit).toBe(2)
       expect(mockListDatasets).not.toHaveBeenCalled()
@@ -199,7 +199,7 @@ describe('#backup:download', () => {
       })
 
       expect(error?.message).toBe(
-        'Backup ID is required in unattended mode. Pass it with --backup-id <id>.',
+        'Backup ID is required in unattended mode. Pass it with `--backup-id <id>`.',
       )
       expect(error?.oclif?.exit).toBe(2)
       expect(mockListDatasets).not.toHaveBeenCalled()
@@ -220,7 +220,7 @@ describe('#backup:download', () => {
       )
 
       expect(error?.message).toBe(
-        `File "${path.resolve(out)}" already exists. Pass --overwrite to replace it.`,
+        `File "${path.resolve(out)}" already exists. Pass \`--overwrite\` to replace it.`,
       )
       expect(error?.oclif?.exit).toBe(2)
       expect(mockConfirm).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
@@ -397,9 +397,7 @@ describe('#backup:download', () => {
         {mocks: {...defaultMocks, isInteractive: false}},
       )
 
-      expect(stdout).toContain(
-        path.join(process.cwd(), 'production-backup-backup-123.tar.gz'),
-      )
+      expect(stdout).toContain(path.join(process.cwd(), 'production-backup-backup-123.tar.gz'))
       expect(error?.message).toContain('Downloading dataset backup failed')
       expect(mockInput).not.toHaveBeenCalled()
     })

--- a/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
@@ -2,6 +2,7 @@ import {existsSync, mkdirSync} from 'node:fs'
 import {mkdir, mkdtemp, writeFile} from 'node:fs/promises'
 import path from 'node:path'
 
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {confirm, input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import nock, {cleanAll, pendingMocks} from 'nock'
@@ -183,7 +184,7 @@ describe('#backup:download', () => {
         'Dataset is required in unattended mode. Pass it as the `<dataset>` argument.\n' +
           'Error: Backup ID is required in unattended mode. Pass it with `--backup-id <id>`.',
       )
-      expect(error?.oclif?.exit).toBe(2)
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
       expect(mockListDatasets).not.toHaveBeenCalled()
       expect(mockSelect).not.toHaveBeenCalled()
       expect(mockInput).not.toHaveBeenCalled()
@@ -201,7 +202,7 @@ describe('#backup:download', () => {
       expect(error?.message).toBe(
         'Backup ID is required in unattended mode. Pass it with `--backup-id <id>`.',
       )
-      expect(error?.oclif?.exit).toBe(2)
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
       expect(mockListDatasets).not.toHaveBeenCalled()
       expect(mockSelect).not.toHaveBeenCalled()
       expect(mockInput).not.toHaveBeenCalled()
@@ -222,7 +223,7 @@ describe('#backup:download', () => {
       expect(error?.message).toBe(
         `File "${path.resolve(out)}" already exists. Pass \`--overwrite\` to replace it.`,
       )
-      expect(error?.oclif?.exit).toBe(2)
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
       expect(mockConfirm).not.toHaveBeenCalled()
     })
 
@@ -295,7 +296,7 @@ describe('#backup:download', () => {
       })
 
       expect(error?.message).toContain('Operation cancelled.')
-      expect(error?.oclif?.exit).toBe(3)
+      expect(error?.oclif?.exit).toBe(exitCodes.USER_ABORT)
     })
 
     test.each([

--- a/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
@@ -116,12 +116,12 @@ describe('#backup:download', () => {
       [
         'concurrency value below minimum',
         ['--backup-id', 'test', '--concurrency', '0'],
-        'concurrency should be in 1 to 24 range',
+        '--concurrency must be between 1 and 24.',
       ],
       [
         'concurrency value above maximum',
         ['--backup-id', 'test', '--concurrency', '25'],
-        'concurrency should be in 1 to 24 range',
+        '--concurrency must be between 1 and 24.',
       ],
     ])('should reject %s', async (_, flags, expectedError) => {
       setupTempDir()
@@ -168,6 +168,55 @@ describe('#backup:download', () => {
 
       expect(error?.message).toContain('Unable to determine project ID')
       expect(error?.oclif?.exit).toBe(1)
+    })
+
+    test('should require a dataset in unattended mode', async () => {
+      mockListDatasets.mockResolvedValue([{name: 'production'}])
+
+      const {error} = await testCommand(DownloadBackupCommand, [], {
+        mocks: {...defaultMocks, isInteractive: false},
+      })
+
+      expect(error?.message).toBe(
+        'Dataset is required in unattended mode. Pass the dataset name as an argument.',
+      )
+      expect(error?.oclif?.exit).toBe(2)
+      expect(mockSelect).not.toHaveBeenCalled()
+      expect(mockInput).not.toHaveBeenCalled()
+    })
+
+    test('should require a backup ID in unattended mode', async () => {
+      mockListDatasets.mockResolvedValue([{name: 'production'}])
+
+      const {error} = await testCommand(DownloadBackupCommand, ['production'], {
+        mocks: {...defaultMocks, isInteractive: false},
+      })
+
+      expect(error?.message).toBe(
+        'Backup ID is required in unattended mode. Pass it with --backup-id <id>.',
+      )
+      expect(error?.oclif?.exit).toBe(2)
+      expect(mockSelect).not.toHaveBeenCalled()
+      expect(mockInput).not.toHaveBeenCalled()
+    })
+
+    test('should reject an existing output file without --overwrite in unattended mode', async () => {
+      mockListDatasets.mockResolvedValue([{name: 'production'}])
+      const out = `tmp/${Date.now()}-backup-unattended/backup.tar.gz`
+      await mkdir(path.dirname(out), {recursive: true})
+      await writeFile(out, 'fake-data')
+
+      const {error} = await testCommand(
+        DownloadBackupCommand,
+        ['production', '--backup-id', 'backup-123', '--out', out],
+        {mocks: {...defaultMocks, isInteractive: false}},
+      )
+
+      expect(error?.message).toBe(
+        `File "${path.resolve(out)}" already exists. Pass --overwrite to replace it.`,
+      )
+      expect(error?.oclif?.exit).toBe(2)
+      expect(mockConfirm).not.toHaveBeenCalled()
     })
 
     test('should error when no backups are available to select', async () => {
@@ -249,13 +298,7 @@ describe('#backup:download', () => {
           const name = 'doc1.json'
           const type = 'document'
           mockBackupAPI({
-            files: [
-              {
-                name,
-                type,
-                url: `https://api.sanity.io/${BACKUP_API_VERSION}/${name}`,
-              },
-            ],
+            files: [{name, type, url: `https://api.sanity.io/${BACKUP_API_VERSION}/${name}`}],
           })
           nock('https://api.sanity.io').get(`/${BACKUP_API_VERSION}/${name}`).reply(500, {
             message: 'Internal Server Error',
@@ -268,13 +311,7 @@ describe('#backup:download', () => {
           const name = 'image1.jpg'
           const type = 'asset'
           mockBackupAPI({
-            files: [
-              {
-                name,
-                type,
-                url: `https://api.sanity.io/${BACKUP_API_VERSION}/${name}`,
-              },
-            ],
+            files: [{name, type, url: `https://api.sanity.io/${BACKUP_API_VERSION}/${name}`}],
           })
           nock('https://api.sanity.io').get(`/${BACKUP_API_VERSION}/${name}`).reply(500, {
             message: 'Internal Server Error',
@@ -345,6 +382,28 @@ describe('#backup:download', () => {
   })
 
   describe('successful downloads', () => {
+    test('should use the default output path in unattended mode', async () => {
+      setupTempDir()
+      mockListDatasets.mockResolvedValue([{name: 'production'}])
+      mockApi({
+        apiVersion: BACKUP_API_VERSION,
+        method: 'get',
+        uri: `/projects/test-project/datasets/production/backups/backup-123`,
+      }).reply(500, {message: 'Backup API error'})
+
+      const {error, stdout} = await testCommand(
+        DownloadBackupCommand,
+        ['production', '--backup-id', 'backup-123'],
+        {mocks: {...defaultMocks, isInteractive: false}},
+      )
+
+      expect(stdout).toContain(
+        path.join(process.cwd(), 'production-backup-backup-123.tar.gz'),
+      )
+      expect(error?.message).toContain('Downloading dataset backup failed')
+      expect(mockInput).not.toHaveBeenCalled()
+    })
+
     test('should download backup with all flags specified', async () => {
       setupTempDir()
       mockListDatasets.mockResolvedValue([{name: 'production'}, {name: 'staging'}])
@@ -379,9 +438,7 @@ describe('#backup:download', () => {
         .get(`/${BACKUP_API_VERSION}/doc1`)
         .reply(200, '{"_id":"doc1","title":"Document 1"}')
         .get(`/${BACKUP_API_VERSION}/image1`)
-        .reply(200, Buffer.from('fake-image-data'), {
-          'content-type': 'image/jpeg',
-        })
+        .reply(200, Buffer.from('fake-image-data'), {'content-type': 'image/jpeg'})
         .get(`/${BACKUP_API_VERSION}/file1`)
         .reply(200, Buffer.from('fake-file-data'))
 

--- a/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
@@ -171,31 +171,38 @@ describe('#backup:download', () => {
     })
 
     test('should require a dataset in unattended mode', async () => {
-      mockListDatasets.mockResolvedValue([{name: 'production'}])
-
       const {error} = await testCommand(DownloadBackupCommand, [], {
-        mocks: {...defaultMocks, isInteractive: false},
+        mocks: {
+          ...defaultMocks,
+          cliConfig: {api: {}},
+          isInteractive: false,
+        },
       })
 
       expect(error?.message).toBe(
-        'Dataset is required in unattended mode. Pass the dataset name as an argument.',
+        'Dataset is required in unattended mode. Pass the dataset name as an argument.\n' +
+          'Error: Backup ID is required in unattended mode. Pass it with --backup-id <id>.',
       )
       expect(error?.oclif?.exit).toBe(2)
+      expect(mockListDatasets).not.toHaveBeenCalled()
       expect(mockSelect).not.toHaveBeenCalled()
       expect(mockInput).not.toHaveBeenCalled()
     })
 
     test('should require a backup ID in unattended mode', async () => {
-      mockListDatasets.mockResolvedValue([{name: 'production'}])
-
       const {error} = await testCommand(DownloadBackupCommand, ['production'], {
-        mocks: {...defaultMocks, isInteractive: false},
+        mocks: {
+          ...defaultMocks,
+          cliConfig: {api: {}},
+          isInteractive: false,
+        },
       })
 
       expect(error?.message).toBe(
         'Backup ID is required in unattended mode. Pass it with --backup-id <id>.',
       )
       expect(error?.oclif?.exit).toBe(2)
+      expect(mockListDatasets).not.toHaveBeenCalled()
       expect(mockSelect).not.toHaveBeenCalled()
       expect(mockInput).not.toHaveBeenCalled()
     })

--- a/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/download.test.ts
@@ -50,6 +50,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -238,7 +239,7 @@ describe('#backup:download', () => {
       })
 
       expect(error?.message).toContain('Operation cancelled.')
-      expect(error?.oclif?.exit).toBe(1)
+      expect(error?.oclif?.exit).toBe(3)
     })
 
     test.each([
@@ -248,7 +249,13 @@ describe('#backup:download', () => {
           const name = 'doc1.json'
           const type = 'document'
           mockBackupAPI({
-            files: [{name, type, url: `https://api.sanity.io/${BACKUP_API_VERSION}/${name}`}],
+            files: [
+              {
+                name,
+                type,
+                url: `https://api.sanity.io/${BACKUP_API_VERSION}/${name}`,
+              },
+            ],
           })
           nock('https://api.sanity.io').get(`/${BACKUP_API_VERSION}/${name}`).reply(500, {
             message: 'Internal Server Error',
@@ -261,7 +268,13 @@ describe('#backup:download', () => {
           const name = 'image1.jpg'
           const type = 'asset'
           mockBackupAPI({
-            files: [{name, type, url: `https://api.sanity.io/${BACKUP_API_VERSION}/${name}`}],
+            files: [
+              {
+                name,
+                type,
+                url: `https://api.sanity.io/${BACKUP_API_VERSION}/${name}`,
+              },
+            ],
           })
           nock('https://api.sanity.io').get(`/${BACKUP_API_VERSION}/${name}`).reply(500, {
             message: 'Internal Server Error',
@@ -366,7 +379,9 @@ describe('#backup:download', () => {
         .get(`/${BACKUP_API_VERSION}/doc1`)
         .reply(200, '{"_id":"doc1","title":"Document 1"}')
         .get(`/${BACKUP_API_VERSION}/image1`)
-        .reply(200, Buffer.from('fake-image-data'), {'content-type': 'image/jpeg'})
+        .reply(200, Buffer.from('fake-image-data'), {
+          'content-type': 'image/jpeg',
+        })
         .get(`/${BACKUP_API_VERSION}/file1`)
         .reply(200, Buffer.from('fake-file-data'))
 

--- a/packages/@sanity/cli/src/commands/backups/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/enable.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -110,7 +111,7 @@ describe('#backup:enable', () => {
     expect(error?.message).toBe(
       'Dataset is required in unattended mode. Pass it as the `<dataset>` argument.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockSelect).not.toHaveBeenCalled()
     expect(mockInput).not.toHaveBeenCalled()
   })

--- a/packages/@sanity/cli/src/commands/backups/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/enable.test.ts
@@ -108,7 +108,7 @@ describe('#backup:enable', () => {
     })
 
     expect(error?.message).toBe(
-      'Dataset is required in unattended mode. Pass the dataset name as an argument.',
+      'Dataset is required in unattended mode. Pass it as the `<dataset>` argument.',
     )
     expect(error?.oclif?.exit).toBe(2)
     expect(mockSelect).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/backups/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/enable.test.ts
@@ -36,6 +36,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -97,6 +98,21 @@ describe('#backup:enable', () => {
       ],
       message: 'Select the dataset name:',
     })
+  })
+
+  test('should require a dataset in unattended mode', async () => {
+    mockListDatasets.mockResolvedValue([{name: 'production'}])
+
+    const {error} = await testCommand(EnableBackupCommand, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe(
+      'Dataset is required in unattended mode. Pass the dataset name as an argument.',
+    )
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockSelect).not.toHaveBeenCalled()
+    expect(mockInput).not.toHaveBeenCalled()
   })
 
   test('should fail when no project ID is available', async () => {

--- a/packages/@sanity/cli/src/commands/backups/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/list.test.ts
@@ -32,6 +32,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -186,6 +187,20 @@ describe('#backup:list', () => {
       message: 'Select the dataset name:',
     })
     expect(stdout).toContain('backup-1')
+  })
+
+  test('should require a dataset in unattended mode', async () => {
+    mockListDatasets.mockResolvedValue([{name: 'production'}])
+
+    const {error} = await testCommand(ListBackupCommand, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe(
+      'Dataset is required in unattended mode. Pass the dataset name as an argument.',
+    )
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockSelect).not.toHaveBeenCalled()
   })
 
   test('should fail with invalid date format', async () => {

--- a/packages/@sanity/cli/src/commands/backups/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/list.test.ts
@@ -197,7 +197,7 @@ describe('#backup:list', () => {
     })
 
     expect(error?.message).toBe(
-      'Dataset is required in unattended mode. Pass the dataset name as an argument.',
+      'Dataset is required in unattended mode. Pass it as the `<dataset>` argument.',
     )
     expect(error?.oclif?.exit).toBe(2)
     expect(mockSelect).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/backups/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/backups/__tests__/list.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -199,7 +200,7 @@ describe('#backup:list', () => {
     expect(error?.message).toBe(
       'Dataset is required in unattended mode. Pass it as the `<dataset>` argument.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockSelect).not.toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/commands/backups/disable.ts
+++ b/packages/@sanity/cli/src/commands/backups/disable.ts
@@ -73,6 +73,10 @@ export class DisableBackupCommand extends SanityCommand<typeof DisableBackupComm
 
     if (dataset) {
       assertDatasetExists(datasets, dataset, this.output)
+    } else if (this.isUnattended()) {
+      this.error('Dataset is required in unattended mode. Pass the dataset name as an argument.', {
+        exit: 2,
+      })
     } else {
       dataset = await this.promptForDataset(datasets)
     }

--- a/packages/@sanity/cli/src/commands/backups/disable.ts
+++ b/packages/@sanity/cli/src/commands/backups/disable.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Args} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 import {type DatasetsResponse} from '@sanity/client'
 
@@ -74,8 +74,8 @@ export class DisableBackupCommand extends SanityCommand<typeof DisableBackupComm
     if (dataset) {
       assertDatasetExists(datasets, dataset, this.output)
     } else if (this.isUnattended()) {
-      this.error('Dataset is required in unattended mode. Pass the dataset name as an argument.', {
-        exit: 2,
+      this.error('Dataset is required in unattended mode. Pass it as the `<dataset>` argument.', {
+        exit: exitCodes.USAGE_ERROR,
       })
     } else {
       dataset = await this.promptForDataset(datasets)

--- a/packages/@sanity/cli/src/commands/backups/download.ts
+++ b/packages/@sanity/cli/src/commands/backups/download.ts
@@ -224,10 +224,7 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
     docOutStream.end()
     await finished(docOutStream)
 
-    progressSpinner.set({
-      step: `Archiving files into a tarball...`,
-      update: true,
-    })
+    progressSpinner.set({step: `Archiving files into a tarball...`, update: true})
     try {
       await archiveDir(tmpOutDir, outFilePath, (processedBytes: number) => {
         progressSpinner.update({
@@ -258,15 +255,14 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
       return path.resolve(this.flags.out)
     }
 
+    const workDir = process.cwd()
+    const defaultPath = path.join(workDir, defaultOutFileName)
     if (this.isUnattended()) {
-      this.error('Output path is required in unattended mode. Pass it with --out <path>.', {
-        exit: 2,
-      })
+      return defaultPath
     }
 
-    const workDir = process.cwd()
     const inputResult = await input({
-      default: path.join(workDir, defaultOutFileName),
+      default: defaultPath,
       message: 'Output path:',
     })
     return path.resolve(inputResult)
@@ -294,7 +290,7 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
       'concurrency' in this.flags &&
       (this.flags.concurrency < 1 || this.flags.concurrency > MAX_DOWNLOAD_CONCURRENCY)
     ) {
-      this.error(`concurrency should be in 1 to ${MAX_DOWNLOAD_CONCURRENCY} range`, {exit: 2})
+      this.error(`--concurrency must be between 1 and ${MAX_DOWNLOAD_CONCURRENCY}.`, {exit: 2})
     }
 
     const defaultOutFileName = `${datasetName}-backup-${backupId}.tar.gz`

--- a/packages/@sanity/cli/src/commands/backups/download.ts
+++ b/packages/@sanity/cli/src/commands/backups/download.ts
@@ -6,7 +6,7 @@ import {finished} from 'node:stream/promises'
 import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 import {boxen, confirm, input, select} from '@sanity/cli-core/ux'
 import {type DatasetsResponse} from '@sanity/client'
 import pMap from 'p-map'
@@ -105,14 +105,14 @@ export class DownloadBackupCommand extends SanityCommand<typeof DownloadBackupCo
       const errors: string[] = []
 
       if (!dataset) {
-        errors.push('Dataset is required in unattended mode. Pass the dataset name as an argument.')
+        errors.push('Dataset is required in unattended mode. Pass it as the `<dataset>` argument.')
       }
       if (!flags['backup-id']) {
-        errors.push('Backup ID is required in unattended mode. Pass it with --backup-id <id>.')
+        errors.push('Backup ID is required in unattended mode. Pass it with `--backup-id <id>`.')
       }
 
       if (errors.length > 0) {
-        this.error(formatCliErrorMessages(errors), {exit: 2})
+        this.error(formatCliErrorMessages(errors), {exit: exitCodes.USAGE_ERROR})
       }
     }
 
@@ -297,7 +297,9 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
       'concurrency' in this.flags &&
       (this.flags.concurrency < 1 || this.flags.concurrency > MAX_DOWNLOAD_CONCURRENCY)
     ) {
-      this.error(`--concurrency must be between 1 and ${MAX_DOWNLOAD_CONCURRENCY}.`, {exit: 2})
+      this.error(`\`--concurrency\` must be between 1 and ${MAX_DOWNLOAD_CONCURRENCY}.`, {
+        exit: exitCodes.USAGE_ERROR,
+      })
     }
 
     const defaultOutFileName = `${datasetName}-backup-${backupId}.tar.gz`
@@ -315,7 +317,9 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
     // If the file already exists, ask for confirmation if it should be overwritten.
     if (!this.flags.overwrite && exists) {
       if (this.isUnattended()) {
-        this.error(`File "${out}" already exists. Pass --overwrite to replace it.`, {exit: 2})
+        this.error(`File "${out}" already exists. Pass \`--overwrite\` to replace it.`, {
+          exit: exitCodes.USAGE_ERROR,
+        })
       }
       const shouldOverwrite = await confirm({
         default: false,
@@ -324,7 +328,7 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
 
       // If the user does not want to overwrite the file, cancel the operation.
       if (!shouldOverwrite) {
-        this.error('Operation cancelled.', {exit: 3})
+        this.error('Operation cancelled.', {exit: exitCodes.USER_ABORT})
       }
     }
 

--- a/packages/@sanity/cli/src/commands/backups/download.ts
+++ b/packages/@sanity/cli/src/commands/backups/download.ts
@@ -123,6 +123,10 @@ export class DownloadBackupCommand extends SanityCommand<typeof DownloadBackupCo
 
     if (dataset) {
       assertDatasetExists(datasets, dataset, this.output)
+    } else if (this.isUnattended()) {
+      this.error('Dataset is required in unattended mode. Pass the dataset name as an argument.', {
+        exit: 2,
+      })
     } else {
       dataset = await promptForDataset({allowCreation: false, datasets})
     }
@@ -220,7 +224,10 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
     docOutStream.end()
     await finished(docOutStream)
 
-    progressSpinner.set({step: `Archiving files into a tarball...`, update: true})
+    progressSpinner.set({
+      step: `Archiving files into a tarball...`,
+      update: true,
+    })
     try {
       await archiveDir(tmpOutDir, outFilePath, (processedBytes: number) => {
         progressSpinner.update({
@@ -251,6 +258,12 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
       return path.resolve(this.flags.out)
     }
 
+    if (this.isUnattended()) {
+      this.error('Output path is required in unattended mode. Pass it with --out <path>.', {
+        exit: 2,
+      })
+    }
+
     const workDir = process.cwd()
     const inputResult = await input({
       default: path.join(workDir, defaultOutFileName),
@@ -268,6 +281,11 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
       this.error(err, {exit: 1})
     }
 
+    if (!this.flags['backup-id'] && this.isUnattended()) {
+      this.error('Backup ID is required in unattended mode. Pass it with --backup-id <id>.', {
+        exit: 2,
+      })
+    }
     const backupId = String(
       this.flags['backup-id'] || (await this.promptForBackupId(projectId, datasetName)),
     )
@@ -276,7 +294,7 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
       'concurrency' in this.flags &&
       (this.flags.concurrency < 1 || this.flags.concurrency > MAX_DOWNLOAD_CONCURRENCY)
     ) {
-      this.error(`concurrency should be in 1 to ${MAX_DOWNLOAD_CONCURRENCY} range`, {exit: 1})
+      this.error(`concurrency should be in 1 to ${MAX_DOWNLOAD_CONCURRENCY} range`, {exit: 2})
     }
 
     const defaultOutFileName = `${datasetName}-backup-${backupId}.tar.gz`
@@ -293,6 +311,9 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
     )
     // If the file already exists, ask for confirmation if it should be overwritten.
     if (!this.flags.overwrite && exists) {
+      if (this.isUnattended()) {
+        this.error(`File "${out}" already exists. Pass --overwrite to replace it.`, {exit: 2})
+      }
       const shouldOverwrite = await confirm({
         default: false,
         message: `File "${out}" already exists, would you like to overwrite it?`,
@@ -300,7 +321,7 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
 
       // If the user does not want to overwrite the file, cancel the operation.
       if (!shouldOverwrite) {
-        this.error('Operation cancelled.', {exit: 1})
+        this.error('Operation cancelled.', {exit: 3})
       }
     }
 

--- a/packages/@sanity/cli/src/commands/backups/download.ts
+++ b/packages/@sanity/cli/src/commands/backups/download.ts
@@ -25,6 +25,7 @@ import {promptForDataset} from '../../prompts/promptForDataset.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {type BackupItem, listBackups} from '../../services/backup.js'
 import {listDatasets} from '../../services/datasets.js'
+import {formatCliErrorMessages} from '../../util/formatCliErrorMessages.js'
 import {humanFileSize} from '../../util/humanFileSize.js'
 import {isPathDirName} from '../../util/isPathDirName.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
@@ -97,8 +98,23 @@ export class DownloadBackupCommand extends SanityCommand<typeof DownloadBackupCo
   static override hiddenAliases: string[] = ['backup:download']
 
   public async run(): Promise<void> {
-    const {args} = await this.parse(DownloadBackupCommand)
+    const {args, flags} = await this.parse(DownloadBackupCommand)
     let {dataset} = args
+
+    if (this.isUnattended()) {
+      const errors: string[] = []
+
+      if (!dataset) {
+        errors.push('Dataset is required in unattended mode. Pass the dataset name as an argument.')
+      }
+      if (!flags['backup-id']) {
+        errors.push('Backup ID is required in unattended mode. Pass it with --backup-id <id>.')
+      }
+
+      if (errors.length > 0) {
+        this.error(formatCliErrorMessages(errors), {exit: 2})
+      }
+    }
 
     const projectId = await this.getProjectId({
       fallback: () =>
@@ -123,10 +139,6 @@ export class DownloadBackupCommand extends SanityCommand<typeof DownloadBackupCo
 
     if (dataset) {
       assertDatasetExists(datasets, dataset, this.output)
-    } else if (this.isUnattended()) {
-      this.error('Dataset is required in unattended mode. Pass the dataset name as an argument.', {
-        exit: 2,
-      })
     } else {
       dataset = await promptForDataset({allowCreation: false, datasets})
     }
@@ -277,11 +289,6 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
       this.error(err, {exit: 1})
     }
 
-    if (!this.flags['backup-id'] && this.isUnattended()) {
-      this.error('Backup ID is required in unattended mode. Pass it with --backup-id <id>.', {
-        exit: 2,
-      })
-    }
     const backupId = String(
       this.flags['backup-id'] || (await this.promptForBackupId(projectId, datasetName)),
     )

--- a/packages/@sanity/cli/src/commands/backups/enable.ts
+++ b/packages/@sanity/cli/src/commands/backups/enable.ts
@@ -76,6 +76,10 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
 
     if (dataset) {
       assertDatasetExists(datasets, dataset, this.output)
+    } else if (this.isUnattended()) {
+      this.error('Dataset is required in unattended mode. Pass the dataset name as an argument.', {
+        exit: 2,
+      })
     } else {
       dataset = await promptForDataset({allowCreation: true, datasets})
 
@@ -93,7 +97,9 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
           enableBackupDebug(`Failed to create dataset ${newDatasetName}: ${message}`, error)
-          this.error(`Failed to create dataset ${newDatasetName}: ${message}`, {exit: 1})
+          this.error(`Failed to create dataset ${newDatasetName}: ${message}`, {
+            exit: 1,
+          })
         }
       }
     }

--- a/packages/@sanity/cli/src/commands/backups/enable.ts
+++ b/packages/@sanity/cli/src/commands/backups/enable.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Args} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {type DatasetsResponse} from '@sanity/client'
 
 import {assertDatasetExists} from '../../actions/backup/assertDatasetExist.js'
@@ -77,8 +77,8 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
     if (dataset) {
       assertDatasetExists(datasets, dataset, this.output)
     } else if (this.isUnattended()) {
-      this.error('Dataset is required in unattended mode. Pass the dataset name as an argument.', {
-        exit: 2,
+      this.error('Dataset is required in unattended mode. Pass it as the `<dataset>` argument.', {
+        exit: exitCodes.USAGE_ERROR,
       })
     } else {
       dataset = await promptForDataset({allowCreation: true, datasets})

--- a/packages/@sanity/cli/src/commands/backups/enable.ts
+++ b/packages/@sanity/cli/src/commands/backups/enable.ts
@@ -97,9 +97,7 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
           enableBackupDebug(`Failed to create dataset ${newDatasetName}: ${message}`, error)
-          this.error(`Failed to create dataset ${newDatasetName}: ${message}`, {
-            exit: 1,
-          })
+          this.error(`Failed to create dataset ${newDatasetName}: ${message}`, {exit: 1})
         }
       }
     }

--- a/packages/@sanity/cli/src/commands/backups/list.ts
+++ b/packages/@sanity/cli/src/commands/backups/list.ts
@@ -1,5 +1,5 @@
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 import {type DatasetsResponse} from '@sanity/client'
 import {Table} from 'console-table-printer'
@@ -101,8 +101,8 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
     if (dataset) {
       assertDatasetExists(datasets, dataset, this.output)
     } else if (this.isUnattended()) {
-      this.error('Dataset is required in unattended mode. Pass the dataset name as an argument.', {
-        exit: 2,
+      this.error('Dataset is required in unattended mode. Pass it as the `<dataset>` argument.', {
+        exit: exitCodes.USAGE_ERROR,
       })
     } else {
       dataset = await this.promptForDataset(datasets)

--- a/packages/@sanity/cli/src/commands/backups/list.ts
+++ b/packages/@sanity/cli/src/commands/backups/list.ts
@@ -100,6 +100,10 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
 
     if (dataset) {
       assertDatasetExists(datasets, dataset, this.output)
+    } else if (this.isUnattended()) {
+      this.error('Dataset is required in unattended mode. Pass the dataset name as an argument.', {
+        exit: 2,
+      })
     } else {
       dataset = await this.promptForDataset(datasets)
     }

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -95,15 +95,9 @@ describe('#dataset:copy', () => {
     })
 
     test.each([
-      {
-        desc: '--list with --attach',
-        flags: ['--list', '--attach', 'job-123'],
-      },
+      {desc: '--list with --attach', flags: ['--list', '--attach', 'job-123']},
       {desc: '--list with --detach', flags: ['--list', '--detach']},
-      {
-        desc: '--attach with --detach',
-        flags: ['--attach', 'job-123', '--detach'],
-      },
+      {desc: '--attach with --detach', flags: ['--attach', 'job-123', '--detach']},
     ])('errors when using mutually exclusive flags: $desc', async ({flags}) => {
       await expect(CopyDatasetCommand.run(flags)).rejects.toThrow(
         expect.objectContaining({

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -84,8 +84,8 @@ describe('#dataset:copy', () => {
       })
 
       await expect(CopyDatasetCommand.run([])).rejects.toThrow(
-        'Source dataset is required. Pass it as the first argument.\n' +
-          'Error: Target dataset is required. Pass it as the second argument.',
+        'Source dataset is required. Pass it as the `<source>` argument.\n' +
+          'Error: Target dataset is required. Pass it as the `<target>` argument.',
       )
       expect(mocks.SanityCmdGetProjectId).not.toHaveBeenCalled()
       expect(mockListDatasets).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
 import {spinnerText} from '@sanity/cli-test/mocks/cli-core/ux'
 import {of} from 'rxjs'
@@ -302,7 +303,7 @@ describe('#dataset:copy', () => {
         args: ['Invalid-Dataset', 'backup'],
         description: 'source dataset name is invalid',
         expectedError: 'must be all lowercase',
-        expectedExit: 2,
+        expectedExit: exitCodes.USAGE_ERROR,
         setupMocks: () => {
           mockValidateDatasetName.mockReturnValue('must be all lowercase')
         },
@@ -311,7 +312,7 @@ describe('#dataset:copy', () => {
         args: ['nonexistent', 'backup'],
         description: 'source dataset does not exist',
         expectedError: 'Source dataset "nonexistent" doesn\'t exist',
-        expectedExit: 1,
+        expectedExit: exitCodes.RUNTIME_ERROR,
         setupMocks: () => {
           mockListDatasets.mockResolvedValue([
             createMockDataset('production'),
@@ -323,7 +324,7 @@ describe('#dataset:copy', () => {
         args: ['production', 'Invalid-Dataset'],
         description: 'target dataset name is invalid',
         expectedError: 'must be all lowercase',
-        expectedExit: 2,
+        expectedExit: exitCodes.USAGE_ERROR,
         setupMocks: () => {
           mockValidateDatasetName.mockImplementationOnce(() => undefined)
           mockValidateDatasetName.mockImplementationOnce(() => 'must be all lowercase')
@@ -337,7 +338,7 @@ describe('#dataset:copy', () => {
         args: ['production', 'staging'],
         description: 'target dataset already exists',
         expectedError: 'Target dataset "staging" already exists',
-        expectedExit: 1,
+        expectedExit: exitCodes.RUNTIME_ERROR,
         setupMocks: () => {
           mockListDatasets.mockResolvedValue([
             createMockDataset('production'),

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -77,10 +77,33 @@ describe('#dataset:copy', () => {
   })
 
   describe('flag validation', () => {
+    test('requires source and target datasets in unattended mode', async () => {
+      mocks.SanityCmdIsUnattended.mockReturnValue(true)
+      mockListDatasets.mockResolvedValue([createMockDataset('production')])
+      vi.mocked(mocks.SanityCmdOutput.error).mockImplementation((message) => {
+        throw new Error(String(message))
+      })
+
+      await expect(CopyDatasetCommand.run([])).rejects.toThrow('Source dataset is required')
+      expect(mockPromptForDataset).not.toHaveBeenCalled()
+
+      await expect(CopyDatasetCommand.run(['production'])).rejects.toThrow(
+        'Target dataset is required',
+      )
+      expect(mockPromptForDatasetName).not.toHaveBeenCalled()
+      vi.mocked(mocks.SanityCmdOutput.error).mockImplementation(() => undefined as never)
+    })
+
     test.each([
-      {desc: '--list with --attach', flags: ['--list', '--attach', 'job-123']},
+      {
+        desc: '--list with --attach',
+        flags: ['--list', '--attach', 'job-123'],
+      },
       {desc: '--list with --detach', flags: ['--list', '--detach']},
-      {desc: '--attach with --detach', flags: ['--attach', 'job-123', '--detach']},
+      {
+        desc: '--attach with --detach',
+        flags: ['--attach', 'job-123', '--detach'],
+      },
     ])('errors when using mutually exclusive flags: $desc', async ({flags}) => {
       await expect(CopyDatasetCommand.run(flags)).rejects.toThrow(
         expect.objectContaining({
@@ -279,6 +302,7 @@ describe('#dataset:copy', () => {
         args: ['Invalid-Dataset', 'backup'],
         description: 'source dataset name is invalid',
         expectedError: 'must be all lowercase',
+        expectedExit: 2,
         setupMocks: () => {
           mockValidateDatasetName.mockReturnValue('must be all lowercase')
         },
@@ -287,6 +311,7 @@ describe('#dataset:copy', () => {
         args: ['nonexistent', 'backup'],
         description: 'source dataset does not exist',
         expectedError: 'Source dataset "nonexistent" doesn\'t exist',
+        expectedExit: 1,
         setupMocks: () => {
           mockListDatasets.mockResolvedValue([
             createMockDataset('production'),
@@ -298,6 +323,7 @@ describe('#dataset:copy', () => {
         args: ['production', 'Invalid-Dataset'],
         description: 'target dataset name is invalid',
         expectedError: 'must be all lowercase',
+        expectedExit: 2,
         setupMocks: () => {
           mockValidateDatasetName.mockImplementationOnce(() => undefined)
           mockValidateDatasetName.mockImplementationOnce(() => 'must be all lowercase')
@@ -311,6 +337,7 @@ describe('#dataset:copy', () => {
         args: ['production', 'staging'],
         description: 'target dataset already exists',
         expectedError: 'Target dataset "staging" already exists',
+        expectedExit: 1,
         setupMocks: () => {
           mockListDatasets.mockResolvedValue([
             createMockDataset('production'),
@@ -318,14 +345,14 @@ describe('#dataset:copy', () => {
           ])
         },
       },
-    ])('errors when $description', async ({args, expectedError, setupMocks}) => {
+    ])('errors when $description', async ({args, expectedError, expectedExit, setupMocks}) => {
       setupMocks()
 
       await CopyDatasetCommand.run(args)
 
       expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
         expect.stringMatching(new RegExp(expectedError)),
-        {exit: 1},
+        {exit: expectedExit},
       )
     })
 

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -79,17 +79,23 @@ describe('#dataset:copy', () => {
   describe('flag validation', () => {
     test('requires source and target datasets in unattended mode', async () => {
       mocks.SanityCmdIsUnattended.mockReturnValue(true)
-      mockListDatasets.mockResolvedValue([createMockDataset('production')])
       vi.mocked(mocks.SanityCmdOutput.error).mockImplementation((message) => {
         throw new Error(String(message))
       })
 
-      await expect(CopyDatasetCommand.run([])).rejects.toThrow('Source dataset is required')
+      await expect(CopyDatasetCommand.run([])).rejects.toThrow(
+        'Source dataset is required. Pass it as the first argument.\n' +
+          'Error: Target dataset is required. Pass it as the second argument.',
+      )
+      expect(mocks.SanityCmdGetProjectId).not.toHaveBeenCalled()
+      expect(mockListDatasets).not.toHaveBeenCalled()
       expect(mockPromptForDataset).not.toHaveBeenCalled()
 
       await expect(CopyDatasetCommand.run(['production'])).rejects.toThrow(
         'Target dataset is required',
       )
+      expect(mocks.SanityCmdGetProjectId).not.toHaveBeenCalled()
+      expect(mockListDatasets).not.toHaveBeenCalled()
       expect(mockPromptForDatasetName).not.toHaveBeenCalled()
       vi.mocked(mocks.SanityCmdOutput.error).mockImplementation(() => undefined as never)
     })

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/create.test.ts
@@ -51,6 +51,7 @@ vi.mock('../../../prompts/promptForProject.js', async () => {
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -116,13 +117,24 @@ describe('#dataset:create', () => {
     expect(stdout).toContain('Dataset created successfully')
   })
 
+  test('requires a dataset name in unattended mode', async () => {
+    const {error} = await testCommand(CreateDatasetCommand, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe('Dataset name is required. Pass it as an argument.')
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockInput).not.toHaveBeenCalled()
+    expect(mockCreateDataset).not.toHaveBeenCalled()
+  })
+
   test('errors when dataset name is invalid', async () => {
     const {error} = await testCommand(CreateDatasetCommand, ['Invalid-Dataset-Name'], {
       mocks: defaultMocks,
     })
 
     expect(error?.message).toContain('must be all lowercase')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('errors when dataset already exists', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/create.test.ts
@@ -122,7 +122,7 @@ describe('#dataset:create', () => {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toBe('Dataset name is required. Pass it as an argument.')
+    expect(error?.message).toBe('Dataset name is required. Pass it as the `<name>` argument.')
     expect(error?.oclif?.exit).toBe(2)
     expect(mockInput).not.toHaveBeenCalled()
     expect(mockCreateDataset).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/create.test.ts
@@ -128,6 +128,27 @@ describe('#dataset:create', () => {
     expect(mockCreateDataset).not.toHaveBeenCalled()
   })
 
+  test('defaults to public visibility in unattended mode', async () => {
+    mockListDatasets.mockResolvedValue([])
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      projectId: testProjectId,
+      uri: '/features',
+    }).reply(200, ['privateDataset'])
+    mockCreateDataset.mockResolvedValue(undefined as never)
+
+    const {error} = await testCommand(CreateDatasetCommand, ['my-dataset'], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error).toBeUndefined()
+    expect(mockSelect).not.toHaveBeenCalled()
+    expect(mockCreateDataset).toHaveBeenCalledWith('my-dataset', {
+      aclMode: 'public',
+    })
+  })
+
   test('errors when dataset name is invalid', async () => {
     const {error} = await testCommand(CreateDatasetCommand, ['Invalid-Dataset-Name'], {
       mocks: defaultMocks,

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/create.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {input, select} from '@sanity/cli-core/ux'
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -123,7 +124,7 @@ describe('#dataset:create', () => {
     })
 
     expect(error?.message).toBe('Dataset name is required. Pass it as the `<name>` argument.')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockInput).not.toHaveBeenCalled()
     expect(mockCreateDataset).not.toHaveBeenCalled()
   })
@@ -155,7 +156,7 @@ describe('#dataset:create', () => {
     })
 
     expect(error?.message).toContain('must be all lowercase')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('errors when dataset already exists', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/delete.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {input} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -107,7 +108,7 @@ describe('#dataset:delete', () => {
     })
 
     expect(error?.message).toBe('Dataset deletion requires confirmation. Re-run with `--force`.')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockInput).not.toHaveBeenCalled()
     expect(mockDeleteDataset).not.toHaveBeenCalled()
   })
@@ -117,7 +118,7 @@ describe('#dataset:delete', () => {
       mocks: defaultMocks,
     })
     expect(commandError?.message).toBe('Dataset name is missing')
-    expect(commandError?.oclif?.exit).toBe(2)
+    expect(commandError?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test.each([

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/delete.test.ts
@@ -82,7 +82,7 @@ describe('#dataset:delete', () => {
     mockDeleteDataset.mockResolvedValue(undefined)
 
     const {stdout} = await testCommand(DeleteDatasetCommand, [TEST_DATASET_NAME], {
-      mocks: defaultMocks,
+      mocks: {...defaultMocks, isInteractive: true},
     })
 
     expect(stdout).toContain(
@@ -96,12 +96,23 @@ describe('#dataset:delete', () => {
     })
   })
 
+  test('requires --force in unattended mode', async () => {
+    const {error} = await testCommand(DeleteDatasetCommand, [TEST_DATASET_NAME], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe('Dataset deletion requires confirmation. Re-run with --force.')
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockInput).not.toHaveBeenCalled()
+    expect(mockDeleteDataset).not.toHaveBeenCalled()
+  })
+
   test('throws error for empty dataset name', async () => {
     const {error: commandError} = await testCommand(DeleteDatasetCommand, ['', '--force'], {
       mocks: defaultMocks,
     })
     expect(commandError?.message).toBe('Dataset name is missing')
-    expect(commandError?.oclif?.exit).toBe(1)
+    expect(commandError?.oclif?.exit).toBe(2)
   })
 
   test.each([
@@ -119,9 +130,21 @@ describe('#dataset:delete', () => {
   })
 
   test.each([
-    {desc: 'when deleting dataset', message: 'Internal Server Error', statusCode: 500},
-    {desc: 'with 404 error when deleting dataset', message: 'Dataset not found', statusCode: 404},
-    {desc: 'with 403 error when deleting dataset', message: 'Forbidden', statusCode: 403},
+    {
+      desc: 'when deleting dataset',
+      message: 'Internal Server Error',
+      statusCode: 500,
+    },
+    {
+      desc: 'with 404 error when deleting dataset',
+      message: 'Dataset not found',
+      statusCode: 404,
+    },
+    {
+      desc: 'with 403 error when deleting dataset',
+      message: 'Forbidden',
+      statusCode: 403,
+    },
   ])('handles API error $desc', async ({message, statusCode}) => {
     const deleteError = new Error(message)
     Object.assign(deleteError, {statusCode})
@@ -165,18 +188,18 @@ describe('#dataset:delete', () => {
     mockInput.mockRejectedValue(new Error('User cancelled'))
 
     const {error} = await testCommand(DeleteDatasetCommand, [TEST_DATASET_NAME], {
-      mocks: defaultMocks,
+      mocks: {...defaultMocks, isInteractive: true},
     })
 
     expect(error?.message).toBe('User cancelled')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBeUndefined()
   })
 
   test('handles project retrieval error', async () => {
     mockGetProjectById.mockRejectedValue(new Error('Project Error'))
 
     const {error} = await testCommand(DeleteDatasetCommand, [TEST_DATASET_NAME], {
-      mocks: defaultMocks,
+      mocks: {...defaultMocks, isInteractive: true},
     })
 
     expect(error?.message).toContain('Project retrieval failed: Project Error')

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/delete.test.ts
@@ -106,7 +106,7 @@ describe('#dataset:delete', () => {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toBe('Dataset deletion requires confirmation. Re-run with --force.')
+    expect(error?.message).toBe('Dataset deletion requires confirmation. Re-run with `--force`.')
     expect(error?.oclif?.exit).toBe(2)
     expect(mockInput).not.toHaveBeenCalled()
     expect(mockDeleteDataset).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/delete.test.ts
@@ -44,6 +44,7 @@ const TEST_PROJECT_ID = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: TEST_PROJECT_ID}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -82,7 +83,7 @@ describe('#dataset:delete', () => {
     mockDeleteDataset.mockResolvedValue(undefined)
 
     const {stdout} = await testCommand(DeleteDatasetCommand, [TEST_DATASET_NAME], {
-      mocks: {...defaultMocks, isInteractive: true},
+      mocks: defaultMocks,
     })
 
     expect(stdout).toContain(
@@ -90,10 +91,14 @@ describe('#dataset:delete', () => {
     )
     expect(stdout).toContain('Dataset deleted successfully\n')
     expect(mockInput).toHaveBeenCalledWith({
-      message:
-        'Are you ABSOLUTELY sure you want to delete this dataset?\n  Type the name of the dataset to confirm delete:',
+      message: `Delete dataset "${TEST_DATASET_NAME}"?\n  Type the dataset name to confirm:`,
       validate: expect.any(Function),
     })
+    const validate = mockInput.mock.calls[0]?.[0].validate
+    expect(await validate?.(TEST_DATASET_NAME)).toBe(true)
+    expect(await validate?.('wrong-dataset')).toBe(
+      `Dataset name doesn't match. Enter "${TEST_DATASET_NAME}" or press Ctrl+C to cancel.`,
+    )
   })
 
   test('requires --force in unattended mode', async () => {
@@ -130,21 +135,9 @@ describe('#dataset:delete', () => {
   })
 
   test.each([
-    {
-      desc: 'when deleting dataset',
-      message: 'Internal Server Error',
-      statusCode: 500,
-    },
-    {
-      desc: 'with 404 error when deleting dataset',
-      message: 'Dataset not found',
-      statusCode: 404,
-    },
-    {
-      desc: 'with 403 error when deleting dataset',
-      message: 'Forbidden',
-      statusCode: 403,
-    },
+    {desc: 'when deleting dataset', message: 'Internal Server Error', statusCode: 500},
+    {desc: 'with 404 error when deleting dataset', message: 'Dataset not found', statusCode: 404},
+    {desc: 'with 403 error when deleting dataset', message: 'Forbidden', statusCode: 403},
   ])('handles API error $desc', async ({message, statusCode}) => {
     const deleteError = new Error(message)
     Object.assign(deleteError, {statusCode})
@@ -188,7 +181,7 @@ describe('#dataset:delete', () => {
     mockInput.mockRejectedValue(new Error('User cancelled'))
 
     const {error} = await testCommand(DeleteDatasetCommand, [TEST_DATASET_NAME], {
-      mocks: {...defaultMocks, isInteractive: true},
+      mocks: defaultMocks,
     })
 
     expect(error?.message).toBe('User cancelled')
@@ -199,7 +192,7 @@ describe('#dataset:delete', () => {
     mockGetProjectById.mockRejectedValue(new Error('Project Error'))
 
     const {error} = await testCommand(DeleteDatasetCommand, [TEST_DATASET_NAME], {
-      mocks: {...defaultMocks, isInteractive: true},
+      mocks: defaultMocks,
     })
 
     expect(error?.message).toContain('Project retrieval failed: Project Error')

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
@@ -72,6 +72,7 @@ const ERROR_MESSAGES = {
 
 const defaultMocks = {
   cliConfig: {api: {dataset: TEST_CONFIG.DATASET, projectId: TEST_CONFIG.PROJECT_ID}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -283,6 +284,7 @@ describe('#dataset:export', () => {
       const {error} = await testCommand(DatasetExportCommand, [], {
         mocks: {
           cliConfigError: new ProjectRootNotFoundError('No project root found'),
+          isInteractive: true,
           token: defaultMocks.token,
         },
       })
@@ -371,7 +373,7 @@ describe('#dataset:export', () => {
 
       expect(error?.message).toContain(ERROR_MESSAGES.ALREADY_EXISTS)
       expect(error?.message).toContain(ERROR_MESSAGES.USE_OVERWRITE)
-      expect(error?.oclif?.exit).toBe(1)
+      expect(error?.oclif?.exit).toBe(2)
     })
 
     test('allows overwrite with flag', async () => {
@@ -548,7 +550,7 @@ describe('#dataset:export', () => {
       )
 
       expect(error?.message).toContain('lowercase')
-      expect(error?.oclif?.exit).toBe(1)
+      expect(error?.oclif?.exit).toBe(2)
     })
 
     test('handles dataset listing errors gracefully', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
@@ -273,9 +273,7 @@ describe('#dataset:export', () => {
         mocks: {...mocks, isInteractive: false},
       })
 
-      expect(error?.message).toBe(
-        'Dataset name is required. Pass it as the first argument.',
-      )
+      expect(error?.message).toBe('Dataset name is required. Pass it as the first argument.')
       expect(error?.oclif?.exit).toBe(2)
       expect(mockSelect).not.toHaveBeenCalled()
       expect(mockInput).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 
 import {type CliConfig, getProjectCliClient, ProjectRootNotFoundError} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {input, select} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
 import {exportDataset, type ExportResult} from '@sanity/export'
@@ -274,7 +275,7 @@ describe('#dataset:export', () => {
       })
 
       expect(error?.message).toBe('Dataset name is required. Pass it as the `<name>` argument.')
-      expect(error?.oclif?.exit).toBe(2)
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
       expect(mockSelect).not.toHaveBeenCalled()
       expect(mockInput).not.toHaveBeenCalled()
     })
@@ -402,7 +403,7 @@ describe('#dataset:export', () => {
 
       expect(error?.message).toContain(ERROR_MESSAGES.ALREADY_EXISTS)
       expect(error?.message).toContain(ERROR_MESSAGES.USE_OVERWRITE)
-      expect(error?.oclif?.exit).toBe(2)
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
 
     test('allows overwrite with flag', async () => {
@@ -579,7 +580,7 @@ describe('#dataset:export', () => {
       )
 
       expect(error?.message).toContain('lowercase')
-      expect(error?.oclif?.exit).toBe(2)
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
 
     test('handles dataset listing errors gracefully', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
@@ -273,7 +273,7 @@ describe('#dataset:export', () => {
         mocks: {...mocks, isInteractive: false},
       })
 
-      expect(error?.message).toBe('Dataset name is required. Pass it as the first argument.')
+      expect(error?.message).toBe('Dataset name is required. Pass it as the `<name>` argument.')
       expect(error?.oclif?.exit).toBe(2)
       expect(mockSelect).not.toHaveBeenCalled()
       expect(mockInput).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/export.test.ts
@@ -266,6 +266,37 @@ describe('#dataset:export', () => {
       )
     })
 
+    test('requires a dataset in unattended mode when no default is configured', async () => {
+      const {mocks} = createTestContext({dataset: null})
+
+      const {error} = await testCommand(DatasetExportCommand, [], {
+        mocks: {...mocks, isInteractive: false},
+      })
+
+      expect(error?.message).toBe(
+        'Dataset name is required. Pass it as the first argument.',
+      )
+      expect(error?.oclif?.exit).toBe(2)
+      expect(mockSelect).not.toHaveBeenCalled()
+      expect(mockInput).not.toHaveBeenCalled()
+    })
+
+    test('uses the default output path in unattended mode', async () => {
+      const {mocks} = createTestContext({datasets: [{name: 'production'}]})
+
+      const {error} = await testCommand(DatasetExportCommand, ['production'], {
+        mocks: {...mocks, isInteractive: false},
+      })
+
+      expect(error).toBeUndefined()
+      expect(mockInput).not.toHaveBeenCalled()
+      expect(mockExportDataset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outputPath: expect.stringMatching(/production\.tar\.gz$/),
+        }),
+      )
+    })
+
     test('prompts for dataset when project was selected via prompt outside a project directory', async () => {
       // Simulates: user is outside a project directory, selects project interactively.
       // getCliConfig() throws ProjectRootNotFoundError for both getProjectId and dataset

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
@@ -247,7 +247,7 @@ describe('#dataset:import', () => {
 
       expect(mockListDatasets).not.toHaveBeenCalled()
       expect(mocks.SanityCmdOutputError).toHaveBeenCalledWith(
-        expect.stringContaining('Missing dataset'),
+        'Dataset is required. Pass it with --dataset <name>.',
         {exit: 2},
       )
     })

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
@@ -1,5 +1,6 @@
 import {Readable} from 'node:stream'
 
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {createMockSanityCommand} from '../../../../test/mockSanityCommand.js'
@@ -248,7 +249,7 @@ describe('#dataset:import', () => {
       expect(mockListDatasets).not.toHaveBeenCalled()
       expect(mocks.SanityCmdOutputError).toHaveBeenCalledWith(
         'Dataset is required. Pass it with `--dataset <name>`.',
-        {exit: 2},
+        {exit: exitCodes.USAGE_ERROR},
       )
     })
 

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
@@ -248,7 +248,7 @@ describe('#dataset:import', () => {
       expect(mockListDatasets).not.toHaveBeenCalled()
       expect(mocks.SanityCmdOutputError).toHaveBeenCalledWith(
         expect.stringContaining('Missing dataset'),
-        {exit: 1},
+        {exit: 2},
       )
     })
 

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
@@ -247,7 +247,7 @@ describe('#dataset:import', () => {
 
       expect(mockListDatasets).not.toHaveBeenCalled()
       expect(mocks.SanityCmdOutputError).toHaveBeenCalledWith(
-        'Dataset is required. Pass it with --dataset <name>.',
+        'Dataset is required. Pass it with `--dataset <name>`.',
         {exit: 2},
       )
     })

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -22,6 +22,7 @@ import {
   listDatasetCopyJobs,
   listDatasets,
 } from '../../services/datasets.js'
+import {formatCliErrorMessages} from '../../util/formatCliErrorMessages.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
 
 const copyDatasetDebug = subdebug('dataset:copy')
@@ -126,6 +127,21 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
 
   public async run(): Promise<void> {
     const {args, flags} = await this.parse(CopyDatasetCommand)
+
+    if (!flags.list && !flags.attach && this.isUnattended()) {
+      const errors: string[] = []
+
+      if (!args.source) {
+        errors.push('Source dataset is required. Pass it as the first argument.')
+      }
+      if (!args.target) {
+        errors.push('Target dataset is required. Pass it as the second argument.')
+      }
+
+      if (errors.length > 0) {
+        this.output.error(formatCliErrorMessages(errors), {exit: 2})
+      }
+    }
 
     const projectId = await this.getProjectId({
       fallback: () =>
@@ -261,9 +277,6 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
 
     // Prompt for source if not provided
     if (!sourceDataset) {
-      if (this.isUnattended()) {
-        this.output.error('Source dataset is required. Pass it as the first argument.', {exit: 2})
-      }
       sourceDataset = await promptForDataset({
         datasets: datasetsResponse,
       })
@@ -281,9 +294,6 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
         return this.output.error(nameError, {exit: 2})
       }
     } else {
-      if (this.isUnattended()) {
-        this.output.error('Target dataset is required. Pass it as the second argument.', {exit: 2})
-      }
       targetDataset = await promptForDatasetName({
         message: 'Target dataset name:',
       })

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -225,20 +225,14 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to attach to copy job: %s', message, error)
-      return this.output.error(`Failed to attach to copy job: ${message}`, {
-        exit: 1,
-      })
+      return this.output.error(`Failed to attach to copy job: ${message}`, {exit: 1})
     }
   }
 
   private async handleCopyMode(
     projectId: string,
     args: {source?: string; target?: string},
-    flags: {
-      detach?: boolean
-      'skip-content-releases'?: boolean
-      'skip-history'?: boolean
-    },
+    flags: {detach?: boolean; 'skip-content-releases'?: boolean; 'skip-history'?: boolean},
   ): Promise<void> {
     copyDatasetDebug('Starting copy mode')
 
@@ -260,9 +254,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to fetch datasets: %s', message, error)
-      return this.output.error(`Failed to fetch datasets: ${message}`, {
-        exit: 1,
-      })
+      return this.output.error(`Failed to fetch datasets: ${message}`, {exit: 1})
     }
 
     const datasetNames = new Set(datasetsResponse.map((ds) => ds.name))
@@ -332,9 +324,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Dataset copying failed: %s', message, error)
-      return this.output.error(`Dataset copying failed: ${message}`, {
-        exit: 1,
-      })
+      return this.output.error(`Dataset copying failed: ${message}`, {exit: 1})
     }
   }
 
@@ -360,9 +350,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to list dataset copy jobs: %s', message, error)
-      return this.output.error(`Failed to list dataset copy jobs: ${message}`, {
-        exit: 1,
-      })
+      return this.output.error(`Failed to list dataset copy jobs: ${message}`, {exit: 1})
     }
   }
 
@@ -376,10 +364,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
         exit(130)
       }
 
-      const subscription = followCopyJobProgress({
-        jobId,
-        projectId,
-      }).subscribe({
+      const subscription = followCopyJobProgress({jobId, projectId}).subscribe({
         complete: () => {
           process.off('SIGINT', sigintHandler)
           spin.succeed('Copy finished.')

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -2,6 +2,7 @@ import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
 import {exit} from '@oclif/core/errors'
+import {exitCodes} from '@sanity/cli-core'
 import {subdebug} from '@sanity/cli-core/debug'
 import {SanityCommand} from '@sanity/cli-core/SanityCommand'
 import {spinner} from '@sanity/cli-core/ux'
@@ -132,14 +133,14 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
       const errors: string[] = []
 
       if (!args.source) {
-        errors.push('Source dataset is required. Pass it as the first argument.')
+        errors.push('Source dataset is required. Pass it as the `<source>` argument.')
       }
       if (!args.target) {
-        errors.push('Target dataset is required. Pass it as the second argument.')
+        errors.push('Target dataset is required. Pass it as the `<target>` argument.')
       }
 
       if (errors.length > 0) {
-        this.output.error(formatCliErrorMessages(errors), {exit: 2})
+        this.output.error(formatCliErrorMessages(errors), {exit: exitCodes.USAGE_ERROR})
       }
     }
 
@@ -260,7 +261,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     if (sourceDataset) {
       const nameError = validateDatasetName(sourceDataset)
       if (nameError) {
-        return this.output.error(nameError, {exit: 2})
+        return this.output.error(nameError, {exit: exitCodes.USAGE_ERROR})
       }
     }
 
@@ -291,7 +292,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     if (targetDataset) {
       const nameError = validateDatasetName(targetDataset)
       if (nameError) {
-        return this.output.error(nameError, {exit: 2})
+        return this.output.error(nameError, {exit: exitCodes.USAGE_ERROR})
       }
     } else {
       targetDataset = await promptForDatasetName({

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -225,14 +225,20 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to attach to copy job: %s', message, error)
-      return this.output.error(`Failed to attach to copy job: ${message}`, {exit: 1})
+      return this.output.error(`Failed to attach to copy job: ${message}`, {
+        exit: 1,
+      })
     }
   }
 
   private async handleCopyMode(
     projectId: string,
     args: {source?: string; target?: string},
-    flags: {detach?: boolean; 'skip-content-releases'?: boolean; 'skip-history'?: boolean},
+    flags: {
+      detach?: boolean
+      'skip-content-releases'?: boolean
+      'skip-history'?: boolean
+    },
   ): Promise<void> {
     copyDatasetDebug('Starting copy mode')
 
@@ -244,7 +250,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     if (sourceDataset) {
       const nameError = validateDatasetName(sourceDataset)
       if (nameError) {
-        return this.output.error(nameError, {exit: 1})
+        return this.output.error(nameError, {exit: 2})
       }
     }
 
@@ -254,13 +260,18 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to fetch datasets: %s', message, error)
-      return this.output.error(`Failed to fetch datasets: ${message}`, {exit: 1})
+      return this.output.error(`Failed to fetch datasets: ${message}`, {
+        exit: 1,
+      })
     }
 
     const datasetNames = new Set(datasetsResponse.map((ds) => ds.name))
 
     // Prompt for source if not provided
     if (!sourceDataset) {
+      if (this.isUnattended()) {
+        this.output.error('Source dataset is required. Pass it as the first argument.', {exit: 2})
+      }
       sourceDataset = await promptForDataset({
         datasets: datasetsResponse,
       })
@@ -275,9 +286,12 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     if (targetDataset) {
       const nameError = validateDatasetName(targetDataset)
       if (nameError) {
-        return this.output.error(nameError, {exit: 1})
+        return this.output.error(nameError, {exit: 2})
       }
     } else {
+      if (this.isUnattended()) {
+        this.output.error('Target dataset is required. Pass it as the second argument.', {exit: 2})
+      }
       targetDataset = await promptForDatasetName({
         message: 'Target dataset name:',
       })
@@ -318,7 +332,9 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Dataset copying failed: %s', message, error)
-      return this.output.error(`Dataset copying failed: ${message}`, {exit: 1})
+      return this.output.error(`Dataset copying failed: ${message}`, {
+        exit: 1,
+      })
     }
   }
 
@@ -344,7 +360,9 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to list dataset copy jobs: %s', message, error)
-      return this.output.error(`Failed to list dataset copy jobs: ${message}`, {exit: 1})
+      return this.output.error(`Failed to list dataset copy jobs: ${message}`, {
+        exit: 1,
+      })
     }
   }
 
@@ -358,7 +376,10 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
         exit(130)
       }
 
-      const subscription = followCopyJobProgress({jobId, projectId}).subscribe({
+      const subscription = followCopyJobProgress({
+        jobId,
+        projectId,
+      }).subscribe({
         complete: () => {
           process.off('SIGINT', sigintHandler)
           spin.succeed('Copy finished.')

--- a/packages/@sanity/cli/src/commands/datasets/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/create.ts
@@ -80,9 +80,14 @@ export class CreateDatasetCommand extends SanityCommand<typeof CreateDatasetComm
     if (datasetName) {
       const nameError = validateDatasetName(datasetName)
       if (nameError) {
-        this.error(nameError, {exit: 1})
+        this.error(nameError, {exit: 2})
       }
     } else {
+      if (this.isUnattended()) {
+        this.error('Dataset name is required. Pass it as an argument.', {
+          exit: 2,
+        })
+      }
       datasetName = await promptForDatasetName()
     }
 
@@ -114,6 +119,7 @@ export class CreateDatasetCommand extends SanityCommand<typeof CreateDatasetComm
         datasetName,
         embeddings: flags.embeddings,
         embeddingsProjection: flags['embeddings-projection'],
+        isUnattended: this.isUnattended(),
         output: this.output,
         projectFeatures,
         projectId,

--- a/packages/@sanity/cli/src/commands/datasets/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/create.ts
@@ -1,5 +1,5 @@
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {createDataset} from '../../actions/dataset/create.js'
 import {validateDatasetName} from '../../actions/dataset/validateDatasetName.js'
@@ -80,12 +80,12 @@ export class CreateDatasetCommand extends SanityCommand<typeof CreateDatasetComm
     if (datasetName) {
       const nameError = validateDatasetName(datasetName)
       if (nameError) {
-        this.error(nameError, {exit: 2})
+        this.error(nameError, {exit: exitCodes.USAGE_ERROR})
       }
     } else {
       if (this.isUnattended()) {
-        this.error('Dataset name is required. Pass it as an argument.', {
-          exit: 2,
+        this.error('Dataset name is required. Pass it as the `<name>` argument.', {
+          exit: exitCodes.USAGE_ERROR,
         })
       }
       datasetName = await promptForDatasetName()

--- a/packages/@sanity/cli/src/commands/datasets/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/delete.ts
@@ -61,12 +61,15 @@ export class DeleteDatasetCommand extends SanityCommand<typeof DeleteDatasetComm
 
     const dsError = validateDatasetName(datasetName)
     if (dsError) {
-      this.error(dsError, {exit: 1})
+      this.error(dsError, {exit: 2})
     }
 
     if (force) {
       this.warn(`'--force' used: skipping confirmation, deleting dataset "${datasetName}"`)
     } else {
+      if (this.isUnattended()) {
+        this.error('Dataset deletion requires confirmation. Re-run with --force.', {exit: 2})
+      }
       try {
         const project = await getProjectById(projectId)
         this.log(
@@ -81,20 +84,14 @@ export class DeleteDatasetCommand extends SanityCommand<typeof DeleteDatasetComm
         this.error(`Project retrieval failed: ${err.message}`, {exit: 1})
       }
 
-      try {
-        await input({
-          message:
-            'Are you ABSOLUTELY sure you want to delete this dataset?\n  Type the name of the dataset to confirm delete:',
-          validate: (input) => {
-            const trimmed = input.trim()
-            return trimmed === datasetName || 'Incorrect dataset name. Ctrl + C to cancel delete.'
-          },
-        })
-      } catch (error) {
-        const err = error instanceof Error ? error : new Error(`${error}`)
-        deleteDatasetDebug(`User cancelled`, err)
-        this.error(`User cancelled`, {exit: 1})
-      }
+      await input({
+        message:
+          'Are you ABSOLUTELY sure you want to delete this dataset?\n  Type the name of the dataset to confirm delete:',
+        validate: (input) => {
+          const trimmed = input.trim()
+          return trimmed === datasetName || 'Incorrect dataset name. Ctrl + C to cancel delete.'
+        },
+      })
     }
 
     try {

--- a/packages/@sanity/cli/src/commands/datasets/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/delete.ts
@@ -85,11 +85,13 @@ export class DeleteDatasetCommand extends SanityCommand<typeof DeleteDatasetComm
       }
 
       await input({
-        message:
-          'Are you ABSOLUTELY sure you want to delete this dataset?\n  Type the name of the dataset to confirm delete:',
+        message: `Delete dataset "${datasetName}"?\n  Type the dataset name to confirm:`,
         validate: (input) => {
           const trimmed = input.trim()
-          return trimmed === datasetName || 'Incorrect dataset name. Ctrl + C to cancel delete.'
+          return (
+            trimmed === datasetName ||
+            `Dataset name doesn't match. Enter "${datasetName}" or press Ctrl+C to cancel.`
+          )
         },
       })
     }

--- a/packages/@sanity/cli/src/commands/datasets/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/delete.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input, logSymbols} from '@sanity/cli-core/ux'
 
 import {validateDatasetName} from '../../actions/dataset/validateDatasetName.js'
@@ -61,14 +61,16 @@ export class DeleteDatasetCommand extends SanityCommand<typeof DeleteDatasetComm
 
     const dsError = validateDatasetName(datasetName)
     if (dsError) {
-      this.error(dsError, {exit: 2})
+      this.error(dsError, {exit: exitCodes.USAGE_ERROR})
     }
 
     if (force) {
       this.warn(`'--force' used: skipping confirmation, deleting dataset "${datasetName}"`)
     } else {
       if (this.isUnattended()) {
-        this.error('Dataset deletion requires confirmation. Re-run with --force.', {exit: 2})
+        this.error('Dataset deletion requires confirmation. Re-run with `--force`.', {
+          exit: exitCodes.USAGE_ERROR,
+        })
       }
       try {
         const project = await getProjectById(projectId)

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import {type Writable} from 'node:stream'
 
 import {Args, Flags} from '@oclif/core'
-import {getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 import {boxen, input, spinner} from '@sanity/cli-core/ux'
 import {type DatasetsResponse} from '@sanity/client'
 import {exportDataset, type ExportOptions, type ExportProgress} from '@sanity/export'
@@ -145,7 +145,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
       } catch (error) {
         exportDebug('Error selecting dataset', error)
         this.error(`Failed to select dataset:\n${error instanceof Error ? error.message : error}`, {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         })
       }
 
@@ -153,7 +153,9 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
         dataset = defaultDataset
         this.log(`Using default dataset: ${dataset}`)
       } else if (this.isUnattended()) {
-        this.error('Dataset name is required. Pass it as the first argument.', {exit: 2})
+        this.error('Dataset name is required. Pass it as the `<name>` argument.', {
+          exit: exitCodes.USAGE_ERROR,
+        })
       } else {
         try {
           dataset = await promptForDataset({allowCreation: false, datasets})
@@ -162,7 +164,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
           this.error(
             `Failed to select dataset:\n${error instanceof Error ? error.message : error}`,
             {
-              exit: 1,
+              exit: exitCodes.RUNTIME_ERROR,
             },
           )
         }
@@ -172,7 +174,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
     // Validate dataset name
     const dsError = validateDatasetName(dataset)
     if (dsError) {
-      this.error(dsError, {exit: 2})
+      this.error(dsError, {exit: exitCodes.USAGE_ERROR})
     }
 
     // Verify existence of dataset before trying to export from it
@@ -306,8 +308,8 @@ dataset: ${dataset.padEnd(46)}`,
     const finalPathStats = await fs.stat(finalPath).catch(noop)
 
     if (!flags.overwrite && finalPathStats && finalPathStats.isFile()) {
-      this.error(`File "${finalPath}" already exists. Pass --overwrite to replace it.`, {
-        exit: 2,
+      this.error(`File "${finalPath}" already exists. Pass \`--overwrite\` to replace it.`, {
+        exit: exitCodes.USAGE_ERROR,
       })
     }
 

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -146,6 +146,9 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
           dataset = defaultDataset
           this.log(`Using default dataset: ${dataset}`)
         } else {
+          if (this.isUnattended()) {
+            this.error('Dataset name is required. Pass it as the first argument.', {exit: 2})
+          }
           dataset = await promptForDataset({allowCreation: false, datasets})
         }
       } catch (error) {
@@ -159,7 +162,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
     // Validate dataset name
     const dsError = validateDatasetName(dataset)
     if (dsError) {
-      this.error(dsError, {exit: 1})
+      this.error(dsError, {exit: 2})
     }
 
     // Verify existence of dataset before trying to export from it
@@ -182,7 +185,9 @@ dataset: ${dataset.padEnd(46)}`,
     // Determine output path
     let destinationPath = targetDestination
     if (!destinationPath) {
-      destinationPath = await this.promptForDestination({dataset})
+      destinationPath = this.isUnattended()
+        ? path.join(process.cwd(), `${dataset}.tar.gz`)
+        : await this.promptForDestination({dataset})
     }
 
     const outputPath = await this.getOutputPath(destinationPath, dataset, flags)
@@ -292,7 +297,7 @@ dataset: ${dataset.padEnd(46)}`,
 
     if (!flags.overwrite && finalPathStats && finalPathStats.isFile()) {
       this.error(`File "${finalPath}" already exists. Use --overwrite flag to overwrite it.`, {
-        exit: 1,
+        exit: 2,
       })
     }
 

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -137,25 +137,32 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
     // Determine dataset name
     let dataset = targetDataset
     if (!dataset) {
+      let defaultDataset: string | undefined
       try {
         // Get default dataset from config (only available when running from a project directory)
         const cliConfig = await this.tryGetCliConfig()
-        const defaultDataset = cliConfig.api?.dataset
-
-        if (defaultDataset) {
-          dataset = defaultDataset
-          this.log(`Using default dataset: ${dataset}`)
-        } else {
-          if (this.isUnattended()) {
-            this.error('Dataset name is required. Pass it as the first argument.', {exit: 2})
-          }
-          dataset = await promptForDataset({allowCreation: false, datasets})
-        }
+        defaultDataset = cliConfig.api?.dataset
       } catch (error) {
         exportDebug('Error selecting dataset', error)
         this.error(`Failed to select dataset:\n${error instanceof Error ? error.message : error}`, {
           exit: 1,
         })
+      }
+
+      if (defaultDataset) {
+        dataset = defaultDataset
+        this.log(`Using default dataset: ${dataset}`)
+      } else if (this.isUnattended()) {
+        this.error('Dataset name is required. Pass it as the first argument.', {exit: 2})
+      } else {
+        try {
+          dataset = await promptForDataset({allowCreation: false, datasets})
+        } catch (error) {
+          exportDebug('Error selecting dataset', error)
+          this.error(`Failed to select dataset:\n${error instanceof Error ? error.message : error}`, {
+            exit: 1,
+          })
+        }
       }
     }
 
@@ -296,7 +303,7 @@ dataset: ${dataset.padEnd(46)}`,
     const finalPathStats = await fs.stat(finalPath).catch(noop)
 
     if (!flags.overwrite && finalPathStats && finalPathStats.isFile()) {
-      this.error(`File "${finalPath}" already exists. Use --overwrite flag to overwrite it.`, {
+      this.error(`File "${finalPath}" already exists. Pass --overwrite to replace it.`, {
         exit: 2,
       })
     }

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -159,9 +159,12 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
           dataset = await promptForDataset({allowCreation: false, datasets})
         } catch (error) {
           exportDebug('Error selecting dataset', error)
-          this.error(`Failed to select dataset:\n${error instanceof Error ? error.message : error}`, {
-            exit: 1,
-          })
+          this.error(
+            `Failed to select dataset:\n${error instanceof Error ? error.message : error}`,
+            {
+              exit: 1,
+            },
+          )
         }
       }
     }

--- a/packages/@sanity/cli/src/commands/datasets/import.ts
+++ b/packages/@sanity/cli/src/commands/datasets/import.ts
@@ -44,10 +44,14 @@ async function getUriStream(uri: string): Promise<NodeJS.ReadableStream> {
   })
 
   try {
-    const response = (await request({stream: true, url: uri})) as {body: NodeJS.ReadableStream}
+    const response = (await request({stream: true, url: uri})) as {
+      body: NodeJS.ReadableStream
+    }
     return response.body
   } catch (err) {
-    throw new Error(`Error fetching source:\n${(err as Error).message}`, {cause: err})
+    throw new Error(`Error fetching source:\n${(err as Error).message}`, {
+      cause: err,
+    })
   }
 }
 
@@ -203,7 +207,7 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
       if (this.isUnattended()) {
         return this.output.error(
           'Missing dataset. Use the --dataset flag to specify a dataset: --dataset <name>',
-          {exit: 1},
+          {exit: 2},
         )
       }
 
@@ -267,7 +271,9 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
       const {numDocs, warnings} = await sanityImport(stream, importOptions)
 
       if (this.stepStart) {
-        const timeSpent = prettyMs(Date.now() - this.stepStart, {secondsDecimalDigits: 2})
+        const timeSpent = prettyMs(Date.now() - this.stepStart, {
+          secondsDecimalDigits: 2,
+        })
         if (this.currentProgress) {
           if (this.spinInterval) {
             clearInterval(this.spinInterval)
@@ -295,7 +301,9 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
             `Import failed due to unicode replacement characters in the data.\n${(err as Error).message}\n\nIf you are certain you want to proceed with the import despite potentially corrupt data, re-run the import with the \`--allow-replacement-characters\` flag set.`,
             {exit: 1},
           )
-        : this.output.error((err as Error).stack || (err as Error).message, {exit: 1})
+        : this.output.error((err as Error).stack || (err as Error).message, {
+            exit: 1,
+          })
     }
   }
 
@@ -315,7 +323,9 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
 
     if (sameStep) {
       if (this.stepStart) {
-        const timeSpent = prettyMs(Date.now() - this.stepStart, {secondsDecimalDigits: 2})
+        const timeSpent = prettyMs(Date.now() - this.stepStart, {
+          secondsDecimalDigits: 2,
+        })
         if (this.currentProgress) {
           this.currentProgress.text = `${percent}${opts.step} (${timeSpent})`
           this.currentProgress.render()

--- a/packages/@sanity/cli/src/commands/datasets/import.ts
+++ b/packages/@sanity/cli/src/commands/datasets/import.ts
@@ -44,14 +44,10 @@ async function getUriStream(uri: string): Promise<NodeJS.ReadableStream> {
   })
 
   try {
-    const response = (await request({stream: true, url: uri})) as {
-      body: NodeJS.ReadableStream
-    }
+    const response = (await request({stream: true, url: uri})) as {body: NodeJS.ReadableStream}
     return response.body
   } catch (err) {
-    throw new Error(`Error fetching source:\n${(err as Error).message}`, {
-      cause: err,
-    })
+    throw new Error(`Error fetching source:\n${(err as Error).message}`, {cause: err})
   }
 }
 
@@ -206,7 +202,7 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
     if (!dataset) {
       if (this.isUnattended()) {
         return this.output.error(
-          'Missing dataset. Use the --dataset flag to specify a dataset: --dataset <name>',
+          'Dataset is required. Pass it with --dataset <name>.',
           {exit: 2},
         )
       }
@@ -271,9 +267,7 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
       const {numDocs, warnings} = await sanityImport(stream, importOptions)
 
       if (this.stepStart) {
-        const timeSpent = prettyMs(Date.now() - this.stepStart, {
-          secondsDecimalDigits: 2,
-        })
+        const timeSpent = prettyMs(Date.now() - this.stepStart, {secondsDecimalDigits: 2})
         if (this.currentProgress) {
           if (this.spinInterval) {
             clearInterval(this.spinInterval)
@@ -301,9 +295,7 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
             `Import failed due to unicode replacement characters in the data.\n${(err as Error).message}\n\nIf you are certain you want to proceed with the import despite potentially corrupt data, re-run the import with the \`--allow-replacement-characters\` flag set.`,
             {exit: 1},
           )
-        : this.output.error((err as Error).stack || (err as Error).message, {
-            exit: 1,
-          })
+        : this.output.error((err as Error).stack || (err as Error).message, {exit: 1})
     }
   }
 
@@ -323,9 +315,7 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
 
     if (sameStep) {
       if (this.stepStart) {
-        const timeSpent = prettyMs(Date.now() - this.stepStart, {
-          secondsDecimalDigits: 2,
-        })
+        const timeSpent = prettyMs(Date.now() - this.stepStart, {secondsDecimalDigits: 2})
         if (this.currentProgress) {
           this.currentProgress.text = `${percent}${opts.step} (${timeSpent})`
           this.currentProgress.render()

--- a/packages/@sanity/cli/src/commands/datasets/import.ts
+++ b/packages/@sanity/cli/src/commands/datasets/import.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import {Args, Flags} from '@oclif/core'
-import {getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 import {createRequester} from '@sanity/cli-core/request'
 import {spinner} from '@sanity/cli-core/ux'
 import {sanityImport} from '@sanity/import'
@@ -201,7 +201,9 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
     let dataset = datasetFlag ?? targetDatasetArg
     if (!dataset) {
       if (this.isUnattended()) {
-        return this.output.error('Dataset is required. Pass it with --dataset <name>.', {exit: 2})
+        return this.output.error('Dataset is required. Pass it with `--dataset <name>`.', {
+          exit: exitCodes.USAGE_ERROR,
+        })
       }
 
       const datasets = await listDatasets(projectId)

--- a/packages/@sanity/cli/src/commands/datasets/import.ts
+++ b/packages/@sanity/cli/src/commands/datasets/import.ts
@@ -201,10 +201,7 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
     let dataset = datasetFlag ?? targetDatasetArg
     if (!dataset) {
       if (this.isUnattended()) {
-        return this.output.error(
-          'Dataset is required. Pass it with --dataset <name>.',
-          {exit: 2},
-        )
+        return this.output.error('Dataset is required. Pass it with --dataset <name>.', {exit: 2})
       }
 
       const datasets = await listDatasets(projectId)


### PR DESCRIPTION
### Description

Adds unattended-mode support for dataset lifecycle commands.

### What to review

Review the flags, prompt handling, and automated coverage.

### Testing

<!-- To be completed before marking ready. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches destructive flows (delete, copy, export/import) and backup download overwrite behavior; unattended mode makes misuse easier in automation but adds explicit guards and `--force` for delete.
> 
> **Overview**
> Adds **unattended (non-interactive) behavior** across dataset and backup CLI commands so CI/scripts can run without prompts.
> 
> When `isUnattended()` is true, commands **fail fast with `USAGE_ERROR`** (and clearer messages) instead of calling `select`/`input`/`confirm`—e.g. required `<dataset>`, `--backup-id`, `--dataset`, source/target for copy, dataset name for create, and **`--force` for delete**. **Export** and **backup download** pick **deterministic default output paths** under `cwd` when `--out` is omitted; existing output files require **`--overwrite`** rather than a confirm prompt. Interactive cancel on backup overwrite now uses **`USER_ABORT`**.
> 
> Validation and usage mistakes increasingly exit with **`exitCodes.USAGE_ERROR`** instead of generic `exit: 1`. **Delete** refreshes the type-to-confirm prompt copy; user cancel during confirm no longer forces exit code 1.
> 
> Tests are extended with `isInteractive: false` / `isUnattended` mocks for the new paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4cdfd5c673f2bfb4eb31f57d35a79aa2cecce34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->