### PR TITLE
refactor(workbench): align interface shape with brett

### DIFF
--- a/.changeset/interface-brett-vocabulary.md
+++ b/.changeset/interface-brett-vocabulary.md
@@ -2,4 +2,4 @@
 "@sanity/workbench-cli": patch
 ---
 
-Dev-server interface records use brett's field names (`type`, `moduleId`)
+Dev-server interface records use `type` and `entry` field names

--- a/.changeset/interface-brett-vocabulary.md
+++ b/.changeset/interface-brett-vocabulary.md
@@ -1,0 +1,5 @@
+---
+"@sanity/workbench-cli": patch
+---
+
+Dev-server interface records use brett's field names (`type`, `moduleId`)

--- a/.changeset/interface-brett-vocabulary.md
+++ b/.changeset/interface-brett-vocabulary.md
@@ -2,4 +2,4 @@
 "@sanity/workbench-cli": patch
 ---
 
-Dev-server interface records use `type` and `entry` field names
+Dev-server interface records align with the workbench: `type`, `src`, and `title`

--- a/packages/@sanity/workbench-cli/src/__tests__/defineView.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineView.test.ts
@@ -36,8 +36,9 @@ describe('type surface', () => {
       title: (props) => {
         expectTypeOf(props).toEqualTypeOf<PanelViewProps>()
         expectTypeOf(props.view).toEqualTypeOf<{
-          entry: string
           name: string
+          src: string
+          title: string
           type: 'panel'
         }>()
         return null

--- a/packages/@sanity/workbench-cli/src/__tests__/defineView.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineView.test.ts
@@ -36,9 +36,9 @@ describe('type surface', () => {
       title: (props) => {
         expectTypeOf(props).toEqualTypeOf<PanelViewProps>()
         expectTypeOf(props.view).toEqualTypeOf<{
-          entry_point: string
-          interface_type: 'panel'
+          entry: string
           name: string
+          type: 'panel'
         }>()
         return null
       },

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -13,7 +13,7 @@ describe('deriveInterfaces', () => {
   test('maps views to panel interfaces', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed', version: 1},
+      {entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel', version: 1},
     ])
   })
 
@@ -22,21 +22,21 @@ describe('deriveInterfaces', () => {
       services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread', version: 1},
+      {entry: './src/service.ts', name: 'unread', type: 'worker', version: 1},
     ])
   })
 
   test('derives an app interface from entry for an SDK app', () => {
     const app = workbenchApp({entry: './src/App.tsx', name: 'my-app'})
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry_point: './src/App.tsx', interface_type: 'app', name: 'my-app'},
+      {entry: './src/App.tsx', name: 'my-app', type: 'app'},
     ])
   })
 
   test('omits the app interface for a dock-only app (no entry)', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     const result = deriveInterfaces(app, {isApp: true})
-    expect(result?.some((iface) => iface.interface_type === 'app')).toBe(false)
+    expect(result?.some((iface) => iface.type === 'app')).toBe(false)
   })
 
   test('combines views, services, and the app view (in that order)', () => {
@@ -47,9 +47,9 @@ describe('deriveInterfaces', () => {
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed', version: 1},
-      {entry_point: './src/service.ts', interface_type: 'worker', name: 'unread', version: 1},
-      {entry_point: './src/App.tsx', interface_type: 'app', name: 'my-app'},
+      {entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel', version: 1},
+      {entry: './src/service.ts', name: 'unread', type: 'worker', version: 1},
+      {entry: './src/App.tsx', name: 'my-app', type: 'app'},
     ])
   })
 
@@ -63,7 +63,7 @@ describe('deriveInterfaces', () => {
     })
     // only the panel — the config rides deriveConfigs, not interfaces
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed', version: 1},
+      {entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel', version: 1},
     ])
   })
 
@@ -77,7 +77,7 @@ describe('deriveInterfaces', () => {
   test('a studio without entry still derives its panels/workers', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     expect(deriveInterfaces(app, {isApp: false})).toEqual([
-      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed', version: 1},
+      {entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel', version: 1},
     ])
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -13,7 +13,7 @@ describe('deriveInterfaces', () => {
   test('maps views to panel interfaces', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel', version: 1},
+      {name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel', version: 1},
     ])
   })
 
@@ -22,14 +22,14 @@ describe('deriveInterfaces', () => {
       services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry: './src/service.ts', name: 'unread', type: 'worker', version: 1},
+      {name: 'unread', src: './src/service.ts', title: 'unread', type: 'worker', version: 1},
     ])
   })
 
   test('derives an app interface from entry for an SDK app', () => {
     const app = workbenchApp({entry: './src/App.tsx', name: 'my-app'})
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry: './src/App.tsx', name: 'my-app', type: 'app'},
+      {name: 'my-app', src: './src/App.tsx', title: 'Test App', type: 'app'},
     ])
   })
 
@@ -47,9 +47,9 @@ describe('deriveInterfaces', () => {
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel', version: 1},
-      {entry: './src/service.ts', name: 'unread', type: 'worker', version: 1},
-      {entry: './src/App.tsx', name: 'my-app', type: 'app'},
+      {name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel', version: 1},
+      {name: 'unread', src: './src/service.ts', title: 'unread', type: 'worker', version: 1},
+      {name: 'my-app', src: './src/App.tsx', title: 'Test App', type: 'app'},
     ])
   })
 
@@ -63,7 +63,7 @@ describe('deriveInterfaces', () => {
     })
     // only the panel — the config rides deriveConfigs, not interfaces
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel', version: 1},
+      {name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel', version: 1},
     ])
   })
 
@@ -77,7 +77,7 @@ describe('deriveInterfaces', () => {
   test('a studio without entry still derives its panels/workers', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     expect(deriveInterfaces(app, {isApp: false})).toEqual([
-      {entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel', version: 1},
+      {name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel', version: 1},
     ])
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
@@ -5,14 +5,14 @@ import {createExposesTracker, exposesSetId, trackExposesSet} from '../exposesSet
 import {type DevServerManifest} from '../registry.js'
 
 const panel = (name: string, src = `./src/${name}.tsx`): DevServerInterface => ({
-  entry_point: src,
-  interface_type: 'panel',
+  entry: src,
   name,
+  type: 'panel',
 })
 const worker = (name: string, src = `./src/${name}.ts`): DevServerInterface => ({
-  entry_point: src,
-  interface_type: 'worker',
+  entry: src,
   name,
+  type: 'worker',
 })
 const mlConfig = (fields: DevServerConfig['fields']): DevServerConfig => ({
   appType: 'media-library',
@@ -52,7 +52,7 @@ describe('exposesSetId', () => {
     )
   })
 
-  test('distinguishes interface_type, name, and entry_point', () => {
+  test('distinguishes type, name, and entry', () => {
     expect(exposesSetId({interfaces: [panel('a')]})).not.toBe(
       exposesSetId({interfaces: [worker('a')]}),
     )

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
@@ -5,13 +5,15 @@ import {createExposesTracker, exposesSetId, trackExposesSet} from '../exposesSet
 import {type DevServerManifest} from '../registry.js'
 
 const panel = (name: string, src = `./src/${name}.tsx`): DevServerInterface => ({
-  entry: src,
   name,
+  src,
+  title: name,
   type: 'panel',
 })
 const worker = (name: string, src = `./src/${name}.ts`): DevServerInterface => ({
-  entry: src,
   name,
+  src,
+  title: name,
   type: 'worker',
 })
 const mlConfig = (fields: DevServerConfig['fields']): DevServerConfig => ({
@@ -52,7 +54,7 @@ describe('exposesSetId', () => {
     )
   })
 
-  test('distinguishes type, name, and entry', () => {
+  test('distinguishes type, name, and src', () => {
     expect(exposesSetId({interfaces: [panel('a')]})).not.toBe(
       exposesSetId({interfaces: [worker('a')]}),
     )

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -29,7 +29,7 @@ describe('startDevManifestWatcher', () => {
   let fakeWatcher: FakeFsWatcher
   let mockExtract: Mock<
     (params: {configPath: string; workDir: string}) => Promise<{
-      interfaces?: {entry: string; name: string; type: string}[] | undefined
+      interfaces?: {name: string; src: string; type: string}[] | undefined
       manifest: unknown
     }>
   >
@@ -260,7 +260,7 @@ describe('startDevManifestWatcher', () => {
     const appManifest = {icon: '<svg/>', title: 'My App', version: '1'}
     // Interfaces ride alongside the manifest (not inside it) and re-sync on
     // every config edit.
-    const appInterfaces = [{entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel'}]
+    const appInterfaces = [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]
     mockFindProjectRoot.mockResolvedValue({
       directory: APP_WORK_DIR,
       path: APP_CONFIG_PATH,

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -29,7 +29,7 @@ describe('startDevManifestWatcher', () => {
   let fakeWatcher: FakeFsWatcher
   let mockExtract: Mock<
     (params: {configPath: string; workDir: string}) => Promise<{
-      interfaces?: {entry_point: string; interface_type: string; name: string}[] | undefined
+      interfaces?: {entry: string; name: string; type: string}[] | undefined
       manifest: unknown
     }>
   >
@@ -260,9 +260,7 @@ describe('startDevManifestWatcher', () => {
     const appManifest = {icon: '<svg/>', title: 'My App', version: '1'}
     // Interfaces ride alongside the manifest (not inside it) and re-sync on
     // every config edit.
-    const appInterfaces = [
-      {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed'},
-    ]
+    const appInterfaces = [{entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel'}]
     mockFindProjectRoot.mockResolvedValue({
       directory: APP_WORK_DIR,
       path: APP_CONFIG_PATH,

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
@@ -164,7 +164,9 @@ describe('startDevServerRegistration', () => {
     const params = {configPath: '/tmp/sanity-project/sanity.cli.ts', workDir: '/tmp/sanity-project'}
     await expect(extract(params)).resolves.toEqual({
       configs: [],
-      interfaces: [{entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel', version: 1}],
+      interfaces: [
+        {name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel', version: 1},
+      ],
       manifest,
     })
     expect(mockExtractManifest).toHaveBeenCalledWith(params)
@@ -203,7 +205,7 @@ describe('startDevServerRegistration', () => {
     expect(mockRegisterDevServer).toHaveBeenCalledWith(
       expect.objectContaining({
         interfaces: expect.arrayContaining([
-          {entry: './src/App.tsx', name: 'test-app', type: 'app'},
+          {name: 'test-app', src: './src/App.tsx', title: 'Test App', type: 'app'},
         ]),
       }),
     )
@@ -224,7 +226,7 @@ describe('startDevServerRegistration', () => {
 
   // Adding/removing a view or service must rebuild the federation remote so the
   // new interface gets an expose + artifact. The watcher drives it.
-  const feed = {entry: './src/Feed.tsx', name: 'feed', type: 'panel'}
+  const feed = {name: 'feed', src: './src/Feed.tsx', type: 'panel'}
 
   test('rebuilds the remote when the interface set changes, then keeps quiet on a repeat', async () => {
     const onInterfaceSetChange = vi.fn().mockResolvedValue(undefined)

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
@@ -164,9 +164,7 @@ describe('startDevServerRegistration', () => {
     const params = {configPath: '/tmp/sanity-project/sanity.cli.ts', workDir: '/tmp/sanity-project'}
     await expect(extract(params)).resolves.toEqual({
       configs: [],
-      interfaces: [
-        {entry_point: './src/FeedPanel.tsx', interface_type: 'panel', name: 'feed', version: 1},
-      ],
+      interfaces: [{entry: './src/FeedPanel.tsx', name: 'feed', type: 'panel', version: 1}],
       manifest,
     })
     expect(mockExtractManifest).toHaveBeenCalledWith(params)
@@ -205,7 +203,7 @@ describe('startDevServerRegistration', () => {
     expect(mockRegisterDevServer).toHaveBeenCalledWith(
       expect.objectContaining({
         interfaces: expect.arrayContaining([
-          {entry_point: './src/App.tsx', interface_type: 'app', name: 'test-app'},
+          {entry: './src/App.tsx', name: 'test-app', type: 'app'},
         ]),
       }),
     )
@@ -215,9 +213,7 @@ describe('startDevServerRegistration', () => {
     await register({cliConfig: {app: workbenchApp()} as any, isApp: true})
 
     const {interfaces} = mockRegisterDevServer.mock.calls[0][0]
-    expect(
-      (interfaces ?? []).some((i: {interface_type: string}) => i.interface_type === 'app'),
-    ).toBe(false)
+    expect((interfaces ?? []).some((i: {type: string}) => i.type === 'app')).toBe(false)
   })
 
   test('rejects a studio that declares `entry` — app views for studios are not implemented yet', async () => {
@@ -228,7 +224,7 @@ describe('startDevServerRegistration', () => {
 
   // Adding/removing a view or service must rebuild the federation remote so the
   // new interface gets an expose + artifact. The watcher drives it.
-  const feed = {entry_point: './src/Feed.tsx', interface_type: 'panel', name: 'feed'}
+  const feed = {entry: './src/Feed.tsx', name: 'feed', type: 'panel'}
 
   test('rebuilds the remote when the interface set changes, then keeps quiet on a repeat', async () => {
     const onInterfaceSetChange = vi.fn().mockResolvedValue(undefined)

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -656,7 +656,7 @@ describe('startWorkbenchDevServer', () => {
           configs: [{appType: 'media-library', fields: [], moduleName: 'media-library'}],
           host: 'localhost',
           id: 'app-1',
-          interfaces: [{entry_point: './src/Feed.tsx', interface_type: 'panel', name: 'feed'}],
+          interfaces: [{entry: './src/Feed.tsx', name: 'feed', type: 'panel'}],
           pid: 3,
           port: 3337,
           type: 'coreApp',
@@ -684,8 +684,8 @@ describe('startWorkbenchDevServer', () => {
       const watchCallback = mockWatchRegistry.mock.calls[0][0]
 
       const base = {host: 'localhost', id: 'app-1', pid: 3, port: 3335, type: 'coreApp'}
-      const feed = {entry_point: './src/Feed.tsx', interface_type: 'panel', name: 'feed'}
-      const alerts = {entry_point: './src/Alerts.tsx', interface_type: 'panel', name: 'alerts'}
+      const feed = {entry: './src/Feed.tsx', name: 'feed', type: 'panel'}
+      const alerts = {entry: './src/Alerts.tsx', name: 'alerts', type: 'panel'}
 
       // First sighting of the app — reconcile softly, don't reload.
       watchCallback([{...base, interfaces: [feed]}])
@@ -707,7 +707,7 @@ describe('startWorkbenchDevServer', () => {
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
       const watchCallback = mockWatchRegistry.mock.calls[0][0]
 
-      const feed = {entry_point: './src/Feed.tsx', interface_type: 'panel', name: 'feed'}
+      const feed = {entry: './src/Feed.tsx', name: 'feed', type: 'panel'}
       const base = {host: 'localhost', id: 'app-1', interfaces: [feed], pid: 3, port: 3335}
 
       watchCallback([{...base, manifest: {title: 'V1', version: '1'}, type: 'coreApp'}])

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -656,7 +656,7 @@ describe('startWorkbenchDevServer', () => {
           configs: [{appType: 'media-library', fields: [], moduleName: 'media-library'}],
           host: 'localhost',
           id: 'app-1',
-          interfaces: [{entry: './src/Feed.tsx', name: 'feed', type: 'panel'}],
+          interfaces: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],
           pid: 3,
           port: 3337,
           type: 'coreApp',
@@ -684,8 +684,8 @@ describe('startWorkbenchDevServer', () => {
       const watchCallback = mockWatchRegistry.mock.calls[0][0]
 
       const base = {host: 'localhost', id: 'app-1', pid: 3, port: 3335, type: 'coreApp'}
-      const feed = {entry: './src/Feed.tsx', name: 'feed', type: 'panel'}
-      const alerts = {entry: './src/Alerts.tsx', name: 'alerts', type: 'panel'}
+      const feed = {name: 'feed', src: './src/Feed.tsx', type: 'panel'}
+      const alerts = {name: 'alerts', src: './src/Alerts.tsx', type: 'panel'}
 
       // First sighting of the app — reconcile softly, don't reload.
       watchCallback([{...base, interfaces: [feed]}])
@@ -707,7 +707,7 @@ describe('startWorkbenchDevServer', () => {
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
       const watchCallback = mockWatchRegistry.mock.calls[0][0]
 
-      const feed = {entry: './src/Feed.tsx', name: 'feed', type: 'panel'}
+      const feed = {name: 'feed', src: './src/Feed.tsx', type: 'panel'}
       const base = {host: 'localhost', id: 'app-1', interfaces: [feed], pid: 3, port: 3335}
 
       watchCallback([{...base, manifest: {title: 'V1', version: '1'}, type: 'coreApp'}])

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -19,11 +19,10 @@ export type DevServerConfig = NonNullable<DevServerManifest['configs']>[number]
 /**
  * Map a workbench app's declarations to the interface records forwarded on its
  * registry entry: `views` → panels, `services` → workers, `entry` → the
- * navigable `app` view (`entry` is the raw `src`, not a resolved URL).
- * `undefined` for a non-branded app; a studio that declares `entry` is rejected
- * (studio app views are not implemented yet). The config is not an
- * interface — see {@link deriveConfigs}. `version` is the contract version the
- * interface's generated module exports, known before the module runs; the app
+ * navigable `app` view. `src` is the raw source, not a resolved URL. `undefined`
+ * for a non-branded app; a studio that declares `entry` is rejected (studio app
+ * views are not implemented yet). The config is not an interface — see
+ * {@link deriveConfigs}. `version` is the module's contract version; the app
  * view has no versioned contract, so it carries none.
  */
 export function deriveInterfaces(
@@ -36,20 +35,17 @@ export function deriveInterfaces(
     throw new Error('App views for studios are not implemented yet')
   }
 
+  const toInterface = (
+    {name, src, title, type}: {name: string; src: string; title?: string; type: string},
+    version: number,
+  ): DevServerInterface => ({name, src, title: title ?? name, type, version})
+
   return [
-    ...(app.views?.map((view) => ({
-      entry: view.src,
-      name: view.name,
-      type: view.type,
-      version: VIEW_CONTRACT_VERSION,
-    })) ?? []),
-    ...(app.services?.map((service) => ({
-      entry: service.src,
-      name: service.name,
-      type: service.type,
-      version: SERVICE_CONTRACT_VERSION,
-    })) ?? []),
-    ...(app.entry === undefined ? [] : [{entry: app.entry, name: app.name, type: 'app' as const}]),
+    ...(app.views ?? []).map((view) => toInterface(view, VIEW_CONTRACT_VERSION)),
+    ...(app.services ?? []).map((service) => toInterface(service, SERVICE_CONTRACT_VERSION)),
+    ...(app.entry === undefined
+      ? []
+      : [{name: app.name, src: app.entry, title: app.title, type: 'app' as const}]),
   ]
 }
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -19,7 +19,7 @@ export type DevServerConfig = NonNullable<DevServerManifest['configs']>[number]
 /**
  * Map a workbench app's declarations to the interface records forwarded on its
  * registry entry: `views` → panels, `services` → workers, `entry` → the
- * navigable `app` view (`entry_point` is the raw `src`, not a resolved URL).
+ * navigable `app` view (`entry` is the raw `src`, not a resolved URL).
  * `undefined` for a non-branded app; a studio that declares `entry` is rejected
  * (studio app views are not implemented yet). The config is not an
  * interface — see {@link deriveConfigs}. `version` is the contract version the
@@ -38,20 +38,20 @@ export function deriveInterfaces(
 
   return [
     ...(app.views?.map((view) => ({
-      entry_point: view.src,
-      interface_type: view.type,
+      entry: view.src,
       name: view.name,
+      type: view.type,
       version: VIEW_CONTRACT_VERSION,
     })) ?? []),
     ...(app.services?.map((service) => ({
-      entry_point: service.src,
-      interface_type: service.type,
+      entry: service.src,
       name: service.name,
+      type: service.type,
       version: SERVICE_CONTRACT_VERSION,
     })) ?? []),
     ...(app.entry === undefined
       ? []
-      : [{entry_point: app.entry, interface_type: 'app' as const, name: app.name}]),
+      : [{entry: app.entry, name: app.name, type: 'app' as const}]),
   ]
 }
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -49,9 +49,7 @@ export function deriveInterfaces(
       type: service.type,
       version: SERVICE_CONTRACT_VERSION,
     })) ?? []),
-    ...(app.entry === undefined
-      ? []
-      : [{entry: app.entry, name: app.name, type: 'app' as const}]),
+    ...(app.entry === undefined ? [] : [{entry: app.entry, name: app.name, type: 'app' as const}]),
   ]
 }
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/exposesSetId.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/exposesSetId.ts
@@ -19,9 +19,7 @@ interface ExposeSet {
  */
 export function exposesSetId({configs, interfaces}: ExposeSet): string {
   const keys = [
-    ...(interfaces ?? []).map((iface) =>
-      [iface.interface_type, iface.name, iface.entry_point].join('::'),
-    ),
+    ...(interfaces ?? []).map((iface) => [iface.type, iface.name, iface.entry].join('::')),
     ...(configs ?? []).flatMap((config) => [
       ['config', config.appType].join('::'),
       ...deriveConfigEntries(config).map((entry) =>

--- a/packages/@sanity/workbench-cli/src/actions/dev/exposesSetId.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/exposesSetId.ts
@@ -19,7 +19,7 @@ interface ExposeSet {
  */
 export function exposesSetId({configs, interfaces}: ExposeSet): string {
   const keys = [
-    ...(interfaces ?? []).map((iface) => [iface.type, iface.name, iface.entry].join('::')),
+    ...(interfaces ?? []).map((iface) => [iface.type, iface.name, iface.src].join('::')),
     ...(configs ?? []).flatMap((config) => [
       ['config', config.appType].join('::'),
       ...deriveConfigEntries(config).map((entry) =>

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -74,15 +74,16 @@ const devServerManifestSchema = z.object({
    * `type: "worker"`). A service is just an interface, so both live
    * in this one list. Carried separately from the manifest — interfaces live in
    * the application service, not the manifest — so the workbench can render
-   * local panels and run local workers without a deploy. `entry` is the
-   * declared `src`. Lenient by design; the workbench is the authority on the
-   * interface shape.
+   * local panels and run local workers without a deploy. `src` is the
+   * declared source file; `title` defaults to `name`. Lenient by design; the
+   * workbench is the authority on the interface shape.
    */
   interfaces: z.optional(
     z.array(
       z.object({
-        entry: z.string(),
         name: z.string(),
+        src: z.string(),
+        title: z.string(),
         type: z.string(),
         // Contract version the interface's generated module exports; the app
         // view has no versioned contract and carries none.

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -70,20 +70,20 @@ const devServerManifestSchema = z.object({
   id: z.optional(z.string()),
   /**
    * Interfaces the app exposes, mapped from the declared `views` (dock panels,
-   * `interface_type: "panel"`) and `services` (background workers,
-   * `interface_type: "worker"`). A service is just an interface, so both live
+   * `type: "panel"`) and `services` (background workers,
+   * `type: "worker"`). A service is just an interface, so both live
    * in this one list. Carried separately from the manifest — interfaces live in
    * the application service, not the manifest — so the workbench can render
-   * local panels and run local workers without a deploy. `entry_point` is the
+   * local panels and run local workers without a deploy. `entry` is the
    * declared `src`. Lenient by design; the workbench is the authority on the
    * interface shape.
    */
   interfaces: z.optional(
     z.array(
       z.object({
-        entry_point: z.string(),
-        interface_type: z.string(),
+        entry: z.string(),
         name: z.string(),
+        type: z.string(),
         // Contract version the interface's generated module exports; the app
         // view has no versioned contract and carries none.
         version: z.optional(z.number()),

--- a/packages/@sanity/workbench-cli/src/defineView.ts
+++ b/packages/@sanity/workbench-cli/src/defineView.ts
@@ -13,8 +13,9 @@ import {
  * @public
  */
 export type PanelViewProps = ViewComponentBaseProps<{
-  entry: string
   name: string
+  src: string
+  title: string
   type: 'panel'
 }>
 

--- a/packages/@sanity/workbench-cli/src/defineView.ts
+++ b/packages/@sanity/workbench-cli/src/defineView.ts
@@ -13,9 +13,9 @@ import {
  * @public
  */
 export type PanelViewProps = ViewComponentBaseProps<{
-  entry_point: string
-  interface_type: 'panel'
+  entry: string
   name: string
+  type: 'panel'
 }>
 
 /**


### PR DESCRIPTION
### Description

The types and attribute names for interfaces followed an older naming scheme from Brett (`interface_type` -> `type`) and used `entry_point` instead of `src` internally, which makes it harder than it should be to follow the code and required additional mapping.

Adds a `title` property for views / services, to align further with Brett.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes the dev-server registry interface contract consumed by the workbench during local dev; mismatched workbench versions could misread entries until both sides align.
> 
> **Overview**
> Dev-server **interface** records now use the same field names as the workbench host: **`type`** (was `interface_type`), **`src`** (was `entry_point`), and a required **`title`** (defaulting from `name` for views/services, from app config for the navigable `app` view).
> 
> `deriveInterfaces` centralizes mapping via `toInterface`; the registry Zod schema, `PanelViewProps`, and `exposesSetId` hashing keys are updated to match. Tests and a patch changeset for `@sanity/workbench-cli` reflect the new wire shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842d13a4a5c620ce6fe6a96e34dbf10d9476112f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->