### PR TITLE
fix(cli-build): silence mixed async/defer warning in bundled Vite dev

### DIFF
--- a/.changeset/pr-1515.md
+++ b/.changeset/pr-1515.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': patch
+---
+
+fix(cli-build): silence mixed async/defer warning in bundled Vite dev

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/decorateIndexWithBridgeScript.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/decorateIndexWithBridgeScript.test.ts
@@ -1,0 +1,30 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {decorateIndexWithBridgeScript} from '../decorateIndexWithBridgeScript'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('decorateIndexWithBridgeScript', () => {
+  test('injects an async module bridge script before </head>', () => {
+    const html =
+      '<html><head></head><body><script async src="/.sanity/runtime/app.js" type="module"></script></body></html>'
+
+    const result = decorateIndexWithBridgeScript(html)
+    const bridgeScript = result.match(/<script\b[^>]*data-sanity-core[^>]*>/)?.[0]
+
+    expect(bridgeScript).toBeDefined()
+    expect(bridgeScript).toContain('async')
+    expect(bridgeScript).toContain('type="module"')
+    expect(bridgeScript).toContain('https://core.sanity-cdn.com/bridge.js')
+  })
+
+  test('uses the staging CDN when SANITY_INTERNAL_ENV is not production', () => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'staging')
+
+    const result = decorateIndexWithBridgeScript('<html><head></head><body></body></html>')
+
+    expect(result).toContain('https://core.sanity-cdn.work/bridge.js')
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
@@ -154,7 +154,10 @@ describe('#getViteConfig', () => {
     expect(config.define).not.toHaveProperty('process.env.VITE_CUSTOM_VAR')
     expect(config.define).not.toHaveProperty('process.env.APP_VAR')
 
-    expect(config.plugins).toHaveLength(4)
+    expect(config.plugins).toHaveLength(5)
+    expect(config.plugins).toEqual(
+      expect.arrayContaining([expect.objectContaining({name: 'sanity/async-module-scripts'})]),
+    )
     expect(config.resolve?.dedupe).toEqual(['react', 'react-dom', 'sanity', 'styled-components'])
   })
 

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -24,6 +24,7 @@ import {type AutoUpdatesBuildConfig} from './autoUpdates.js'
 import {VENDOR_DIR} from './constants.js'
 import {createExternalFromImportMap} from './createExternalFromImportMap.js'
 import {normalizeBasePath} from './normalizeBasePath.js'
+import {sanityAsyncModuleScriptsPlugin} from './vite/plugin-sanity-async-module-scripts.js'
 import {sanityBuildEntries} from './vite/plugin-sanity-build-entries.js'
 import {sanityFaviconsPlugin} from './vite/plugin-sanity-favicons.js'
 import {sanityRuntimeRewritePlugin} from './vite/plugin-sanity-runtime-rewrite.js'
@@ -151,7 +152,10 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
   const envVars = options.getEnvironmentVariables()
 
   const sharedPlugins: PluginOption = [
+    // viteReact must precede sanityAsyncModuleScriptsPlugin so the latter's
+    // `order: 'pre'` transformIndexHtml runs after react-refresh injection.
     viteReact(),
+    sanityAsyncModuleScriptsPlugin(),
     ...(reactCompiler ? [babel({presets: [reactCompilerPreset(reactCompiler)]})] : []),
     ...(schemaExtraction?.enabled
       ? [

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/BasicDocument.tsx
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/BasicDocument.tsx
@@ -49,7 +49,7 @@ export function BasicDocument(props: BasicDocumentProps): JSX.Element {
       </head>
       <body>
         <div id="root" />
-        <script src={entryPath} type="module" />
+        <script async src={entryPath} type="module" />
         <NoJavascript />
       </body>
     </html>

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/DefaultDocument.tsx
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/DefaultDocument.tsx
@@ -151,7 +151,7 @@ export function DefaultDocument(props: DefaultDocumentProps): React.JSX.Element 
       </head>
       <body>
         <div id="sanity" />
-        <script src={entryPath} type="module" />
+        <script async src={entryPath} type="module" />
         <NoJavascript />
       </body>
     </html>

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/__tests__/BasicDocument.test.tsx
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/__tests__/BasicDocument.test.tsx
@@ -1,0 +1,23 @@
+import {renderToStaticMarkup} from 'react-dom/server'
+import {describe, expect, test} from 'vitest'
+
+import {BasicDocument} from '../BasicDocument.js'
+
+describe('BasicDocument', () => {
+  test('marks the entry module script as async so it matches the bridge script', () => {
+    const html = renderToStaticMarkup(<BasicDocument entryPath="/.sanity/runtime/app.js" />)
+    const entryScript = html.match(/<script\b[^>]*src="\/\.sanity\/runtime\/app\.js"[^>]*>/)?.[0]
+
+    expect(entryScript).toBeDefined()
+    expect(entryScript).toContain('async')
+    expect(entryScript).toContain('type="module"')
+  })
+
+  test('uses the provided title', () => {
+    const html = renderToStaticMarkup(
+      <BasicDocument entryPath="/.sanity/runtime/app.js" title="My App" />,
+    )
+
+    expect(html).toContain('<title>My App</title>')
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/__tests__/DefaultDocument.test.tsx
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/__tests__/DefaultDocument.test.tsx
@@ -1,0 +1,23 @@
+import {renderToStaticMarkup} from 'react-dom/server'
+import {describe, expect, test} from 'vitest'
+
+import {DefaultDocument} from '../DefaultDocument.js'
+
+describe('DefaultDocument', () => {
+  test('marks the entry module script as async so it matches the bridge script', () => {
+    const html = renderToStaticMarkup(<DefaultDocument entryPath="/.sanity/runtime/app.js" />)
+    const entryScript = html.match(/<script\b[^>]*src="\/\.sanity\/runtime\/app\.js"[^>]*>/)?.[0]
+
+    expect(entryScript).toBeDefined()
+    expect(entryScript).toContain('async')
+    expect(entryScript).toContain('type="module"')
+  })
+
+  test('renders stylesheet links for provided css paths', () => {
+    const html = renderToStaticMarkup(
+      <DefaultDocument css={['/styles.css']} entryPath="/.sanity/runtime/app.js" />,
+    )
+
+    expect(html).toContain('<link href="/styles.css" rel="stylesheet"/>')
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/vite/__tests__/plugin-sanity-async-module-scripts.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/vite/__tests__/plugin-sanity-async-module-scripts.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, test} from 'vitest'
+
+import {sanityAsyncModuleScriptsPlugin} from '../plugin-sanity-async-module-scripts'
+
+describe('sanityAsyncModuleScriptsPlugin', () => {
+  const plugin = sanityAsyncModuleScriptsPlugin()
+  const transform = plugin.transformIndexHtml
+  if (!transform || typeof transform === 'function' || !('handler' in transform)) {
+    throw new Error('expected transformIndexHtml handler object')
+  }
+  const handler = transform.handler as (html: string) => string
+
+  test('adds async to module scripts that lack it', () => {
+    const html =
+      '<script type="module">import "/@react-refresh"</script><script src="/app.js" type="module"></script>'
+
+    expect(handler(html)).toBe(
+      '<script async type="module">import "/@react-refresh"</script><script async src="/app.js" type="module"></script>',
+    )
+  })
+
+  test('leaves already-async module scripts unchanged', () => {
+    const html = '<script async src="https://core.sanity-cdn.com/bridge.js" type="module"></script>'
+
+    expect(handler(html)).toBe(html)
+  })
+
+  test('does not modify classic or non-module scripts', () => {
+    const html =
+      '<script>globalThis.__SANITY_STAGING__ = true</script><script type="application/json" id="x"></script>'
+
+    expect(handler(html)).toBe(html)
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/vite/plugin-sanity-async-module-scripts.ts
+++ b/packages/@sanity/cli-build/src/actions/build/vite/plugin-sanity-async-module-scripts.ts
@@ -1,0 +1,30 @@
+import {type Plugin} from 'vite'
+
+/**
+ * Ensures every `type="module"` script in HTML is marked `async`.
+ *
+ * Vite warns and falls back to defer when module scripts mix async and defer.
+ * Sanity's bridge script is intentionally async; `@vitejs/plugin-react` injects
+ * a react-refresh preamble without `async` under `experimental.bundledDev`.
+ * Aligning all module scripts to async silences that warning.
+ *
+ * @internal
+ */
+export function sanityAsyncModuleScriptsPlugin(): Plugin {
+  return {
+    name: 'sanity/async-module-scripts',
+    transformIndexHtml: {
+      handler(html) {
+        return html.replaceAll(/<script\b([^>]*)>/gi, (tag, attrs: string) => {
+          if (!/\btype\s*=\s*(["']?)module\1/i.test(attrs) || /\basync\b/i.test(attrs)) {
+            return tag
+          }
+          return `<script async${attrs ? ` ${attrs.trimStart()}` : ''}>`
+        })
+      },
+      // Run after `@vitejs/plugin-react`'s `order: 'pre'` preamble injection so
+      // the react-refresh script is rewritten too.
+      order: 'pre',
+    },
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

With `unstable_bundledDev: true`, Vite logs:

> Mixed async and defer script modules … Every script, including inline ones, need to be marked as async …

That warning came from mixing:

1. Sanity’s async bridge module script
2. Non-async studio/app entry module scripts
3. `@vitejs/plugin-react`’s non-async react-refresh preamble (injected under bundledDev)

This change:

- Marks the entry `<script type="module">` tags `async` in `DefaultDocument` / `BasicDocument`
- Adds a Vite plugin that ensures every `type="module"` script (including the react-refresh preamble) is marked `async` after HTML transforms

Verified locally that `sanity dev` with `unstable_bundledDev: true` no longer prints the warning.

### What to review

- Entry script `async` on default studio/app documents
- `sanityAsyncModuleScriptsPlugin` placement after `viteReact()` so it rewrites the react-refresh inject
- Unit coverage for documents, bridge decorator, plugin, and vite config plugin count

### Testing

- Unit tests for the new/changed document templates, bridge decorator, async-module plugin, and `getViteConfig`
- Manual smoke: `sanity dev` with `unstable_bundledDev: true` — ready message appears without the mixed async/defer warning

### Notes for release

Silence Vite mixed async/defer script warning when using `unstable_bundledDev`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fccbd26-b4e2-4902-874e-6155b3ba1109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fccbd26-b4e2-4902-874e-6155b3ba1109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

