### PR TITLE
feat(deploy): report workbench URLs on deploy and undeploy

### DIFF
--- a/.changeset/pr-1507.md
+++ b/.changeset/pr-1507.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+'@sanity/workbench-cli': minor
+---
+
+feat(deploy): report workbench URLs on deploy and undeploy

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -309,6 +309,7 @@ describe('checkAppTarget (workbench backend)', () => {
     expect(reporter.results[0]).toMatchObject({status: 'pass'})
     expect(reporter.results[0]?.message).toContain('Deploys to existing application "Drop Desk"')
     expect(reporter.results[0]?.target?.action).toBe('update')
+    expect(reporter.results[0]?.target?.url).toBe('https://org-1.sanity.run/application/app-1')
   })
 
   test('unknown appId → fail check pointing to deployment.appId', async () => {
@@ -367,10 +368,10 @@ describe('checkStudioTarget (workbench backend)', () => {
 
     expect(reporter.results[0]).toMatchObject({status: 'pass'})
     expect(reporter.results[0]?.message).toContain(
-      'Deploys to existing studio https://my-studio.sanity.studio',
+      'Deploys to existing studio https://org-1.sanity.run/studio/app-1',
     )
     expect(target?.action).toBe('update')
-    expect(target?.url).toBe('https://my-studio.sanity.studio')
+    expect(target?.url).toBe('https://org-1.sanity.run/studio/app-1')
   })
 
   test('no appId with a studioHost → pass check for the studio that would be created', async () => {
@@ -384,8 +385,9 @@ describe('checkStudioTarget (workbench backend)', () => {
     })
 
     expect(reporter.results[0]).toMatchObject({status: 'pass'})
-    expect(reporter.results[0]?.message).toContain('Would create studio hostname')
+    expect(reporter.results[0]?.message).toContain('Would create studio hostname my-studio')
     expect(reporter.results[0]?.message).toContain('titled "New Studio"')
+    expect(reporter.results[0]?.target?.url).toBeNull()
     expect(mockGetApplication).not.toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -10,6 +10,7 @@ import {
   buildExposes,
   deployConfig,
   deployCoreApp as deployWorkbenchCoreApp,
+  getApplicationUrl,
   getWorkbench,
   resolveInstallationId,
   summarizeConfig,
@@ -198,10 +199,11 @@ async function runAppDeployment(
   // Dry run stops here — everything below mutates.
   if (dryRun) return
 
-  if (installationId && version && configAppType) {
+  if (installationId && version && configAppType && organizationId) {
     await deployConfig({
       appType: configAppType,
       installationId,
+      organizationId,
       output,
       sourceDir,
       version,
@@ -245,6 +247,7 @@ async function runAppDeployment(
       title: appTitle,
       version,
     })
+    const url = getApplicationUrl({id: applicationId, organizationId, type: 'coreApp'})
     logAppDeployed({
       applicationId,
       cliConfig,
@@ -252,6 +255,7 @@ async function runAppDeployment(
       organizationId,
       output,
       title: appTitle,
+      url,
     })
     return {
       applicationType: 'coreApp',
@@ -264,7 +268,7 @@ async function runAppDeployment(
         // A redeploy ignores the slug, so only a create reports the one it used.
         ...(appId ? {} : {slug}),
         title: appTitle,
-        url: getCoreAppUrl(organizationId, applicationId),
+        url,
       },
     }
   }
@@ -408,6 +412,7 @@ export function logAppDeployed({
   organizationId,
   output,
   title,
+  url = getCoreAppUrl(organizationId, applicationId),
 }: {
   applicationId: string
   cliConfig: DeployAppOptions['cliConfig']
@@ -415,8 +420,8 @@ export function logAppDeployed({
   organizationId: string
   output: DeployAppOptions['output']
   title: string | null
+  url?: string
 }): void {
-  const url = getCoreAppUrl(organizationId, applicationId)
   const named = title ? ` — "${title}"` : ''
   output.log(`\nSuccess! Application deployed to ${styleText('cyan', url)}${named}`)
   output.log(created ? 'Created a new application.' : 'Updated the existing application.')

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -122,7 +122,6 @@ async function runAppDeployment(
       status: 'fail',
     })
   } else if (deployApplication && workbench) {
-    // Both modes, so a bad appId fails before the build rather than at the POST.
     await checkAppTarget(reporter, {
       appId,
       isWorkbenchApp: true,

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -199,7 +199,7 @@ export function describeAppTarget(
     case 'found': {
       const {application} = resolution
       const title = application.title ?? application.appHost
-      const url = getCoreAppUrl(application.organizationId, application.id)
+      const url = application.url ?? getCoreAppUrl(application.organizationId, application.id)
       return {
         message: `Deploys to existing application "${title}" at ${url}`,
         status: 'pass',
@@ -306,7 +306,7 @@ export async function checkAppTarget(
 /** Same contract as {@link describeAppTarget}, for the studio verdicts. */
 export function describeStudioTarget(
   resolution: StudioDeployTargetResolution,
-  {isExternal, title}: {isExternal: boolean; title?: string},
+  {isExternal, isWorkbench, title}: {isExternal: boolean; isWorkbench?: boolean; title?: string},
 ): DeployCheck {
   const studioUrl = (host: string) => (isExternal ? host : `https://${host}.sanity.studio`)
 
@@ -315,7 +315,7 @@ export function describeStudioTarget(
       return {message: `Deploy target not resolved — ${resolution.message}`, status: 'skip'}
     }
     case 'found': {
-      const url = studioUrl(resolution.application.appHost)
+      const url = resolution.application.url ?? studioUrl(resolution.application.appHost)
       return {
         message: `Deploys to existing studio ${url}`,
         status: 'pass',
@@ -347,12 +347,13 @@ export function describeStudioTarget(
       }
     }
     case 'would-create': {
-      const url = studioUrl(resolution.appHost)
+      // A workbench studio's URL needs the application id, which only exists after the create.
+      const url = isWorkbench ? null : studioUrl(resolution.appHost)
       const titled = title ? ` titled "${title}"` : ''
       return {
         message: isExternal
           ? `Would register external studio at ${resolution.appHost}${titled}`
-          : `Would create studio hostname ${url}${titled} (name availability is checked on deploy)`,
+          : `Would create studio hostname ${url ?? resolution.appHost}${titled} (name availability is checked on deploy)`,
         status: 'pass',
         // `title || null`, not `?? null`, so target.title tracks the same
         // truthiness the message's `titled` suffix uses (an empty title is no title)
@@ -365,8 +366,7 @@ export function describeStudioTarget(
 /**
  * Reports the studio deploy target as a check and returns the resolved target;
  * `isWorkbenchApp` selects the backend. Both modes run it — a real deploy uses
- * the returned target to reject a bad `appId` before building and to report the
- * studio URL from the resolved slug.
+ * it to reject a bad `appId` before building.
  */
 export async function checkStudioTarget(
   reporter: DeployCheckReporter,
@@ -399,7 +399,11 @@ export async function checkStudioTarget(
     formatError: (err) => `Failed to resolve deploy target: ${getErrorMessage(err)}`,
     name: 'target',
     work: async () => {
-      const check = describeStudioTarget(await resolve, {isExternal, title})
+      const check = describeStudioTarget(await resolve, {
+        isExternal,
+        isWorkbench: !!options.isWorkbenchApp,
+        title,
+      })
       reporter.report(check)
       return check.target ?? null
     },

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -9,6 +9,7 @@ import {
   type BrettWorkspace,
   buildExposes,
   deployStudio as deployWorkbenchStudio,
+  getApplicationUrl,
   getWorkbench,
 } from '@sanity/workbench-cli/deploy'
 import {type StudioManifest} from 'sanity'
@@ -25,7 +26,6 @@ import {
   checkPackageVersion,
   checkStudioTarget,
   type DeployCheckReporter,
-  type DeployTarget,
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
@@ -97,7 +97,6 @@ async function runStudioDeployment(
   // resolve/create on user-applications, unchanged.
   let application: UserApplication | null = null
   let studioCreated = false
-  let studioTarget: DeployTarget | null = null
   if (workbench && !isExternal) {
     reporter.report(
       organizationId
@@ -108,9 +107,8 @@ async function runStudioDeployment(
             status: 'fail',
           },
     )
-    // Both modes, so a bad appId fails before the build; its resolved URL feeds
-    // the deploy result.
-    studioTarget = await checkStudioTarget(reporter, {
+    // Both modes, so a bad appId fails before the build.
+    await checkStudioTarget(reporter, {
       appId,
       isWorkbenchApp: true,
       studioHost: cliConfig.studioHost,
@@ -174,7 +172,8 @@ async function runStudioDeployment(
       version,
       workspaces: toWorkspaces(studioManifest),
     })
-    logWorkbenchStudioDeployed({applicationId, cliConfig, output})
+    const url = getApplicationUrl({id: applicationId, organizationId, type: 'studio'})
+    logWorkbenchStudioDeployed({applicationId, cliConfig, output, url})
     return {
       applicationType: 'studio',
       applicationVersion: version,
@@ -183,7 +182,7 @@ async function runStudioDeployment(
         action: appId ? 'update' : 'create',
         applicationId,
         title: appTitle,
-        url: studioTarget?.url ?? null,
+        url,
       },
     }
   }
@@ -392,12 +391,14 @@ function logWorkbenchStudioDeployed({
   applicationId,
   cliConfig,
   output,
+  url,
 }: {
   applicationId: string
   cliConfig: DeployAppOptions['cliConfig']
   output: DeployAppOptions['output']
+  url: string
 }): void {
-  output.log(`\nSuccess! Studio deployed`)
+  output.log(`\nSuccess! Studio deployed to ${styleText('cyan', url)}`)
   if (getAppId(cliConfig)) return
 
   output.log(`\nAdd ${styleText('cyan', `appId: '${applicationId}'`)}`)

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -107,7 +107,6 @@ async function runStudioDeployment(
             status: 'fail',
           },
     )
-    // Both modes, so a bad appId fails before the build.
     await checkStudioTarget(reporter, {
       appId,
       isWorkbenchApp: true,

--- a/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
+++ b/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
@@ -1,4 +1,4 @@
-import {getApplication} from '@sanity/workbench-cli/deploy'
+import {getApplication, getApplicationUrl} from '@sanity/workbench-cli/deploy'
 
 import {
   getUserApplication,
@@ -14,6 +14,8 @@ interface DeployTargetApp {
   appHost: string
   id: string
   title: string | null
+
+  url?: string
 }
 
 /** A coreApp verdict also carries the organization, for the dashboard URL. */
@@ -200,6 +202,7 @@ async function resolveAppById(
           id: application.id,
           organizationId: application.organizationId,
           title: application.title,
+          url: getApplicationUrl(application),
         },
         type: 'found',
       }

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -630,7 +630,11 @@ describe('#undeploy', () => {
 
     const payload = JSON.parse(stdout)
     expect(payload.undeployed).toBe(true)
-    expect(payload.application).toMatchObject({deletes: 'application', id: 'wb-app-1'})
+    expect(payload.application).toMatchObject({
+      deletes: 'application',
+      id: 'wb-app-1',
+      url: 'https://org-1.sanity.run/application/wb-app-1',
+    })
   })
 
   test('media library dry run reports the installation config', async () => {

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -350,7 +350,11 @@ describe('#deploy app', () => {
     )
     const result = JSON.parse(stdout)
     expect(result.deployed).toBe(true)
-    expect(result.target).toMatchObject({applicationId: 'app_new', slug: 'drop-desk-host'})
+    expect(result.target).toMatchObject({
+      applicationId: 'app_new',
+      slug: 'drop-desk-host',
+      url: `https://${organizationId}.sanity.run/application/app_new`,
+    })
   })
 
   test('a dry run surfaces the configured slug in the report and --json target', async () => {

--- a/packages/@sanity/workbench-cli/src/_exports/deploy.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/deploy.ts
@@ -16,4 +16,6 @@ export {
   type BrettInterface,
   type BrettWorkspace,
   getApplication,
+  getApplicationUrl,
+  getWorkbenchUrl,
 } from '../services/applications.js'

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployConfig.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployConfig.test.ts
@@ -80,6 +80,7 @@ describe('deployConfig', () => {
     await deployConfig({
       appType: 'media-library',
       installationId: 'inst_ml',
+      organizationId: 'org-1',
       output,
       sourceDir: '/tmp/build/app',
       version: '3.99.0',
@@ -91,6 +92,21 @@ describe('deployConfig', () => {
     const post = mockRequest.mock.calls.find(([arg]) => arg.method === 'POST')?.[0]
     expect(post.uri).toBe('/installations/inst_ml/configs')
     expect(post.headers['content-type']).toMatch(/multipart\/form-data/)
+  })
+
+  test('reports the workbench URL on success', async () => {
+    stubBrett([])
+
+    await deployConfig({
+      appType: 'media-library',
+      installationId: 'inst_ml',
+      organizationId: 'org-1',
+      output,
+      sourceDir: '/tmp/build/app',
+      version: '3.99.0',
+    })
+
+    expect(vi.mocked(output.log).mock.calls.join('\n')).toContain('https://org-1.sanity.run')
   })
 })
 

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployConfig.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployConfig.ts
@@ -5,6 +5,7 @@ import {createGzip} from 'node:zlib'
 import {type Output, subdebug} from '@sanity/cli-core'
 import {pack} from 'tar-fs'
 
+import {getWorkbenchUrl} from '../../services/applications.js'
 import {createConfig, resolveSingletonInstallationId} from '../../services/installations.js'
 import {summarizeExposeGroup} from './buildExposes.js'
 
@@ -57,14 +58,16 @@ export function summarizeConfig(config: {
 export async function deployConfig(options: {
   appType: string
   installationId: string
+  organizationId: string
   output: Output
   sourceDir: string
   version: string
 }): Promise<void> {
-  const {appType, installationId, output, sourceDir, version} = options
+  const {appType, installationId, organizationId, output, sourceDir, version} = options
   const tarball = pack(dirname(sourceDir), {entries: [basename(sourceDir)]}).pipe(createGzip())
   await createConfig(installationId, {tarball, version})
 
   debug('Deployed config for app type: %s', appType)
-  output.log(`\n🚀 ${styleText('bold', 'Success!')} Config deployed`)
+  const url = getWorkbenchUrl(organizationId)
+  output.log(`\n🚀 ${styleText('bold', 'Success!')} Config deployed to ${styleText('cyan', url)}`)
 }

--- a/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
@@ -91,7 +91,7 @@ describe('createWorkbenchUndeployAdapter — application', () => {
     })
   })
 
-  test('found → target with the Brett application, its interfaces, and dashboard URL', async () => {
+  test('found → target with the Brett application, its interfaces, and workbench URL', async () => {
     mockRequest.mockResolvedValue({
       id: 'wb-app-1',
       organizationId: 'org-1',
@@ -112,11 +112,11 @@ describe('createWorkbenchUndeployAdapter — application', () => {
       organizationId: 'org-1',
       title: 'My App',
       type: 'coreApp',
-      url: expect.stringContaining('/@org-1/application/wb-app-1'),
+      url: 'https://org-1.sanity.run/application/wb-app-1',
     })
   })
 
-  test('a studio target points at its sanity.studio hostname', async () => {
+  test('a studio target points at its workbench studio URL', async () => {
     mockRequest.mockResolvedValue({
       id: 'wb-studio-1',
       organizationId: 'org-1',
@@ -133,7 +133,7 @@ describe('createWorkbenchUndeployAdapter — application', () => {
     }).resolveTarget()
 
     expect(resolution.type === 'found' && resolution.target.url).toBe(
-      'https://my-studio.sanity.studio',
+      'https://org-1.sanity.run/studio/wb-studio-1',
     )
   })
 
@@ -221,6 +221,7 @@ describe('createWorkbenchUndeployAdapter — config-only singleton', () => {
       id: null,
       organizationId: 'org-1',
       title: 'media-library',
+      url: 'https://org-1.sanity.run',
     })
   })
 

--- a/packages/@sanity/workbench-cli/src/actions/undeploy/workbenchUndeployAdapter.ts
+++ b/packages/@sanity/workbench-cli/src/actions/undeploy/workbenchUndeployAdapter.ts
@@ -4,9 +4,13 @@ import {
   type UndeployConfigTarget,
   type UndeployTargetResolution,
 } from '@sanity/cli-core/undeploy'
-import {getCoreAppUrl} from '@sanity/cli-core/util'
 
-import {deleteApplication, getApplication} from '../../services/applications.js'
+import {
+  deleteApplication,
+  getApplication,
+  getApplicationUrl,
+  getWorkbenchUrl,
+} from '../../services/applications.js'
 import {deleteConfig, listConfigs} from '../../services/installations.js'
 import {type DeployedExpose, summarizeExposes} from '../deploy/buildExposes.js'
 import {resolveInstallationId, summarizeConfig} from '../deploy/deployConfig.js'
@@ -108,12 +112,7 @@ async function resolveApplicationTarget({
       ],
       title: application.title,
       type,
-      url:
-        type === 'studio'
-          ? application.slug
-            ? `https://${application.slug}.sanity.studio`
-            : null
-          : getCoreAppUrl(application.organizationId, application.id),
+      url: getApplicationUrl({...application, type}),
     },
     type: 'found',
   }
@@ -182,7 +181,7 @@ async function resolveConfigTarget({
         summary: config ? [summarizeConfig(config)] : undefined,
         title: workbench.name,
         type: 'coreApp',
-        url: null,
+        url: getWorkbenchUrl(organizationId),
       },
       type: 'found',
     },

--- a/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
+++ b/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
@@ -11,6 +11,8 @@ import {
   createApplication,
   createDeployment,
   getApplication,
+  getApplicationUrl,
+  getWorkbenchUrl,
 } from '../applications.js'
 
 vi.mock(import('@sanity/cli-core'), async (importOriginal) => ({
@@ -171,5 +173,27 @@ describe('createDeployment', () => {
     })
 
     expect(appendedFields()).toContainEqual(['workspaces', JSON.stringify(workspaces)])
+  })
+})
+
+describe('getWorkbenchUrl / getApplicationUrl', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  test('builds production URLs on sanity.run', () => {
+    expect(getWorkbenchUrl('org-1')).toBe('https://org-1.sanity.run')
+    expect(getApplicationUrl({id: 'app-1', organizationId: 'org-1', type: 'coreApp'})).toBe(
+      'https://org-1.sanity.run/application/app-1',
+    )
+    expect(getApplicationUrl({id: 'app-1', organizationId: 'org-1', type: 'studio'})).toBe(
+      'https://org-1.sanity.run/studio/app-1',
+    )
+  })
+
+  test('builds staging URLs on run.sanity.work', () => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'staging')
+    expect(getWorkbenchUrl('org-1')).toBe('https://org-1.run.sanity.work')
+    expect(getApplicationUrl({id: 'app-1', organizationId: 'org-1', type: 'coreApp'})).toBe(
+      'https://org-1.run.sanity.work/application/app-1',
+    )
   })
 })

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -43,7 +43,6 @@ export interface BrettWorkspace {
   title?: string
 }
 
-/** The URL of an organization's workbench. */
 export function getWorkbenchUrl(organizationId: string): string {
   return `https://${organizationId}.${isStaging() ? 'run.sanity.work' : 'sanity.run'}`
 }

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -2,6 +2,7 @@ import {PassThrough} from 'node:stream'
 import {type Gzip} from 'node:zlib'
 
 import {getGlobalCliClient} from '@sanity/cli-core'
+import {isStaging} from '@sanity/cli-core/util'
 import FormData from 'form-data'
 
 import {APP_WORKBENCH_API_VERSION} from './apiVersion.js'
@@ -40,6 +41,19 @@ export interface BrettWorkspace {
   name?: string
   subtitle?: string
   title?: string
+}
+
+/** The URL of an organization's workbench. */
+export function getWorkbenchUrl(organizationId: string): string {
+  return `https://${organizationId}.${isStaging() ? 'run.sanity.work' : 'sanity.run'}`
+}
+
+/** Where a deployed application is served on its organization's workbench. */
+export function getApplicationUrl(
+  application: Pick<Application, 'id' | 'organizationId' | 'type'>,
+): string {
+  const segment = application.type === 'studio' ? 'studio' : 'application'
+  return `${getWorkbenchUrl(application.organizationId)}/${segment}/${application.id}`
 }
 
 async function getClient() {


### PR DESCRIPTION
### Description

After `sanity deploy` / `sanity undeploy`, workbench apps report the dashboard URL (core apps) or a `sanity.studio` URL (studios) — but workbench apps are served on the workbench host. This reports the new sanity.run scheme instead ([SDK-1898](https://linear.app/sanity/issue/SDK-1898/cli-update-deploy-undeploy-urls)):

- with an app interface: `https://<org-id>.sanity.run/<application|studio>/<app-id>`
- without one (the media-library config): `https://<org-id>.sanity.run`
- staging swaps the domain for `<org-id>.run.sanity.work`

The scheme lives in `@sanity/workbench-cli` (`getWorkbenchUrl` / `getApplicationUrl` next to the `Application` type), so it can't bleed into the shell: `@sanity/cli` only consumes the helpers on workbench paths. Non-workbench deploys and undeploys keep their current URLs.

Dry runs report the same URLs as real deploys, with one exception: a workbench studio that would be created reports `url: null`, since the URL needs the application id that only exists after the create.

Stacked on #1506.

### Notes for release

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI messaging and JSON fields only on workbench paths; URL logic is centralized with tests and non-workbench behavior is preserved.
> 
> **Overview**
> Workbench **deploy** and **undeploy** now surface URLs on the org workbench host (`https://<org>.sanity.run/...`, staging via `run.sanity.work`) instead of dashboard or `sanity.studio` links.
> 
> `@sanity/workbench-cli` adds **`getWorkbenchUrl`** and **`getApplicationUrl`** (core app → `/application/<id>`, studio → `/studio/<id>`). Deploy checks, JSON `target`, success logs, config-only deploys, and the workbench undeploy adapter use these helpers. Plain (non-workbench) deploy/undeploy URLs are unchanged.
> 
> **Dry-run behavior:** workbench studios that **would be created** report **`url: null`** because the URL needs an app id that does not exist yet. Config deploy now requires **`organizationId`** so success output can include the workbench URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54e540621b44beaff5fb0dc23ab072060e9a9f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->