### PR TITLE
feat(workbench): forward app slug to the dev workbench

### DIFF
--- a/.changeset/forward-workbench-app-slug.md
+++ b/.changeset/forward-workbench-app-slug.md
@@ -1,0 +1,6 @@
+---
+"@sanity/cli-core": patch
+"@sanity/cli": patch
+---
+
+Forward a workbench app's `slug` from `unstable_defineApp` to the running workbench dev server via its inlined manifest.

--- a/packages/@sanity/cli-core/src/manifest.ts
+++ b/packages/@sanity/cli-core/src/manifest.ts
@@ -17,6 +17,7 @@ export const coreAppManifestSchema = z.object({
   group: z.optional(z.string()),
   icon: z.optional(z.string()),
   priority: z.optional(z.number()),
+  slug: z.optional(z.string()),
   title: z.optional(z.string()),
   version: z.string(),
 })

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -1,6 +1,7 @@
 import {readFile} from 'node:fs/promises'
 
 import {getCliConfigUncached} from '@sanity/cli-core'
+import {unstable_defineApp} from '@sanity/workbench-cli'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {extractCoreAppManifest, resolveTitleUpdate} from '../extractCoreAppManifest.js'
@@ -69,6 +70,41 @@ describe('extractCoreAppManifest', () => {
     const result = await extractCoreAppManifest({workDir: '/project'})
 
     expect(result?.priority).toBe(0)
+  })
+
+  test('forwards slug from a workbench app', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: unstable_defineApp({
+        name: 'my-app',
+        organizationId: 'org-1',
+        slug: 'my-slug',
+        title: 'My App',
+      }),
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result).toEqual({slug: 'my-slug', title: 'My App', version: '1'})
+  })
+
+  test('omits slug when a workbench app declares none', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: unstable_defineApp({name: 'my-app', organizationId: 'org-1', title: 'My App'}),
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result).not.toHaveProperty('slug')
+  })
+
+  test('does not forward slug for a non-workbench app', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: {organizationId: 'org-1', slug: 'my-slug', title: 'My App'},
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result).toEqual({title: 'My App', version: '1'})
   })
 
   test('reads icon from file path and inlines in manifest', async () => {

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -4,6 +4,7 @@ import {relative, resolve} from 'node:path'
 import {doImport, getCliConfigUncached} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {spinner} from '@sanity/cli-core/ux'
+import {isWorkbenchApp} from '@sanity/workbench-cli'
 
 import {type sanitizeIcon as sanitizeIconFn} from './sanitizeIcon.js'
 import {type CoreAppManifest, coreAppManifestSchema} from './types.js'
@@ -107,12 +108,15 @@ export async function extractCoreAppManifest(
       return undefined
     }
 
+    const slug = isWorkbenchApp(app) ? app.slug : undefined
+
     const manifest: CoreAppManifest = coreAppManifestSchema.parse({
       version: '1',
       ...(icon ? {icon} : {}),
       ...(app.title ? {title: app.title} : {}),
       ...(app.group ? {group: app.group} : {}),
       ...(app.priority === undefined ? {} : {priority: app.priority}),
+      ...(slug ? {slug} : {}),
     })
 
     spin.succeed(`Extracted manifest`)


### PR DESCRIPTION
### Description

This forwards `slug` on the manifest too, gated to workbench apps — `slug` only exists on a branded `unstable_defineApp` config (the legacy `app` schema strips it), so narrowing via `isWorkbenchApp` is the gate.

Note: the workbench doesn't consume `manifest.slug` yet — a follow-up in the workbench repo adds `slug` to `CoreApplicationManifest` and reads it in `createCoreApplicationFromLocal`. It has to live on `manifest.slug`, not `application.slug`, since a local app is external and that schema requires `slug: null`.

### What to review

- `extractCoreAppManifest` reads `app.slug` only when `isWorkbenchApp(app)` narrows the config, so the forwarding is inherently workbench-gated.
- `slug` added to the shared `coreAppManifestSchema` in `@sanity/cli-core` — both packages bump so a published `@sanity/cli` doesn't strip the field against an older `cli-core`.

### Testing

Unit tests in `extractCoreAppManifest.test.ts` cover the three cases: slug forwarded for a workbench app, omitted when undeclared, and not forwarded for a non-branded app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, gated manifest field addition with tests; no auth or runtime behavior changes until the workbench reads the field.
> 
> **Overview**
> Workbench apps defined with `unstable_defineApp` can now pass their **`slug`** through the inlined core app manifest used by the workbench dev server.
> 
> The shared **`coreAppManifestSchema`** in `@sanity/cli-core` gains an optional `slug` field (both `@sanity/cli` and `@sanity/cli-core` are patched so published versions stay aligned). **`extractCoreAppManifest`** includes `slug` only when `isWorkbenchApp(app)` narrows the config and a slug is set—legacy/non-workbench app configs do not forward it even if a `slug` property is present.
> 
> Unit tests cover forwarding for workbench apps, omission when undeclared, and no forwarding for non-workbench configs. Workbench consumption of `manifest.slug` is expected in a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1cd24dcd2c2c86fd03f5b3e4f54c62b0fda4230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->