### PR TITLE
build: exclude test files via .swcrc instead of --ignore globs

### DIFF
--- a/packages/@sanity/cli-build/.swcrc
+++ b/packages/@sanity/cli-build/.swcrc
@@ -14,5 +14,6 @@
     "target": "es2023"
   },
   "isModule": true,
-  "sourceMaps": true
+  "sourceMaps": true,
+  "exclude": ["\\.test\\.ts$", "__tests__"]
 }

--- a/packages/@sanity/cli-build/package.json
+++ b/packages/@sanity/cli-build/package.json
@@ -46,7 +46,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ src --ignore '**/*.test.ts' --ignore '**/__tests__/**'",
+    "build": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ src",
     "build:types": "pkg-utils build --emitDeclarationOnly",
     "check:types": "tsc --noEmit",
     "lint": "eslint .",

--- a/packages/@sanity/cli-core/.swcrc
+++ b/packages/@sanity/cli-core/.swcrc
@@ -14,5 +14,6 @@
     "target": "es2023"
   },
   "isModule": true,
-  "sourceMaps": true
+  "sourceMaps": true,
+  "exclude": ["\\.test\\.ts$", "__tests__"]
 }

--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -103,7 +103,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ src --ignore '**/*.test.ts' --ignore '**/__tests__/**'",
+    "build": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ src",
     "build:types": "pkg-utils build --emitDeclarationOnly",
     "check:types": "tsc --noEmit",
     "lint": "eslint .",

--- a/packages/@sanity/cli/.swcrc
+++ b/packages/@sanity/cli/.swcrc
@@ -17,5 +17,6 @@
     "type": "nodenext"
   },
   "isModule": true,
-  "sourceMaps": true
+  "sourceMaps": true,
+  "exclude": ["\\.test\\.ts$", "__tests__"]
 }

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ src --ignore '**/*.test.ts' --ignore '**/__tests__/**'",
+    "build": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ src",
     "postbuild": "pnpm run manifest:generate && pnpm run check:topic-aliases",
     "build:types": "pkg-utils build --emitDeclarationOnly",
     "check:topic-aliases": "tsx scripts/check-topic-aliases.ts",

--- a/packages/@sanity/workbench-cli/.swcrc
+++ b/packages/@sanity/workbench-cli/.swcrc
@@ -14,5 +14,6 @@
     "target": "es2023"
   },
   "isModule": true,
-  "sourceMaps": true
+  "sourceMaps": true,
+  "exclude": ["\\.test\\.ts$", "__tests__"]
 }

--- a/packages/@sanity/workbench-cli/package.json
+++ b/packages/@sanity/workbench-cli/package.json
@@ -49,7 +49,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ src --ignore '**/*.test.ts' --ignore '**/__tests__/**'",
+    "build": "swc --delete-dir-on-start --strip-leading-paths --out-dir dist/ src",
     "build:types": "pkg-utils build --emitDeclarationOnly",
     "check:types": "tsc --noEmit",
     "lint": "eslint .",


### PR DESCRIPTION
### Description

The swc build scripts excluded test files by passing glob ignores as single-quoted CLI arguments:

```
swc ... --ignore '**/*.test.ts' --ignore '**/__tests__/**'
```

On Windows this does not work. `cmd.exe` does not strip the single quotes, so swc receives the quote characters as part of the pattern, matches nothing, and compiles the test files into `dist/`. On Linux/macOS the shell strips the quotes, so the ignores apply and the problem stays hidden.

The consequence surfaced on the org-commands branch: a plain (non-`.test.ts`) helper inside a `__tests__` folder got compiled to `dist/commands/.../__tests__/httpError.js`, `oclif manifest` picked it up as a command it could not resolve, and the build failed on every Windows job. Any non-test `.ts` file placed in a `__tests__` folder would hit the same wall.

This moves the patterns into each package's `.swcrc` `exclude` field instead. swc parses `.swcrc` itself, so no shell is involved and the behavior is the same on every platform. The regexes contain no path separators, so they match Windows (`\`) and POSIX (`/`) paths alike.

Applied to the four packages that build with swc: `cli`, `cli-core`, `cli-build`, and `workbench-cli`.

### What to review

- The `exclude` regexes in each `.swcrc`: `["\\.test\\.ts$", "__tests__"]`. `\.test\.ts$` covers the test files, `__tests__` covers anything inside a test folder. These map one-to-one to the old `**/*.test.ts` and `**/__tests__/**` globs.
- The removed `--ignore` flags in each package's `build` script.

### Testing

No automated test, since this is build tooling. Verified by comparing the compiled output before and after:

- Built each way and diffed the full `dist` file list. The output is identical (485 files, zero difference in both directions), so this is an equivalence change, not a behavior change.
- Clean full build with the turbo cache bypassed: no `.test.js` and no `__tests__` artifacts in any package's `dist`, and `oclif manifest` (postbuild) succeeds.
- Typecheck, lint, and depcheck pass. Unit smoke run green.
- The cross-platform part cannot be exercised on the Linux/macOS CI, but the mechanism no longer depends on the shell, which was the entire cause.

### Notes for release

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tooling only; same exclusion intent as before, with verified identical dist file lists on Unix.
> 
> **Overview**
> Fixes **Windows swc builds** that were compiling test sources into `dist/` because `cmd.exe` leaves single quotes on `--ignore` globs, so swc never matched `**/*.test.ts` or `**/__tests__/**`.
> 
> For **`@sanity/cli`**, **`cli-core`**, **`cli-build`**, and **`workbench-cli`**, test exclusion now lives in each package's **`.swcrc`** via `exclude: ["\\.test\\.ts$", "__tests__"]` (parsed by swc, no shell). The **`build`** scripts drop the redundant **`--ignore`** flags.
> 
> Intended to be **output-equivalent** on Unix while stopping stray `__tests__` artifacts from breaking steps like **`oclif manifest`** on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa7b6ffb9e6fb102c93d7c02baf962e7244b9f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->