### PR TITLE
feat(cli): support unattended mode in advanced dataset commands

### DIFF
--- a/.changeset/pr-1498.md
+++ b/.changeset/pr-1498.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): support unattended mode in advanced dataset commands

--- a/.changeset/pr-1498.md
+++ b/.changeset/pr-1498.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-feat(cli): support unattended mode in advanced dataset commands

--- a/.changeset/tidy-datasets-listen.md
+++ b/.changeset/tidy-datasets-listen.md
@@ -1,0 +1,7 @@
+---
+'@sanity/cli': minor
+---
+
+Prevent dataset alias and embeddings commands from opening prompts in unattended environments. Missing alias or dataset arguments and required confirmations now report actionable usage errors, while alias creation without a target dataset creates an unlinked alias.
+
+Invalid alias names, dataset names, embeddings projections, and dataset visibility inputs now use the CLI's usage-error exit code.

--- a/.changeset/tidy-datasets-listen.md
+++ b/.changeset/tidy-datasets-listen.md
@@ -2,6 +2,7 @@
 '@sanity/cli': minor
 ---
 
-Prevent dataset alias and embeddings commands from opening prompts in unattended environments. Missing alias or dataset arguments and required confirmations now report actionable usage errors, while alias creation without a target dataset creates an unlinked alias.
+feat(cli): support unattended mode in advanced dataset commands
 
-Invalid alias names, dataset names, embeddings projections, and dataset visibility inputs now use the CLI's usage-error exit code.
+Return usage errors instead of prompting for missing alias, dataset, confirmation, or embeddings
+values, while allowing unlinked aliases without a target dataset.

--- a/packages/@sanity/cli/src/actions/dataset/resolveDataset.ts
+++ b/packages/@sanity/cli/src/actions/dataset/resolveDataset.ts
@@ -12,6 +12,7 @@ interface ResolveDatasetOptions {
   projectId: string
 
   dataset?: string
+  isUnattended?: boolean
 }
 
 interface ResolveDatasetResult {
@@ -26,6 +27,7 @@ interface ResolveDatasetResult {
  */
 export async function resolveDataset({
   dataset,
+  isUnattended,
   output,
   projectId,
 }: ResolveDatasetOptions): Promise<ResolveDatasetResult> {
@@ -38,6 +40,7 @@ export async function resolveDataset({
   if (dataset) {
     assertDatasetExists(datasets, dataset, output)
   } else {
+    if (isUnattended) output.error('Dataset name is required. Pass it as an argument.', {exit: 2})
     dataset = await promptForDataset({datasets})
   }
 

--- a/packages/@sanity/cli/src/actions/dataset/resolveDataset.ts
+++ b/packages/@sanity/cli/src/actions/dataset/resolveDataset.ts
@@ -1,4 +1,4 @@
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {type DatasetsResponse} from '@sanity/client'
 
 import {promptForDataset} from '../../prompts/promptForDataset.js'
@@ -32,7 +32,9 @@ export async function resolveDataset({
   projectId,
 }: ResolveDatasetOptions): Promise<ResolveDatasetResult> {
   if (!dataset && isUnattended) {
-    output.error('Dataset name is required. Pass it as an argument.', {exit: 2})
+    output.error('Dataset name is required. Pass it as the `<dataset>` argument.', {
+      exit: exitCodes.USAGE_ERROR,
+    })
   }
 
   const datasets = await listDatasets(projectId)

--- a/packages/@sanity/cli/src/actions/dataset/resolveDataset.ts
+++ b/packages/@sanity/cli/src/actions/dataset/resolveDataset.ts
@@ -31,6 +31,10 @@ export async function resolveDataset({
   output,
   projectId,
 }: ResolveDatasetOptions): Promise<ResolveDatasetResult> {
+  if (!dataset && isUnattended) {
+    output.error('Dataset name is required. Pass it as an argument.', {exit: 2})
+  }
+
   const datasets = await listDatasets(projectId)
 
   if (datasets.length === 0) {
@@ -40,7 +44,6 @@ export async function resolveDataset({
   if (dataset) {
     assertDatasetExists(datasets, dataset, output)
   } else {
-    if (isUnattended) output.error('Dataset name is required. Pass it as an argument.', {exit: 2})
     dataset = await promptForDataset({datasets})
   }
 

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/create.test.ts
@@ -166,7 +166,9 @@ describe('#dataset:alias:create', () => {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toBe('Dataset alias name is required. Pass it as the first argument.')
+    expect(error?.message).toBe(
+      'Dataset alias name is required. Pass it as the `<aliasName>` argument.',
+    )
     expect(error?.oclif?.exit).toBe(2)
     expect(mockListDatasets).not.toHaveBeenCalled()
     expect(mockSelect).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/create.test.ts
@@ -1,3 +1,4 @@
+import {select} from '@sanity/cli-core/ux'
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -34,8 +35,17 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
   }
 })
 
+vi.mock('@sanity/cli-core/ux', async () => {
+  const actual = await vi.importActual<typeof import('@sanity/cli-core/ux')>('@sanity/cli-core/ux')
+  return {
+    ...actual,
+    select: vi.fn(),
+  }
+})
+
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -43,6 +53,8 @@ const defaultMocks = {
   },
   token: testToken,
 }
+
+const mockSelect = vi.mocked(select)
 
 describe('#dataset:alias:create', () => {
   afterEach(() => {
@@ -115,6 +127,51 @@ describe('#dataset:alias:create', () => {
     const {stdout} = await testCommand(CreateAliasCommand, ['test-alias'], {mocks: defaultMocks})
 
     expect(stdout).toContain('Dataset alias ~test-alias created successfully')
+  })
+
+  test('creates an unlinked alias without prompting in unattended mode', async () => {
+    mockListDatasets.mockResolvedValue([{name: 'production'} as never])
+
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      projectId: testProjectId,
+      uri: `/features`,
+    }).reply(200, ['advancedDatasetManagement'])
+
+    mockApi({
+      apiVersion: DATASET_API_VERSION,
+      method: 'get',
+      projectId: testProjectId,
+      uri: `/aliases`,
+    }).reply(200, [])
+
+    mockApi({
+      apiVersion: DATASET_API_VERSION,
+      method: 'put',
+      projectId: testProjectId,
+      uri: `/aliases/test-alias`,
+    }).reply(200, {aliasName: 'test-alias', datasetName: null})
+
+    const {stdout} = await testCommand(CreateAliasCommand, ['test-alias'], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(stdout).toContain('Dataset alias ~test-alias created successfully')
+    expect(mockSelect).not.toHaveBeenCalled()
+  })
+
+  test('requires an alias name in unattended mode', async () => {
+    const {error} = await testCommand(CreateAliasCommand, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe(
+      'Dataset alias name is required. Pass it as the first argument.',
+    )
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockListDatasets).not.toHaveBeenCalled()
+    expect(mockSelect).not.toHaveBeenCalled()
   })
 
   test('fails when alias already exists', async () => {
@@ -234,18 +291,9 @@ describe('#dataset:alias:create', () => {
     ['a', 'production', 'Alias name must be at least two characters long'],
     ['test-alias', 'Invalid Dataset', 'Dataset name must be all lowercase characters'],
   ])('fails with invalid input: alias=%s, dataset=%s', async (alias, dataset, expectedError) => {
-    mockListDatasets.mockResolvedValue([{name: 'production'} as never])
-
-    mockApi({
-      apiVersion: PROJECT_FEATURES_API_VERSION,
-      method: 'get',
-      projectId: testProjectId,
-      uri: `/features`,
-    }).reply(200, ['advancedDatasetManagement'])
-
     const {error} = await testCommand(CreateAliasCommand, [alias, dataset], {mocks: defaultMocks})
 
     expect(error?.message).toContain(expectedError)
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 })

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/create.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {select} from '@sanity/cli-core/ux'
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -169,7 +170,7 @@ describe('#dataset:alias:create', () => {
     expect(error?.message).toBe(
       'Dataset alias name is required. Pass it as the `<aliasName>` argument.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockListDatasets).not.toHaveBeenCalled()
     expect(mockSelect).not.toHaveBeenCalled()
   })
@@ -294,6 +295,6 @@ describe('#dataset:alias:create', () => {
     const {error} = await testCommand(CreateAliasCommand, [alias, dataset], {mocks: defaultMocks})
 
     expect(error?.message).toContain(expectedError)
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 })

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/create.test.ts
@@ -166,9 +166,7 @@ describe('#dataset:alias:create', () => {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toBe(
-      'Dataset alias name is required. Pass it as the first argument.',
-    )
+    expect(error?.message).toBe('Dataset alias name is required. Pass it as the first argument.')
     expect(error?.oclif?.exit).toBe(2)
     expect(mockListDatasets).not.toHaveBeenCalled()
     expect(mockSelect).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/delete.test.ts
@@ -23,6 +23,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -91,6 +92,24 @@ describe('#dataset:alias:delete', () => {
 
     expect(stderr).toContain("'--force' used: skipping confirmation")
     expect(stdout).toContain('Dataset alias deleted successfully')
+    expect(mockInput).not.toHaveBeenCalled()
+  })
+
+  test('requires --force instead of prompting in unattended mode', async () => {
+    mockApi({
+      apiVersion: DATASET_ALIASES_API_VERSION,
+      projectId: testProjectId,
+      uri: '/aliases',
+    }).reply(200, [{datasetName: 'production', name: 'test-alias'}])
+
+    const {error} = await testCommand(DeleteAliasCommand, ['test-alias'], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe(
+      'Dataset alias deletion requires confirmation. Re-run with --force.',
+    )
+    expect(error?.oclif?.exit).toBe(2)
     expect(mockInput).not.toHaveBeenCalled()
   })
 
@@ -172,7 +191,7 @@ describe('#dataset:alias:delete', () => {
     })
 
     expect(error?.message).toContain('Alias name must be at least two characters long')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('fails when no project ID available', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/delete.test.ts
@@ -1,4 +1,5 @@
 import {NonInteractiveError} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {input} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -109,7 +110,7 @@ describe('#dataset:alias:delete', () => {
     expect(error?.message).toBe(
       'Dataset alias deletion requires confirmation. Re-run with `--force`.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockInput).not.toHaveBeenCalled()
   })
 
@@ -191,7 +192,7 @@ describe('#dataset:alias:delete', () => {
     })
 
     expect(error?.message).toContain('Alias name must be at least two characters long')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('fails when no project ID available', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/delete.test.ts
@@ -107,7 +107,7 @@ describe('#dataset:alias:delete', () => {
     })
 
     expect(error?.message).toBe(
-      'Dataset alias deletion requires confirmation. Re-run with --force.',
+      'Dataset alias deletion requires confirmation. Re-run with `--force`.',
     )
     expect(error?.oclif?.exit).toBe(2)
     expect(mockInput).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/link.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/link.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -120,7 +121,7 @@ describe('#dataset:alias:link', () => {
     expect(error?.message).toBe(
       'Relinking a dataset alias requires confirmation. Re-run with `--force`.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('requires all arguments in unattended mode', async () => {
@@ -136,7 +137,7 @@ describe('#dataset:alias:link', () => {
       'Dataset alias name is required. Pass it as the `<aliasName>` argument.\n' +
         'Error: Target dataset is required. Pass it as the `<targetDataset>` argument.',
     )
-    expect(missingBoth.error?.oclif?.exit).toBe(2)
+    expect(missingBoth.error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
 
     const missingTarget = await testCommand(LinkAliasCommand, ['staging'], {
       mocks: {...defaultMocks, isInteractive: false},
@@ -145,7 +146,7 @@ describe('#dataset:alias:link', () => {
     expect(missingTarget.error?.message).toBe(
       'Target dataset is required. Pass it as the `<targetDataset>` argument.',
     )
-    expect(missingTarget.error?.oclif?.exit).toBe(2)
+    expect(missingTarget.error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockListDatasets).not.toHaveBeenCalled()
   })
 
@@ -185,7 +186,7 @@ describe('#dataset:alias:link', () => {
     const {error} = await testCommand(LinkAliasCommand, [alias, dataset], {mocks: defaultMocks})
 
     expect(error?.message).toContain(expectedError)
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('fails when no project ID', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/link.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/link.test.ts
@@ -35,6 +35,7 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -102,6 +103,39 @@ describe('#dataset:alias:link', () => {
     expect(stdout).toContain('Dataset alias ~staging linked to production successfully')
   })
 
+  test('requires --force instead of prompting to relink in unattended mode', async () => {
+    mockListDatasets.mockResolvedValue([{name: 'production'}, {name: 'development'}] as never)
+
+    mockApi({
+      apiVersion: DATASET_API_VERSION,
+      method: 'get',
+      projectId: testProjectId,
+      uri: `/aliases`,
+    }).reply(200, [{datasetName: 'development', name: 'staging'}])
+
+    const {error} = await testCommand(LinkAliasCommand, ['staging', 'production'], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe(
+      'Relinking a dataset alias requires confirmation. Re-run with --force.',
+    )
+    expect(error?.oclif?.exit).toBe(2)
+  })
+
+  test.each([
+    [[], 'Dataset alias name is required. Pass it as the first argument.'],
+    [['staging'], 'Target dataset is required. Pass it as the second argument.'],
+  ])('requires all arguments in unattended mode: %j', async (args, expectedError) => {
+    const {error} = await testCommand(LinkAliasCommand, args, {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe(expectedError)
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockListDatasets).not.toHaveBeenCalled()
+  })
+
   test('links unlinked alias without requiring confirmation', async () => {
     mockListDatasets.mockResolvedValue([{name: 'production'}] as never)
 
@@ -138,7 +172,7 @@ describe('#dataset:alias:link', () => {
     const {error} = await testCommand(LinkAliasCommand, [alias, dataset], {mocks: defaultMocks})
 
     expect(error?.message).toContain(expectedError)
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('fails when no project ID', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/link.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/link.test.ts
@@ -118,7 +118,7 @@ describe('#dataset:alias:link', () => {
     })
 
     expect(error?.message).toBe(
-      'Relinking a dataset alias requires confirmation. Re-run with --force.',
+      'Relinking a dataset alias requires confirmation. Re-run with `--force`.',
     )
     expect(error?.oclif?.exit).toBe(2)
   })
@@ -133,8 +133,8 @@ describe('#dataset:alias:link', () => {
     })
 
     expect(missingBoth.error?.message).toBe(
-      'Dataset alias name is required. Pass it as the first argument.\n' +
-        'Error: Target dataset is required. Pass it as the second argument.',
+      'Dataset alias name is required. Pass it as the `<aliasName>` argument.\n' +
+        'Error: Target dataset is required. Pass it as the `<targetDataset>` argument.',
     )
     expect(missingBoth.error?.oclif?.exit).toBe(2)
 
@@ -143,7 +143,7 @@ describe('#dataset:alias:link', () => {
     })
 
     expect(missingTarget.error?.message).toBe(
-      'Target dataset is required. Pass it as the second argument.',
+      'Target dataset is required. Pass it as the `<targetDataset>` argument.',
     )
     expect(missingTarget.error?.oclif?.exit).toBe(2)
     expect(mockListDatasets).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/link.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/link.test.ts
@@ -123,16 +123,29 @@ describe('#dataset:alias:link', () => {
     expect(error?.oclif?.exit).toBe(2)
   })
 
-  test.each([
-    [[], 'Dataset alias name is required. Pass it as the first argument.'],
-    [['staging'], 'Target dataset is required. Pass it as the second argument.'],
-  ])('requires all arguments in unattended mode: %j', async (args, expectedError) => {
-    const {error} = await testCommand(LinkAliasCommand, args, {
+  test('requires all arguments in unattended mode', async () => {
+    const missingBoth = await testCommand(LinkAliasCommand, [], {
+      mocks: {
+        ...defaultMocks,
+        cliConfig: {api: {}},
+        isInteractive: false,
+      },
+    })
+
+    expect(missingBoth.error?.message).toBe(
+      'Dataset alias name is required. Pass it as the first argument.\n' +
+        'Error: Target dataset is required. Pass it as the second argument.',
+    )
+    expect(missingBoth.error?.oclif?.exit).toBe(2)
+
+    const missingTarget = await testCommand(LinkAliasCommand, ['staging'], {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toBe(expectedError)
-    expect(error?.oclif?.exit).toBe(2)
+    expect(missingTarget.error?.message).toBe(
+      'Target dataset is required. Pass it as the second argument.',
+    )
+    expect(missingTarget.error?.oclif?.exit).toBe(2)
     expect(mockListDatasets).not.toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/unlink.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/unlink.test.ts
@@ -23,6 +23,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -100,6 +101,34 @@ describe('#dataset:alias:unlink', () => {
     expect(mockInput).not.toHaveBeenCalled()
   })
 
+  test('requires --force instead of prompting in unattended mode', async () => {
+    mockApi({
+      apiVersion: DATASET_ALIASES_API_VERSION,
+      projectId: testProjectId,
+      uri: '/aliases',
+    }).reply(200, [{datasetName: 'production', name: 'staging'}])
+
+    const {error} = await testCommand(UnlinkAliasCommand, ['staging'], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe(
+      'Unlinking a dataset alias requires confirmation. Re-run with --force.',
+    )
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockInput).not.toHaveBeenCalled()
+  })
+
+  test('requires an alias name in unattended mode', async () => {
+    const {error} = await testCommand(UnlinkAliasCommand, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe('Dataset alias name is required. Pass it as an argument.')
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockInput).not.toHaveBeenCalled()
+  })
+
   test('prompts for alias name when no alias provided', async () => {
     mockApi({
       apiVersion: DATASET_ALIASES_API_VERSION,
@@ -166,7 +195,7 @@ describe('#dataset:alias:unlink', () => {
     expect(error?.message).toContain(
       'Alias name must only contain letters, numbers, dashes and underscores',
     )
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('shows error when alias does not exist', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/unlink.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/unlink.test.ts
@@ -113,7 +113,7 @@ describe('#dataset:alias:unlink', () => {
     })
 
     expect(error?.message).toBe(
-      'Unlinking a dataset alias requires confirmation. Re-run with --force.',
+      'Unlinking a dataset alias requires confirmation. Re-run with `--force`.',
     )
     expect(error?.oclif?.exit).toBe(2)
     expect(mockInput).not.toHaveBeenCalled()
@@ -124,7 +124,9 @@ describe('#dataset:alias:unlink', () => {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toBe('Dataset alias name is required. Pass it as an argument.')
+    expect(error?.message).toBe(
+      'Dataset alias name is required. Pass it as the `<aliasName>` argument.',
+    )
     expect(error?.oclif?.exit).toBe(2)
     expect(mockInput).not.toHaveBeenCalled()
   })

--- a/packages/@sanity/cli/src/commands/datasets/alias/__tests__/unlink.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/__tests__/unlink.test.ts
@@ -1,4 +1,5 @@
 import {NonInteractiveError} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {input} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -115,7 +116,7 @@ describe('#dataset:alias:unlink', () => {
     expect(error?.message).toBe(
       'Unlinking a dataset alias requires confirmation. Re-run with `--force`.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockInput).not.toHaveBeenCalled()
   })
 
@@ -127,7 +128,7 @@ describe('#dataset:alias:unlink', () => {
     expect(error?.message).toBe(
       'Dataset alias name is required. Pass it as the `<aliasName>` argument.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockInput).not.toHaveBeenCalled()
   })
 
@@ -197,7 +198,7 @@ describe('#dataset:alias:unlink', () => {
     expect(error?.message).toContain(
       'Alias name must only contain letters, numbers, dashes and underscores',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('shows error when alias does not exist', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/alias/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/create.ts
@@ -59,6 +59,24 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
   public async run(): Promise<void> {
     const {args} = await this.parse(CreateAliasCommand)
 
+    if (!args.aliasName && this.isUnattended()) {
+      this.error('Dataset alias name is required. Pass it as the first argument.', {exit: 2})
+    }
+
+    if (args.aliasName) {
+      const nameError = validateDatasetAliasName(args.aliasName)
+      if (nameError) {
+        this.error(nameError, {exit: 2})
+      }
+    }
+
+    if (args.targetDataset) {
+      const datasetErr = validateDatasetName(args.targetDataset)
+      if (datasetErr) {
+        this.error(datasetErr, {exit: 2})
+      }
+    }
+
     const projectId = await this.getProjectId({
       fallback: () =>
         promptForProject({
@@ -81,23 +99,6 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
       this.error('This project cannot create a dataset alias - see https://www.sanity.io/pricing', {
         exit: 1,
       })
-    }
-
-    if (args.aliasName) {
-      const nameError = validateDatasetAliasName(args.aliasName)
-      if (nameError) {
-        this.error(nameError, {exit: 1})
-      }
-    }
-
-    if (args.targetDataset) {
-      const datasetErr = validateDatasetName(args.targetDataset)
-      if (datasetErr) {
-        this.error(datasetErr, {exit: 1})
-      }
-    }
-    if (!args.aliasName && this.isUnattended()) {
-      this.error('Dataset alias name is required. Pass it as the first argument.', {exit: 2})
     }
 
     try {
@@ -123,7 +124,8 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
       }
 
       const targetDataset =
-        args.targetDataset || (datasets.length > 0 ? await selectDataset(datasets) : null)
+        args.targetDataset ||
+        (!this.isUnattended() && datasets.length > 0 ? await selectDataset(datasets) : null)
 
       if (targetDataset && !datasets.includes(targetDataset)) {
         this.error(

--- a/packages/@sanity/cli/src/commands/datasets/alias/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/create.ts
@@ -1,4 +1,5 @@
 import {Args} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {validateDatasetAliasName} from '../../../actions/dataset/validateDatasetAliasName.js'
@@ -95,6 +96,9 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
         this.error(datasetErr, {exit: 1})
       }
     }
+    if (!args.aliasName && this.isUnattended()) {
+      this.error('Dataset alias name is required. Pass it as the first argument.', {exit: 2})
+    }
 
     try {
       const [datasetsResponse, aliases] = await Promise.all([
@@ -133,6 +137,7 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
       const linkMessage = targetDataset ? ` and linked to ${targetDataset}` : ''
       this.log(`Dataset alias ${aliasOutputName} created${linkMessage} successfully`)
     } catch (error) {
+      if (error instanceof CLIError) throw error
       createAliasDebug(`Error creating dataset alias`, error)
       this.error(
         `Dataset alias creation failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/@sanity/cli/src/commands/datasets/alias/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/create.ts
@@ -1,6 +1,6 @@
 import {Args} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {validateDatasetAliasName} from '../../../actions/dataset/validateDatasetAliasName.js'
 import {validateDatasetName} from '../../../actions/dataset/validateDatasetName.js'
@@ -60,20 +60,22 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
     const {args} = await this.parse(CreateAliasCommand)
 
     if (!args.aliasName && this.isUnattended()) {
-      this.error('Dataset alias name is required. Pass it as the first argument.', {exit: 2})
+      this.error('Dataset alias name is required. Pass it as the `<aliasName>` argument.', {
+        exit: exitCodes.USAGE_ERROR,
+      })
     }
 
     if (args.aliasName) {
       const nameError = validateDatasetAliasName(args.aliasName)
       if (nameError) {
-        this.error(nameError, {exit: 2})
+        this.error(nameError, {exit: exitCodes.USAGE_ERROR})
       }
     }
 
     if (args.targetDataset) {
       const datasetErr = validateDatasetName(args.targetDataset)
       if (datasetErr) {
-        this.error(datasetErr, {exit: 2})
+        this.error(datasetErr, {exit: exitCodes.USAGE_ERROR})
       }
     }
 

--- a/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
@@ -1,4 +1,5 @@
 import {Args, Flags} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {input} from '@sanity/cli-core/ux'
 
@@ -78,6 +79,11 @@ export class DeleteAliasCommand extends SanityCommand<typeof DeleteAliasCommand>
       if (force) {
         this.warn(`'--force' used: skipping confirmation, deleting alias "${displayName}"`)
       } else {
+        if (this.isUnattended()) {
+          this.error('Dataset alias deletion requires confirmation. Re-run with --force.', {
+            exit: 2,
+          })
+        }
         await this.confirmDeletion(apiName, existingAlias.datasetName)
       }
 
@@ -85,6 +91,7 @@ export class DeleteAliasCommand extends SanityCommand<typeof DeleteAliasCommand>
 
       this.log('Dataset alias deleted successfully')
     } catch (error) {
+      if (error instanceof CLIError) throw error
       const errorMessage = error instanceof Error ? error.message : String(error)
 
       deleteAliasDebug(`Error deleting dataset alias ${args.aliasName}`, error)

--- a/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
@@ -1,6 +1,6 @@
 import {Args, Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input} from '@sanity/cli-core/ux'
 
 import {processAliasName} from '../../../actions/dataset/processAliasName.js'
@@ -53,7 +53,7 @@ export class DeleteAliasCommand extends SanityCommand<typeof DeleteAliasCommand>
 
     const nameError = validateDatasetAliasName(apiName)
     if (nameError) {
-      this.error(nameError, {exit: 2})
+      this.error(nameError, {exit: exitCodes.USAGE_ERROR})
     }
 
     const projectId = await this.getProjectId({
@@ -80,8 +80,8 @@ export class DeleteAliasCommand extends SanityCommand<typeof DeleteAliasCommand>
         this.warn(`'--force' used: skipping confirmation, deleting alias "${displayName}"`)
       } else {
         if (this.isUnattended()) {
-          this.error('Dataset alias deletion requires confirmation. Re-run with --force.', {
-            exit: 2,
+          this.error('Dataset alias deletion requires confirmation. Re-run with `--force`.', {
+            exit: exitCodes.USAGE_ERROR,
           })
         }
         await this.confirmDeletion(apiName, existingAlias.datasetName)

--- a/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
@@ -49,6 +49,13 @@ export class DeleteAliasCommand extends SanityCommand<typeof DeleteAliasCommand>
     const {args, flags} = await this.parse(DeleteAliasCommand)
     const {force} = flags
 
+    const {apiName, displayName} = processAliasName(args.aliasName)
+
+    const nameError = validateDatasetAliasName(apiName)
+    if (nameError) {
+      this.error(nameError, {exit: 2})
+    }
+
     const projectId = await this.getProjectId({
       fallback: () =>
         promptForProject({
@@ -58,13 +65,6 @@ export class DeleteAliasCommand extends SanityCommand<typeof DeleteAliasCommand>
           ],
         }),
     })
-
-    const {apiName, displayName} = processAliasName(args.aliasName)
-
-    const nameError = validateDatasetAliasName(apiName)
-    if (nameError) {
-      this.error(nameError, {exit: 1})
-    }
 
     try {
       const aliases = await listAliases(projectId)

--- a/packages/@sanity/cli/src/commands/datasets/alias/link.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/link.ts
@@ -1,6 +1,6 @@
 import {Args, Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input} from '@sanity/cli-core/ux'
 
 import {processAliasName} from '../../../actions/dataset/processAliasName.js'
@@ -70,14 +70,14 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
       const errors: string[] = []
 
       if (!args.aliasName) {
-        errors.push('Dataset alias name is required. Pass it as the first argument.')
+        errors.push('Dataset alias name is required. Pass it as the `<aliasName>` argument.')
       }
       if (!args.targetDataset) {
-        errors.push('Target dataset is required. Pass it as the second argument.')
+        errors.push('Target dataset is required. Pass it as the `<targetDataset>` argument.')
       }
 
       if (errors.length > 0) {
-        this.error(formatCliErrorMessages(errors), {exit: 2})
+        this.error(formatCliErrorMessages(errors), {exit: exitCodes.USAGE_ERROR})
       }
     }
 
@@ -85,14 +85,14 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
       const {apiName} = processAliasName(args.aliasName)
       const nameError = validateDatasetAliasName(apiName)
       if (nameError) {
-        this.error(nameError, {exit: 2})
+        this.error(nameError, {exit: exitCodes.USAGE_ERROR})
       }
     }
 
     if (args.targetDataset) {
       const datasetErr = validateDatasetName(args.targetDataset)
       if (datasetErr) {
-        this.error(datasetErr, {exit: 2})
+        this.error(datasetErr, {exit: exitCodes.USAGE_ERROR})
       }
     }
 
@@ -152,8 +152,8 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
 
       if (existingAlias.datasetName && !force) {
         if (this.isUnattended()) {
-          this.error('Relinking a dataset alias requires confirmation. Re-run with --force.', {
-            exit: 2,
+          this.error('Relinking a dataset alias requires confirmation. Re-run with `--force`.', {
+            exit: exitCodes.USAGE_ERROR,
           })
         }
         await this.confirmRelink(existingAlias.datasetName, targetDataset)

--- a/packages/@sanity/cli/src/commands/datasets/alias/link.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/link.ts
@@ -65,6 +65,28 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
     const {args, flags} = await this.parse(LinkAliasCommand)
     const {force} = flags
 
+    if (this.isUnattended() && !args.aliasName) {
+      this.error('Dataset alias name is required. Pass it as the first argument.', {exit: 2})
+    }
+    if (this.isUnattended() && !args.targetDataset) {
+      this.error('Target dataset is required. Pass it as the second argument.', {exit: 2})
+    }
+
+    if (args.aliasName) {
+      const {apiName} = processAliasName(args.aliasName)
+      const nameError = validateDatasetAliasName(apiName)
+      if (nameError) {
+        this.error(nameError, {exit: 2})
+      }
+    }
+
+    if (args.targetDataset) {
+      const datasetErr = validateDatasetName(args.targetDataset)
+      if (datasetErr) {
+        this.error(datasetErr, {exit: 2})
+      }
+    }
+
     const projectId = await this.getProjectId({
       fallback: () =>
         promptForProject({
@@ -74,27 +96,6 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
           ],
         }),
     })
-
-    if (args.aliasName) {
-      const {apiName} = processAliasName(args.aliasName)
-      const nameError = validateDatasetAliasName(apiName)
-      if (nameError) {
-        this.error(nameError, {exit: 1})
-      }
-    }
-
-    if (args.targetDataset) {
-      const datasetErr = validateDatasetName(args.targetDataset)
-      if (datasetErr) {
-        this.error(datasetErr, {exit: 1})
-      }
-    }
-    if (this.isUnattended() && !args.aliasName) {
-      this.error('Dataset alias name is required. Pass it as the first argument.', {exit: 2})
-    }
-    if (this.isUnattended() && !args.targetDataset) {
-      this.error('Target dataset is required. Pass it as the second argument.', {exit: 2})
-    }
 
     try {
       const [datasetsResponse, aliases] = await Promise.all([

--- a/packages/@sanity/cli/src/commands/datasets/alias/link.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/link.ts
@@ -1,4 +1,5 @@
 import {Args, Flags} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {input} from '@sanity/cli-core/ux'
 
@@ -88,6 +89,12 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
         this.error(datasetErr, {exit: 1})
       }
     }
+    if (this.isUnattended() && !args.aliasName) {
+      this.error('Dataset alias name is required. Pass it as the first argument.', {exit: 2})
+    }
+    if (this.isUnattended() && !args.targetDataset) {
+      this.error('Target dataset is required. Pass it as the second argument.', {exit: 2})
+    }
 
     try {
       const [datasetsResponse, aliases] = await Promise.all([
@@ -134,6 +141,11 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
       }
 
       if (existingAlias.datasetName && !force) {
+        if (this.isUnattended()) {
+          this.error('Relinking a dataset alias requires confirmation. Re-run with --force.', {
+            exit: 2,
+          })
+        }
         await this.confirmRelink(existingAlias.datasetName, targetDataset)
       } else if (force && existingAlias.datasetName) {
         this.warn(`'--force' used: skipping confirmation, linking alias to ${targetDataset}`)
@@ -143,6 +155,7 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
 
       this.log(`Dataset alias ${displayName} linked to ${targetDataset} successfully`)
     } catch (error) {
+      if (error instanceof CLIError) throw error
       linkAliasDebug(`Error linking dataset alias`, error)
       this.error(
         `Dataset alias linking failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/@sanity/cli/src/commands/datasets/alias/link.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/link.ts
@@ -11,6 +11,7 @@ import {promptForProject} from '../../../prompts/promptForProject.js'
 import {selectDataset} from '../../../prompts/selectDataset.js'
 import {listAliases, updateAlias} from '../../../services/datasetAliases.js'
 import {listDatasets} from '../../../services/datasets.js'
+import {formatCliErrorMessages} from '../../../util/formatCliErrorMessages.js'
 import {getProjectIdFlag} from '../../../util/sharedFlags.js'
 
 const linkAliasDebug = subdebug('dataset:alias:link')
@@ -65,11 +66,19 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
     const {args, flags} = await this.parse(LinkAliasCommand)
     const {force} = flags
 
-    if (this.isUnattended() && !args.aliasName) {
-      this.error('Dataset alias name is required. Pass it as the first argument.', {exit: 2})
-    }
-    if (this.isUnattended() && !args.targetDataset) {
-      this.error('Target dataset is required. Pass it as the second argument.', {exit: 2})
+    if (this.isUnattended()) {
+      const errors: string[] = []
+
+      if (!args.aliasName) {
+        errors.push('Dataset alias name is required. Pass it as the first argument.')
+      }
+      if (!args.targetDataset) {
+        errors.push('Target dataset is required. Pass it as the second argument.')
+      }
+
+      if (errors.length > 0) {
+        this.error(formatCliErrorMessages(errors), {exit: 2})
+      }
     }
 
     if (args.aliasName) {

--- a/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
@@ -1,6 +1,6 @@
 import {Args, Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input} from '@sanity/cli-core/ux'
 
 import {processAliasName} from '../../../actions/dataset/processAliasName.js'
@@ -55,14 +55,16 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
     const {force} = flags
 
     if (!args.aliasName && this.isUnattended()) {
-      this.error('Dataset alias name is required. Pass it as an argument.', {exit: 2})
+      this.error('Dataset alias name is required. Pass it as the `<aliasName>` argument.', {
+        exit: exitCodes.USAGE_ERROR,
+      })
     }
 
     if (args.aliasName) {
       const {apiName} = processAliasName(args.aliasName)
       const nameError = validateDatasetAliasName(apiName)
       if (nameError) {
-        this.error(nameError, {exit: 2})
+        this.error(nameError, {exit: exitCodes.USAGE_ERROR})
       }
     }
 
@@ -82,7 +84,7 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
 
       const nameError = validateDatasetAliasName(apiName)
       if (nameError) {
-        this.error(nameError, {exit: 2})
+        this.error(nameError, {exit: exitCodes.USAGE_ERROR})
       }
 
       const aliases = await listAliases(projectId)
@@ -101,8 +103,8 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
         this.warn(`'--force' used: skipping confirmation, unlinking alias "${displayName}"`)
       } else {
         if (this.isUnattended()) {
-          this.error('Unlinking a dataset alias requires confirmation. Re-run with --force.', {
-            exit: 2,
+          this.error('Unlinking a dataset alias requires confirmation. Re-run with `--force`.', {
+            exit: exitCodes.USAGE_ERROR,
           })
         }
         await this.confirmUnlink(linkedAlias.datasetName)

--- a/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
@@ -54,6 +54,18 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
     const {args, flags} = await this.parse(UnlinkAliasCommand)
     const {force} = flags
 
+    if (!args.aliasName && this.isUnattended()) {
+      this.error('Dataset alias name is required. Pass it as an argument.', {exit: 2})
+    }
+
+    if (args.aliasName) {
+      const {apiName} = processAliasName(args.aliasName)
+      const nameError = validateDatasetAliasName(apiName)
+      if (nameError) {
+        this.error(nameError, {exit: 2})
+      }
+    }
+
     const projectId = await this.getProjectId({
       fallback: () =>
         promptForProject({
@@ -63,9 +75,6 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
           ],
         }),
     })
-    if (!args.aliasName && this.isUnattended()) {
-      this.error('Dataset alias name is required. Pass it as an argument.', {exit: 2})
-    }
 
     try {
       const aliasNameInput = args.aliasName || (await promptForDatasetAliasName())
@@ -73,7 +82,7 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
 
       const nameError = validateDatasetAliasName(apiName)
       if (nameError) {
-        this.error(nameError, {exit: 1})
+        this.error(nameError, {exit: 2})
       }
 
       const aliases = await listAliases(projectId)

--- a/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
@@ -1,4 +1,5 @@
 import {Args, Flags} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {input} from '@sanity/cli-core/ux'
 
@@ -62,6 +63,9 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
           ],
         }),
     })
+    if (!args.aliasName && this.isUnattended()) {
+      this.error('Dataset alias name is required. Pass it as an argument.', {exit: 2})
+    }
 
     try {
       const aliasNameInput = args.aliasName || (await promptForDatasetAliasName())
@@ -87,12 +91,18 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
       if (force) {
         this.warn(`'--force' used: skipping confirmation, unlinking alias "${displayName}"`)
       } else {
+        if (this.isUnattended()) {
+          this.error('Unlinking a dataset alias requires confirmation. Re-run with --force.', {
+            exit: 2,
+          })
+        }
         await this.confirmUnlink(linkedAlias.datasetName)
       }
 
       const result = await unlinkAlias(projectId, apiName)
       this.log(`Dataset alias ${displayName} unlinked from ${result.datasetName} successfully`)
     } catch (error) {
+      if (error instanceof CLIError) throw error
       unlinkAliasDebug('Error unlinking dataset alias', error)
       this.error(
         `Dataset alias unlink failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/disable.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {select} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -83,7 +84,7 @@ describe('#dataset:embeddings:disable', () => {
     })
 
     expect(error?.message).toBe('Dataset name is required. Pass it as the `<dataset>` argument.')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockListDatasets).not.toHaveBeenCalled()
     expect(mockSelect).not.toHaveBeenCalled()
   })

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/disable.test.ts
@@ -82,7 +82,7 @@ describe('#dataset:embeddings:disable', () => {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toBe('Dataset name is required. Pass it as an argument.')
+    expect(error?.message).toBe('Dataset name is required. Pass it as the `<dataset>` argument.')
     expect(error?.oclif?.exit).toBe(2)
     expect(mockListDatasets).not.toHaveBeenCalled()
     expect(mockSelect).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/disable.test.ts
@@ -33,6 +33,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/disable.test.ts
@@ -48,6 +48,7 @@ describe('#dataset:embeddings:disable', () => {
   afterEach(() => {
     const pending = pendingMocks()
     cleanAll()
+    vi.clearAllMocks()
     vi.restoreAllMocks()
     expect(pending, 'pending mocks').toEqual([])
   })
@@ -74,6 +75,17 @@ describe('#dataset:embeddings:disable', () => {
 
     expect(mockSelect).toHaveBeenCalled()
     expect(stdout).toContain('Disabled embeddings for dataset production')
+  })
+
+  test('should require a dataset without prompting in unattended mode', async () => {
+    const {error} = await testCommand(DatasetEmbeddingsDisableCommand, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe('Dataset name is required. Pass it as an argument.')
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockListDatasets).not.toHaveBeenCalled()
+    expect(mockSelect).not.toHaveBeenCalled()
   })
 
   test('should surface API errors from disable call', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/enable.test.ts
@@ -56,6 +56,7 @@ describe('#dataset:embeddings:enable', () => {
   afterEach(() => {
     const pending = pendingMocks()
     cleanAll()
+    vi.clearAllMocks()
     vi.restoreAllMocks()
     expect(pending, 'pending mocks').toEqual([])
   })
@@ -99,6 +100,17 @@ describe('#dataset:embeddings:enable', () => {
 
     expect(mockSelect).toHaveBeenCalled()
     expect(stdout).toContain('Embeddings enabled for dataset staging')
+  })
+
+  test('should require a dataset without prompting in unattended mode', async () => {
+    const {error} = await testCommand(DatasetEmbeddingsEnableCommand, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe('Dataset name is required. Pass it as an argument.')
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockListDatasets).not.toHaveBeenCalled()
+    expect(mockSelect).not.toHaveBeenCalled()
   })
 
   test('--wait should poll until status is ready', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/enable.test.ts
@@ -41,6 +41,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -159,7 +160,7 @@ describe('#dataset:embeddings:enable', () => {
 
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Invalid projection')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('should reject non-projection expression', async () => {
@@ -174,7 +175,7 @@ describe('#dataset:embeddings:enable', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Invalid projection')
     expect(error?.message).toContain('Expected a GROQ projection')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('should accept complex valid projection', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/enable.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {select} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -108,7 +109,7 @@ describe('#dataset:embeddings:enable', () => {
     })
 
     expect(error?.message).toBe('Dataset name is required. Pass it as the `<dataset>` argument.')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockListDatasets).not.toHaveBeenCalled()
     expect(mockSelect).not.toHaveBeenCalled()
   })
@@ -172,7 +173,7 @@ describe('#dataset:embeddings:enable', () => {
 
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Invalid projection')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('should reject non-projection expression', async () => {
@@ -187,7 +188,7 @@ describe('#dataset:embeddings:enable', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Invalid projection')
     expect(error?.message).toContain('Expected a GROQ projection')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('should accept complex valid projection', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/enable.test.ts
@@ -107,7 +107,7 @@ describe('#dataset:embeddings:enable', () => {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toBe('Dataset name is required. Pass it as an argument.')
+    expect(error?.message).toBe('Dataset name is required. Pass it as the `<dataset>` argument.')
     expect(error?.oclif?.exit).toBe(2)
     expect(mockListDatasets).not.toHaveBeenCalled()
     expect(mockSelect).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/status.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/status.test.ts
@@ -33,6 +33,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/status.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/status.test.ts
@@ -107,7 +107,7 @@ describe('#dataset:embeddings:status', () => {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toBe('Dataset name is required. Pass it as an argument.')
+    expect(error?.message).toBe('Dataset name is required. Pass it as the `<dataset>` argument.')
     expect(error?.oclif?.exit).toBe(2)
     expect(mockListDatasets).not.toHaveBeenCalled()
     expect(mockSelect).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/status.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/status.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {select} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
@@ -108,7 +109,7 @@ describe('#dataset:embeddings:status', () => {
     })
 
     expect(error?.message).toBe('Dataset name is required. Pass it as the `<dataset>` argument.')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockListDatasets).not.toHaveBeenCalled()
     expect(mockSelect).not.toHaveBeenCalled()
   })

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/status.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/__tests__/status.test.ts
@@ -48,6 +48,7 @@ describe('#dataset:embeddings:status', () => {
   afterEach(() => {
     const pending = pendingMocks()
     cleanAll()
+    vi.clearAllMocks()
     vi.restoreAllMocks()
     expect(pending, 'pending mocks').toEqual([])
   })
@@ -99,6 +100,17 @@ describe('#dataset:embeddings:status', () => {
 
     expect(mockSelect).toHaveBeenCalled()
     expect(stdout).toContain('Dataset:    staging')
+  })
+
+  test('should require a dataset without prompting in unattended mode', async () => {
+    const {error} = await testCommand(DatasetEmbeddingsStatusCommand, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toBe('Dataset name is required. Pass it as an argument.')
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockListDatasets).not.toHaveBeenCalled()
+    expect(mockSelect).not.toHaveBeenCalled()
   })
 
   test('should surface API errors from settings call', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/disable.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/disable.ts
@@ -1,6 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Args} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {resolveDataset} from '../../../actions/dataset/resolveDataset.js'
@@ -53,8 +54,14 @@ export class DatasetEmbeddingsDisableCommand extends SanityCommand<
     })
 
     try {
-      ;({dataset} = await resolveDataset({dataset, output: this.output, projectId}))
+      ;({dataset} = await resolveDataset({
+        dataset,
+        isUnattended: this.isUnattended(),
+        output: this.output,
+        projectId,
+      }))
     } catch (error) {
+      if (error instanceof CLIError) throw error
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to resolve dataset: ${message}`, error)
       this.error(message, {exit: 1})

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/enable.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/enable.ts
@@ -2,7 +2,7 @@ import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 
 import {resolveDataset} from '../../../actions/dataset/resolveDataset.js'
@@ -95,7 +95,7 @@ export class DatasetEmbeddingsEnableCommand extends SanityCommand<
         validateProjection(projection)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
-        this.error(`Invalid projection: ${message}`, {exit: 2})
+        this.error(`Invalid projection: ${message}`, {exit: exitCodes.USAGE_ERROR})
       }
     }
 

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/enable.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/enable.ts
@@ -1,6 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 
@@ -76,8 +77,14 @@ export class DatasetEmbeddingsEnableCommand extends SanityCommand<
     })
 
     try {
-      ;({dataset} = await resolveDataset({dataset, output: this.output, projectId}))
+      ;({dataset} = await resolveDataset({
+        dataset,
+        isUnattended: this.isUnattended(),
+        output: this.output,
+        projectId,
+      }))
     } catch (error) {
+      if (error instanceof CLIError) throw error
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to resolve dataset: ${message}`, error)
       this.error(message, {exit: 1})
@@ -88,7 +95,7 @@ export class DatasetEmbeddingsEnableCommand extends SanityCommand<
         validateProjection(projection)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
-        this.error(`Invalid projection: ${message}`, {exit: 1})
+        this.error(`Invalid projection: ${message}`, {exit: 2})
       }
     }
 

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/status.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/status.ts
@@ -1,4 +1,5 @@
 import {Args} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {resolveDataset} from '../../../actions/dataset/resolveDataset.js'
@@ -48,8 +49,14 @@ export class DatasetEmbeddingsStatusCommand extends SanityCommand<
     })
 
     try {
-      ;({dataset} = await resolveDataset({dataset, output: this.output, projectId}))
+      ;({dataset} = await resolveDataset({
+        dataset,
+        isUnattended: this.isUnattended(),
+        output: this.output,
+        projectId,
+      }))
     } catch (error) {
+      if (error instanceof CLIError) throw error
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to resolve dataset: ${message}`, error)
       this.error(message, {exit: 1})

--- a/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/get.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/get.test.ts
@@ -1,4 +1,5 @@
 import {NonInteractiveError} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -68,7 +69,7 @@ describe('#dataset:visibility:get', () => {
     })
 
     expect(error?.message).toContain('Dataset name must only contain')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('shows error when no project ID is available', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/get.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/get.test.ts
@@ -68,7 +68,7 @@ describe('#dataset:visibility:get', () => {
     })
 
     expect(error?.message).toContain('Dataset name must only contain')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('shows error when no project ID is available', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/set.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/set.test.ts
@@ -1,4 +1,5 @@
 import {NonInteractiveError} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -107,7 +108,7 @@ describe('#dataset:visibility:set', () => {
     )
 
     expect(error?.message).toContain('Dataset name must only contain')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('handles error when listing datasets fails', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/set.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/__tests__/set.test.ts
@@ -107,7 +107,7 @@ describe('#dataset:visibility:set', () => {
     )
 
     expect(error?.message).toContain('Dataset name must only contain')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('handles error when listing datasets fails', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/visibility/get.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/get.ts
@@ -1,5 +1,5 @@
 import {Args} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {validateDatasetName} from '../../../actions/dataset/validateDatasetName.js'
 import {promptForProject} from '../../../prompts/promptForProject.js'
@@ -47,7 +47,7 @@ export class DatasetVisibilityGetCommand extends SanityCommand<typeof DatasetVis
 
     const dsError = validateDatasetName(dataset)
     if (dsError) {
-      this.error(dsError, {exit: 2})
+      this.error(dsError, {exit: exitCodes.USAGE_ERROR})
     }
 
     let current

--- a/packages/@sanity/cli/src/commands/datasets/visibility/get.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/get.ts
@@ -47,7 +47,7 @@ export class DatasetVisibilityGetCommand extends SanityCommand<typeof DatasetVis
 
     const dsError = validateDatasetName(dataset)
     if (dsError) {
-      this.error(dsError, {exit: 1})
+      this.error(dsError, {exit: 2})
     }
 
     let current

--- a/packages/@sanity/cli/src/commands/datasets/visibility/set.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/set.ts
@@ -60,7 +60,7 @@ export class DatasetVisibilitySetCommand extends SanityCommand<typeof DatasetVis
 
     const dsError = validateDatasetName(dataset)
     if (dsError) {
-      this.error(dsError, {exit: 1})
+      this.error(dsError, {exit: 2})
     }
 
     let datasets: DatasetsResponse

--- a/packages/@sanity/cli/src/commands/datasets/visibility/set.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/set.ts
@@ -1,5 +1,5 @@
 import {Args} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {DatasetsResponse} from '@sanity/client'
 
 import {validateDatasetName} from '../../../actions/dataset/validateDatasetName.js'
@@ -60,7 +60,7 @@ export class DatasetVisibilitySetCommand extends SanityCommand<typeof DatasetVis
 
     const dsError = validateDatasetName(dataset)
     if (dsError) {
-      this.error(dsError, {exit: 2})
+      this.error(dsError, {exit: exitCodes.USAGE_ERROR})
     }
 
     let datasets: DatasetsResponse


### PR DESCRIPTION
### Description

Adds unattended-mode support for advanced dataset commands.

### What to review

Review the flags, prompt handling, and automated coverage.

### Testing

<!-- To be completed before marking ready. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how destructive alias operations behave in CI (must pass `--force`) and alter exit codes for validation errors; interactive behavior is preserved when stdin is a TTY.
> 
> **Overview**
> Advanced dataset CLI commands now respect **unattended mode** (`isUnattended()` / non-interactive runs) so CI and scripts get clear usage errors instead of hanging on prompts.
> 
> **Dataset resolution:** `resolveDataset` accepts `isUnattended` and fails with `USAGE_ERROR` when `<dataset>` is omitted. Embeddings enable/disable/status pass that flag through.
> 
> **Aliases:** Unattended runs require explicit arguments (alias name; link also requires target dataset). Delete, unlink, and relink skip interactive confirmation and instruct callers to pass **`--force`**. Create can make an **unlinked** alias with only the alias name (no dataset picker). Input validation failures use **`exitCodes.USAGE_ERROR`** instead of generic exit `1`.
> 
> **Other:** Visibility get/set only align validation exits with `USAGE_ERROR`. Several commands rethrow **`CLIError`** from catch blocks so usage errors are not wrapped. Tests cover unattended paths with `isInteractive: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f3db70c46e439f696a4cc54b36e6d88e18f3464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->