### PR TITLE
fix(build): stop baking the staging flag into workbench chunks

### DIFF
--- a/.changeset/pr-1508.md
+++ b/.changeset/pr-1508.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': patch
+---
+
+fix(build): stop baking the staging flag into workbench chunks

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
@@ -315,6 +315,23 @@ describe('#getViteConfig', () => {
     expect(config.define?.__SANITY_STAGING__).toBe(true)
   })
 
+  test('should not define staging flag for workbench apps', async () => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'staging')
+
+    const options = {
+      cwd: mockTestCwd,
+      entries: mockEntries,
+      getEnvironmentVariables,
+      isWorkbenchApp: true,
+      mode: 'development' as const,
+      reactCompiler: undefined,
+    }
+
+    const config = await getViteConfig(options)
+
+    expect(config.define).not.toHaveProperty('__SANITY_STAGING__')
+  })
+
   test('should configure auto-updates builds with vendor chunks and import map', async () => {
     const autoUpdates = {
       imports: {sanity: 'https://sanity-cdn.example/sanity'},

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -180,7 +180,12 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     configFile: false,
     define: {
       __SANITY_BUILD_TIMESTAMP__: JSON.stringify(Date.now()),
-      __SANITY_STAGING__: process.env.SANITY_INTERNAL_ENV === 'staging',
+      // Workbench chunks load as federation remotes into hosts from any
+      // environment, so they read `globalThis.__SANITY_STAGING__` at runtime
+      // instead of an inlined value.
+      ...(isWorkbenchApp
+        ? {}
+        : {__SANITY_STAGING__: process.env.SANITY_INTERNAL_ENV === 'staging'}),
       'process.env.MODE': JSON.stringify(mode),
       'process.env.PKG_BUILD_VERSION': JSON.stringify(process.env.PKG_BUILD_VERSION),
       /**


### PR DESCRIPTION
### Description

Workbench chunks deploy as federation remotes and load into host pages from any environment, but the build compile-time-defines `__SANITY_STAGING__` — baking the build machine's env into the chunks. The hosted workbench remote is built without `SANITY_INTERNAL_ENV`, so it's stuck on production and staging dev needs `SANITY_INTERNAL_WORKBENCH_REMOTE_URL` as a workaround.

Drop the define for workbench app builds so chunks read `globalThis.__SANITY_STAGING__` at runtime — the host page already injects it, and `getSanityEnv()`'s `typeof` guard treats an absent global as production. Studio and plain app builds keep the define.

Needs a workbench remote redeploy to take effect. Fixes [SDK-1901](https://linear.app/sanity/issue/SDK-1901/workbench-remote-is-env-blind-staging-dev-requires-sanity-internal).

### What to review

The `define` block in `getViteConfig.ts`.

### Testing

Unit test: workbench builds don't define `__SANITY_STAGING__` even with `SANITY_INTERNAL_ENV=staging`.