### PR TITLE
fix(workbench): inline app-id define via rolldownOptions

### DIFF
--- a/.changeset/workbench-rolldown-define.md
+++ b/.changeset/workbench-rolldown-define.md
@@ -1,0 +1,5 @@
+---
+"@sanity/workbench-cli": patch
+---
+
+Bake the app-id define via vite's `optimizeDeps.rolldownOptions` instead of the deprecated `esbuildOptions`

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-app-id.node.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-app-id.node.test.ts
@@ -7,5 +7,8 @@ test('defines the app id for the pipeline and for dev dep pre-bundling', () => {
   const config = (plugin.config as () => Record<string, unknown>)()
 
   const define = {__SANITY_APP_ID__: '"favorites"'}
-  expect(config).toEqual({define, optimizeDeps: {esbuildOptions: {define}}})
+  expect(config).toEqual({
+    define,
+    optimizeDeps: {rolldownOptions: {transform: {define}}},
+  })
 })

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-app-id.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-app-id.ts
@@ -4,13 +4,13 @@ import {type Plugin} from 'vite'
  * Bake the app's bus identity into its bundle: `@sanity/runtime` reads
  * `__SANITY_APP_ID__` where it connects. `define` covers everything the
  * pipeline transforms (all of a production build, and dev-served source); the
- * esbuild define covers dev's pre-bundled dependencies, which skip Vite's
+ * rolldown define covers dev's pre-bundled dependencies, which skip Vite's
  * define transform.
  */
 export function sanityAppId(appId: string): Plugin {
   const define = {__SANITY_APP_ID__: JSON.stringify(appId)}
   return {
-    config: () => ({define, optimizeDeps: {esbuildOptions: {define}}}),
+    config: () => ({define, optimizeDeps: {rolldownOptions: {transform: {define}}}}),
     name: 'sanity/workbench/app-id',
   }
 }


### PR DESCRIPTION
### Description

vite 8's rolldown-based dep optimizer deprecated `optimizeDeps.esbuildOptions`. The `sanity/workbench/app-id` plugin used it to define `__SANITY_APP_ID__` for dev's pre-bundled deps, so every workbench `dev`/`build` now logs:

```
[vite] warning: `optimizeDeps.esbuildOptions` option was specified by "sanity/workbench/app-id" plugin. This option is deprecated, please use `optimizeDeps.rolldownOptions` instead.
```

Move the define to `optimizeDeps.rolldownOptions`, the supported path. rolldown's `define` is the same `Record<string, string>` with the same replacement semantics, so the app id is still baked into pre-bundled deps — just without the warning.

### What to review

The one-line swap in `plugin-sanity-app-id.ts`. `define` still covers the pipeline transform; only the dep-optimizer half moves from esbuild to rolldown.

### Testing

The plugin's unit test asserts the emitted config shape (now `rolldownOptions`). The runtime path — app id baked into pre-bundled deps — is exercised by the workbench e2e once this ships to the dist-tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-option swap in build tooling with unchanged define semantics; no auth, data, or runtime behavior changes beyond silencing the Vite warning.
> 
> **Overview**
> Updates the **`sanity/workbench/app-id`** Vite plugin so dev dependency pre-bundling still inlines **`__SANITY_APP_ID__`** without triggering Vite 8’s deprecation warning for **`optimizeDeps.esbuildOptions`**.
> 
> The plugin keeps top-level **`define`** for normal pipeline transforms and moves the dep-optimizer half to **`optimizeDeps.rolldownOptions.transform.define`**, with the same define map. The unit test now asserts that config shape; a changeset records a patch for **`@sanity/workbench-cli`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a83fb7de4088cb9008dd536a2c538279a89c67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->