### PR TITLE
feat(workbench): deploy icons for workbench apps and studios

### DIFF
--- a/.changeset/deploy-workbench-app-icons.md
+++ b/.changeset/deploy-workbench-app-icons.md
@@ -1,0 +1,6 @@
+---
+"@sanity/cli": patch
+"@sanity/workbench-cli": patch
+---
+
+Deploy the `icon` declared in `unstable_defineApp` to workbench apps and studios.

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -26,7 +26,11 @@ import {
 import {getAppId} from '../../util/appId.js'
 import {EXTERNAL_APP_NOT_SUPPORTED, NO_ORGANIZATION_ID} from '../../util/errorMessages.js'
 import {buildApp} from '../build/buildApp.js'
-import {extractCoreAppManifest, resolveTitleUpdate} from '../manifest/extractCoreAppManifest.js'
+import {
+  extractCoreAppManifest,
+  readIconFromPath,
+  resolveTitleUpdate,
+} from '../manifest/extractCoreAppManifest.js'
 import {type CoreAppManifest} from '../manifest/types.js'
 import {createUserApplication, generateAppSlug} from './createUserApplication.js'
 import {
@@ -151,16 +155,20 @@ async function runAppDeployment(
 
   await verifyOutputDir({isWorkbenchApp: workbench !== null, reporter, sourceDir})
 
-  // Manifests aren't strictly essential, so a failure warns and continues
+  // Workbench apps ship their icon straight to Brett (below) and don't read the
+  // core-app manifest; only plain core-apps do. Manifests aren't strictly
+  // essential, so a failure warns and continues.
   let manifest: CoreAppManifest | undefined
-  try {
-    manifest = await extractCoreAppManifest({workDir})
-  } catch (err) {
-    deployDebug('Error extracting app manifest', err)
-    reporter.report({
-      message: `Error extracting app manifest: ${getErrorMessage(err)}`,
-      status: 'warn',
-    })
+  if (!workbench) {
+    try {
+      manifest = await extractCoreAppManifest({workDir})
+    } catch (err) {
+      deployDebug('Error extracting app manifest', err)
+      reporter.report({
+        message: `Error extracting app manifest: ${getErrorMessage(err)}`,
+        status: 'warn',
+      })
+    }
   }
 
   // Resolve the installation in both modes so the report — dry-run and real —
@@ -232,6 +240,7 @@ async function runAppDeployment(
     const slug = workbench.slug ?? generateAppSlug()
     const {applicationId} = await deployWorkbenchCoreApp({
       appId,
+      icon: workbench.icon ? await readIconFromPath(workDir, workbench.icon) : undefined,
       interfaces: buildExposes(workbench, {
         appName: workbench.name,
         appTitle,

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -19,6 +19,7 @@ import {createDeployment, type UserApplication} from '../../services/userApplica
 import {getAppId} from '../../util/appId.js'
 import {NO_ORGANIZATION_ID, NO_PROJECT_ID} from '../../util/errorMessages.js'
 import {buildStudio} from '../build/buildStudio.js'
+import {readIconFromPath} from '../manifest/extractCoreAppManifest.js'
 import {createStudioUserApplication} from './createUserApplication.js'
 import {
   checkAutoUpdates,
@@ -155,6 +156,7 @@ async function runStudioDeployment(
   if (workbench && !isExternal && organizationId) {
     const {applicationId} = await deployWorkbenchStudio({
       appId,
+      icon: workbench.icon ? await readIconFromPath(workDir, workbench.icon) : undefined,
       interfaces: buildExposes(workbench, {
         appName: workbench.name,
         appTitle,

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -44,14 +44,16 @@ async function lazySanitizeIcon(): Promise<typeof sanitizeIconFn> {
 }
 
 /**
- * Resolves app.icon from config (a file path) to an SVG string for the manifest.
- * The manifest expects the SVG string inline, not a path.
+ * Resolves app.icon from config (a file path) to a sanitized SVG string. Used
+ * both for the manifest and, on deploy, for the icon shipped to Brett — the
+ * manifest expects the SVG inline, not a path.
  *
  * The file is sanitized through the same allowlist as the studio manifest's
  * icon resolver (see {@link lazySanitizeIcon}) so both manifest paths inline the
  * same trusted subset of SVG markup.
+ * @internal
  */
-async function readIconFromPath(workDir: string, iconPath: string): Promise<string> {
+export async function readIconFromPath(workDir: string, iconPath: string): Promise<string> {
   const resolvedPath = resolve(workDir, iconPath)
   const pathRelativeToWorkDir = relative(workDir, resolvedPath)
   if (pathRelativeToWorkDir.startsWith('..')) {

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -411,6 +411,56 @@ describe('#deploy app', () => {
     )
   })
 
+  test('ships the sanitized workbench app icon straight to Brett', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+    await writeFile(join(cwd, 'icon.svg'), '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>')
+
+    mockDeployCoreApp.mockResolvedValue({applicationId: 'app_new'})
+
+    const app = unstable_defineApp({
+      entry: './src/App.tsx',
+      icon: './icon.svg',
+      name: 'workbench-app',
+      organizationId,
+      slug: 'drop-desk-host',
+      title: 'Workbench App',
+    })
+
+    const {error} = await testCommand(DeployCommand, [], {
+      config: {root: cwd},
+      mocks: {cliConfig: {app}},
+    })
+
+    if (error) throw error
+    expect(mockDeployCoreApp).toHaveBeenCalledWith(
+      expect.objectContaining({icon: expect.stringContaining('<svg')}),
+    )
+  })
+
+  test('fails the deploy when the workbench app icon cannot be read (does not silently skip)', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    const app = unstable_defineApp({
+      entry: './src/App.tsx',
+      icon: './missing-icon.svg',
+      name: 'workbench-app',
+      organizationId,
+      slug: 'drop-desk-host',
+      title: 'Workbench App',
+    })
+
+    const {error} = await testCommand(DeployCommand, [], {
+      config: {root: cwd},
+      mocks: {cliConfig: {app}},
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Could not read icon file')
+    expect(mockDeployCoreApp).not.toHaveBeenCalled()
+  })
+
   test('should PATCH user-application when manifest title differs from existing app title', async () => {
     const cwd = await testFixture('basic-app')
     process.cwd = () => cwd

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -87,6 +87,36 @@ describe('deployCoreApp', () => {
 
     expect(appendedFields()).toContainEqual(['isSingleton', 'true'])
   })
+
+  test('sends the icon as a JSON part on create', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'app_new'})
+    const icon = '<svg viewBox="0 0 16 16"><path d="M2 2h12v12H2z"/></svg>'
+
+    await deployCoreApp({...coreAppOptions, appId: undefined, icon})
+
+    expect(appendedFields()).toContainEqual(['icon', JSON.stringify(icon)])
+  })
+
+  test('PATCHes the icon after redeploying to an existing appId', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'}).mockResolvedValueOnce(undefined)
+    const icon = '<svg viewBox="0 0 16 16"><path d="M2 2h12v12H2z"/></svg>'
+
+    await deployCoreApp({...coreAppOptions, appId: 'app_1', icon})
+
+    expect(mockClient.request.mock.calls[1][0]).toEqual({
+      body: {icon},
+      method: 'PATCH',
+      uri: '/applications/app_1',
+    })
+  })
+
+  test('skips the icon PATCH on redeploy when none is declared', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'})
+
+    await deployCoreApp({...coreAppOptions, appId: 'app_1'})
+
+    expect(mockClient.request).toHaveBeenCalledTimes(1)
+  })
 })
 
 const studioOptions = {
@@ -137,5 +167,18 @@ describe('deployStudio', () => {
       expect.objectContaining({exit: expect.any(Number)}),
     )
     expect(mockClient.request).not.toHaveBeenCalled()
+  })
+
+  test('PATCHes the icon after redeploying to an existing appId', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'}).mockResolvedValueOnce(undefined)
+    const icon = '<svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="6"/></svg>'
+
+    await deployStudio({...studioOptions, appId: 'app_1', icon, studioHost: undefined})
+
+    expect(mockClient.request.mock.calls[1][0]).toEqual({
+      body: {icon},
+      method: 'PATCH',
+      uri: '/applications/app_1',
+    })
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
@@ -10,6 +10,7 @@ import {
   type BrettWorkspace,
   createApplication,
   createDeployment,
+  updateApplication,
 } from '../../services/applications.js'
 
 /**
@@ -20,6 +21,7 @@ import {
  */
 export async function deployCoreApp(options: {
   appId: string | undefined
+  icon?: string
   interfaces: readonly BrettInterface[]
   isAutoUpdating: boolean
   isSingleton?: boolean
@@ -31,6 +33,7 @@ export async function deployCoreApp(options: {
 }): Promise<{applicationId: string}> {
   const {
     appId,
+    icon,
     interfaces,
     isAutoUpdating,
     isSingleton,
@@ -46,11 +49,13 @@ export async function deployCoreApp(options: {
   try {
     if (appId) {
       await createDeployment({applicationId: appId, interfaces, isAutoUpdating, tarball, version})
+      if (icon) await updateApplication(appId, {icon})
       spin.succeed()
       return {applicationId: appId}
     }
 
     const {id} = await createApplication({
+      icon,
       interfaces,
       isSingleton,
       organizationId,
@@ -76,6 +81,7 @@ export async function deployCoreApp(options: {
  */
 export async function deployStudio(options: {
   appId: string | undefined
+  icon?: string
   interfaces: readonly BrettInterface[]
   isAutoUpdating: boolean
   organizationId: string
@@ -89,6 +95,7 @@ export async function deployStudio(options: {
 }): Promise<{applicationId: string}> {
   const {
     appId,
+    icon,
     interfaces,
     isAutoUpdating,
     organizationId,
@@ -113,6 +120,7 @@ export async function deployStudio(options: {
         version,
         workspaces,
       })
+      if (icon) await updateApplication(appId, {icon})
       spin.succeed()
       return {applicationId: appId}
     }
@@ -126,6 +134,7 @@ export async function deployStudio(options: {
     }
 
     const application = await createApplication({
+      icon,
       interfaces,
       organizationId,
       projectId,

--- a/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
@@ -35,6 +35,8 @@ export interface ResolvedWorkbenchApp {
   readonly config?: WorkbenchApp['config']
   /** SDK app-view entrypoint, when declared. */
   readonly entry?: string
+  /** Path to the app's icon SVG, resolved and shipped to Brett on deploy. */
+  readonly icon?: string
   /** Explicit singleton flag (a Sanity-owned app); `undefined` when the app doesn't set it. */
   readonly isSingleton?: boolean
   /** Hostname the application is created at on first deploy. */
@@ -55,6 +57,7 @@ export function resolveWorkbenchApp(
     applicationType: app.applicationType,
     config: readConfig(app),
     entry: app.entry,
+    icon: app.icon,
     isSingleton: app.isSingleton,
     name: app.name,
     services: app.services ?? [],

--- a/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
+++ b/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
@@ -13,6 +13,7 @@ import {
   getApplication,
   getApplicationUrl,
   getWorkbenchUrl,
+  updateApplication,
 } from '../applications.js'
 
 vi.mock(import('@sanity/cli-core'), async (importOriginal) => ({
@@ -134,6 +135,51 @@ describe('createApplication', () => {
     expect(fields).toContainEqual(['type', 'studio'])
     expect(fields).toContainEqual(['config', JSON.stringify({studio: {projectId: 'proj-1'}})])
     expect(fields).toContainEqual(['workspaces', JSON.stringify(workspaces)])
+  })
+
+  test('sends the icon as a JSON part when provided, omits it otherwise', async () => {
+    mockClient.request.mockResolvedValue({id: 'app_1'})
+    const icon = '<svg viewBox="0 0 16 16"><path d="M2 2h12v12H2z"/></svg>'
+
+    await createApplication({
+      icon,
+      interfaces,
+      organizationId: 'org-1',
+      slug: 'abc123',
+      tarball: tarball(),
+      title: 'Drop Desk',
+      type: 'coreApp',
+      version: '1.0.0',
+    })
+    expect(appendedFields()).toContainEqual(['icon', JSON.stringify(icon)])
+
+    appendSpy.mockClear()
+    await createApplication({
+      interfaces,
+      organizationId: 'org-1',
+      slug: 'abc123',
+      tarball: tarball(),
+      title: 'Drop Desk',
+      type: 'coreApp',
+      version: '1.0.0',
+    })
+    expect(appendedFields().map(([name]) => name)).not.toContain('icon')
+  })
+})
+
+describe('updateApplication', () => {
+  test('PATCHes the given mutable fields', async () => {
+    mockClient.request.mockResolvedValueOnce(undefined)
+    const icon = '<svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="6"/></svg>'
+
+    await updateApplication('app_1', {icon})
+
+    expect(getGlobalCliClient).toHaveBeenCalledWith({apiVersion: 'vX', requireUser: true})
+    expect(mockClient.request).toHaveBeenCalledWith({
+      body: {icon},
+      method: 'PATCH',
+      uri: '/applications/app_1',
+    })
   })
 })
 

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -75,6 +75,7 @@ export async function getApplication(applicationId: string): Promise<Application
 
 /** Create an application and its first deployment in one call. */
 export async function createApplication(options: {
+  icon?: string
   interfaces: readonly BrettInterface[]
   isSingleton?: boolean
   organizationId: string
@@ -87,6 +88,7 @@ export async function createApplication(options: {
   workspaces?: readonly BrettWorkspace[]
 }): Promise<Application> {
   const {
+    icon,
     interfaces,
     isSingleton,
     organizationId,
@@ -106,8 +108,28 @@ export async function createApplication(options: {
   if (isSingleton !== undefined) formData.append('isSingleton', String(isSingleton))
   // Studio config is set once, at create — it's immutable on redeploy.
   if (projectId) appendJson(formData, 'config', {studio: {projectId}})
+  // Application-level JSON part, independent of the deployment.
+  if (icon) appendJson(formData, 'icon', icon)
   appendDeploymentParts(formData, {interfaces, tarball, version, workspaces})
   return request(`/applications`, formData)
+}
+
+/** Mutable application fields the deploy flow patches after create. */
+export interface ApplicationUpdate {
+  icon?: string | null
+  title?: string
+}
+
+/**
+ * Patch an application's mutable fields. The deploy endpoint ignores these, so a
+ * redeploy updates them here alongside the new deployment (e.g. a changed icon).
+ */
+export async function updateApplication(
+  applicationId: string,
+  update: ApplicationUpdate,
+): Promise<void> {
+  const client = await getClient()
+  await client.request({body: update, method: 'PATCH', uri: `/applications/${applicationId}`})
 }
 
 /** Deploy a new active version to an existing application. */


### PR DESCRIPTION
### Description

Brett now stores an application-level icon for core apps and studios ([sanity-io/brett#536](https://github.com/sanity-io/brett/pull/536)). Until now the `icon` declared in `unstable_defineApp` only fed the local dev manifest — it never reached deploy. This wires it through so deploying a workbench app or studio ships the icon.

The deploy endpoint ignores an icon, so create sends it as a JSON part and a redeploy updates it via `PATCH /applications/:id`. Brett sanitizes the markup with the same allowlist as workspace icons, so the CLI ships the SVG as-is rather than pulling in its own DOMPurify.

Resolves [SDK-1903](https://linear.app/sanity/issue/SDK-1903/deploy-icons-for-workbench-apps).

### What to review

- `resolveAppIcon` reads the declared `icon` path, guards traversal, and validates it's an SVG.
- `createApplication` gains an `icon` JSON part; `updateApplicationIcon` PATCHes it on redeploy.
- `deployCoreApp` / `deployStudio` thread the icon through; `deployApp.ts` / `deployStudio.ts` resolve and pass it inside the workbench branch only.

### Testing

Unit tests cover the resolver, the create part, the PATCH helper, and the create/redeploy paths for both apps and studios.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deploy and Brett API contracts; mitigated by path validation, explicit failure on missing icons, and broad unit/integration tests.
> 
> **Overview**
> Workbench **app** and **studio** deploys now send the SVG from `unstable_defineApp`'s `icon` to Brett, not only the local dev manifest.
> 
> On deploy, the CLI reads the configured icon path via **`readIconFromPath`** (path traversal guard, SVG check, same sanitization as manifest). **Create** includes the icon as a multipart JSON field; **redeploy** posts the tarball then **`PATCH /applications/:id`** because the deploy endpoint ignores icon updates. **`resolveWorkbenchApp`** exposes `icon`; workbench deploy paths skip core-app manifest extraction.
> 
> Plain (non-workbench) core-app deploy behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8651ee5cd11c9fcb949d6a87fdb2ce48995b421e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->