### PR TITLE
feat: Allow boolean for reactCompiler config

### DIFF
--- a/.changeset/pr-1513.md
+++ b/.changeset/pr-1513.md
@@ -1,0 +1,8 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+---
+
+feat: Allow boolean for reactCompiler config

--- a/.changeset/pr-1513.md
+++ b/.changeset/pr-1513.md
@@ -5,4 +5,4 @@
 '@sanity/cli': minor
 ---
 
-Allow a boolean to be used as a value for the reactCompiler config. This will be replaced by an empty object at runtime when passed to the reactCompilerPreset plugin.
+feat: Allow boolean for reactCompiler config

--- a/.changeset/pr-1513.md
+++ b/.changeset/pr-1513.md
@@ -5,4 +5,4 @@
 '@sanity/cli': minor
 ---
 
-feat: Allow boolean for reactCompiler config
+Allow a boolean to be used as a value for the reactCompiler config. This will be replaced by an empty object at runtime when passed to the reactCompilerPreset plugin.

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
@@ -299,6 +299,26 @@ describe('#getViteConfig', () => {
     })
   })
 
+  test('should handle react compiler boolean configuration', async () => {
+    const {default: babel} = await import('@rolldown/plugin-babel')
+    const {reactCompilerPreset} = await import('@vitejs/plugin-react')
+
+    const options = {
+      cwd: mockTestCwd,
+      entries: mockEntries,
+      getEnvironmentVariables,
+      mode: 'development' as const,
+      reactCompiler: true,
+    }
+
+    await getViteConfig(options)
+
+    expect(reactCompilerPreset).toHaveBeenCalledWith({})
+    expect(babel).toHaveBeenCalledWith({
+      presets: [expect.objectContaining({name: 'react-compiler-preset'})],
+    })
+  })
+
   test('should set staging flag when SANITY_INTERNAL_ENV is staging', async () => {
     vi.stubEnv('SANITY_INTERNAL_ENV', 'staging')
 

--- a/packages/@sanity/cli-build/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildStaticFiles.ts
@@ -40,7 +40,7 @@ interface StaticBuildOptions {
   isWorkbenchApp?: boolean
   minify?: boolean
   profile?: boolean
-  reactCompiler?: ReactCompilerConfig
+  reactCompiler?: boolean | ReactCompilerConfig
   schemaExtraction?: CliConfig['schemaExtraction']
   sourceMap?: boolean
   vite?: UserViteConfig

--- a/packages/@sanity/cli-build/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildStudio.ts
@@ -42,7 +42,7 @@ export interface BuildOptions {
   minify: boolean
   outDir: string | undefined
   output: Output
-  reactCompiler: CliConfig['reactCompiler']
+  reactCompiler: boolean | CliConfig['reactCompiler'] | undefined
   schemaExtraction: CliConfig['schemaExtraction']
   sourceMap: boolean
   stats: boolean

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -52,7 +52,7 @@ interface ViteOptions {
    */
   mode: 'development' | 'production'
 
-  reactCompiler: ReactCompilerConfig | undefined
+  reactCompiler: boolean | ReactCompilerConfig | undefined
 
   /**
    * Additional plugins when configured, eg. typegen
@@ -152,7 +152,9 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
 
   const sharedPlugins: PluginOption = [
     viteReact(),
-    ...(reactCompiler ? [babel({presets: [reactCompilerPreset(reactCompiler)]})] : []),
+    ...(reactCompiler
+      ? [babel({presets: [reactCompilerPreset(reactCompiler === true ? {} : reactCompiler)]})]
+      : []),
     ...(schemaExtraction?.enabled
       ? [
           sanitySchemaExtractionPlugin({

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -87,7 +87,7 @@ export interface CliConfig {
   }
 
   /** Configuration options for React Compiler */
-  reactCompiler?: ReactCompilerConfig
+  reactCompiler?: boolean | ReactCompilerConfig
 
   /** Wraps the Studio in \<React.StrictMode\> root to aid in flagging potential problems related to concurrent features (startTransition, useTransition, useDeferredValue, Suspense). Can also be enabled by setting SANITY_STUDIO_REACT_STRICT_MODE="true"|"false". It only applies to sanity dev in development mode and is ignored in sanity build and in production. Defaults to true. */
   reactStrictMode?: boolean

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -25,7 +25,7 @@ export interface DevServerOptions {
   cwd: string
   httpPort: number
 
-  reactCompiler: ReactCompilerConfig | undefined
+  reactCompiler: boolean | ReactCompilerConfig | undefined
   reactStrictMode: boolean | undefined
 
   staticPath: string


### PR DESCRIPTION
### Description

In order to simplify build options for deploying with blueprints and to work towards upcoming changes to the configuration once the rust react compiler is available in vite 8.

### What to review

Ensure the new type was put in all the right places.

### Testing

Added a new test to ensure the boolean value of true works as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible typing and preset normalization; behavior for existing object configs is unchanged.
> 
> **Overview**
> **`reactCompiler` in `sanity.cli` / CLI config can now be `true` or a full React Compiler options object**, not only the object form. The type is threaded through `@sanity/cli-core`, build (`buildStaticFiles`, `buildStudio`, `getViteConfig`), and dev server options.
> 
> When the value is **`true`**, Vite setup enables the compiler with **default preset options** (`reactCompilerPreset({})`). Object configs are unchanged and still passed through as before.
> 
> A unit test in `getViteConfig.test.ts` asserts that `reactCompiler: true` wires Babel with the compiler preset. Changeset marks `@sanity/cli`, `@sanity/cli-build`, and `@sanity/cli-core` as **minor**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d39aa5e27405539ea8d015d0ddbed61747544dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->