### PR TITLE
feat(cli-build): add bridge toggle and workbench SPA build steps

### DIFF
--- a/.changeset/workbench-remote-spa-build-steps.md
+++ b/.changeset/workbench-remote-spa-build-steps.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli-build": patch
+---
+
+Add a `bridge` option to the build-entries plugin and the standalone SPA build steps for workbench remotes (gated on `SANITY_INTERNAL_IS_WORKBENCH_REMOTE`)

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/buildStaticFiles.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/buildStaticFiles.test.ts
@@ -68,6 +68,7 @@ describe('buildStaticFiles', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
   })
 
   describe('federation enabled / isWorkbenchApp=true', () => {
@@ -134,6 +135,63 @@ describe('buildStaticFiles', () => {
       )
     })
   })
+
+  describe('workbench remote SPA (SANITY_INTERNAL_IS_WORKBENCH_REMOTE=true)', () => {
+    beforeEach(() => {
+      vi.stubEnv('SANITY_INTERNAL_IS_WORKBENCH_REMOTE', 'true')
+    })
+
+    test('emits the SPA (runtime + static + favicons) for an app with an entry', async () => {
+      await buildStaticFiles({
+        basePath: '/',
+        cwd,
+        entry: './src/App',
+        isApp: true,
+        isWorkbenchApp: true,
+        outputDir,
+      })
+
+      expect(mockWriteSanityRuntime).toHaveBeenCalled()
+      expect(mockCopyDir).toHaveBeenCalledWith(
+        path.join(cwd, 'static'),
+        path.join(outputDir, 'static'),
+      )
+      expect(mockWriteFavicons).toHaveBeenCalledWith('/static', path.join(outputDir, 'static'))
+      // The SPA path resolves entries via writeSanityRuntime, not resolveEntries.
+      expect(mockResolveEntries).not.toHaveBeenCalled()
+      expect(mockBuildApp).toHaveBeenCalled()
+    })
+
+    test('emits the SPA for a federated studio (no entry)', async () => {
+      await buildStaticFiles({
+        basePath: '/',
+        cwd,
+        isWorkbenchApp: true,
+        outputDir,
+      })
+
+      expect(mockWriteSanityRuntime).toHaveBeenCalled()
+      expect(mockWriteFavicons).toHaveBeenCalled()
+      expect(mockBuildApp).toHaveBeenCalled()
+    })
+
+    test('skips the SPA for a dock-only app (isApp with no entry)', async () => {
+      await buildStaticFiles({
+        basePath: '/',
+        cwd,
+        isApp: true,
+        isWorkbenchApp: true,
+        outputDir,
+      })
+
+      expect(mockWriteSanityRuntime).not.toHaveBeenCalled()
+      expect(mockWriteFavicons).not.toHaveBeenCalled()
+      expect(mockCopyDir).not.toHaveBeenCalled()
+      expect(mockResolveEntries).toHaveBeenCalled()
+      expect(mockBuildApp).toHaveBeenCalled()
+    })
+  })
+
   describe('isWorkbenchapp=false', () => {
     test('should run a vite build, write favicons and return chunk stats', async () => {
       const basePath = '/' // this is OS-agnostic, even on windows :shrug:

--- a/packages/@sanity/cli-build/src/actions/build/buildStaticFiles.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildStaticFiles.ts
@@ -81,8 +81,30 @@ export async function buildStaticFiles(
    * runtime generation, static file copies, and favicons.
    */
   if (isWorkbenchApp) {
-    buildDebug('Resolving entries for federation build')
-    const entries = await resolveEntries({cwd, entry, isApp, isWorkbenchApp})
+    // A workbench remote can also serve itself standalone. When
+    // `SANITY_INTERNAL_IS_WORKBENCH_REMOTE` is set, emit an SPA (index.html +
+    // bootstrap + favicons) into the same `dist` as the federation output via a
+    // dedicated `client` environment (see plugin-sanity-environment). Skipped for
+    // a dock-only app (no `./App` to mount), matching `exposesApp` in plugin.ts.
+    const emitSpa = process.env.SANITY_INTERNAL_IS_WORKBENCH_REMOTE === 'true' && !(isApp && !entry)
+
+    let entries: Awaited<ReturnType<typeof resolveEntries>>
+    if (emitSpa) {
+      buildDebug('Writing Sanity runtime files (workbench remote SPA)')
+      ;({entries} = await writeSanityRuntime({
+        appTitle,
+        basePath,
+        cwd,
+        entry,
+        isApp,
+        isWorkbenchApp,
+        reactStrictMode: false,
+        watch: false,
+      }))
+    } else {
+      buildDebug('Resolving entries for federation build')
+      entries = await resolveEntries({cwd, entry, isApp, isWorkbenchApp})
+    }
 
     buildDebug('Resolving vite config (federation)')
     let viteConfig = await getViteConfig({
@@ -114,6 +136,16 @@ export async function buildStaticFiles(
         viteConfig,
         extendViteConfig,
       )
+    }
+
+    if (emitSpa) {
+      const fromPath = path.join(cwd, 'static')
+      const staticPath = path.join(outputDir, 'static')
+      buildDebug(`Copying static files from ${fromPath} to output dir`)
+      await copyDir(fromPath, staticPath)
+      buildDebug('Writing favicons to output dir')
+      const faviconBasePath = `${basePath.replace(/\/+$/, '')}/static`
+      await writeFavicons(faviconBasePath, staticPath)
     }
 
     buildDebug('Bundling federation environment')

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -199,12 +199,19 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     logLevel: mode === 'production' ? 'silent' : 'info',
     mode,
     plugins: [
-      // Federation builds only need the federation plugin — skip client-specific
-      // plugins (favicons, runtime rewrite, build entries)
+      // Federation builds skip the serve-only client plugins (favicons, runtime
+      // rewrite) — they no-op at build. `sanityBuildEntries` is scoped to the
+      // `client` environment so it emits the standalone SPA `index.html`
+      // (bridge-free) when the workbench remote SPA is enabled, and no-ops in the
+      // federation env / when no client env exists (see plugin-sanity-environment).
       ...(isWorkbenchApp
         ? [
             ...sharedPlugins,
             await workbenchVitePlugins({appId: workbenchAppId, cwd, entries, exposes, isApp}),
+            {
+              ...sanityBuildEntries({basePath, bridge: false, cwd, isApp}),
+              applyToEnvironment: (env) => env.name === 'client',
+            } satisfies Plugin,
           ]
         : [
             ...sharedPlugins,

--- a/packages/@sanity/cli-build/src/actions/build/vite/__tests__/plugin-sanity-build-entries.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/vite/__tests__/plugin-sanity-build-entries.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, test, vi} from 'vitest'
+
+import {sanityBuildEntries} from '../plugin-sanity-build-entries.js'
+
+vi.mock('../../renderDocument.js', () => ({
+  renderDocument: vi
+    .fn()
+    .mockResolvedValue('<html><head></head><body><div id="root"></div></body></html>'),
+}))
+
+function makeBundle() {
+  return {
+    'static/sanity-abc.js': {
+      facadeModuleId: '/project/.sanity/runtime/app.js',
+      fileName: 'static/sanity-abc.js',
+      imports: [],
+      name: 'sanity',
+      type: 'chunk',
+      viteMetadata: {importedCss: undefined},
+    },
+  }
+}
+
+async function emitIndexHtml(bridge?: boolean): Promise<string> {
+  const plugin = sanityBuildEntries({basePath: '/', bridge, cwd: '/project'})
+
+  let emitted: {fileName: string; source: string} | undefined
+  const context = {
+    emitFile: (file: {fileName: string; source: string}) => {
+      emitted = file
+    },
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (plugin.generateBundle as any).call(context, {}, makeBundle())
+
+  if (!emitted) throw new Error('index.html was not emitted')
+  return emitted.source
+}
+
+describe('sanityBuildEntries index.html', () => {
+  test('injects the core-ui bridge script by default', async () => {
+    const html = await emitIndexHtml()
+    expect(html).toContain('bridge.js')
+  })
+
+  test('omits the bridge script when bridge is false', async () => {
+    const html = await emitIndexHtml(false)
+    expect(html).not.toContain('bridge.js')
+    // The document itself is still emitted.
+    expect(html).toContain('id="root"')
+  })
+})

--- a/packages/@sanity/cli-build/src/actions/build/vite/plugin-sanity-build-entries.ts
+++ b/packages/@sanity/cli-build/src/actions/build/vite/plugin-sanity-build-entries.ts
@@ -30,10 +30,15 @@ const entryChunkId = '.sanity/runtime/app.js'
 export function sanityBuildEntries(options: {
   autoUpdates?: AutoUpdatesBuildConfig
   basePath: string
+  /**
+   * Injects the core-ui bridge script into the emitted `index.html`. Defaults to
+   * `true`. Workbench remotes serve themselves standalone and pass `false`.
+   */
+  bridge?: boolean
   cwd: string
   isApp?: boolean
 }): Plugin {
-  const {autoUpdates, basePath, cwd, isApp} = options
+  const {autoUpdates, basePath, bridge = true, cwd, isApp} = options
 
   return {
     apply: 'build',
@@ -101,23 +106,21 @@ export function sanityBuildEntries(options: {
           }
         : undefined
 
+      const html = await renderDocument({
+        autoUpdatesCssUrls: autoUpdates?.cssUrls,
+        importMap,
+        isApp,
+        props: {
+          basePath,
+          css,
+          entryPath,
+        },
+        studioRootPath: cwd,
+      })
+
       this.emitFile({
         fileName: 'index.html',
-        source: decorateIndexWithStagingScript(
-          decorateIndexWithBridgeScript(
-            await renderDocument({
-              autoUpdatesCssUrls: autoUpdates?.cssUrls,
-              importMap,
-              isApp,
-              props: {
-                basePath,
-                css,
-                entryPath,
-              },
-              studioRootPath: cwd,
-            }),
-          ),
-        ),
+        source: decorateIndexWithStagingScript(bridge ? decorateIndexWithBridgeScript(html) : html),
         type: 'asset',
       })
     },


### PR DESCRIPTION
### Description

`sanityBuildEntries` always injected the `bridge.js` script, and workbench builds skipped SPA generation. Adds a `bridge` option (default `true`) and, for workbench builds, the SPA steps (runtime bootstrap, static copy, favicons) — gated on `SANITY_INTERNAL_IS_WORKBENCH_REMOTE` and an exposed `./App`.

Inert until the `client` env lands in the stacked follow-up; with the flag unset, output is unchanged. [SDK-1038](https://linear.app/sanity/issue/SDK-1038)

### What to review

`bridge` defaults `true`, so non-workbench `index.html` is byte-identical. The SPA steps mirror the existing non-workbench branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production build orchestration for workbench apps behind an internal env flag; default studio and federation paths are preserved when the flag is off.
> 
> **Overview**
> Workbench federation builds can now also emit a **standalone SPA** into the same `dist` when `SANITY_INTERNAL_IS_WORKBENCH_REMOTE` is `true`: runtime bootstrap via `writeSanityRuntime`, static copy, and favicons (skipped for dock-only apps with no entry). Federation-only behavior is unchanged when the flag is unset.
> 
> `sanityBuildEntries` gains an optional **`bridge`** flag (default `true`) so emitted `index.html` can omit the core-ui `bridge.js` script. Workbench vite config registers that plugin on the **`client`** environment only with `bridge: false`, leaving normal studio/app builds byte-identical at default settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 321db1c170bb365003cf1ee834cfece78feb6d4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->