### PR TITLE
feat(cli): add unattended mode support to undeploy command

### DIFF
--- a/.changeset/confirm-unattended-undeploys.md
+++ b/.changeset/confirm-unattended-undeploys.md
@@ -2,5 +2,7 @@
 '@sanity/cli': minor
 ---
 
-Require `--yes` before unattended undeploys instead of treating non-interactive or JSON output as
-consent, and return distinct usage and cancellation exit codes while keeping JSON errors on stdout.
+feat(cli): require confirmation for unattended undeploys
+
+Require `--yes` instead of treating non-interactive or JSON output as consent, distinguish usage
+errors from cancellations, and keep JSON errors machine-readable.

--- a/.changeset/confirm-unattended-undeploys.md
+++ b/.changeset/confirm-unattended-undeploys.md
@@ -1,0 +1,6 @@
+---
+'@sanity/cli': minor
+---
+
+Require `--yes` before unattended undeploys instead of treating non-interactive or JSON output as
+consent, and return distinct usage and cancellation exit codes while keeping JSON errors on stdout.

--- a/.changeset/pr-1504.md
+++ b/.changeset/pr-1504.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): add unattended mode support to undeploy command

--- a/.changeset/pr-1504.md
+++ b/.changeset/pr-1504.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': minor
----
-
-feat(cli): add unattended mode support to undeploy command

--- a/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
@@ -17,7 +17,11 @@ vi.mock('@sanity/cli-core/ux', async () => import('@sanity/cli-test/mocks/cli-co
 const mockOutput = () => ({error: vi.fn(), log: vi.fn(), warn: vi.fn()}) as unknown as Output
 
 const options = (output: Output, flags: Partial<UndeployOptions['flags']> = {}): UndeployOptions =>
-  ({flags: {'dry-run': false, yes: false, ...flags}, output}) as UndeployOptions
+  ({
+    flags: {'dry-run': false, yes: false, ...flags},
+    isUnattended: false,
+    output,
+  }) as UndeployOptions
 
 function target(overrides: Partial<UndeployTarget> = {}): UndeployTarget {
   return {
@@ -64,7 +68,12 @@ describe('runUndeploy dry run', () => {
     const output = mockOutput()
     await runUndeploy(
       options(output, {'dry-run': true}),
-      adapter({resolveTarget: async () => ({message: 'No application ID provided', type: 'none'})}),
+      adapter({
+        resolveTarget: async () => ({
+          message: 'No application ID provided',
+          type: 'none',
+        }),
+      }),
     )
 
     expect(output.log).toHaveBeenCalledWith(expect.stringContaining('Nothing to undeploy.'))
@@ -109,6 +118,23 @@ describe('runUndeploy real run', () => {
     await runUndeploy(options(output), adapter({undeploy}))
 
     expect(undeploy).not.toHaveBeenCalled()
+    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled.', {
+      exit: 3,
+    })
+  })
+
+  test('an unattended run requires explicit confirmation', async () => {
+    const output = mockOutput()
+    const undeploy = vi.fn()
+
+    await runUndeploy({...options(output), isUnattended: true}, adapter({undeploy}))
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(undeploy).not.toHaveBeenCalled()
+    expect(output.error).toHaveBeenCalledWith(
+      'Undeploy requires confirmation in unattended mode. Pass --yes to continue.',
+      {exit: 2},
+    )
   })
 
   test('--yes skips the confirmation', async () => {
@@ -175,12 +201,16 @@ describe('runUndeploy real run', () => {
   test('Ctrl+C on the prompt reads as a cancellation, not an error dump', async () => {
     const output = mockOutput()
     vi.mocked(confirm).mockRejectedValueOnce(
-      Object.assign(new Error('User force closed'), {name: 'ExitPromptError'}),
+      Object.assign(new Error('User force closed'), {
+        name: 'ExitPromptError',
+      }),
     )
 
     await runUndeploy(options(output), adapter())
 
-    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled by user', {exit: 1})
+    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled by user', {
+      exit: 1,
+    })
   })
 })
 
@@ -219,11 +249,19 @@ describe('runUndeploy --json', () => {
     const output = mockOutput()
     await runUndeploy(
       options(output, {json: true, yes: true}),
-      adapter({resolveTarget: async () => ({message: 'No application ID provided', type: 'none'})}),
+      adapter({
+        resolveTarget: async () => ({
+          message: 'No application ID provided',
+          type: 'none',
+        }),
+      }),
     )
 
     const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
-    expect(payload).toEqual({reason: 'No application ID provided', undeployed: false})
+    expect(payload).toEqual({
+      reason: 'No application ID provided',
+      undeployed: false,
+    })
   })
 
   test('a failed deletion emits a {undeployed: false} error envelope and still errors on stderr', async () => {
@@ -240,7 +278,9 @@ describe('runUndeploy --json', () => {
     const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
     expect(payload.undeployed).toBe(false)
     expect(payload.error.message).toContain('boom')
-    expect(output.error).toHaveBeenCalledWith(payload.error.message, {exit: 1})
+    expect(output.error).toHaveBeenCalledWith(payload.error.message, {
+      exit: 1,
+    })
   })
 })
 
@@ -257,7 +297,10 @@ describe('describeUndeployTarget', () => {
       target: target({id: 'core-1', title: 'My App', type: 'coreApp'}),
       type: 'found',
     })
-    expect(check).toEqual({message: 'Undeploys application "My App" (core-1)', status: 'pass'})
+    expect(check).toEqual({
+      message: 'Undeploys application "My App" (core-1)',
+      status: 'pass',
+    })
   })
 
   test('an untitled application → pass check naming the ID', () => {
@@ -275,7 +318,11 @@ describe('describeUndeployTarget', () => {
         solution: 'Set it',
         type: 'none',
       }),
-    ).toEqual({message: 'No application ID provided', solution: 'Set it', status: 'skip'})
+    ).toEqual({
+      message: 'No application ID provided',
+      solution: 'Set it',
+      status: 'skip',
+    })
   })
 })
 
@@ -342,7 +389,12 @@ describe('undeployPlanToJson', () => {
   })
 
   test('an undeployable plan reports the full target', () => {
-    const json = undeployPlanToJson({checks: [], reason: null, target: target(), type: 'studio'})
+    const json = undeployPlanToJson({
+      checks: [],
+      reason: null,
+      target: target(),
+      type: 'studio',
+    })
     expect(json.canUndeploy).toBe(true)
     expect(json.application).toEqual(target())
   })
@@ -353,7 +405,12 @@ describe('renderUndeployPlan', () => {
     const output = mockOutput()
     renderUndeployPlan(
       {
-        checks: [{message: 'Undeploys studio https://my-studio.sanity.studio', status: 'pass'}],
+        checks: [
+          {
+            message: 'Undeploys studio https://my-studio.sanity.studio',
+            status: 'pass',
+          },
+        ],
         reason: null,
         target: target(),
         type: 'studio',

--- a/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
@@ -68,12 +68,7 @@ describe('runUndeploy dry run', () => {
     const output = mockOutput()
     await runUndeploy(
       options(output, {'dry-run': true}),
-      adapter({
-        resolveTarget: async () => ({
-          message: 'No application ID provided',
-          type: 'none',
-        }),
-      }),
+      adapter({resolveTarget: async () => ({message: 'No application ID provided', type: 'none'})}),
     )
 
     expect(output.log).toHaveBeenCalledWith(expect.stringContaining('Nothing to undeploy.'))
@@ -118,9 +113,7 @@ describe('runUndeploy real run', () => {
     await runUndeploy(options(output), adapter({undeploy}))
 
     expect(undeploy).not.toHaveBeenCalled()
-    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled.', {
-      exit: 3,
-    })
+    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled', {exit: 3})
   })
 
   test('an unattended run requires explicit confirmation', async () => {
@@ -132,7 +125,7 @@ describe('runUndeploy real run', () => {
     expect(confirm).not.toHaveBeenCalled()
     expect(undeploy).not.toHaveBeenCalled()
     expect(output.error).toHaveBeenCalledWith(
-      'Undeploy requires confirmation in unattended mode. Pass --yes to continue.',
+      'Undeploy requires confirmation. Pass --yes to continue.',
       {exit: 2},
     )
   })
@@ -201,16 +194,12 @@ describe('runUndeploy real run', () => {
   test('Ctrl+C on the prompt reads as a cancellation, not an error dump', async () => {
     const output = mockOutput()
     vi.mocked(confirm).mockRejectedValueOnce(
-      Object.assign(new Error('User force closed'), {
-        name: 'ExitPromptError',
-      }),
+      Object.assign(new Error('User force closed'), {name: 'ExitPromptError'}),
     )
 
     await runUndeploy(options(output), adapter())
 
-    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled by user', {
-      exit: 1,
-    })
+    expect(output.error).toHaveBeenCalledWith('Undeploy cancelled', {exit: 3})
   })
 })
 
@@ -249,19 +238,11 @@ describe('runUndeploy --json', () => {
     const output = mockOutput()
     await runUndeploy(
       options(output, {json: true, yes: true}),
-      adapter({
-        resolveTarget: async () => ({
-          message: 'No application ID provided',
-          type: 'none',
-        }),
-      }),
+      adapter({resolveTarget: async () => ({message: 'No application ID provided', type: 'none'})}),
     )
 
     const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
-    expect(payload).toEqual({
-      reason: 'No application ID provided',
-      undeployed: false,
-    })
+    expect(payload).toEqual({reason: 'No application ID provided', undeployed: false})
   })
 
   test('a failed deletion emits a {undeployed: false} error envelope and still errors on stderr', async () => {
@@ -278,9 +259,7 @@ describe('runUndeploy --json', () => {
     const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
     expect(payload.undeployed).toBe(false)
     expect(payload.error.message).toContain('boom')
-    expect(output.error).toHaveBeenCalledWith(payload.error.message, {
-      exit: 1,
-    })
+    expect(output.error).toHaveBeenCalledWith(payload.error.message, {exit: 1})
   })
 })
 
@@ -297,10 +276,7 @@ describe('describeUndeployTarget', () => {
       target: target({id: 'core-1', title: 'My App', type: 'coreApp'}),
       type: 'found',
     })
-    expect(check).toEqual({
-      message: 'Undeploys application "My App" (core-1)',
-      status: 'pass',
-    })
+    expect(check).toEqual({message: 'Undeploys application "My App" (core-1)', status: 'pass'})
   })
 
   test('an untitled application → pass check naming the ID', () => {
@@ -318,11 +294,7 @@ describe('describeUndeployTarget', () => {
         solution: 'Set it',
         type: 'none',
       }),
-    ).toEqual({
-      message: 'No application ID provided',
-      solution: 'Set it',
-      status: 'skip',
-    })
+    ).toEqual({message: 'No application ID provided', solution: 'Set it', status: 'skip'})
   })
 })
 
@@ -389,12 +361,7 @@ describe('undeployPlanToJson', () => {
   })
 
   test('an undeployable plan reports the full target', () => {
-    const json = undeployPlanToJson({
-      checks: [],
-      reason: null,
-      target: target(),
-      type: 'studio',
-    })
+    const json = undeployPlanToJson({checks: [], reason: null, target: target(), type: 'studio'})
     expect(json.canUndeploy).toBe(true)
     expect(json.application).toEqual(target())
   })
@@ -405,12 +372,7 @@ describe('renderUndeployPlan', () => {
     const output = mockOutput()
     renderUndeployPlan(
       {
-        checks: [
-          {
-            message: 'Undeploys studio https://my-studio.sanity.studio',
-            status: 'pass',
-          },
-        ],
+        checks: [{message: 'Undeploys studio https://my-studio.sanity.studio', status: 'pass'}],
         reason: null,
         target: target(),
         type: 'studio',

--- a/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {CLIError} from '@oclif/core/errors'
-import {type Output, subdebug} from '@sanity/cli-core'
+import {exitCodes, type Output, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {confirm, spinner} from '@sanity/cli-core/ux'
 
@@ -27,6 +27,7 @@ type UndeployFlags = UndeployCommand['flags']
 
 export interface UndeployOptions {
   flags: UndeployFlags
+  isUnattended: boolean
   output: Output
 }
 
@@ -115,12 +116,21 @@ async function undeployApp(
   }
 
   const {target} = resolution
+  if (!flags.yes && options.isUnattended) {
+    throw new CLIError(
+      'Undeploy requires confirmation in unattended mode. Pass --yes to continue.',
+      {exit: exitCodes.USAGE_ERROR},
+    )
+  }
+
   if (!flags.yes) {
     const shouldUndeploy = await confirm({
       default: false,
       message: confirmUndeployMessage(target),
     })
-    if (!shouldUndeploy) return undefined
+    if (!shouldUndeploy) {
+      throw new CLIError('Undeploy cancelled.', {exit: exitCodes.USER_ABORT})
+    }
   }
 
   const spin = spinner(

--- a/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
@@ -117,10 +117,9 @@ async function undeployApp(
 
   const {target} = resolution
   if (!flags.yes && options.isUnattended) {
-    throw new CLIError(
-      'Undeploy requires confirmation in unattended mode. Pass --yes to continue.',
-      {exit: exitCodes.USAGE_ERROR},
-    )
+    throw new CLIError('Undeploy requires confirmation. Pass --yes to continue.', {
+      exit: exitCodes.USAGE_ERROR,
+    })
   }
 
   if (!flags.yes) {
@@ -129,7 +128,7 @@ async function undeployApp(
       message: confirmUndeployMessage(target),
     })
     if (!shouldUndeploy) {
-      throw new CLIError('Undeploy cancelled.', {exit: exitCodes.USER_ABORT})
+      throw new CLIError('Undeploy cancelled', {exit: exitCodes.USER_ABORT})
     }
   }
 
@@ -217,7 +216,7 @@ function normalizeFailure(
 ): {exit: number; message: string} {
   // Ctrl+C on the confirmation prompt isn't a real failure
   if (error instanceof Error && error.name === 'ExitPromptError') {
-    return {exit: 1, message: 'Undeploy cancelled by user'}
+    return {exit: exitCodes.USER_ABORT, message: 'Undeploy cancelled'}
   }
   // A failed check already carries its own message and exit code
   if (error instanceof CLIError) {

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -578,7 +578,7 @@ describe('#undeploy', () => {
     const payload = JSON.parse(stdout)
     expect(payload).toEqual({
       error: {
-        message: 'Undeploy requires confirmation in unattended mode. Pass --yes to continue.',
+        message: 'Undeploy requires confirmation. Pass --yes to continue.',
       },
       undeployed: false,
     })

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -44,6 +44,7 @@ describe('#undeploy', () => {
           api: {projectId: 'test'},
           studioHost: 'my-host',
         },
+        isInteractive: true,
         token: 'test-token',
       },
     })
@@ -74,6 +75,7 @@ describe('#undeploy', () => {
           app: {},
           deployment: {appId: 'core-id'},
         },
+        isInteractive: true,
         token: 'test-token',
       },
     })
@@ -114,6 +116,7 @@ describe('#undeploy', () => {
           app: {},
           deployment: {appId: 'core-id'},
         },
+        isInteractive: true,
         token: 'test-token',
       },
     })
@@ -162,7 +165,7 @@ describe('#undeploy', () => {
 
     vi.mocked(confirm).mockResolvedValueOnce(false)
 
-    await testCommand(UndeployCommand, [], {
+    const {error} = await testCommand(UndeployCommand, [], {
       mocks: {
         cliConfig: {
           api: {projectId: 'test'},
@@ -173,7 +176,27 @@ describe('#undeploy', () => {
       },
     })
 
-    // No delete call should be made since prompt was rejected
+    expect(error?.oclif?.exit).toBe(3)
+  })
+
+  test('requires --yes before prompting in unattended mode', async () => {
+    mockApi({
+      apiVersion: 'v2024-08-01',
+      query: {appHost: 'my-host', appType: 'studio'},
+      uri: '/projects/test/user-applications',
+    }).reply(200, {appHost: 'my-host', id: 'app-id'})
+
+    const {error} = await testCommand(UndeployCommand, [], {
+      mocks: {
+        cliConfig: {api: {projectId: 'test'}, studioHost: 'my-host'},
+        isInteractive: false,
+        token: 'test-token',
+      },
+    })
+
+    expect(error?.message).toContain('Pass --yes to continue')
+    expect(error?.oclif?.exit).toBe(2)
+    expect(confirm).not.toHaveBeenCalled()
   })
 
   test('undeploys if prompt is accepted', async () => {
@@ -531,7 +554,7 @@ describe('#undeploy', () => {
     expect(payload.application.id).toBe('app-id')
   })
 
-  test('--json without --yes undeploys unattended, never prompting', async () => {
+  test('--json without --yes reports the required confirmation as JSON', async () => {
     mockApi({
       apiVersion: 'v2024-08-01',
       query: {appHost: 'my-host', appType: 'studio'},
@@ -541,14 +564,7 @@ describe('#undeploy', () => {
       id: 'app-id',
     })
 
-    mockApi({
-      apiVersion: 'v2024-08-01',
-      method: 'delete',
-      query: {appType: 'studio'},
-      uri: '/user-applications/app-id',
-    }).reply(200)
-
-    const {stdout} = await testCommand(UndeployCommand, ['--json'], {
+    const {error, stdout} = await testCommand(UndeployCommand, ['--json'], {
       mocks: {
         cliConfig: {
           api: {projectId: 'test'},
@@ -560,7 +576,13 @@ describe('#undeploy', () => {
 
     expect(confirm).not.toHaveBeenCalled()
     const payload = JSON.parse(stdout)
-    expect(payload.undeployed).toBe(true)
+    expect(payload).toEqual({
+      error: {
+        message: 'Undeploy requires confirmation in unattended mode. Pass --yes to continue.',
+      },
+      undeployed: false,
+    })
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('handles error when deployment.appId does not exist for the org', async () => {

--- a/packages/@sanity/cli/src/commands/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/undeploy.ts
@@ -52,9 +52,6 @@ export class UndeployCommand extends SanityCommand<typeof UndeployCommand> {
       ? createAppUndeployAdapter(cliConfig)
       : createStudioUndeployAdapter(cliConfig)
 
-    // An unattended run (--yes, --json, non-TTY) can't answer the confirmation
-    // prompt, so it consents up front; machine callers preview with --dry-run.
-    const undeployFlags = this.isUnattended() ? {...flags, yes: true} : flags
-    await runUndeploy({flags: undeployFlags, output: this.output}, adapter)
+    await runUndeploy({flags, isUnattended: this.isUnattended(), output: this.output}, adapter)
   }
 }


### PR DESCRIPTION
### Description

Adds unattended-mode support to the undeploy command.

### What to review

Review the flags, prompt handling, and automated coverage.

### Testing

<!-- To be completed before marking ready. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes destructive undeploy behavior for CI/scripts that relied on `--json` or non-TTY auto-consent; callers must add `--yes`, but interactive flows and explicit `--yes` paths are unchanged.
> 
> **Overview**
> **Breaking behavior change:** `sanity undeploy` no longer treats non-interactive or `--json` runs as implicit consent. Unattended runs without `--yes` fail with a usage error (`Pass --yes to continue`, exit **2**) instead of deleting; scripts and CI must pass `--yes` explicitly.
> 
> The command stops auto-setting `yes: true` when `isUnattended()` is true and passes `isUnattended` into `runUndeploy`, which blocks deletion before any prompt when unattended and `yes` is false.
> 
> **Exit codes and messaging** are aligned with `@sanity/cli-core` conventions: user decline and Ctrl+C on the prompt use **USER_ABORT** (3) with `Undeploy cancelled`; missing confirmation in unattended mode uses **USAGE_ERROR** (2). With `--json`, the same confirmation requirement surfaces as `{ undeployed: false, error: { message } }` on stdout.
> 
> Tests cover unattended `--yes` requirement, rejected prompts, and the updated `--json` without `--yes` case (no delete, machine-readable error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c8918c258968a78e188c4280b020a7d219619f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->