### PR TITLE
feat(cli): improve unattended mode for project management commands

### DIFF
--- a/.changeset/pr-1503.md
+++ b/.changeset/pr-1503.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): improve unattended mode for project management commands

--- a/.changeset/pr-1503.md
+++ b/.changeset/pr-1503.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-feat(cli): improve unattended mode for project management commands

--- a/.changeset/unattended-command-selection.md
+++ b/.changeset/unattended-command-selection.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': minor
+---
+
+Avoid interactive login-provider and package-manager prompts in unattended environments, using deterministic choices when possible and actionable errors otherwise.

--- a/.changeset/unattended-command-selection.md
+++ b/.changeset/unattended-command-selection.md
@@ -2,4 +2,7 @@
 '@sanity/cli': minor
 ---
 
-Avoid interactive login-provider and package-manager prompts in unattended environments, using deterministic choices when possible and actionable errors otherwise.
+feat(cli): avoid interactive setup choices in unattended mode
+
+Choose login providers and package managers deterministically when possible, and return usage errors
+when a choice is required.

--- a/.changeset/unattended-project-creation.md
+++ b/.changeset/unattended-project-creation.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': minor
+---
+
+Make `projects create` automation-safe by erroring with flag guidance instead of prompting when no organizations are available or the choice is ambiguous, returning a usage exit code for invalid dataset names, and keeping JSON output parseable when creating a dataset.

--- a/.changeset/unattended-project-creation.md
+++ b/.changeset/unattended-project-creation.md
@@ -2,4 +2,7 @@
 '@sanity/cli': minor
 ---
 
-Make `projects create` automation-safe by erroring with flag guidance instead of prompting when no organizations are available or the choice is ambiguous, returning a usage exit code for invalid dataset names, and keeping JSON output parseable when creating a dataset.
+feat(cli): support unattended project creation
+
+Require organization flags when selection is ambiguous, validate dataset names as usage errors, and
+keep dataset creation JSON machine-readable.

--- a/packages/@sanity/cli/src/actions/auth/login/getProvider.ts
+++ b/packages/@sanity/cli/src/actions/auth/login/getProvider.ts
@@ -69,11 +69,17 @@ export async function getProvider({
       return undefined
     }
 
-    if (!isInteractive() && realProviderNames.length > 1) {
-      throw new Error(
-        `Multiple login providers available: ${realProviderNames.join(', ')}. ` +
-          'Use `--provider <name>` to select one in unattended mode.',
-      )
+    if (!isInteractive()) {
+      if (realProviderNames.length === 1) {
+        return providers.find((provider) => provider.name === realProviderNames[0])
+      }
+
+      if (realProviderNames.length > 1) {
+        throw new Error(
+          `Multiple login providers available: ${realProviderNames.join(', ')}. ` +
+            'Use `--provider <name>` to select one in unattended mode.',
+        )
+      }
     }
 
     const provider = await promptForProviders(providers)

--- a/packages/@sanity/cli/src/actions/dataset/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/actions/dataset/__tests__/create.test.ts
@@ -1,0 +1,54 @@
+import {createMockOutput} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {createDataset as createDatasetService} from '../../../services/datasets.js'
+import {createDataset} from '../create.js'
+import {determineDatasetAclMode} from '../determineDatasetAclMode.js'
+
+const mockSpinnerSucceed = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/cli-core/ux', () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn(() => ({succeed: mockSpinnerSucceed})),
+  })),
+}))
+vi.mock('../../../services/datasets.js', () => ({
+  createDataset: vi.fn(),
+}))
+vi.mock('../determineDatasetAclMode.js', () => ({
+  determineDatasetAclMode: vi.fn(),
+}))
+
+const mockCreateDatasetService = vi.mocked(createDatasetService)
+const mockDetermineDatasetAclMode = vi.mocked(determineDatasetAclMode)
+const output = createMockOutput()
+const dataset = {aclMode: 'public' as const, datasetName: 'production'}
+const options = {
+  datasetName: 'production',
+  output,
+  projectFeatures: [],
+  projectId: 'project-id',
+}
+
+describe('actions/dataset/create', () => {
+  beforeEach(() => {
+    mockDetermineDatasetAclMode.mockResolvedValue('public')
+    mockCreateDatasetService.mockResolvedValue(dataset)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('logs human-readable success output by default', async () => {
+    await expect(createDataset(options)).resolves.toEqual(dataset)
+
+    expect(output.log).toHaveBeenCalledWith('Dataset created successfully')
+  })
+
+  test('omits human-readable success output when silent', async () => {
+    await expect(createDataset({...options, silent: true})).resolves.toEqual(dataset)
+
+    expect(output.log).not.toHaveBeenCalled()
+  })
+})

--- a/packages/@sanity/cli/src/actions/dataset/create.ts
+++ b/packages/@sanity/cli/src/actions/dataset/create.ts
@@ -56,6 +56,11 @@ interface CreateDatasetOptions {
   isUnattended?: boolean
 
   /**
+   * Whether to omit human-readable success output
+   */
+  silent?: boolean
+
+  /**
    * Requested visibility mode from flags/options
    */
   visibility?: string
@@ -83,6 +88,7 @@ export async function createDataset(options: CreateDatasetOptions): Promise<Data
     output,
     projectFeatures,
     projectId,
+    silent = false,
     visibility,
   } = options
 
@@ -111,7 +117,7 @@ export async function createDataset(options: CreateDatasetOptions): Promise<Data
       projectId,
     })
     spin.succeed()
-    output.log(`Dataset created successfully`)
+    if (!silent) output.log(`Dataset created successfully`)
     return newDataset
   } catch (error) {
     debug('Error creating dataset', {datasetName, error})

--- a/packages/@sanity/cli/src/actions/organizations/__tests__/getOrganization.test.ts
+++ b/packages/@sanity/cli/src/actions/organizations/__tests__/getOrganization.test.ts
@@ -60,12 +60,7 @@ describe('actions/organizations/getOrganization', () => {
 
   test('throws if requestedId does not match returned listed orgs', async () => {
     await expect(
-      getOrganization({
-        isUnattended: true,
-        output,
-        requestedId: 'nope',
-        user,
-      }),
+      getOrganization({isUnattended: true, output, requestedId: 'nope', user}),
     ).rejects.toThrow(`Organization "nope" not found or you don't have access to it`)
   })
 
@@ -85,7 +80,7 @@ describe('actions/organizations/getOrganization', () => {
       mockListOrgs.mockResolvedValue([])
 
       await expect(getOrganization(baseFlags)).rejects.toThrow(
-        'No organizations are available. Create an organization in sanity.io/manage, then pass its ID or slug with --organization.',
+        'No organizations are available. Create an organization at https://www.sanity.io/manage, then pass its ID or slug with --organization.',
       )
       expect(mockPromptForOrgName).not.toHaveBeenCalled()
       expect(uxMocks.select).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/actions/organizations/__tests__/getOrganization.test.ts
+++ b/packages/@sanity/cli/src/actions/organizations/__tests__/getOrganization.test.ts
@@ -60,24 +60,56 @@ describe('actions/organizations/getOrganization', () => {
 
   test('throws if requestedId does not match returned listed orgs', async () => {
     await expect(
-      getOrganization({isUnattended: true, output, requestedId: 'nope', user}),
+      getOrganization({
+        isUnattended: true,
+        output,
+        requestedId: 'nope',
+        user,
+      }),
     ).rejects.toThrow(`Organization "nope" not found or you don't have access to it`)
   })
 
   test('prompts to create an org if none returned by list orgs', async () => {
     mockListOrgs.mockResolvedValue([])
-    await getOrganization(baseFlags)
+    await getOrganization({...baseFlags, isUnattended: false})
     expect(output.log).toHaveBeenCalledWith(
       'You need to create an organization to create projects.',
     )
+    expect(mockPromptForOrgName).toHaveBeenCalled()
+    expect(mockCreateOrg).toHaveBeenCalled()
     expect(mockGetOrgsWithGrantInfo).not.toHaveBeenCalled()
   })
 
   describe('unattended mode', () => {
-    test('should return first attached-grant-info orgs if at least one exists', async () => {
+    test('throws an actionable error instead of prompting if no organizations exist', async () => {
+      mockListOrgs.mockResolvedValue([])
+
+      await expect(getOrganization(baseFlags)).rejects.toThrow(
+        'No organizations are available. Create an organization in sanity.io/manage, then pass its ID or slug with --organization.',
+      )
+      expect(mockPromptForOrgName).not.toHaveBeenCalled()
+      expect(uxMocks.select).not.toHaveBeenCalled()
+    })
+
+    test('returns the only organization with attach access', async () => {
       const result = await getOrganization(baseFlags)
       expect(result).toEqual(org)
     })
+
+    test('requires an explicit organization when multiple organizations have attach access', async () => {
+      const otherOrg = {id: 'org-2', name: 'Org 2', slug: 'org-2'}
+      mockListOrgs.mockResolvedValue([org, otherOrg])
+      mockGetOrgsWithGrantInfo.mockResolvedValue([
+        orgWithGrantInfo,
+        {hasAttachGrant: true, organization: otherOrg},
+      ])
+
+      await expect(getOrganization(baseFlags)).rejects.toThrow(
+        'Multiple organizations are available. Select one with --organization <slug|id>.',
+      )
+      expect(uxMocks.select).not.toHaveBeenCalled()
+    })
+
     test('should return undefined if no attached-grant-info orgs exist', async () => {
       mockGetOrgsWithGrantInfo.mockResolvedValue([])
       const result = await getOrganization(baseFlags)

--- a/packages/@sanity/cli/src/actions/organizations/getOrganization.ts
+++ b/packages/@sanity/cli/src/actions/organizations/getOrganization.ts
@@ -60,7 +60,7 @@ export async function getOrganization({
   if (organizations.length === 0) {
     if (isUnattended) {
       throw new Error(
-        'No organizations are available. Create an organization in sanity.io/manage, then pass its ID or slug with --organization.',
+        'No organizations are available. Create an organization at https://www.sanity.io/manage, then pass its ID or slug with --organization.',
       )
     }
 

--- a/packages/@sanity/cli/src/actions/organizations/getOrganization.ts
+++ b/packages/@sanity/cli/src/actions/organizations/getOrganization.ts
@@ -58,6 +58,12 @@ export async function getOrganization({
   // If the user has no organizations, prompt them to create one with the same name as
   // their user, but allow them to customize it if they want
   if (organizations.length === 0) {
+    if (isUnattended) {
+      throw new Error(
+        'No organizations are available. Create an organization in sanity.io/manage, then pass its ID or slug with --organization.',
+      )
+    }
+
     output.log('You need to create an organization to create projects.')
     return promptAndCreateNewOrganization(user)
   }
@@ -72,10 +78,14 @@ export async function getOrganization({
   debug('User has attach access to %d organizations.', withAttach.length)
   const organizationChoices = getOrganizationChoices(withGrantInfo)
 
-  // In unattended mode  use defaults without prompting
   if (isUnattended) {
-    // Use the first organization with attach permissions
-    return withAttach.length > 0 ? withAttach[0].organization : undefined
+    if (withAttach.length > 1) {
+      throw new Error(
+        'Multiple organizations are available. Select one with --organization <slug|id>.',
+      )
+    }
+
+    return withAttach[0]?.organization
   }
 
   // If the user only has a single organization (and they have attach access to it),

--- a/packages/@sanity/cli/src/commands/__tests__/install.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/install.test.ts
@@ -48,7 +48,7 @@ describe('#install', () => {
       expect(mockGetPackageManagerChoice).toHaveBeenCalledWith(
         convertToSystemPath('/test/project'),
         {
-          interactive: true,
+          interactive: false,
         },
       )
       expect(mockInstallDeclaredPackages).toHaveBeenCalledWith(
@@ -59,6 +59,21 @@ describe('#install', () => {
         }),
       )
       expect(mockInstallNewPackages).not.toHaveBeenCalled()
+    })
+
+    test('uses package manager fallback in unattended mode', async () => {
+      mockGetPackageManagerChoice.mockResolvedValueOnce({chosen: 'npm'})
+      mockInstallDeclaredPackages.mockResolvedValueOnce()
+
+      const {error} = await testCommand(Install, [], {
+        mocks: {...defaultMocks, isInteractive: false},
+      })
+
+      if (error) throw error
+      expect(mockGetPackageManagerChoice).toHaveBeenCalledWith(
+        convertToSystemPath('/test/project'),
+        {interactive: false},
+      )
     })
 
     test('installs declared packages with yarn', async () => {
@@ -261,7 +276,7 @@ describe('#install', () => {
       expect(mockGetPackageManagerChoice).toHaveBeenCalledWith(
         convertToSystemPath('/test/project'),
         {
-          interactive: true,
+          interactive: false,
         },
       )
       expect(mockInstallDeclaredPackages).toHaveBeenCalledWith(

--- a/packages/@sanity/cli/src/commands/__tests__/install.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/install.test.ts
@@ -35,20 +35,22 @@ afterEach(() => {
 
 describe('#install', () => {
   describe('install declared packages (no arguments)', () => {
-    test('installs declared packages with npm', async () => {
+    test('installs declared packages with npm in interactive mode', async () => {
       mockGetPackageManagerChoice.mockResolvedValueOnce({
         chosen: 'npm',
         mostOptimal: 'npm',
       })
       mockInstallDeclaredPackages.mockResolvedValueOnce()
 
-      const {error} = await testCommand(Install, [], {mocks: defaultMocks})
+      const {error} = await testCommand(Install, [], {
+        mocks: {...defaultMocks, isInteractive: true},
+      })
 
       if (error) throw error
       expect(mockGetPackageManagerChoice).toHaveBeenCalledWith(
         convertToSystemPath('/test/project'),
         {
-          interactive: false,
+          interactive: true,
         },
       )
       expect(mockInstallDeclaredPackages).toHaveBeenCalledWith(
@@ -271,12 +273,14 @@ describe('#install', () => {
       })
       mockInstallDeclaredPackages.mockResolvedValueOnce()
 
-      await testCommand(Install, [], {mocks: defaultMocks})
+      await testCommand(Install, [], {
+        mocks: {...defaultMocks, isInteractive: true},
+      })
 
       expect(mockGetPackageManagerChoice).toHaveBeenCalledWith(
         convertToSystemPath('/test/project'),
         {
-          interactive: false,
+          interactive: true,
         },
       )
       expect(mockInstallDeclaredPackages).toHaveBeenCalledWith(

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -1315,17 +1315,18 @@ describe('#login', {timeout: 10_000}, () => {
       expect(error?.oclif?.exit).toBe(1)
     })
 
-    test('succeeds non-interactively with a single OAuth provider', async () => {
+    test('selects the sole OAuth provider when experimental SSO is enabled', async () => {
       mockedGetCliToken.mockResolvedValue('')
       mockedIsInteractive.mockReturnValue(false)
       mockSingleProviderLogin()
 
-      const commandPromise = testCommand(LoginCommand, [])
+      const commandPromise = testCommand(LoginCommand, ['--experimental'])
       await simulateOAuthCallback(commandPromise, 'test-session-id')
       const {error, stdout} = await commandPromise
 
       if (error) throw error
       expect(stdout).toContain('Login successful')
+      expect(mockSelect).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/@sanity/cli/src/commands/install.ts
+++ b/packages/@sanity/cli/src/commands/install.ts
@@ -34,7 +34,9 @@ export class Install extends SanityCommand<typeof Install> {
     const root = await this.getProjectRoot()
     const workDir = root.directory
 
-    const pkgManager = await getPackageManagerChoice(workDir, {interactive: true})
+    const pkgManager = await getPackageManagerChoice(workDir, {
+      interactive: !this.isUnattended(),
+    })
 
     await (packages.length > 0
       ? installNewPackages(

--- a/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
@@ -271,4 +271,19 @@ describe('#projects:create', () => {
       expect.stringContaining('Project created successfully'),
     )
   })
+
+  test('keeps JSON output parseable when creating a dataset', async () => {
+    await CreateProjectCommand.run([
+      'My Project',
+      '--organization=org-1',
+      '--dataset=production',
+      '--json',
+    ])
+
+    const output = vi
+      .mocked(mocks.SanityCmdOutput.log)
+      .mock.calls.map(([message]) => String(message))
+    expect(output).toEqual([JSON.stringify(mockProject, null, 2)])
+    expect(JSON.parse(output[0]!)).toEqual(mockProject)
+  })
 })

--- a/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
@@ -85,9 +85,10 @@ describe('#projects:create', () => {
   test('throws error if provided invalid dataset flag', async () => {
     const datasetError = 'terrible name'
     mockValidateDatasetName.mockReturnValue(datasetError) // returns error if invalid
-    await expect(CreateProjectCommand.run(['--dataset=~~invalid-name'])).rejects.toThrow(
-      datasetError,
-    )
+    await expect(CreateProjectCommand.run(['--dataset=~~invalid-name'])).rejects.toMatchObject({
+      message: expect.stringContaining(datasetError),
+      oclif: {exit: 2},
+    })
   })
 
   test('errors when retrieving organization fails', async () => {
@@ -285,5 +286,6 @@ describe('#projects:create', () => {
       .mock.calls.map(([message]) => String(message))
     expect(output).toEqual([JSON.stringify(mockProject, null, 2)])
     expect(JSON.parse(output[0]!)).toEqual(mockProject)
+    expect(mockCreateDataset).toHaveBeenCalledWith(expect.objectContaining({silent: true}))
   })
 })

--- a/packages/@sanity/cli/src/commands/projects/create.ts
+++ b/packages/@sanity/cli/src/commands/projects/create.ts
@@ -63,7 +63,7 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
       parse: async (input) => {
         const datasetNameError = validateDatasetName(input)
         if (datasetNameError) {
-          throw new CLIError(datasetNameError, {exit: 1})
+          throw new CLIError(datasetNameError, {exit: 2})
         }
 
         return input
@@ -189,6 +189,7 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
           output: this.output,
           projectFeatures,
           projectId,
+          silent: this.flags.json,
           visibility: datasetVisibility,
         })
       }


### PR DESCRIPTION
### Description

Improves unattended-mode behavior for project management commands.

### What to review

Review the flags, prompt handling, and automated coverage.

### Testing

<!-- To be completed before marking ready. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Unattended org selection no longer defaults to the first org when several exist, which may break scripts that omitted `--organization`; changes are localized to CLI UX and covered by new tests.
> 
> **Overview**
> Makes **unattended / CI** flows avoid prompts where a single choice is obvious, and **fail with clear flag guidance** when a human choice is required.
> 
> **Login** auto-picks the only real OAuth provider in non-interactive mode (including when `--experimental` adds the synthetic SSO entry); multiple providers still require `--provider`.
> 
> **Organization resolution** no longer creates or silently picks among orgs in unattended mode: zero orgs → actionable error; multiple orgs with attach access → require `--organization`; a single attachable org still auto-selects.
> 
> **Install** passes `interactive: false` into package manager selection when unattended.
> 
> **Project create** treats invalid `--dataset` as a usage error (exit **2**), and with **`--json`** suppresses dataset success text via `silent` so stdout stays a single parseable JSON object.
> 
> Tests cover org/login/install/create/dataset behavior; two minor **changesets** document the release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c5c43e4711ae7d65f684036793eeffcf10ca30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->