### PR TITLE
feat(workbench): submit dock group/priority on the app interface

### DIFF
--- a/.changeset/sdk-1910.md
+++ b/.changeset/sdk-1910.md
@@ -1,0 +1,7 @@
+---
+'@sanity/workbench-cli': minor
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+---
+
+feat(workbench): submit dock `group`/`priority` on the app interface instead of the manifest

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -29,12 +29,13 @@ export interface CliConfig {
     projectId?: string
   }
 
-  /** Configuration for custom Sanity apps built with the App SDK */
+  /**
+   * Configuration for custom Sanity apps built with the App SDK. Dock placement
+   * (`group`/`priority`) is declared through `unstable_defineApp`.
+   */
   app?: {
     /** The entrypoint for your custom app. By default, `src/App.tsx` */
     entry?: string
-    /** Dock group the app renders in. Defaults to `dock.applications`. */
-    group?: 'dock.applications' | 'dock.system' | 'dock.user'
     /**
      * Path to an icon file relative to project root.
      * The file must be an SVG.
@@ -44,8 +45,6 @@ export interface CliConfig {
     id?: string
     /** The ID for the Sanity organization that manages this application */
     organizationId?: string
-    /** Sort position within the dock group, ascending. Defaults to `100`. */
-    priority?: number
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
     /** Dashboard visibility of the application. Defaults to `default`. */

--- a/packages/@sanity/cli-core/src/manifest.ts
+++ b/packages/@sanity/cli-core/src/manifest.ts
@@ -14,9 +14,7 @@ import {z} from 'zod/mini'
  * CLI produces the payload in full.
  */
 export const coreAppManifestSchema = z.object({
-  group: z.optional(z.string()),
   icon: z.optional(z.string()),
-  priority: z.optional(z.number()),
   slug: z.optional(z.string()),
   title: z.optional(z.string()),
   version: z.string(),

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -245,6 +245,8 @@ async function runAppDeployment(
         appName: workbench.name,
         appTitle,
         exposesAppView: workbench.entry !== undefined,
+        group: workbench.group,
+        priority: workbench.priority,
         version,
       }),
       isAutoUpdating,

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -161,6 +161,8 @@ async function runStudioDeployment(
         appName: workbench.name,
         appTitle,
         exposesAppView: true,
+        group: workbench.group,
+        priority: workbench.priority,
         version,
       }),
       isAutoUpdating,

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -52,24 +52,14 @@ describe('extractCoreAppManifest', () => {
     expect(mockReadFile).not.toHaveBeenCalled()
   })
 
-  test('merges group and priority into the manifest', async () => {
+  test('drops group and priority — they ride on the app interface, not the manifest', async () => {
     mockGetCliConfig.mockResolvedValue({
       app: {group: 'dock.system', organizationId: 'org-1', priority: 20, title: 'My App'},
     } as never)
 
     const result = await extractCoreAppManifest({workDir: '/project'})
 
-    expect(result).toEqual({group: 'dock.system', priority: 20, title: 'My App', version: '1'})
-  })
-
-  test('keeps priority 0 (not dropped as a falsy value)', async () => {
-    mockGetCliConfig.mockResolvedValue({
-      app: {organizationId: 'org-1', priority: 0, title: 'My App'},
-    } as never)
-
-    const result = await extractCoreAppManifest({workDir: '/project'})
-
-    expect(result?.priority).toBe(0)
+    expect(result).toEqual({title: 'My App', version: '1'})
   })
 
   test('forwards slug from a workbench app', async () => {

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -116,8 +116,6 @@ export async function extractCoreAppManifest(
       version: '1',
       ...(icon ? {icon} : {}),
       ...(app.title ? {title: app.title} : {}),
-      ...(app.group ? {group: app.group} : {}),
-      ...(app.priority === undefined ? {} : {priority: app.priority}),
       ...(slug ? {slug} : {}),
     })
 

--- a/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
@@ -25,19 +25,23 @@ describe('resolveWorkbenchApp', () => {
       applicationType: undefined,
       config: undefined,
       entry: undefined,
+      group: undefined,
       isSingleton: undefined,
       name: 'my-app',
+      priority: undefined,
       services: [],
       views: [],
     })
   })
 
-  test('passes through declared views, services, entry, slug, and visibility', () => {
+  test('passes through declared views, services, entry, slug, visibility, and dock placement', () => {
     const config = asConfig(
       unstable_defineApp({
         entry: './src/App.tsx',
+        group: 'dock.system',
         name: 'my-app',
         organizationId: 'org-123',
+        priority: 20,
         services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
         slug: 'my-app-host',
         title: 'My App',
@@ -49,6 +53,8 @@ describe('resolveWorkbenchApp', () => {
     const resolved = resolveWorkbenchApp(config)
     expect(resolved).toMatchObject({
       entry: './src/App.tsx',
+      group: 'dock.system',
+      priority: 20,
       services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
       slug: 'my-app-host',
       views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
@@ -78,6 +78,33 @@ describe('buildExposes', () => {
     }
     expect(buildExposes(exposes, {...context, exposesAppView: false})[0]?.type).toBe('panel')
   })
+
+  test('carries dock placement on the app view metadata only', () => {
+    const exposes: WorkbenchExposes = {
+      services: [{name: 'unread', src: './src/unread.ts', type: 'worker'}],
+      views: [{name: 'feed', src: './src/feed.tsx', type: 'panel'}],
+    }
+
+    const [app, view, service] = buildExposes(exposes, {
+      ...context,
+      group: 'dock.system',
+      priority: 20,
+    })
+
+    expect(app?.metadata).toEqual({group: 'dock.system', priority: 20})
+    expect(view?.metadata).toBeNull()
+    expect(service?.metadata).toBeNull()
+  })
+
+  test('keeps priority 0 in the app view metadata', () => {
+    const [app] = buildExposes({}, {...context, priority: 0})
+    expect(app?.metadata).toEqual({priority: 0})
+  })
+
+  test('sets null metadata when no dock placement is declared', () => {
+    const [app] = buildExposes({}, context)
+    expect(app?.metadata).toBeNull()
+  })
 })
 
 describe('summarizeExposes', () => {

--- a/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
@@ -1,4 +1,5 @@
-import {interfaceModuleId} from '../../contract.js'
+import {interfaceModuleId, toMetadata} from '../../contract.js'
+import {type DockGroup} from '../../defineApp.js'
 import {type WorkbenchExposes} from '../../resolveWorkbenchApp.js'
 import {type BrettInterface} from '../../services/applications.js'
 
@@ -8,6 +9,11 @@ interface BuildExposesContext {
   /** Whether the build exposes the app view (`./App`) — apps with an `entry`, and every studio. */
   exposesAppView: boolean
   version: string
+
+  /** Dock group the app renders in, on the `app` interface only. */
+  group?: DockGroup
+  /** Sort position within the dock group, on the `app` interface only. */
+  priority?: number
 }
 
 /**
@@ -17,12 +23,12 @@ interface BuildExposesContext {
  */
 export function buildExposes(
   exposes: WorkbenchExposes,
-  {appName, appTitle, exposesAppView, version}: BuildExposesContext,
+  {appName, appTitle, exposesAppView, group, priority, version}: BuildExposesContext,
 ): BrettInterface[] {
   const records: BrettInterface[] = []
   if (exposesAppView) {
     records.push({
-      metadata: null,
+      metadata: toMetadata({group, priority}),
       moduleId: interfaceModuleId('app', appName),
       name: appName,
       title: appTitle,

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -72,7 +72,7 @@ describe('deriveInterfaces', () => {
     ])
   })
 
-  test('carries null metadata on every interface (not yet populated)', () => {
+  test('carries null metadata on every interface when no dock placement is declared', () => {
     const app = workbenchApp({
       entry: './src/App.tsx',
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
@@ -86,6 +86,39 @@ describe('deriveInterfaces', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     const result = deriveInterfaces(app, {isApp: true})
     expect(result?.some((iface) => iface.type === 'app')).toBe(false)
+  })
+
+  test('carries dock placement on the app interface metadata only', () => {
+    const app = workbenchApp({
+      entry: './src/App.tsx',
+      group: 'dock.system',
+      name: 'my-app',
+      priority: 20,
+      views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
+    })
+    const result = deriveInterfaces(app, {isApp: true})
+
+    expect(result).toEqual([
+      {
+        id: 'my-app-panel-feed',
+        metadata: null,
+        moduleId: 'views/feed',
+        name: 'feed',
+        src: './src/FeedPanel.tsx',
+        title: 'feed',
+        type: 'panel',
+        version: '1',
+      },
+      {
+        id: 'my-app-app-my-app',
+        metadata: {group: 'dock.system', priority: 20},
+        moduleId: 'App',
+        name: 'my-app',
+        src: './src/App.tsx',
+        title: 'Test App',
+        type: 'app',
+      },
+    ])
   })
 
   test('combines views, services, and the app view (in that order)', () => {

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -6,6 +6,7 @@ import {
   interfaceModuleId,
   MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION,
   SERVICE_CONTRACT_VERSION,
+  toMetadata,
   VIEW_CONTRACT_VERSION,
 } from '../../contract.js'
 import {isWorkbenchApp, readConfig} from '../../defineApp.js'
@@ -68,7 +69,7 @@ export function deriveInterfaces(
       : [
           {
             id: interfaceId('app', app.name),
-            metadata: null,
+            metadata: toMetadata({group: app.group, priority: app.priority}),
             moduleId: interfaceModuleId('app', app.name),
             name: app.name,
             src: app.entry,

--- a/packages/@sanity/workbench-cli/src/contract.ts
+++ b/packages/@sanity/workbench-cli/src/contract.ts
@@ -54,6 +54,16 @@ export const AppInterfaceMetadataSchema = z.object({
 export type AppInterfaceMetadata = z.infer<typeof AppInterfaceMetadataSchema>
 
 /**
+ * The `app` interface's metadata from its declared placement, or `null` when it
+ * sets none. Only the `app` interface carries metadata today.
+ * @internal
+ */
+export function toMetadata({group, priority}: AppInterfaceMetadata): AppInterfaceMetadata | null {
+  if (group === undefined && priority === undefined) return null
+  return {group, priority}
+}
+
+/**
  * The module-federation id a build exposes an interface at. Dev stamps the same
  * id a deploy would, so the workbench loads a local interface like a deployed one.
  * @internal

--- a/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
@@ -6,7 +6,13 @@
 
 import {type AppVisibility, type CliConfig} from '@sanity/cli-core'
 
-import {type DefineAppInput, isWorkbenchApp, readConfig, type WorkbenchApp} from './defineApp.js'
+import {
+  type DefineAppInput,
+  type DockGroup,
+  isWorkbenchApp,
+  readConfig,
+  type WorkbenchApp,
+} from './defineApp.js'
 
 /**
  * Bundled so adding a declaration family touches this type and the artifact
@@ -35,10 +41,14 @@ export interface ResolvedWorkbenchApp {
   readonly config?: WorkbenchApp['config']
   /** SDK app-view entrypoint, when declared. */
   readonly entry?: string
+  /** Dock group the app renders in, when declared. */
+  readonly group?: DockGroup
   /** Path to the app's icon SVG, resolved and shipped to Brett on deploy. */
   readonly icon?: string
   /** Explicit singleton flag (a Sanity-owned app); `undefined` when the app doesn't set it. */
   readonly isSingleton?: boolean
+  /** Sort position within the dock group, when declared. */
+  readonly priority?: number
   /** Hostname the application is created at on first deploy. */
   readonly slug?: string
   /** Dashboard visibility declared by the app; `undefined` when unset. */
@@ -59,9 +69,11 @@ export function resolveWorkbenchApp(
     applicationType: app.applicationType,
     config: readConfig(app),
     entry: app.entry,
+    group: app.group,
     icon: app.icon,
     isSingleton: app.isSingleton,
     name: app.name,
+    priority: app.priority,
     services: app.services ?? [],
     slug: app.slug,
     views: app.views ?? [],


### PR DESCRIPTION
### Description

Workbench apps declare their dock placement (`group`/`priority`) through `unstable_defineApp`, but the CLI only ever wrote those to the core-app manifest. Workbench apps deploy through Brett's `/applications` endpoints, which don't read the manifest — so placement never reached the server.

Brett takes `group`/`priority` as `metadata` on the app interface (`interfaces("app")[0].metadata`). This sends them there instead, for both deploy and `sanity dev`, so a locally-served app and a deployed one read placement from the same source.

### Testing

Unit tests updated/added across `buildExposes`, `deriveInterfaces`, `resolveWorkbenchApp`, and `extractCoreAppManifest`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how dock placement is submitted for workbench deploys and dev; wrong metadata would mis-order or mis-group apps in the dashboard, but scope is limited to interface payload shaping with solid unit test coverage.
> 
> **Overview**
> Workbench apps declare dock **`group`** / **`priority`** via `unstable_defineApp`, but Brett reads placement from the **`app` interface’s `metadata`**, not the core-app manifest—so manifest-only values never affected deploys.
> 
> This PR **stops writing `group`/`priority` into the core-app manifest** (schema + `extractCoreAppManifest`) and **removes them from the public `CliConfig.app` surface**, documenting that placement belongs on `unstable_defineApp`. **`resolveWorkbenchApp`** forwards the values; **`buildExposes`** and **`deriveInterfaces`** attach them only on the `app` interface via **`toMetadata`** (including **`priority: 0`**), leaving views/services at `metadata: null`. **App and studio workbench deploys** pass `group`/`priority` into `buildExposes` so **`sanity dev` and deploy** share the same source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40fbca54fc186129ebd1816639d4aecdcfd0684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->