### PR TITLE
feat(workbench): sync app title on redeploy

### DIFF
--- a/.changeset/sync-workbench-title-on-redeploy.md
+++ b/.changeset/sync-workbench-title-on-redeploy.md
@@ -1,0 +1,5 @@
+---
+"@sanity/workbench-cli": patch
+---
+
+Sync a workbench app's title from config to the deployed application on every redeploy, not just on create.

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -97,25 +97,29 @@ describe('deployCoreApp', () => {
     expect(appendedFields()).toContainEqual(['icon', JSON.stringify(icon)])
   })
 
-  test('PATCHes the icon after redeploying to an existing appId', async () => {
+  test('updates the title and icon after redeploying to an existing appId', async () => {
     mockClient.request.mockResolvedValueOnce({id: 'dep_1'}).mockResolvedValueOnce(undefined)
     const icon = '<svg viewBox="0 0 16 16"><path d="M2 2h12v12H2z"/></svg>'
 
     await deployCoreApp({...coreAppOptions, appId: 'app_1', icon})
 
     expect(mockClient.request.mock.calls[1][0]).toEqual({
-      body: {icon},
+      body: {icon, title: 'Drop Desk'},
       method: 'PATCH',
       uri: '/applications/app_1',
     })
   })
 
-  test('skips the icon PATCH on redeploy when none is declared', async () => {
-    mockClient.request.mockResolvedValueOnce({id: 'dep_1'})
+  test('updates the title on redeploy even when no icon is declared', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'}).mockResolvedValueOnce(undefined)
 
     await deployCoreApp({...coreAppOptions, appId: 'app_1'})
 
-    expect(mockClient.request).toHaveBeenCalledTimes(1)
+    expect(mockClient.request.mock.calls[1][0]).toEqual({
+      body: {title: 'Drop Desk'},
+      method: 'PATCH',
+      uri: '/applications/app_1',
+    })
   })
 })
 
@@ -169,14 +173,14 @@ describe('deployStudio', () => {
     expect(mockClient.request).not.toHaveBeenCalled()
   })
 
-  test('PATCHes the icon after redeploying to an existing appId', async () => {
+  test('updates the title and icon after redeploying to an existing appId', async () => {
     mockClient.request.mockResolvedValueOnce({id: 'dep_1'}).mockResolvedValueOnce(undefined)
     const icon = '<svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="6"/></svg>'
 
     await deployStudio({...studioOptions, appId: 'app_1', icon, studioHost: undefined})
 
     expect(mockClient.request.mock.calls[1][0]).toEqual({
-      body: {icon},
+      body: {icon, title: 'My Studio'},
       method: 'PATCH',
       uri: '/applications/app_1',
     })

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
@@ -51,7 +51,7 @@ export async function deployCoreApp(options: {
   try {
     if (appId) {
       await createDeployment({applicationId: appId, interfaces, isAutoUpdating, tarball, version})
-      if (icon) await updateApplication(appId, {icon})
+      await updateApplication(appId, {title, ...(icon ? {icon} : {})})
       spin.succeed()
       return {applicationId: appId}
     }
@@ -123,7 +123,7 @@ export async function deployStudio(options: {
         version,
         workspaces,
       })
-      if (icon) await updateApplication(appId, {icon})
+      await updateApplication(appId, {title, ...(icon ? {icon} : {})})
       spin.succeed()
       return {applicationId: appId}
     }

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -125,7 +125,7 @@ export interface ApplicationUpdate {
 
 /**
  * Patch an application's mutable fields. The deploy endpoint ignores these, so a
- * redeploy updates them here alongside the new deployment (e.g. a changed icon).
+ * redeploy syncs the title (and icon) from config here alongside the new deployment.
  */
 export async function updateApplication(
   applicationId: string,


### PR DESCRIPTION
### Description

A redeploy of a workbench app creates a new deployment but never updated the application record. `POST /applications/:id/deployments` only ships deployment-scoped data, so application-level fields set at create (title, icon) don't change on redeploy — editing `app.title` in `sanity.cli.ts` and redeploying left the deployed app's title stale.

This syncs the title from config on every redeploy via the generic `updateApplication` PATCH (added for icons in the base PR), so a redeploy now updates the existing application and creates a new deployment. It matches what the legacy user-application coreApp path already does via `syncApplicationTitle`.

Stacked on #1518.

### What to review

- `deployCoreApp` / `deployStudio` redeploy branch: after `createDeployment`, PATCH `{title, ...icon}`.
- Title is always config-derived (`flags.title` → `app.title` → app name), so config stays the source of truth. `--title` now also takes effect on redeploy, not just create.

### Testing

Unit tests updated: a redeploy PATCHes the title (with and without an icon) for both apps and studios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to workbench deploy redeploy path; always sends config title on PATCH with no auth or data-model changes.
> 
> **Overview**
> **Workbench redeploys now PATCH the application title** (and icon when present) from CLI config, fixing stale titles after changing `app.title` in `sanity.cli.ts`.
> 
> Previously, redeploy only called `updateApplication` when an icon was set. **`deployCoreApp` and `deployStudio`** now always call `updateApplication` after `createDeployment` with `{ title, ...(icon ? { icon } : {}) }`, since deployment POST does not carry application-level fields.
> 
> Unit tests cover title-only PATCH on redeploy for core apps and title+icon for studios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ffd81207d7930f38d2298a9da4be595a2d96ddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->