### PR TITLE
feat(cli): support unattended mode for GraphQL commands

### DIFF
--- a/.changeset/calm-graphql-automation.md
+++ b/.changeset/calm-graphql-automation.md
@@ -2,6 +2,7 @@
 '@sanity/cli': minor
 ---
 
-Make GraphQL and schema commands safe to automate by requiring `--force` or `--yes` for
-confirmation-gated operations, preserving machine-readable schema JSON on stdout, validating schema
-inputs before starting work, and returning distinct usage and cancellation exit codes.
+feat(cli): support unattended mode for GraphQL and schema commands
+
+Require `--force` or `--yes` for confirmation-gated operations, keep schema JSON machine-readable,
+and distinguish usage errors from cancellations.

--- a/.changeset/calm-graphql-automation.md
+++ b/.changeset/calm-graphql-automation.md
@@ -1,0 +1,7 @@
+---
+'@sanity/cli': minor
+---
+
+Make GraphQL and schema commands safe to automate by requiring `--force` or `--yes` for
+confirmation-gated operations, preserving machine-readable schema JSON on stdout, validating schema
+inputs before starting work, and returning distinct usage and cancellation exit codes.

--- a/.changeset/pr-1500.md
+++ b/.changeset/pr-1500.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-feat(cli): support unattended mode for GraphQL commands

--- a/.changeset/pr-1500.md
+++ b/.changeset/pr-1500.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): support unattended mode for GraphQL commands

--- a/packages/@sanity/cli/src/actions/graphql/resolveApiGeneration.ts
+++ b/packages/@sanity/cli/src/actions/graphql/resolveApiGeneration.ts
@@ -1,5 +1,5 @@
 import {CLIError} from '@oclif/core/errors'
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 import {oneline} from 'oneline'
 
@@ -43,9 +43,9 @@ export async function resolveApiGeneration({
       throw new CLIError(
         oneline`
         Specified generation (${specifiedGeneration}) for API at index ${index} differs from the one currently deployed (${currentGeneration}).
-        Pass --force to continue.
+        Pass \`--force\` to continue.
       `,
-        {exit: 2},
+        {exit: exitCodes.USAGE_ERROR},
       )
     }
 

--- a/packages/@sanity/cli/src/actions/graphql/resolveApiGeneration.ts
+++ b/packages/@sanity/cli/src/actions/graphql/resolveApiGeneration.ts
@@ -1,5 +1,5 @@
 import {CLIError} from '@oclif/core/errors'
-import {exitCodes, type Output} from '@sanity/cli-core'
+import {type Output} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 import {oneline} from 'oneline'
 
@@ -61,7 +61,7 @@ export async function resolveApiGeneration({
       }))
 
     if (!confirmDeploy) {
-      throw new CLIError('GraphQL deployment cancelled', {exit: exitCodes.USER_ABORT})
+      return undefined
     }
 
     return specifiedGeneration

--- a/packages/@sanity/cli/src/actions/graphql/resolveApiGeneration.ts
+++ b/packages/@sanity/cli/src/actions/graphql/resolveApiGeneration.ts
@@ -1,5 +1,5 @@
 import {CLIError} from '@oclif/core/errors'
-import {isInteractive, type Output} from '@sanity/cli-core'
+import {type Output} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 import {oneline} from 'oneline'
 
@@ -13,12 +13,14 @@ export async function resolveApiGeneration({
   index,
   output,
   specifiedGeneration,
+  unattended,
 }: {
   currentGeneration?: string
   force?: boolean
   index: number
   output: Output
   specifiedGeneration?: string
+  unattended?: boolean
 }): Promise<string | undefined> {
   // a) If no API is currently deployed:
   //    use the specificed one from config, or use whichever generation is the latest
@@ -37,13 +39,13 @@ export async function resolveApiGeneration({
   }
 
   if (specifiedGeneration && specifiedGeneration !== currentGeneration) {
-    if (!force && !isInteractive()) {
+    if (!force && unattended) {
       throw new CLIError(
         oneline`
         Specified generation (${specifiedGeneration}) for API at index ${index} differs from the one currently deployed (${currentGeneration}).
         Re-run the command with \`--force\` to force deployment.
       `,
-        {exit: 1},
+        {exit: 2},
       )
     }
 
@@ -58,7 +60,11 @@ export async function resolveApiGeneration({
         message: 'Are you sure you want to deploy?',
       }))
 
-    return confirmDeploy ? specifiedGeneration : undefined
+    if (!confirmDeploy) {
+      throw new CLIError('Operation cancelled', {exit: 3})
+    }
+
+    return specifiedGeneration
   }
 
   if (specifiedGeneration) {

--- a/packages/@sanity/cli/src/actions/graphql/resolveApiGeneration.ts
+++ b/packages/@sanity/cli/src/actions/graphql/resolveApiGeneration.ts
@@ -1,5 +1,5 @@
 import {CLIError} from '@oclif/core/errors'
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 import {oneline} from 'oneline'
 
@@ -20,7 +20,7 @@ export async function resolveApiGeneration({
   index: number
   output: Output
   specifiedGeneration?: string
-  unattended?: boolean
+  unattended: boolean
 }): Promise<string | undefined> {
   // a) If no API is currently deployed:
   //    use the specificed one from config, or use whichever generation is the latest
@@ -43,7 +43,7 @@ export async function resolveApiGeneration({
       throw new CLIError(
         oneline`
         Specified generation (${specifiedGeneration}) for API at index ${index} differs from the one currently deployed (${currentGeneration}).
-        Re-run the command with \`--force\` to force deployment.
+        Pass --force to continue.
       `,
         {exit: 2},
       )
@@ -61,7 +61,7 @@ export async function resolveApiGeneration({
       }))
 
     if (!confirmDeploy) {
-      throw new CLIError('Operation cancelled', {exit: 3})
+      throw new CLIError('GraphQL deployment cancelled', {exit: exitCodes.USER_ABORT})
     }
 
     return specifiedGeneration

--- a/packages/@sanity/cli/src/actions/schema/listSchemas.ts
+++ b/packages/@sanity/cli/src/actions/schema/listSchemas.ts
@@ -45,7 +45,7 @@ export async function listSchemas(options: ListSchemasOptions): Promise<void> {
   )
 
   const schemas = await getDatasetSchemas(projectDatasets, id)
-  const parsedSchemas = parseSchemas(schemas, output)
+  const parsedSchemas = parseSchemas(schemas, output, json)
 
   if (parsedSchemas.length === 0) {
     const datasetString = getDatasetsOutString(projectDatasets.map((dataset) => dataset.dataset))
@@ -76,7 +76,11 @@ async function getDatasetSchemas(projectDatasets: Workspace[], id?: string) {
   )
 }
 
-function parseSchemas(schemas: PromiseSettledResult<StoredWorkspaceSchema[]>[], output: Output) {
+function parseSchemas(
+  schemas: PromiseSettledResult<StoredWorkspaceSchema[]>[],
+  output: Output,
+  json: boolean,
+) {
   return schemas
     .map((schema) => {
       if (schema.status === 'fulfilled') return schema.value
@@ -91,7 +95,8 @@ function parseSchemas(schemas: PromiseSettledResult<StoredWorkspaceSchema[]>[], 
           'statusCode' in error.cause &&
           error.cause.statusCode === 401
         ) {
-          output.log(
+          const logDiagnostic = json ? output.warn.bind(output) : output.log.bind(output)
+          logDiagnostic(
             styleText(
               'yellow',
               `${logSymbols.warning} ↳ No permissions to read schema from "${error.dataset}". ${
@@ -102,7 +107,8 @@ function parseSchemas(schemas: PromiseSettledResult<StoredWorkspaceSchema[]>[], 
           return []
         }
 
-        output.log(
+        const logDiagnostic = json ? output.warn.bind(output) : output.log.bind(output)
+        logDiagnostic(
           styleText('red', `↳ Failed to fetch schema from "${error.dataset}":\n  ${error.message}`),
         )
         return []

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-schema-errors.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-schema-errors.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -220,7 +221,7 @@ describe('#graphql:deploy schema errors', () => {
       })
 
       expect(error).toBeDefined()
-      expect(error?.oclif?.exit).toBe(3)
+      expect(error?.oclif?.exit).toBe(exitCodes.USER_ABORT)
       expect(stderr).toContain('--tag')
       expect(stderr).toContain('for ALL APIs')
       expect(stdout).toContain('GraphQL deployment cancelled')

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-schema-errors.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-schema-errors.test.ts
@@ -216,11 +216,12 @@ describe('#graphql:deploy schema errors', () => {
       mockConfirm.mockResolvedValue(false)
 
       const {error, stderr} = await testCommand(GraphQLDeployCommand, ['--tag', 'custom'], {
-        mocks: multiApiMocks,
+        mocks: {...multiApiMocks, isInteractive: true},
       })
 
       expect(error).toBeDefined()
       expect(error?.message).toContain('Operation cancelled')
+      expect(error?.oclif?.exit).toBe(3)
       expect(stderr).toContain('--tag')
       expect(stderr).toContain('for ALL APIs')
     })

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-schema-errors.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-schema-errors.test.ts
@@ -215,15 +215,15 @@ describe('#graphql:deploy schema errors', () => {
       mockExtractGraphQLAPIs.mockResolvedValue(apis)
       mockConfirm.mockResolvedValue(false)
 
-      const {error, stderr} = await testCommand(GraphQLDeployCommand, ['--tag', 'custom'], {
+      const {error, stderr, stdout} = await testCommand(GraphQLDeployCommand, ['--tag', 'custom'], {
         mocks: {...multiApiMocks, isInteractive: true},
       })
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('GraphQL deployment cancelled')
       expect(error?.oclif?.exit).toBe(3)
       expect(stderr).toContain('--tag')
       expect(stderr).toContain('for ALL APIs')
+      expect(stdout).toContain('GraphQL deployment cancelled')
     })
 
     test('skips confirmation with --force when flags override multiple APIs', async () => {

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-schema-errors.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/deploy-schema-errors.test.ts
@@ -220,7 +220,7 @@ describe('#graphql:deploy schema errors', () => {
       })
 
       expect(error).toBeDefined()
-      expect(error?.message).toContain('Operation cancelled')
+      expect(error?.message).toContain('GraphQL deployment cancelled')
       expect(error?.oclif?.exit).toBe(3)
       expect(stderr).toContain('--tag')
       expect(stderr).toContain('for ALL APIs')

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
@@ -16,6 +16,7 @@ const testProjectId = 'test-project'
 
 const defaultMocks = {
   cliConfig: {api: {dataset: 'production', projectId: testProjectId}},
+  isInteractive: true,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -141,9 +142,19 @@ describe('graphql undeploy', () => {
 
   test('cancels deletion when user declines confirmation', async () => {
     mockConfirm.mockResolvedValue(false)
-    const {stdout} = await testCommand(Undeploy, [], {mocks: defaultMocks})
-    expect(stdout).toBe('Operation cancelled\n')
+    const {error} = await testCommand(Undeploy, [], {mocks: defaultMocks})
+    expect(error?.oclif?.exit).toBe(3)
     expect(pendingMocks()).toHaveLength(0) // No API call should be made
+  })
+
+  test('requires --force before prompting in unattended mode', async () => {
+    const {error} = await testCommand(Undeploy, [], {
+      mocks: {...defaultMocks, isInteractive: false},
+    })
+
+    expect(error?.message).toContain('Pass --force to continue')
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockConfirm).not.toHaveBeenCalled()
   })
 
   test('successfully undeploys with --api flag', async () => {
@@ -267,7 +278,7 @@ describe('graphql undeploy', () => {
     expect(error?.message).toContain(
       'Dataset is required. Specify it with --dataset or configure it in your project.',
     )
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('handles API deletion error', async () => {
@@ -285,7 +296,7 @@ describe('graphql undeploy', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('GraphQL API deletion failed')
     expect(error?.message).toContain('GraphQL API not found')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(3)
   })
 
   test('handles user cancelling confirmation prompt', async () => {
@@ -326,7 +337,7 @@ describe('graphql undeploy', () => {
       const {error, stdout} = await testCommand(
         Undeploy,
         ['--project-id', 'flag-project', '--dataset', 'staging'],
-        {mocks: noProjectRootMocks},
+        {mocks: {...noProjectRootMocks, isInteractive: true}},
       )
 
       if (error) throw error
@@ -340,7 +351,7 @@ describe('graphql undeploy', () => {
 
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain('Dataset is required')
-      expect(error?.oclif?.exit).toBe(1)
+      expect(error?.oclif?.exit).toBe(2)
     })
   })
 })

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
@@ -1,4 +1,5 @@
 import {ProjectRootNotFoundError} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {convertToSystemPath, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
@@ -142,7 +143,7 @@ describe('graphql undeploy', () => {
   test('cancels deletion when user declines confirmation', async () => {
     mockConfirm.mockResolvedValue(false)
     const {error, stdout} = await testCommand(Undeploy, [], {mocks: defaultMocks})
-    expect(error?.oclif?.exit).toBe(3)
+    expect(error?.oclif?.exit).toBe(exitCodes.USER_ABORT)
     expect(stdout).toContain('GraphQL API undeploy cancelled')
     expect(pendingMocks()).toHaveLength(0) // No API call should be made
   })
@@ -152,8 +153,8 @@ describe('graphql undeploy', () => {
       mocks: {...defaultMocks, isInteractive: false},
     })
 
-    expect(error?.message).toContain('Pass --force to continue')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.message).toContain('Pass `--force` to continue')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockConfirm).not.toHaveBeenCalled()
   })
 
@@ -276,9 +277,9 @@ describe('graphql undeploy', () => {
 
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain(
-      'Dataset is required. Specify it with --dataset or configure it in your project.',
+      'Dataset is required. Pass it with `--dataset <name>` or configure it in your project.',
     )
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('handles API deletion error', async () => {
@@ -305,7 +306,7 @@ describe('graphql undeploy', () => {
     const {error, stderr} = await testCommand(Undeploy, [], {mocks: defaultMocks})
 
     expect(error).toBeInstanceOf(Error)
-    expect(error?.oclif?.exit).toBe(130)
+    expect(error?.oclif?.exit).toBe(exitCodes.SIGINT)
     expect(stderr).toContain('Aborted by user')
   })
 
@@ -351,7 +352,7 @@ describe('graphql undeploy', () => {
 
       expect(error).toBeInstanceOf(Error)
       expect(error?.message).toContain('Dataset is required')
-      expect(error?.oclif?.exit).toBe(2)
+      expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     })
   })
 })

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
@@ -141,9 +141,9 @@ describe('graphql undeploy', () => {
 
   test('cancels deletion when user declines confirmation', async () => {
     mockConfirm.mockResolvedValue(false)
-    const {error} = await testCommand(Undeploy, [], {mocks: defaultMocks})
-    expect(error?.message).toBe('GraphQL API undeploy cancelled')
+    const {error, stdout} = await testCommand(Undeploy, [], {mocks: defaultMocks})
     expect(error?.oclif?.exit).toBe(3)
+    expect(stdout).toContain('GraphQL API undeploy cancelled')
     expect(pendingMocks()).toHaveLength(0) // No API call should be made
   })
 
@@ -300,13 +300,13 @@ describe('graphql undeploy', () => {
   })
 
   test('handles user cancelling confirmation prompt', async () => {
-    mockConfirm.mockRejectedValue(new Error('User cancelled'))
+    mockConfirm.mockRejectedValue(Object.assign(new Error('SIGINT'), {name: 'ExitPromptError'}))
 
-    const {error} = await testCommand(Undeploy, [], {mocks: defaultMocks})
+    const {error, stderr} = await testCommand(Undeploy, [], {mocks: defaultMocks})
 
     expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toBe('GraphQL API undeploy cancelled')
-    expect(error?.oclif?.exit).toBe(3)
+    expect(error?.oclif?.exit).toBe(130)
+    expect(stderr).toContain('Aborted by user')
   })
 
   test('propagates errors from getGraphQLAPIs when using --api flag', async () => {

--- a/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/graphql/__tests__/undeploy.test.ts
@@ -61,8 +61,7 @@ describe('graphql undeploy', () => {
 
     expect(mockConfirm).toHaveBeenCalledWith({
       default: false,
-      message:
-        'Are you absolutely sure you want to delete the current GraphQL API connected to the "production" dataset in project test-project?',
+      message: 'Delete the GraphQL API for dataset "production" in project test-project?',
     })
     expect(stdout).toBe('GraphQL API deleted\n')
   })
@@ -82,7 +81,7 @@ describe('graphql undeploy', () => {
     expect(mockConfirm).toHaveBeenCalledWith({
       default: false,
       message:
-        'Are you absolutely sure you want to delete the GraphQL API connected to the "production" dataset in project test-project, tagged "beta"?',
+        'Delete the GraphQL API for dataset "production" in project test-project with tag "beta"?',
     })
     expect(stdout).toBe('GraphQL API deleted\n')
   })
@@ -122,7 +121,7 @@ describe('graphql undeploy', () => {
     expect(mockConfirm).toHaveBeenCalledWith({
       default: false,
       message:
-        'Are you absolutely sure you want to delete the GraphQL API connected to the "staging" dataset in project custom-project, tagged "experimental"?',
+        'Delete the GraphQL API for dataset "staging" in project custom-project with tag "experimental"?',
     })
   })
 
@@ -143,6 +142,7 @@ describe('graphql undeploy', () => {
   test('cancels deletion when user declines confirmation', async () => {
     mockConfirm.mockResolvedValue(false)
     const {error} = await testCommand(Undeploy, [], {mocks: defaultMocks})
+    expect(error?.message).toBe('GraphQL API undeploy cancelled')
     expect(error?.oclif?.exit).toBe(3)
     expect(pendingMocks()).toHaveLength(0) // No API call should be made
   })
@@ -296,7 +296,7 @@ describe('graphql undeploy', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('GraphQL API deletion failed')
     expect(error?.message).toContain('GraphQL API not found')
-    expect(error?.oclif?.exit).toBe(3)
+    expect(error?.oclif?.exit).toBe(1)
   })
 
   test('handles user cancelling confirmation prompt', async () => {
@@ -305,8 +305,8 @@ describe('graphql undeploy', () => {
     const {error} = await testCommand(Undeploy, [], {mocks: defaultMocks})
 
     expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toBe('Operation cancelled')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.message).toBe('GraphQL API undeploy cancelled')
+    expect(error?.oclif?.exit).toBe(3)
   })
 
   test('propagates errors from getGraphQLAPIs when using --api flag', async () => {

--- a/packages/@sanity/cli/src/commands/graphql/deploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/deploy.ts
@@ -1,5 +1,5 @@
 import {Flags} from '@oclif/core'
-import {isInteractive, SanityCommand} from '@sanity/cli-core'
+import {SanityCommand} from '@sanity/cli-core'
 import {confirm, spinner} from '@sanity/cli-core/ux'
 import get from 'lodash-es/get.js'
 
@@ -148,13 +148,20 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
 
       if (flags.force) {
         this.warn(`--force specified, continuing...`)
+      } else if (this.isUnattended()) {
+        this.error(
+          'Flag overrides for multiple APIs require confirmation. Pass --force to continue.',
+          {
+            exit: 2,
+          },
+        )
       } else {
         const confirmed = await confirm({
           default: false,
           message: 'Continue with flag overrides for all APIs?',
         })
         if (!confirmed) {
-          this.error('Operation cancelled', {exit: 1})
+          this.error('Operation cancelled', {exit: 3})
         }
       }
     }
@@ -219,7 +226,10 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
 
       if (!dataset) {
         spin.fail()
-        this.error(`No dataset specified for API at index ${index}`, {exit: 1})
+        this.error(
+          `Dataset is required for API at index ${index}. Pass --dataset <name> or configure a dataset for the API.`,
+          {exit: 2},
+        )
       }
 
       // Handle extraction errors early (computed in worker), before network calls and prompts.
@@ -267,6 +277,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
         index,
         output: this.output,
         specifiedGeneration,
+        unattended: this.isUnattended(),
       })
 
       if (!generation) {
@@ -325,12 +336,12 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
           continue
         }
 
-        if (!isInteractive()) {
+        if (this.isUnattended()) {
           spin.fail()
           this.renderBreakingChanges(valid)
           this.error(
             'Dangerous changes found - falling back. Re-run the command with the `--force` flag to force deployment.',
-            {exit: 1},
+            {exit: 2},
           )
         }
 
@@ -343,7 +354,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
 
         if (!shouldDeploy) {
           spin.fail()
-          continue
+          this.error('Operation cancelled', {exit: 3})
         }
 
         spin.succeed()
@@ -508,7 +519,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
     }
 
     // If no API is deployed, default to true if non-interactive
-    if (!isInteractive()) {
+    if (this.isUnattended()) {
       return true
     }
 

--- a/packages/@sanity/cli/src/commands/graphql/deploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/deploy.ts
@@ -150,9 +150,9 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
         this.warn(`--force specified, continuing...`)
       } else if (this.isUnattended()) {
         this.error(
-          'Flag overrides for multiple APIs require confirmation. Pass --force to continue.',
+          'Flag overrides for multiple APIs require confirmation. Pass `--force` to continue.',
           {
-            exit: 2,
+            exit: exitCodes.USAGE_ERROR,
           },
         )
       } else {
@@ -228,8 +228,8 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
       if (!dataset) {
         spin.fail()
         this.error(
-          `Dataset is required for API at index ${index}. Pass --dataset <name> or configure a dataset for the API.`,
-          {exit: 2},
+          `Dataset is required for API at index ${index}. Pass it with \`--dataset <name>\` or configure a dataset for the API.`,
+          {exit: exitCodes.USAGE_ERROR},
         )
       }
 
@@ -341,8 +341,8 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
           spin.fail()
           this.renderBreakingChanges(valid)
           this.error(
-            'GraphQL deployment requires confirmation because the schema contains dangerous changes. Pass --force to continue.',
-            {exit: 2},
+            'GraphQL deployment requires confirmation because the schema contains dangerous changes. Pass `--force` to continue.',
+            {exit: exitCodes.USAGE_ERROR},
           )
         }
 

--- a/packages/@sanity/cli/src/commands/graphql/deploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/deploy.ts
@@ -161,7 +161,8 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
           message: 'Continue with flag overrides for all APIs?',
         })
         if (!confirmed) {
-          this.error('GraphQL deployment cancelled', {exit: exitCodes.USER_ABORT})
+          this.log('GraphQL deployment cancelled')
+          this.exit(exitCodes.USER_ABORT)
         }
       }
     }
@@ -281,9 +282,9 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
       })
 
       if (!generation) {
-        // User cancelled
-        spin.fail()
-        continue
+        spin.stop()
+        this.log('GraphQL deployment cancelled')
+        this.exit(exitCodes.USER_ABORT)
       }
 
       if (!this.isRecognizedApiGeneration(generation)) {
@@ -353,8 +354,8 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
         })
 
         if (!shouldDeploy) {
-          spin.fail()
-          this.error('GraphQL deployment cancelled', {exit: exitCodes.USER_ABORT})
+          this.log('GraphQL deployment cancelled')
+          this.exit(exitCodes.USER_ABORT)
         }
 
         spin.succeed()

--- a/packages/@sanity/cli/src/commands/graphql/deploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/deploy.ts
@@ -1,5 +1,5 @@
 import {Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 import {confirm, spinner} from '@sanity/cli-core/ux'
 import get from 'lodash-es/get.js'
 
@@ -161,7 +161,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
           message: 'Continue with flag overrides for all APIs?',
         })
         if (!confirmed) {
-          this.error('Operation cancelled', {exit: 3})
+          this.error('GraphQL deployment cancelled', {exit: exitCodes.USER_ABORT})
         }
       }
     }
@@ -340,7 +340,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
           spin.fail()
           this.renderBreakingChanges(valid)
           this.error(
-            'Dangerous changes found - falling back. Re-run the command with the `--force` flag to force deployment.',
+            'GraphQL deployment requires confirmation because the schema contains dangerous changes. Pass --force to continue.',
             {exit: 2},
           )
         }
@@ -354,7 +354,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
 
         if (!shouldDeploy) {
           spin.fail()
-          this.error('Operation cancelled', {exit: 3})
+          this.error('GraphQL deployment cancelled', {exit: exitCodes.USER_ABORT})
         }
 
         spin.succeed()

--- a/packages/@sanity/cli/src/commands/graphql/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/undeploy.ts
@@ -119,9 +119,9 @@ export class Undeploy extends SanityCommand<typeof Undeploy> {
 
     if (!dataset) {
       this.error(
-        'Dataset is required. Specify it with --dataset or configure it in your project.',
+        'Dataset is required. Pass it with `--dataset <name>` or configure it in your project.',
         {
-          exit: 2,
+          exit: exitCodes.USAGE_ERROR,
         },
       )
     }
@@ -129,8 +129,8 @@ export class Undeploy extends SanityCommand<typeof Undeploy> {
     // Confirm deletion unless --force is used
     if (!force) {
       if (this.isUnattended()) {
-        this.error('GraphQL API undeploy requires confirmation. Pass --force to continue.', {
-          exit: 2,
+        this.error('GraphQL API undeploy requires confirmation. Pass `--force` to continue.', {
+          exit: exitCodes.USAGE_ERROR,
         })
       }
 

--- a/packages/@sanity/cli/src/commands/graphql/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/undeploy.ts
@@ -139,20 +139,14 @@ export class Undeploy extends SanityCommand<typeof Undeploy> {
           ? `Delete the GraphQL API for dataset "${dataset}" in project ${projectId}?`
           : `Delete the GraphQL API for dataset "${dataset}" in project ${projectId} with tag "${tag}"?`
 
-      let confirmed: boolean
-      try {
-        confirmed = await confirm({
-          default: false,
-          message: confirmMessage,
-        })
-      } catch (error) {
-        const err = error instanceof Error ? error : new Error(`${error}`)
-        undeployGraphqlDebug('User cancelled', err)
-        this.error('GraphQL API undeploy cancelled', {exit: exitCodes.USER_ABORT})
-      }
+      const confirmed = await confirm({
+        default: false,
+        message: confirmMessage,
+      })
 
       if (!confirmed) {
-        this.error('GraphQL API undeploy cancelled', {exit: exitCodes.USER_ABORT})
+        this.log('GraphQL API undeploy cancelled')
+        this.exit(exitCodes.USER_ABORT)
       }
     }
 

--- a/packages/@sanity/cli/src/commands/graphql/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/undeploy.ts
@@ -1,5 +1,5 @@
 import {Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 
 import {getGraphQLAPIs} from '../../actions/graphql/getGraphQLAPIs.js'
@@ -136,22 +136,23 @@ export class Undeploy extends SanityCommand<typeof Undeploy> {
 
       const confirmMessage =
         tag === 'default'
-          ? `Are you absolutely sure you want to delete the current GraphQL API connected to the "${dataset}" dataset in project ${projectId}?`
-          : `Are you absolutely sure you want to delete the GraphQL API connected to the "${dataset}" dataset in project ${projectId}, tagged "${tag}"?`
+          ? `Delete the GraphQL API for dataset "${dataset}" in project ${projectId}?`
+          : `Delete the GraphQL API for dataset "${dataset}" in project ${projectId} with tag "${tag}"?`
 
+      let confirmed: boolean
       try {
-        const confirmed = await confirm({
+        confirmed = await confirm({
           default: false,
           message: confirmMessage,
         })
-
-        if (!confirmed) {
-          this.error('Operation cancelled', {exit: 3})
-        }
       } catch (error) {
         const err = error instanceof Error ? error : new Error(`${error}`)
         undeployGraphqlDebug('User cancelled', err)
-        this.error('Operation cancelled', {exit: 3})
+        this.error('GraphQL API undeploy cancelled', {exit: exitCodes.USER_ABORT})
+      }
+
+      if (!confirmed) {
+        this.error('GraphQL API undeploy cancelled', {exit: exitCodes.USER_ABORT})
       }
     }
 

--- a/packages/@sanity/cli/src/commands/graphql/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/undeploy.ts
@@ -121,13 +121,19 @@ export class Undeploy extends SanityCommand<typeof Undeploy> {
       this.error(
         'Dataset is required. Specify it with --dataset or configure it in your project.',
         {
-          exit: 1,
+          exit: 2,
         },
       )
     }
 
     // Confirm deletion unless --force is used
     if (!force) {
+      if (this.isUnattended()) {
+        this.error('GraphQL API undeploy requires confirmation. Pass --force to continue.', {
+          exit: 2,
+        })
+      }
+
       const confirmMessage =
         tag === 'default'
           ? `Are you absolutely sure you want to delete the current GraphQL API connected to the "${dataset}" dataset in project ${projectId}?`
@@ -140,13 +146,12 @@ export class Undeploy extends SanityCommand<typeof Undeploy> {
         })
 
         if (!confirmed) {
-          this.log('Operation cancelled')
-          return
+          this.error('Operation cancelled', {exit: 3})
         }
       } catch (error) {
         const err = error instanceof Error ? error : new Error(`${error}`)
         undeployGraphqlDebug('User cancelled', err)
-        this.error('Operation cancelled', {exit: 1})
+        this.error('Operation cancelled', {exit: 3})
       }
     }
 

--- a/packages/@sanity/cli/src/commands/schemas/__tests__/extract.test.ts
+++ b/packages/@sanity/cli/src/commands/schemas/__tests__/extract.test.ts
@@ -1,6 +1,10 @@
+import {access} from 'node:fs/promises'
+
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {createMockSanityCommand} from '../../../../test/mockSanityCommand.js'
+
+vi.mock('node:fs/promises')
 
 // First: create the mocks and mocked SanityCommand class
 const {MockedSanityCommand, mocks} = createMockSanityCommand()
@@ -25,6 +29,7 @@ vi.mock('../../../actions/schema/watchExtractSchema.js', () => ({
 
 // Finally, import the module under test: extract schema command
 const {ExtractSchemaCommand} = await import('../extract.js')
+const mockAccess = vi.mocked(access)
 
 describe('schema extract command', () => {
   beforeEach(() => {
@@ -33,7 +38,8 @@ describe('schema extract command', () => {
     mocks.SanityCmdGetCliConfig.mockResolvedValue({schemaExtraction: {}})
     mockExtractSchema.mockResolvedValue(undefined)
     mockWatchExtractSchema.mockResolvedValue(undefined)
-    mockExtractOptions.mockReturnValue({})
+    mockAccess.mockRejectedValue(new Error('ENOENT'))
+    mockExtractOptions.mockReturnValue({outputPath: '/some/dir/schema.json'})
   })
   afterEach(() => {
     vi.clearAllMocks()
@@ -49,5 +55,18 @@ describe('schema extract command', () => {
   })
   test('schema command bad flags', async () => {
     await expect(ExtractSchemaCommand.run(['--poop'])).rejects.toThrow('Nonexistent flag')
+  })
+  test('requires --force before overwriting an existing schema file', async () => {
+    mockAccess.mockResolvedValue(undefined)
+
+    await expect(ExtractSchemaCommand.run([])).rejects.toThrow('--force')
+    expect(mockExtractSchema).not.toHaveBeenCalled()
+  })
+
+  test('overwrites an existing schema file with --force', async () => {
+    mockAccess.mockResolvedValue(undefined)
+
+    await ExtractSchemaCommand.run(['--force'])
+    expect(mockExtractSchema).toHaveBeenCalledOnce()
   })
 })

--- a/packages/@sanity/cli/src/commands/schemas/__tests__/extract.test.ts
+++ b/packages/@sanity/cli/src/commands/schemas/__tests__/extract.test.ts
@@ -1,5 +1,7 @@
 import {access} from 'node:fs/promises'
 
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
+import * as uxMocks from '@sanity/cli-test/mocks/cli-core/ux'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {createMockSanityCommand} from '../../../../test/mockSanityCommand.js'
@@ -13,6 +15,7 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
   return {...actual, SanityCommand: MockedSanityCommand}
 })
+vi.mock('@sanity/cli-core/ux', () => import('@sanity/cli-test/mocks/cli-core/ux'))
 
 // Third: mock extract schema command imports
 const mockExtractSchema = vi.hoisted(() => vi.fn())
@@ -40,6 +43,7 @@ describe('schema extract command', () => {
     mockWatchExtractSchema.mockResolvedValue(undefined)
     mockAccess.mockRejectedValue(new Error('ENOENT'))
     mockExtractOptions.mockReturnValue({outputPath: '/some/dir/schema.json'})
+    mocks.SanityCmdIsUnattended.mockReturnValue(false)
   })
   afterEach(() => {
     vi.clearAllMocks()
@@ -56,10 +60,36 @@ describe('schema extract command', () => {
   test('schema command bad flags', async () => {
     await expect(ExtractSchemaCommand.run(['--poop'])).rejects.toThrow('Nonexistent flag')
   })
-  test('requires --force before overwriting an existing schema file', async () => {
+  test('requires --force before overwriting an existing schema file in unattended mode', async () => {
     mockAccess.mockResolvedValue(undefined)
+    mocks.SanityCmdIsUnattended.mockReturnValue(true)
 
     await expect(ExtractSchemaCommand.run([])).rejects.toThrow('--force')
+    expect(uxMocks.confirm).not.toHaveBeenCalled()
+    expect(mockExtractSchema).not.toHaveBeenCalled()
+  })
+
+  test('prompts before overwriting an existing schema file in interactive mode', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    uxMocks.confirm.mockResolvedValue(true)
+
+    await ExtractSchemaCommand.run([])
+
+    expect(uxMocks.confirm).toHaveBeenCalledWith({
+      default: false,
+      message: 'Schema file already exists at "/some/dir/schema.json". Overwrite it?',
+    })
+    expect(mockExtractSchema).toHaveBeenCalledOnce()
+  })
+
+  test('cancels when overwriting an existing schema file is declined', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    uxMocks.confirm.mockResolvedValue(false)
+
+    await ExtractSchemaCommand.run([])
+
+    expect(mocks.SanityCmdOutputLog).toHaveBeenCalledWith('Schema extraction cancelled')
+    expect(mocks.OclifCmdExit).toHaveBeenCalledWith(exitCodes.USER_ABORT)
     expect(mockExtractSchema).not.toHaveBeenCalled()
   })
 
@@ -67,6 +97,7 @@ describe('schema extract command', () => {
     mockAccess.mockResolvedValue(undefined)
 
     await ExtractSchemaCommand.run(['--force'])
+    expect(uxMocks.confirm).not.toHaveBeenCalled()
     expect(mockExtractSchema).toHaveBeenCalledOnce()
   })
 })

--- a/packages/@sanity/cli/src/commands/schemas/delete.ts
+++ b/packages/@sanity/cli/src/commands/schemas/delete.ts
@@ -1,6 +1,7 @@
 import {Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
 import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {confirm} from '@sanity/cli-core/ux'
 
 import {deleteSchemaAction} from '../../actions/schema/deleteSchemaAction.js'
 import {parseIds} from '../../actions/schema/utils/schemaStoreValidation.js'
@@ -52,17 +53,40 @@ export class DeleteSchemaCommand extends SanityCommand<typeof DeleteSchemaComman
       default: false,
       description: 'Enable verbose logging',
     }),
+    yes: Flags.boolean({
+      char: 'y',
+      default: false,
+      description: 'Delete schemas without prompting for confirmation',
+    }),
   }
 
   static override hiddenAliases: string[] = ['schema:delete']
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(DeleteSchemaCommand)
-    const {dataset} = flags
+    const {dataset, yes} = flags
 
     deleteSchemaDebug('Running schema delete with flags: %O', flags)
 
     const ids = parseIds(flags.ids)
+
+    if (!yes && this.isUnattended()) {
+      this.error(
+        'Schema deletion requires confirmation. Re-run with --yes to delete the schemas.',
+        {
+          exit: 2,
+        },
+      )
+    }
+
+    if (!yes) {
+      const confirmed = await confirm({
+        default: false,
+        message: `Delete ${ids.length} schema${ids.length === 1 ? '' : 's'}?`,
+      })
+
+      if (!confirmed) this.exit(3)
+    }
 
     try {
       const workDir = await this.getProjectRoot()

--- a/packages/@sanity/cli/src/commands/schemas/delete.ts
+++ b/packages/@sanity/cli/src/commands/schemas/delete.ts
@@ -71,12 +71,9 @@ export class DeleteSchemaCommand extends SanityCommand<typeof DeleteSchemaComman
     const ids = parseIds(flags.ids)
 
     if (!yes && this.isUnattended()) {
-      this.error(
-        'Schema deletion requires confirmation. Re-run with --yes to delete the schemas.',
-        {
-          exit: 2,
-        },
-      )
+      this.error('Schema deletion requires confirmation. Pass `--yes` to delete the schemas.', {
+        exit: exitCodes.USAGE_ERROR,
+      })
     }
 
     if (!yes) {

--- a/packages/@sanity/cli/src/commands/schemas/delete.ts
+++ b/packages/@sanity/cli/src/commands/schemas/delete.ts
@@ -86,7 +86,8 @@ export class DeleteSchemaCommand extends SanityCommand<typeof DeleteSchemaComman
       })
 
       if (!confirmed) {
-        this.error('Schema deletion cancelled', {exit: exitCodes.USER_ABORT})
+        this.log('Schema deletion cancelled')
+        this.exit(exitCodes.USER_ABORT)
       }
     }
 

--- a/packages/@sanity/cli/src/commands/schemas/delete.ts
+++ b/packages/@sanity/cli/src/commands/schemas/delete.ts
@@ -1,6 +1,6 @@
 import {Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 
 import {deleteSchemaAction} from '../../actions/schema/deleteSchemaAction.js'
@@ -85,7 +85,9 @@ export class DeleteSchemaCommand extends SanityCommand<typeof DeleteSchemaComman
         message: `Delete ${ids.length} schema${ids.length === 1 ? '' : 's'}?`,
       })
 
-      if (!confirmed) this.exit(3)
+      if (!confirmed) {
+        this.error('Schema deletion cancelled', {exit: exitCodes.USER_ABORT})
+      }
     }
 
     try {

--- a/packages/@sanity/cli/src/commands/schemas/deploy.ts
+++ b/packages/@sanity/cli/src/commands/schemas/deploy.ts
@@ -55,7 +55,7 @@ export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaComman
       description: 'The name of the workspace to deploy a schema for',
       helpValue: '<name>',
       parse: async (input) => {
-        if (!input) throw new CLIError('workspace argument cannot be empty if specified', {exit: 1})
+        if (!input) throw new CLIError('workspace argument cannot be empty if specified', {exit: 2})
         return input
       },
     }),

--- a/packages/@sanity/cli/src/commands/schemas/deploy.ts
+++ b/packages/@sanity/cli/src/commands/schemas/deploy.ts
@@ -3,7 +3,7 @@ import {styleText} from 'node:util'
 import {Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
 import {formatSchemaValidation, SchemaExtractionError} from '@sanity/cli-build/_internal/extract'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 
 import {deploySchemas} from '../../actions/schema/deploySchemas.js'
 import {schemasDeployDebug} from '../../actions/schema/utils/debug.js'
@@ -55,7 +55,12 @@ export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaComman
       description: 'The name of the workspace to deploy a schema for',
       helpValue: '<name>',
       parse: async (input) => {
-        if (!input) throw new CLIError('workspace argument cannot be empty if specified', {exit: 2})
+        if (!input) {
+          throw new CLIError(
+            'Workspace name cannot be empty. Pass a value with `--workspace <name>`.',
+            {exit: exitCodes.USAGE_ERROR},
+          )
+        }
         return input
       },
     }),

--- a/packages/@sanity/cli/src/commands/schemas/extract.ts
+++ b/packages/@sanity/cli/src/commands/schemas/extract.ts
@@ -79,7 +79,7 @@ export class ExtractSchemaCommand extends SanityCommand<typeof ExtractSchemaComm
     )
     if (outputExists && !flags.force) {
       this.error(
-        `Schema file already exists at "${extractOptions.outputPath}". Pass \`--force\` to overwrite it.`,
+        `Schema file already exists at "${extractOptions.outputPath}". Pass --force to overwrite it.`,
         {exit: 2},
       )
     }

--- a/packages/@sanity/cli/src/commands/schemas/extract.ts
+++ b/packages/@sanity/cli/src/commands/schemas/extract.ts
@@ -81,8 +81,8 @@ export class ExtractSchemaCommand extends SanityCommand<typeof ExtractSchemaComm
     if (outputExists && !flags.force) {
       if (this.isUnattended()) {
         this.error(
-          `Schema file already exists at "${extractOptions.outputPath}". Pass --force to overwrite it.`,
-          {exit: 2},
+          `Schema file already exists at "${extractOptions.outputPath}". Pass \`--force\` to overwrite it.`,
+          {exit: exitCodes.USAGE_ERROR},
         )
       }
 

--- a/packages/@sanity/cli/src/commands/schemas/extract.ts
+++ b/packages/@sanity/cli/src/commands/schemas/extract.ts
@@ -1,7 +1,8 @@
 import {access} from 'node:fs/promises'
 
 import {Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
+import {confirm} from '@sanity/cli-core/ux'
 
 import {extractSchema} from '../../actions/schema/extractSchema.js'
 import {getExtractOptions} from '../../actions/schema/getExtractOptions.js'
@@ -78,10 +79,22 @@ export class ExtractSchemaCommand extends SanityCommand<typeof ExtractSchemaComm
       () => false,
     )
     if (outputExists && !flags.force) {
-      this.error(
-        `Schema file already exists at "${extractOptions.outputPath}". Pass --force to overwrite it.`,
-        {exit: 2},
-      )
+      if (this.isUnattended()) {
+        this.error(
+          `Schema file already exists at "${extractOptions.outputPath}". Pass --force to overwrite it.`,
+          {exit: 2},
+        )
+      }
+
+      const shouldOverwrite = await confirm({
+        default: false,
+        message: `Schema file already exists at "${extractOptions.outputPath}". Overwrite it?`,
+      })
+
+      if (!shouldOverwrite) {
+        this.output.log('Schema extraction cancelled')
+        return this.exit(exitCodes.USER_ABORT)
+      }
     }
 
     if (flags.watch) {

--- a/packages/@sanity/cli/src/commands/schemas/extract.ts
+++ b/packages/@sanity/cli/src/commands/schemas/extract.ts
@@ -1,3 +1,5 @@
+import {access} from 'node:fs/promises'
+
 import {Flags} from '@oclif/core'
 import {SanityCommand} from '@sanity/cli-core'
 
@@ -33,6 +35,9 @@ export class ExtractSchemaCommand extends SanityCommand<typeof ExtractSchemaComm
     'enforce-required-fields': Flags.boolean({
       description: 'Makes the schema generated treat fields marked as required as non-optional',
     }),
+    force: Flags.boolean({
+      description: 'Overwrite an existing schema file',
+    }),
     format: Flags.string({
       default: 'groq-type-nodes',
       description: 'Output format (currently only groq-type-nodes)',
@@ -67,6 +72,17 @@ export class ExtractSchemaCommand extends SanityCommand<typeof ExtractSchemaComm
       projectRoot,
       schemaExtraction,
     })
+
+    const outputExists = await access(extractOptions.outputPath).then(
+      () => true,
+      () => false,
+    )
+    if (outputExists && !flags.force) {
+      this.error(
+        `Schema file already exists at "${extractOptions.outputPath}". Pass \`--force\` to overwrite it.`,
+        {exit: 2},
+      )
+    }
 
     if (flags.watch) {
       return watchExtractSchema({

--- a/packages/@sanity/cli/src/commands/schemas/list.ts
+++ b/packages/@sanity/cli/src/commands/schemas/list.ts
@@ -61,17 +61,16 @@ export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(ListSchemaCommand)
+    const errors: string[] = []
+    const id = parseWorkspaceSchemaId(errors, flags.id)?.schemaId
+    if (errors.length > 0) {
+      this.error(`Invalid arguments:\n${errors.map((error) => `  - ${error}`).join('\n')}`, {
+        exit: 2,
+      })
+    }
 
     try {
       const projectRoot = await this.getProjectRoot()
-
-      const errors: string[] = []
-      const id = parseWorkspaceSchemaId(errors, flags.id)?.schemaId
-      if (errors.length > 0) {
-        this.error(`Invalid arguments:\n${errors.map((error) => `  - ${error}`).join('\n')}`, {
-          exit: 1,
-        })
-      }
 
       await listSchemas({
         configPath: projectRoot.path,

--- a/packages/@sanity/cli/src/commands/schemas/list.ts
+++ b/packages/@sanity/cli/src/commands/schemas/list.ts
@@ -1,5 +1,5 @@
 import {Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 
 import {listSchemas} from '../../actions/schema/listSchemas.js'
 import {schemasListDebug} from '../../actions/schema/utils/debug.js'
@@ -65,7 +65,7 @@ export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
     const id = parseWorkspaceSchemaId(errors, flags.id)?.schemaId
     if (errors.length > 0) {
       this.error(`Invalid arguments:\n${errors.map((error) => `  - ${error}`).join('\n')}`, {
-        exit: 2,
+        exit: exitCodes.USAGE_ERROR,
       })
     }
 

--- a/packages/@sanity/cli/test/integration/commands/graphql/deploy-errors.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/graphql/deploy-errors.test.ts
@@ -9,16 +9,7 @@ import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 import {GraphQLDeployCommand} from '../../../../src/commands/graphql/deploy.js'
 import {GRAPHQL_API_VERSION} from '../../../../src/services/graphql.js'
 
-const mockIsInteractive = vi.hoisted(() => vi.fn())
 const mockConfirm = vi.hoisted(() => vi.fn())
-
-vi.mock('@sanity/cli-core', async () => {
-  const actual = await vi.importActual('@sanity/cli-core')
-  return {
-    ...actual,
-    isInteractive: mockIsInteractive,
-  }
-})
 
 vi.mock('@sanity/cli-core/ux', async () => {
   const actual = await vi.importActual('@sanity/cli-core/ux')
@@ -73,14 +64,16 @@ describe('#graphql:deploy errors', {timeout: 60 * 1000}, () => {
       validationError: null,
     })
 
-    const {error, stdout} = await testCommand(GraphQLDeployCommand, [])
+    const {error, stdout} = await testCommand(GraphQLDeployCommand, [], {
+      mocks: {isInteractive: false},
+    })
 
     expect(error).toBeDefined()
-    expect(error?.message).toContain('Dangerous changes found')
+    expect(error?.message).toContain('schema contains dangerous changes')
     expect(error?.message).toContain('--force')
     expect(stdout).toContain('Found BREAKING changes')
     expect(stdout).toContain('Field "oldField" was removed')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('handles validation errors', async () => {

--- a/packages/@sanity/cli/test/integration/commands/graphql/deploy-errors.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/graphql/deploy-errors.test.ts
@@ -2,6 +2,7 @@ import {writeFile} from 'node:fs/promises'
 import {join} from 'node:path'
 
 import {getCliConfig} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
 import nock, {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
@@ -73,7 +74,7 @@ describe('#graphql:deploy errors', {timeout: 60 * 1000}, () => {
     expect(error?.message).toContain('--force')
     expect(stdout).toContain('Found BREAKING changes')
     expect(stdout).toContain('Field "oldField" was removed')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('handles validation errors', async () => {

--- a/packages/@sanity/cli/test/integration/commands/graphql/deploy-generation.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/graphql/deploy-generation.test.ts
@@ -6,15 +6,7 @@ import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 import {GraphQLDeployCommand} from '../../../../src/commands/graphql/deploy.js'
 import {GRAPHQL_API_VERSION} from '../../../../src/services/graphql.js'
 
-const mockIsInteractive = vi.hoisted(() => vi.fn())
 const mockConfirm = vi.hoisted(() => vi.fn())
-vi.mock('@sanity/cli-core', async () => {
-  const actual = await vi.importActual('@sanity/cli-core')
-  return {
-    ...actual,
-    isInteractive: mockIsInteractive,
-  }
-})
 
 vi.mock('@sanity/cli-core/ux', async () => {
   const actual = await vi.importActual('@sanity/cli-core/ux')
@@ -83,8 +75,6 @@ describe('#graphql:deploy generation', {timeout: 60 * 1000}, () => {
   })
 
   test('changes generation with --force from gen2 to gen3', async () => {
-    mockIsInteractive.mockReturnValue(false)
-
     nock(`https://${projectId}.api.sanity.io`)
       .head(`/${GRAPHQL_API_VERSION}/apis/graphql/${dataset}/default`)
       .reply(200, '', {
@@ -128,7 +118,6 @@ describe('#graphql:deploy generation', {timeout: 60 * 1000}, () => {
   })
 
   test('prompts for generation change in interactive mode and user declines', async () => {
-    mockIsInteractive.mockReturnValue(true)
     mockConfirm.mockResolvedValue(false) // User declines the generation change
 
     nock(`https://${projectId}.api.sanity.io`)
@@ -138,9 +127,12 @@ describe('#graphql:deploy generation', {timeout: 60 * 1000}, () => {
         'x-sanity-graphql-playground': 'true',
       })
 
-    const {error, stderr} = await testCommand(GraphQLDeployCommand, ['--generation', 'gen3'])
+    const {error, stderr} = await testCommand(GraphQLDeployCommand, ['--generation', 'gen3'], {
+      mocks: {isInteractive: true},
+    })
 
-    if (error) throw error
+    expect(error?.message).toBe('GraphQL deployment cancelled')
+    expect(error?.oclif?.exit).toBe(3)
     expect(stderr).toContain('Specified generation (gen3)')
     expect(stderr).toContain('currently deployed (gen2)')
     expect(mockConfirm).toHaveBeenCalledWith(
@@ -152,8 +144,6 @@ describe('#graphql:deploy generation', {timeout: 60 * 1000}, () => {
   })
 
   test('fails changing generation in non-interactive mode without --force', async () => {
-    mockIsInteractive.mockReturnValue(false)
-
     nock(`https://${projectId}.api.sanity.io`)
       .head(`/${GRAPHQL_API_VERSION}/apis/graphql/${dataset}/default`)
       .reply(200, '', {
@@ -161,17 +151,18 @@ describe('#graphql:deploy generation', {timeout: 60 * 1000}, () => {
         'x-sanity-graphql-playground': 'true',
       })
 
-    const {error} = await testCommand(GraphQLDeployCommand, ['--generation', 'gen3'])
+    const {error} = await testCommand(GraphQLDeployCommand, ['--generation', 'gen3'], {
+      mocks: {isInteractive: false},
+    })
 
     expect(error).toBeDefined()
     expect(error?.message).toContain('Specified generation (gen3)')
     expect(error?.message).toContain('differs from the one currently deployed (gen2)')
     expect(error?.message).toContain('--force')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('changes generation in interactive mode when user confirms', async () => {
-    mockIsInteractive.mockReturnValue(true)
     mockConfirm.mockResolvedValue(true) // User confirms the generation change
 
     nock(`https://${projectId}.api.sanity.io`)
@@ -203,7 +194,9 @@ describe('#graphql:deploy generation', {timeout: 60 * 1000}, () => {
       return {location: `/v1/graphql/${dataset}/default`}
     })
 
-    const {error, stderr} = await testCommand(GraphQLDeployCommand, ['--generation', 'gen3'])
+    const {error, stderr} = await testCommand(GraphQLDeployCommand, ['--generation', 'gen3'], {
+      mocks: {isInteractive: true},
+    })
 
     if (error) throw error
     expect(stderr).toContain('Specified generation (gen3)')

--- a/packages/@sanity/cli/test/integration/commands/graphql/deploy-generation.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/graphql/deploy-generation.test.ts
@@ -127,14 +127,18 @@ describe('#graphql:deploy generation', {timeout: 60 * 1000}, () => {
         'x-sanity-graphql-playground': 'true',
       })
 
-    const {error, stderr} = await testCommand(GraphQLDeployCommand, ['--generation', 'gen3'], {
-      mocks: {isInteractive: true},
-    })
+    const {error, stderr, stdout} = await testCommand(
+      GraphQLDeployCommand,
+      ['--generation', 'gen3'],
+      {
+        mocks: {isInteractive: true},
+      },
+    )
 
-    expect(error?.message).toBe('GraphQL deployment cancelled')
     expect(error?.oclif?.exit).toBe(3)
     expect(stderr).toContain('Specified generation (gen3)')
     expect(stderr).toContain('currently deployed (gen2)')
+    expect(stdout).toContain('GraphQL deployment cancelled')
     expect(mockConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'Are you sure you want to deploy?',

--- a/packages/@sanity/cli/test/integration/commands/graphql/deploy-generation.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/graphql/deploy-generation.test.ts
@@ -1,4 +1,5 @@
 import {getCliConfig} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
 import nock, {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
@@ -135,7 +136,7 @@ describe('#graphql:deploy generation', {timeout: 60 * 1000}, () => {
       },
     )
 
-    expect(error?.oclif?.exit).toBe(3)
+    expect(error?.oclif?.exit).toBe(exitCodes.USER_ABORT)
     expect(stderr).toContain('Specified generation (gen3)')
     expect(stderr).toContain('currently deployed (gen2)')
     expect(stdout).toContain('GraphQL deployment cancelled')
@@ -163,7 +164,7 @@ describe('#graphql:deploy generation', {timeout: 60 * 1000}, () => {
     expect(error?.message).toContain('Specified generation (gen3)')
     expect(error?.message).toContain('differs from the one currently deployed (gen2)')
     expect(error?.message).toContain('--force')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('changes generation in interactive mode when user confirms', async () => {

--- a/packages/@sanity/cli/test/integration/commands/graphql/deploy.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/graphql/deploy.test.ts
@@ -269,9 +269,9 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
       mocks: {isInteractive: true},
     })
 
-    expect(error?.message).toBe('GraphQL deployment cancelled')
     expect(error?.oclif?.exit).toBe(3)
     expect(stdout).toContain('Found BREAKING changes')
+    expect(stdout).toContain('GraphQL deployment cancelled')
     expect(stderr).not.toContain('Deployed!')
     expect(mockConfirm).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/@sanity/cli/test/integration/commands/graphql/deploy.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/graphql/deploy.test.ts
@@ -7,15 +7,6 @@ import {GraphQLDeployCommand} from '../../../../src/commands/graphql/deploy.js'
 import {GRAPHQL_API_VERSION} from '../../../../src/services/graphql.js'
 
 const mockConfirm = vi.hoisted(() => vi.fn())
-const mockIsInteractive = vi.hoisted(() => vi.fn())
-
-vi.mock('@sanity/cli-core', async () => {
-  const actual = await vi.importActual('@sanity/cli-core')
-  return {
-    ...actual,
-    isInteractive: mockIsInteractive,
-  }
-})
 
 vi.mock('@sanity/cli-core/ux', async () => {
   const actual = await vi.importActual('@sanity/cli-core/ux')
@@ -172,7 +163,6 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
   })
 
   test('prompts for playground in interactive mode for new deployment', async () => {
-    mockIsInteractive.mockReturnValue(true)
     mockConfirm.mockResolvedValue(true)
 
     nock(`https://${projectId}.api.sanity.io`)
@@ -201,6 +191,7 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
 
     const {error, stderr} = await testCommand(GraphQLDeployCommand, [], {
       config: {root: cwd},
+      mocks: {isInteractive: true},
     })
 
     if (error) throw error
@@ -249,7 +240,6 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
   })
 
   test('prompts and allows user to decline dangerous changes', async () => {
-    mockIsInteractive.mockReturnValue(true)
     mockConfirm.mockResolvedValue(false)
 
     nock(`https://${projectId}.api.sanity.io`)
@@ -275,9 +265,12 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
       validationError: null,
     })
 
-    const {error, stderr, stdout} = await testCommand(GraphQLDeployCommand, [])
+    const {error, stderr, stdout} = await testCommand(GraphQLDeployCommand, [], {
+      mocks: {isInteractive: true},
+    })
 
-    if (error) throw error
+    expect(error?.message).toBe('GraphQL deployment cancelled')
+    expect(error?.oclif?.exit).toBe(3)
     expect(stdout).toContain('Found BREAKING changes')
     expect(stderr).not.toContain('Deployed!')
     expect(mockConfirm).toHaveBeenCalledWith(
@@ -345,7 +338,6 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
   })
 
   test('renders dangerousChanges in output', async () => {
-    mockIsInteractive.mockReturnValue(true)
     mockConfirm.mockResolvedValue(false)
 
     nock(`https://${projectId}.api.sanity.io`)
@@ -375,16 +367,17 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
       validationError: null,
     })
 
-    const {error, stdout} = await testCommand(GraphQLDeployCommand, [])
+    const {error, stdout} = await testCommand(GraphQLDeployCommand, [], {
+      mocks: {isInteractive: true},
+    })
 
-    if (error) throw error
+    expect(error?.oclif?.exit).toBe(3)
     expect(stdout).toContain('Found potentially dangerous changes from previous schema')
     expect(stdout).toContain('Field "count" changed type from "Int" to "String"')
     expect(stdout).toContain('Enum value "ACTIVE" was added')
   })
 
   test('prompts and allows user to accept dangerous changes in interactive mode', async () => {
-    mockIsInteractive.mockReturnValue(true)
     mockConfirm.mockResolvedValue(true) // User accepts the dangerous changes
 
     nock(`https://${projectId}.api.sanity.io`)
@@ -419,7 +412,9 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
       location: `/v1/graphql/${dataset}/default`,
     })
 
-    const {error, stderr, stdout} = await testCommand(GraphQLDeployCommand, [])
+    const {error, stderr, stdout} = await testCommand(GraphQLDeployCommand, [], {
+      mocks: {isInteractive: true},
+    })
 
     if (error) throw error
     expect(stdout).toContain('Found BREAKING changes')

--- a/packages/@sanity/cli/test/integration/commands/graphql/deploy.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/graphql/deploy.test.ts
@@ -1,4 +1,5 @@
 import {getCliConfig} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
 import nock, {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
@@ -269,7 +270,7 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
       mocks: {isInteractive: true},
     })
 
-    expect(error?.oclif?.exit).toBe(3)
+    expect(error?.oclif?.exit).toBe(exitCodes.USER_ABORT)
     expect(stdout).toContain('Found BREAKING changes')
     expect(stdout).toContain('GraphQL deployment cancelled')
     expect(stderr).not.toContain('Deployed!')
@@ -371,7 +372,7 @@ describe('#graphql:deploy', {timeout: 60 * 1000}, () => {
       mocks: {isInteractive: true},
     })
 
-    expect(error?.oclif?.exit).toBe(3)
+    expect(error?.oclif?.exit).toBe(exitCodes.USER_ABORT)
     expect(stdout).toContain('Found potentially dangerous changes from previous schema')
     expect(stdout).toContain('Field "count" changed type from "Int" to "String"')
     expect(stdout).toContain('Enum value "ACTIVE" was added')

--- a/packages/@sanity/cli/test/integration/commands/schemas/delete.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/schemas/delete.test.ts
@@ -5,6 +5,13 @@ import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 import {DeleteSchemaCommand} from '../../../../src/commands/schemas/delete.js'
 import {SCHEMA_API_VERSION} from '../../../../src/services/schemas.js'
 
+const mockConfirm = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/cli-core/ux', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core/ux')>()),
+  confirm: mockConfirm,
+}))
+
 const schemaIds = ['_.schemas.production', '_.schemas.staging']
 
 describe('#schema:delete', {timeout: 60 * 1000}, () => {
@@ -18,6 +25,25 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+  })
+
+  test('requires explicit confirmation in unattended mode', async () => {
+    const {error} = await testCommand(DeleteSchemaCommand, ['--ids', '_.schemas.production'], {
+      mocks: {isInteractive: false},
+    })
+
+    expect(error?.message).toContain('Re-run with --yes')
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mockConfirm).not.toHaveBeenCalled()
+  })
+
+  test('exits with user-abort when interactive confirmation is declined', async () => {
+    mockConfirm.mockResolvedValue(false)
+    const {error} = await testCommand(DeleteSchemaCommand, ['--ids', '_.schemas.production'], {
+      mocks: {isInteractive: true},
+    })
+
+    expect(error?.oclif?.exit).toBe(3)
   })
 
   test('successfully deletes a single schema', async () => {
@@ -41,6 +67,7 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
     }).reply(200, {deleted: true})
 
     const {error, stdout} = await testCommand(DeleteSchemaCommand, [
+      '--yes',
       '--ids',
       '_.schemas.production',
     ])
@@ -72,6 +99,7 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
     }
 
     const {error, stdout} = await testCommand(DeleteSchemaCommand, [
+      '--yes',
       '--ids',
       '_.schemas.production,_.schemas.staging',
     ])
@@ -92,6 +120,7 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
     }).reply(200, {deleted: true})
 
     const {error, stdout} = await testCommand(DeleteSchemaCommand, [
+      '--yes',
       '--ids',
       '_.schemas.production',
       '--dataset',
@@ -106,16 +135,20 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
     {desc: 'no project ID is found', projectId: undefined},
     {desc: 'project ID is empty string', projectId: ''},
   ])('throws an error if $desc', async ({projectId: testProjectId}) => {
-    const {error} = await testCommand(DeleteSchemaCommand, ['--ids', '_.schemas.production'], {
-      mocks: {cliConfig: {api: {dataset: 'test', projectId: testProjectId}}},
-    })
+    const {error} = await testCommand(
+      DeleteSchemaCommand,
+      ['--yes', '--ids', '_.schemas.production'],
+      {
+        mocks: {cliConfig: {api: {dataset: 'test', projectId: testProjectId}}},
+      },
+    )
 
     expect(error?.message).toContain('Unable to determine project ID')
     expect(error?.oclif?.exit).toBe(1)
   })
 
   test('throws an error if ids is an empty string', async () => {
-    const {error} = await testCommand(DeleteSchemaCommand, ['--ids'])
+    const {error} = await testCommand(DeleteSchemaCommand, ['--yes', '--ids'])
 
     expect(error?.message).toContain('Flag --ids expects a value')
     expect(error?.oclif?.exit).toBe(2)
@@ -168,7 +201,7 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
       ids: ' , , ',
     },
   ])('throws error when $desc', async ({expectedError, ids}) => {
-    const {error} = await testCommand(DeleteSchemaCommand, ['--ids', ids])
+    const {error} = await testCommand(DeleteSchemaCommand, ['--yes', '--ids', ids])
 
     expect(error?.message).toContain(expectedError)
     expect(error?.oclif?.exit).toBe(2)
@@ -176,6 +209,7 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
 
   test('throws error when dataset flag is not provided a value', async () => {
     const {error} = await testCommand(DeleteSchemaCommand, [
+      '--yes',
       '--ids',
       '_.schemas.production',
       '--dataset',
@@ -195,7 +229,11 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
       uri: `/projects/${projectId}/datasets/staging/schemas/_.schemas.nonexistent`,
     }).reply(200, [])
 
-    const {error} = await testCommand(DeleteSchemaCommand, ['--ids', '_.schemas.nonexistent'])
+    const {error} = await testCommand(DeleteSchemaCommand, [
+      '--yes',
+      '--ids',
+      '_.schemas.nonexistent',
+    ])
 
     expect(error?.message).toContain('Deleted 0/1 schemas')
     expect(error?.message).toContain('not found')
@@ -231,6 +269,7 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
     }).reply(200, [])
 
     const {error} = await testCommand(DeleteSchemaCommand, [
+      '--yes',
       '--ids',
       '_.schemas.production,_.schemas.nonexistent',
     ])
@@ -263,7 +302,11 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
       error: 'Delete failed',
     })
 
-    const {error} = await testCommand(DeleteSchemaCommand, ['--ids', '_.schemas.production'])
+    const {error} = await testCommand(DeleteSchemaCommand, [
+      '--yes',
+      '--ids',
+      '_.schemas.production',
+    ])
 
     expect(error?.message).toContain('Failed to delete ids')
     expect(error?.oclif?.exit).toBe(1)
@@ -294,6 +337,7 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
     })
 
     const {error, stderr} = await testCommand(DeleteSchemaCommand, [
+      '--yes',
       '--ids',
       '_.schemas.production',
       '--verbose',

--- a/packages/@sanity/cli/test/integration/commands/schemas/delete.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/schemas/delete.test.ts
@@ -39,12 +39,16 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
 
   test('exits with user-abort when interactive confirmation is declined', async () => {
     mockConfirm.mockResolvedValue(false)
-    const {error} = await testCommand(DeleteSchemaCommand, ['--ids', '_.schemas.production'], {
-      mocks: {isInteractive: true},
-    })
+    const {error, stdout} = await testCommand(
+      DeleteSchemaCommand,
+      ['--ids', '_.schemas.production'],
+      {
+        mocks: {isInteractive: true},
+      },
+    )
 
-    expect(error?.message).toBe('Schema deletion cancelled')
     expect(error?.oclif?.exit).toBe(3)
+    expect(stdout).toContain('Schema deletion cancelled')
   })
 
   test('successfully deletes a single schema', async () => {

--- a/packages/@sanity/cli/test/integration/commands/schemas/delete.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/schemas/delete.test.ts
@@ -1,4 +1,5 @@
 import {getCliConfig} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
 import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 
@@ -32,8 +33,8 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
       mocks: {isInteractive: false},
     })
 
-    expect(error?.message).toContain('Re-run with --yes')
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.message).toContain('Pass `--yes`')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
     expect(mockConfirm).not.toHaveBeenCalled()
   })
 
@@ -47,7 +48,7 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
       },
     )
 
-    expect(error?.oclif?.exit).toBe(3)
+    expect(error?.oclif?.exit).toBe(exitCodes.USER_ABORT)
     expect(stdout).toContain('Schema deletion cancelled')
   })
 

--- a/packages/@sanity/cli/test/integration/commands/schemas/delete.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/schemas/delete.test.ts
@@ -43,6 +43,7 @@ describe('#schema:delete', {timeout: 60 * 1000}, () => {
       mocks: {isInteractive: true},
     })
 
+    expect(error?.message).toBe('Schema deletion cancelled')
     expect(error?.oclif?.exit).toBe(3)
   })
 

--- a/packages/@sanity/cli/test/integration/commands/schemas/list.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/schemas/list.test.ts
@@ -214,6 +214,28 @@ describe('#schema:list', {timeout: 60 * 1000}, () => {
     expect(stdout).toContain('↳ Failed to fetch schema from "test":\n  Bad request')
   })
 
+  test('writes JSON diagnostics to stderr without corrupting stdout', async () => {
+    mockApi({
+      apiVersion: SCHEMA_API_VERSION,
+      uri: `/projects/${projectId}/datasets/test/schemas`,
+    }).reply(400, {error: 'Bad request'})
+    mockApi({
+      apiVersion: SCHEMA_API_VERSION,
+      uri: `/projects/${projectId}/datasets/staging/schemas`,
+    }).reply(200, [
+      {
+        _createdAt: '2025-05-28T18:49:44Z',
+        _id: '_.schemas.staging',
+        workspace: {name: 'staging'},
+      },
+    ])
+
+    const {stderr, stdout} = await testCommand(ListSchemaCommand, ['--json'])
+
+    expect(JSON.parse(stdout)).toEqual([expect.objectContaining({_id: '_.schemas.staging'})])
+    expect(stderr).toContain('Failed to fetch schema from "test"')
+  })
+
   test('prints warning if schema request fails due to permissions', async () => {
     mockApi({
       apiVersion: SCHEMA_API_VERSION,

--- a/packages/@sanity/cli/test/integration/commands/schemas/list.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/schemas/list.test.ts
@@ -162,7 +162,7 @@ describe('#schema:list', {timeout: 60 * 1000}, () => {
     const {error} = await testCommand(ListSchemaCommand, ['--id', id])
 
     expect(error?.message).toContain(expectedError)
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('throws an error if no schemas are found', async () => {

--- a/packages/@sanity/cli/test/integration/commands/schemas/list.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/schemas/list.test.ts
@@ -1,4 +1,5 @@
 import {getCliConfig} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mockApi, testCommand, testFixture} from '@sanity/cli-test'
 import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 
@@ -162,7 +163,7 @@ describe('#schema:list', {timeout: 60 * 1000}, () => {
     const {error} = await testCommand(ListSchemaCommand, ['--id', id])
 
     expect(error?.message).toContain(expectedError)
-    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
   })
 
   test('throws an error if no schemas are found', async () => {


### PR DESCRIPTION
### Description

Adds unattended-mode support for GraphQL commands.

### What to review

Review the flags, prompt handling, and automated coverage.

### Testing

<!-- To be completed before marking ready. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation and exit-code behavior for deploy, undeploy, and schema delete/extract—scripts relying on old exit codes or silent skips may need updates, though defaults in interactive use are largely preserved.
> 
> **Overview**
> Adds **unattended-mode** behavior across GraphQL deploy/undeploy and experimental schema commands so CI and scripted runs do not hang on prompts.
> 
> **GraphQL:** Deploy and undeploy now use `isUnattended()` instead of raw `isInteractive()`. In unattended mode, destructive or ambiguous steps require **`--force`** (generation mismatch, breaking changes, multi-API flag overrides, undeploy). User declines and cancellations exit with **`USER_ABORT`** and clearer messages instead of generic “Operation cancelled”. Missing dataset / usage mistakes use **`USAGE_ERROR`**.
> 
> **Schema:** **`schema delete`** gains **`--yes`** and blocks unattended deletes without it, with an interactive confirm otherwise. **`schema extract`** gains **`--force`** to overwrite an existing output file; unattended runs error without it. **`schema list --json`** routes fetch/permission diagnostics to **stderr** (`warn`) so **stdout** stays valid JSON.
> 
> Tests are aligned with explicit `isInteractive` mocks and the new exit codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2bd3f1a6b9275135a92fdc865eeb17d1b749cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->