### PR TITLE
fix(cli): report all missing options in unattended `sanity init`

### DIFF
--- a/.changeset/pr-1536.md
+++ b/.changeset/pr-1536.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-fix(init): report all missing unattended options
+fix(cli): report all missing options in unattended `sanity init`

--- a/.changeset/pr-1536.md
+++ b/.changeset/pr-1536.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': patch
----
-
-fix(cli): report all missing options in unattended `sanity init`

--- a/.changeset/pr-1536.md
+++ b/.changeset/pr-1536.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(init): report all missing unattended options

--- a/.changeset/unattended-error-aggregation.md
+++ b/.changeset/unattended-error-aggregation.md
@@ -1,0 +1,8 @@
+---
+'@sanity/cli': patch
+---
+
+fix(init): report all missing unattended options
+
+Validate output path, project selection, and organization prerequisites together so unattended
+`sanity init` runs report every applicable usage error in one pass.

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -10,6 +10,7 @@ import {promptForConfigFiles} from '../../prompts/init/nextjs.js'
 import {getCliUser} from '../../services/user.js'
 import {CLIInitStepCompleted, type InitStepResult} from '../../telemetry/init.telemetry.js'
 import {detectFrameworkRecord} from '../../util/detectFramework.js'
+import {formatCliErrorMessages} from '../../util/formatCliErrorMessages.js'
 import {getProjectDefaults} from '../../util/getProjectDefaults.js'
 import {validateSession} from '../auth/ensureAuthenticated.js'
 import {getProviderName} from '../auth/getProviderName.js'
@@ -189,7 +190,10 @@ export async function initAction(options: InitOptions, context: InitContext): Pr
   async function installSkills(): Promise<void> {
     if (mcpResult.skillsToInstall.length === 0) return
     try {
-      const skillsResult = await setupSkills({agents: mcpResult.skillsToInstall, output})
+      const skillsResult = await setupSkills({
+        agents: mcpResult.skillsToInstall,
+        output,
+      })
       trace.log({
         installedAgents: skillsResult.installedAgents,
         skipped: skillsResult.skipped,
@@ -326,37 +330,39 @@ function checkFlagsInUnattendedMode(
 ): void {
   debug('Unattended mode, validating required options')
 
-  if (options.projectName && !options.organization) {
-    throw new InitError('`--project-name` requires `--organization <id>` in unattended mode', 1)
-  }
+  const errors: string[] = []
 
   if (isAppTemplate) {
     if (!options.outputPath) {
-      throw new InitError('`--output-path` must be specified in unattended mode', 1)
+      errors.push('`--output-path` must be specified in unattended mode')
     }
 
-    const hasProjectFlag = Boolean(options.project || options.projectName)
-
-    if (!hasProjectFlag && !options.organization) {
-      throw new InitError(
+    if (options.projectName && !options.organization) {
+      errors.push('`--project-name` requires `--organization <id>` in unattended mode')
+    } else if (!options.project && !options.organization) {
+      errors.push(
         'The --organization flag is required for app templates in unattended mode. ' +
           'Use --organization <id>, or pass --project <id> / --project-name <name>.',
-        1,
+      )
+    }
+  } else {
+    if (!isNextJs && !options.bare && !options.outputPath) {
+      errors.push('`--output-path` must be specified in unattended mode')
+    }
+
+    if (!options.project && !options.projectName) {
+      errors.push(
+        '`--project <id>` or `--project-name <name>` must be specified in unattended mode',
       )
     }
 
-    return
+    if (!options.project && !options.organization) {
+      errors.push('`--project-name` requires `--organization <id>` in unattended mode')
+    }
   }
 
-  if (!isNextJs && !options.bare && !options.outputPath) {
-    throw new InitError('`--output-path` must be specified in unattended mode', 1)
-  }
-
-  if (!options.project && !options.projectName) {
-    throw new InitError(
-      '`--project <id>` or `--project-name <name>` must be specified in unattended mode',
-      1,
-    )
+  if (errors.length > 0) {
+    throw new InitError(formatCliErrorMessages(errors), 2)
   }
 }
 

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -1,6 +1,11 @@
 import {styleText} from 'node:util'
 
-import {type SanityOrgUser, subdebug, type TelemetryUserProperties} from '@sanity/cli-core'
+import {
+  exitCodes,
+  type SanityOrgUser,
+  subdebug,
+  type TelemetryUserProperties,
+} from '@sanity/cli-core'
 import {logSymbols, spinner} from '@sanity/cli-core/ux'
 import {type TelemetryTrace} from '@sanity/telemetry'
 import {type Framework, frameworks} from '@vercel/frameworks'
@@ -334,35 +339,44 @@ function checkFlagsInUnattendedMode(
 
   if (isAppTemplate) {
     if (!options.outputPath) {
-      errors.push('`--output-path` must be specified in unattended mode')
+      errors.push(
+        'Output path is required in unattended mode. Pass it with `--output-path <path>`.',
+      )
     }
 
     if (options.projectName && !options.organization) {
-      errors.push('`--project-name` requires `--organization <id>` in unattended mode')
+      errors.push(
+        'Organization is required when creating a project in unattended mode. Pass it with `--organization <id>`.',
+      )
     } else if (!options.project && !options.organization) {
       errors.push(
-        'The --organization flag is required for app templates in unattended mode. ' +
-          'Use --organization <id>, or pass --project <id> / --project-name <name>.',
+        'Project or organization is required for app templates in unattended mode. ' +
+          'Pass `--project <id>` or `--organization <id>`. To create a project, pass ' +
+          '`--project-name <name>` with `--organization <id>`.',
       )
     }
   } else {
     if (!isNextJs && !options.bare && !options.outputPath) {
-      errors.push('`--output-path` must be specified in unattended mode')
+      errors.push(
+        'Output path is required in unattended mode. Pass it with `--output-path <path>`.',
+      )
     }
 
     if (!options.project && !options.projectName) {
       errors.push(
-        '`--project <id>` or `--project-name <name>` must be specified in unattended mode',
+        'Project is required in unattended mode. Pass it with `--project <id>` or `--project-name <name>`.',
       )
     }
 
     if (!options.project && !options.organization) {
-      errors.push('`--project-name` requires `--organization <id>` in unattended mode')
+      errors.push(
+        'Organization is required when creating a project in unattended mode. Pass it with `--organization <id>`.',
+      )
     }
   }
 
   if (errors.length > 0) {
-    throw new InitError(formatCliErrorMessages(errors), 2)
+    throw new InitError(formatCliErrorMessages(errors), exitCodes.USAGE_ERROR)
   }
 }
 

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -30,11 +30,13 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
 
       return {
         projects: {
-          list: vi
-            .fn()
-            .mockResolvedValue([
-              {createdAt: '2024-01-01T00:00:00Z', displayName: 'Test', id: 'test'},
-            ]),
+          list: vi.fn().mockResolvedValue([
+            {
+              createdAt: '2024-01-01T00:00:00Z',
+              displayName: 'Test',
+              id: 'test',
+            },
+          ]),
         },
         request: globalTestClient.request,
         users: {
@@ -224,7 +226,10 @@ describe('#init: bootstrap-app-initialization', () => {
 
     // Skills install runs before scaffolding (and thus before the "Success!"
     // message), so its progress + result surface above the success output.
-    expect(mocks.setupSkills).toHaveBeenCalledWith({agents: ['cursor'], output: expect.any(Object)})
+    expect(mocks.setupSkills).toHaveBeenCalledWith({
+      agents: ['cursor'],
+      output: expect.any(Object),
+    })
     const bootstrapOrder = mocks.bootstrapTemplate.mock.invocationCallOrder[0]
     const skillsOrder = mocks.setupSkills.mock.invocationCallOrder[0]
     expect(skillsOrder).toBeLessThan(bootstrapOrder)
@@ -434,9 +439,10 @@ describe('#init: bootstrap-app-initialization', () => {
     )
 
     expect(error).toBeInstanceOf(Error)
-    expect(error?.oclif?.exit).toBe(1)
-    expect(error?.message).toContain(
-      'The --organization flag is required for app templates in unattended mode',
+    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.message).toBe(
+      'The --organization flag is required for app templates in unattended mode. ' +
+        'Use --organization <id>, or pass --project <id> / --project-name <name>.',
     )
   })
 
@@ -505,9 +511,34 @@ describe('#init: bootstrap-app-initialization', () => {
     )
 
     expect(error).toBeInstanceOf(Error)
-    expect(error?.oclif?.exit).toBe(1)
-    expect(error?.message).toContain(
-      'The --organization flag is required for app templates in unattended mode',
+    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.message).toBe(
+      'The --organization flag is required for app templates in unattended mode. ' +
+        'Use --organization <id>, or pass --project <id> / --project-name <name>.',
     )
+  })
+
+  test('reports missing app template options before scaffolding', async () => {
+    mocks.select.mockReset()
+
+    const {error} = await testCommand(
+      InitCommand,
+      ['--yes', '--template=app-quickstart', '--package-manager=npm'],
+      {
+        mocks: {
+          ...defaultMocks,
+        },
+      },
+    )
+
+    expect(error?.oclif?.exit).toBe(2)
+    expect(error?.message).toBe(
+      '`--output-path` must be specified in unattended mode\n' +
+        'Error: The --organization flag is required for app templates in unattended mode. ' +
+        'Use --organization <id>, or pass --project <id> / --project-name <name>.',
+    )
+    expect(mocks.select).not.toHaveBeenCalled()
+    expect(mocks.bootstrapTemplate).not.toHaveBeenCalled()
+    expect(mocks.createOrAppendEnvVars).not.toHaveBeenCalled()
   })
 })

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.bootstrap-app.test.ts
@@ -441,8 +441,9 @@ describe('#init: bootstrap-app-initialization', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.oclif?.exit).toBe(2)
     expect(error?.message).toBe(
-      'The --organization flag is required for app templates in unattended mode. ' +
-        'Use --organization <id>, or pass --project <id> / --project-name <name>.',
+      'Project or organization is required for app templates in unattended mode. ' +
+        'Pass `--project <id>` or `--organization <id>`. To create a project, pass ' +
+        '`--project-name <name>` with `--organization <id>`.',
     )
   })
 
@@ -513,8 +514,9 @@ describe('#init: bootstrap-app-initialization', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.oclif?.exit).toBe(2)
     expect(error?.message).toBe(
-      'The --organization flag is required for app templates in unattended mode. ' +
-        'Use --organization <id>, or pass --project <id> / --project-name <name>.',
+      'Project or organization is required for app templates in unattended mode. ' +
+        'Pass `--project <id>` or `--organization <id>`. To create a project, pass ' +
+        '`--project-name <name>` with `--organization <id>`.',
     )
   })
 
@@ -533,9 +535,10 @@ describe('#init: bootstrap-app-initialization', () => {
 
     expect(error?.oclif?.exit).toBe(2)
     expect(error?.message).toBe(
-      '`--output-path` must be specified in unattended mode\n' +
-        'Error: The --organization flag is required for app templates in unattended mode. ' +
-        'Use --organization <id>, or pass --project <id> / --project-name <name>.',
+      'Output path is required in unattended mode. Pass it with `--output-path <path>`.\n' +
+        'Error: Project or organization is required for app templates in unattended mode. ' +
+        'Pass `--project <id>` or `--organization <id>`. To create a project, pass ' +
+        '`--project-name <name>` with `--organization <id>`.',
     )
     expect(mocks.select).not.toHaveBeenCalled()
     expect(mocks.bootstrapTemplate).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.get-project-details.test.ts
@@ -1308,6 +1308,6 @@ describe('#init: promptForAppTemplateSetup', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('--organization')
     expect(error?.message).toContain('--project')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 })

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -211,7 +211,9 @@ describe('#init: oclif command setup', () => {
     })
 
     // Should throw output-path error for non-Next.js projects
-    expect(error?.message).toBe('`--output-path` must be specified in unattended mode')
+    expect(error?.message).toBe(
+      'Output path is required in unattended mode. Pass it with `--output-path <path>`.',
+    )
     expect(error?.oclif?.exit).toBe(2)
   })
 
@@ -230,7 +232,7 @@ describe('#init: oclif command setup', () => {
 
     // Should NOT throw output-path error — bare mode doesn't need it
     expect(error?.message ?? '').not.toContain(
-      '`--output-path` must be specified in unattended mode',
+      'Output path is required in unattended mode. Pass it with `--output-path <path>`.',
     )
   })
 
@@ -255,8 +257,9 @@ describe('#init: oclif command setup', () => {
     )
 
     expect(error?.message).toBe(
-      '`--project <id>` or `--project-name <name>` must be specified in unattended mode\n' +
-        'Error: `--project-name` requires `--organization <id>` in unattended mode',
+      'Project is required in unattended mode. Pass it with `--project <id>` or `--project-name <name>`.\n' +
+        'Error: Organization is required when creating a project in unattended mode. ' +
+        'Pass it with `--organization <id>`.',
     )
     expect(error?.oclif?.exit).toBe(2)
   })
@@ -278,7 +281,8 @@ describe('#init: oclif command setup', () => {
     )
 
     expect(error?.message).toBe(
-      '`--project-name` requires `--organization <id>` in unattended mode',
+      'Organization is required when creating a project in unattended mode. ' +
+        'Pass it with `--organization <id>`.',
     )
     expect(error?.oclif?.exit).toBe(2)
   })
@@ -293,9 +297,11 @@ describe('#init: oclif command setup', () => {
     })
 
     expect(error?.message).toBe(
-      '`--output-path` must be specified in unattended mode\n' +
-        'Error: `--project <id>` or `--project-name <name>` must be specified in unattended mode\n' +
-        'Error: `--project-name` requires `--organization <id>` in unattended mode',
+      'Output path is required in unattended mode. Pass it with `--output-path <path>`.\n' +
+        'Error: Project is required in unattended mode. ' +
+        'Pass it with `--project <id>` or `--project-name <name>`.\n' +
+        'Error: Organization is required when creating a project in unattended mode. ' +
+        'Pass it with `--organization <id>`.',
     )
     expect(error?.oclif?.exit).toBe(2)
     expect(mocks.getById).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.setup.test.ts
@@ -91,7 +91,11 @@ describe('#init: oclif command setup', () => {
   })
 
   test.each([
-    {flag: 'env', message: 'Env filename (`--env`) must start with `.env`', value: 'invalid.txt'},
+    {
+      flag: 'env',
+      message: 'Env filename (`--env`) must start with `.env`',
+      value: 'invalid.txt',
+    },
     {
       flag: 'visibility',
       message: 'Expected --visibility=opaque to be one of: public, private',
@@ -207,8 +211,8 @@ describe('#init: oclif command setup', () => {
     })
 
     // Should throw output-path error for non-Next.js projects
-    expect(error?.message).toContain('`--output-path` must be specified in unattended mode')
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.message).toBe('`--output-path` must be specified in unattended mode')
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('does not require `output-path` in unattended mode when `bare` is used', async () => {
@@ -250,10 +254,11 @@ describe('#init: oclif command setup', () => {
       },
     )
 
-    expect(error?.message).toContain(
-      '`--project <id>` or `--project-name <name>` must be specified in unattended mode',
+    expect(error?.message).toBe(
+      '`--project <id>` or `--project-name <name>` must be specified in unattended mode\n' +
+        'Error: `--project-name` requires `--organization <id>` in unattended mode',
     )
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
   })
 
   test('throws error when in unattended mode and `project-name` set without `organization`', async () => {
@@ -272,10 +277,28 @@ describe('#init: oclif command setup', () => {
       },
     )
 
-    expect(error?.message).toContain(
+    expect(error?.message).toBe(
       '`--project-name` requires `--organization <id>` in unattended mode',
     )
-    expect(error?.oclif?.exit).toBe(1)
+    expect(error?.oclif?.exit).toBe(2)
+  })
+
+  test('reports all missing unattended options before authentication', async () => {
+    mocks.detectFrameworkRecord.mockResolvedValueOnce(null)
+
+    const {error} = await testCommand(InitCommand, ['--yes'], {
+      mocks: {
+        ...defaultMocks,
+      },
+    })
+
+    expect(error?.message).toBe(
+      '`--output-path` must be specified in unattended mode\n' +
+        'Error: `--project <id>` or `--project-name <name>` must be specified in unattended mode\n' +
+        'Error: `--project-name` requires `--organization <id>` in unattended mode',
+    )
+    expect(error?.oclif?.exit).toBe(2)
+    expect(mocks.getById).not.toHaveBeenCalled()
   })
 
   test('logs properly if app template flag is not valid', async () => {

--- a/packages/@sanity/cli/src/util/__tests__/formatCliErrorMessages.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/formatCliErrorMessages.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, test} from 'vitest'
+
+import {formatCliErrorMessages} from '../formatCliErrorMessages.js'
+
+describe('formatCliErrorMessages', () => {
+  test('formats each message as a separate CLI error', () => {
+    expect(formatCliErrorMessages(['First message', 'Second message', 'Third message'])).toBe(
+      'First message\nError: Second message\nError: Third message',
+    )
+  })
+
+  test('preserves a single message', () => {
+    expect(formatCliErrorMessages(['Only message'])).toBe('Only message')
+  })
+})

--- a/packages/@sanity/cli/src/util/formatCliErrorMessages.ts
+++ b/packages/@sanity/cli/src/util/formatCliErrorMessages.ts
@@ -1,0 +1,3 @@
+export function formatCliErrorMessages(messages: readonly string[]): string {
+  return messages.join('\nError: ')
+}


### PR DESCRIPTION
`sanity init` would only show one validation error at a time, which makes it clunky for agents to use in unattended mode. This changes validation to happen as a batch, and reports all errors at once, so agents only need to screw up once.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only init flag validation and messaging; no auth, API, or scaffolding behavior changes beyond failing earlier with clearer, batched errors.
> 
> **Overview**
> Unattended **`sanity init`** now validates required flags in one pass and prints **every** applicable usage problem instead of stopping after the first failure.
> 
> `checkFlagsInUnattendedMode` collects errors for output path, project, and organization (with separate rules for app vs studio templates), then throws a single `InitError` built via new **`formatCliErrorMessages`** (`first line` + `\nError: ` for the rest). Exit code moves from **1** to **`exitCodes.USAGE_ERROR` (2)**. Copy is rewritten to point at the right flags (e.g. `--output-path`, `--project`, `--organization`).
> 
> Tests cover multi-error output, early failure before auth/scaffolding, and the formatter helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba27fa6eea21bf12bd32ef430ac5af8e62bb750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->