### PR TITLE
feat(workbench): align interface records with brett's shape

### DIFF
--- a/.changeset/align-interface-shape-with-brett.md
+++ b/.changeset/align-interface-shape-with-brett.md
@@ -1,0 +1,5 @@
+---
+"@sanity/workbench-cli": patch
+---
+
+Align dev and deploy interface records with Brett's shape: string `version`, per-type nullable `metadata`, and a `moduleId` plus generated `id` on local dev interfaces.

--- a/.changeset/forward-workbench-app-slug.md
+++ b/.changeset/forward-workbench-app-slug.md
@@ -1,0 +1,6 @@
+---
+"@sanity/cli-core": patch
+"@sanity/cli": patch
+---
+
+Forward a workbench app's `slug` from `unstable_defineApp` to the running workbench dev server via its inlined manifest.

--- a/packages/@sanity/cli-core/src/manifest.ts
+++ b/packages/@sanity/cli-core/src/manifest.ts
@@ -17,6 +17,7 @@ export const coreAppManifestSchema = z.object({
   group: z.optional(z.string()),
   icon: z.optional(z.string()),
   priority: z.optional(z.number()),
+  slug: z.optional(z.string()),
   title: z.optional(z.string()),
   version: z.string(),
 })

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -1,6 +1,7 @@
 import {readFile} from 'node:fs/promises'
 
 import {getCliConfigUncached} from '@sanity/cli-core'
+import {unstable_defineApp} from '@sanity/workbench-cli'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {extractCoreAppManifest, resolveTitleUpdate} from '../extractCoreAppManifest.js'
@@ -69,6 +70,41 @@ describe('extractCoreAppManifest', () => {
     const result = await extractCoreAppManifest({workDir: '/project'})
 
     expect(result?.priority).toBe(0)
+  })
+
+  test('forwards slug from a workbench app', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: unstable_defineApp({
+        name: 'my-app',
+        organizationId: 'org-1',
+        slug: 'my-slug',
+        title: 'My App',
+      }),
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result).toEqual({slug: 'my-slug', title: 'My App', version: '1'})
+  })
+
+  test('omits slug when a workbench app declares none', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: unstable_defineApp({name: 'my-app', organizationId: 'org-1', title: 'My App'}),
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result).not.toHaveProperty('slug')
+  })
+
+  test('does not forward slug for a non-workbench app', async () => {
+    mockGetCliConfig.mockResolvedValue({
+      app: {organizationId: 'org-1', slug: 'my-slug', title: 'My App'},
+    } as never)
+
+    const result = await extractCoreAppManifest({workDir: '/project'})
+
+    expect(result).toEqual({title: 'My App', version: '1'})
   })
 
   test('reads icon from file path and inlines in manifest', async () => {

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -4,6 +4,7 @@ import {relative, resolve} from 'node:path'
 import {doImport, getCliConfigUncached} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {spinner} from '@sanity/cli-core/ux'
+import {isWorkbenchApp} from '@sanity/workbench-cli'
 
 import {type sanitizeIcon as sanitizeIconFn} from './sanitizeIcon.js'
 import {type CoreAppManifest, coreAppManifestSchema} from './types.js'
@@ -107,12 +108,15 @@ export async function extractCoreAppManifest(
       return undefined
     }
 
+    const slug = isWorkbenchApp(app) ? app.slug : undefined
+
     const manifest: CoreAppManifest = coreAppManifestSchema.parse({
       version: '1',
       ...(icon ? {icon} : {}),
       ...(app.title ? {title: app.title} : {}),
       ...(app.group ? {group: app.group} : {}),
       ...(app.priority === undefined ? {} : {priority: app.priority}),
+      ...(slug ? {slug} : {}),
     })
 
     spin.succeed(`Extracted manifest`)

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
@@ -18,9 +18,24 @@ describe('buildExposes', () => {
     }
 
     expect(buildExposes(exposes, context)).toEqual([
-      {moduleId: 'App', name: 'drop-desk', title: 'Drop Desk', type: 'app', version: '1.2.3'},
-      {moduleId: 'views/feed', name: 'feed', title: 'Feed', type: 'panel', version: '1.2.3'},
       {
+        metadata: null,
+        moduleId: 'App',
+        name: 'drop-desk',
+        title: 'Drop Desk',
+        type: 'app',
+        version: '1.2.3',
+      },
+      {
+        metadata: null,
+        moduleId: 'views/feed',
+        name: 'feed',
+        title: 'Feed',
+        type: 'panel',
+        version: '1.2.3',
+      },
+      {
+        metadata: null,
         moduleId: 'services/unread',
         name: 'unread',
         title: 'Unread',

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -21,7 +21,7 @@ vi.mock('tar-fs', () => ({pack: () => ({pipe: () => Readable.from(['tar'])})}))
 const mockClient = {request: vi.fn()}
 const output = {error: vi.fn(), log: vi.fn()} as unknown as Output
 const interfaces: BrettInterface[] = [
-  {moduleId: 'App', name: 'app', title: 'App', type: 'app', version: '1.0.0'},
+  {metadata: null, moduleId: 'App', name: 'app', title: 'App', type: 'app', version: '1.0.0'},
 ]
 const workspaces: BrettWorkspace[] = [
   {basePath: '/', dataset: 'production', name: 'default', projectId: 'proj-1', title: 'Default'},

--- a/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
@@ -1,3 +1,4 @@
+import {interfaceModuleId} from '../../contract.js'
 import {type WorkbenchExposes} from '../../resolveWorkbenchApp.js'
 import {type BrettInterface} from '../../services/applications.js'
 
@@ -18,23 +19,37 @@ export function buildExposes(
   exposes: WorkbenchExposes,
   {appName, appTitle, exposesAppView, version}: BuildExposesContext,
 ): BrettInterface[] {
-  const toRecord = (
-    prefix: string,
-    decl: {name: string; title?: string; type: string},
-  ): BrettInterface => ({
-    moduleId: `${prefix}/${decl.name}`,
-    name: decl.name,
-    title: decl.title ?? decl.name,
-    type: decl.type,
-    version,
-  })
-
   const records: BrettInterface[] = []
   if (exposesAppView) {
-    records.push({moduleId: 'App', name: appName, title: appTitle, type: 'app', version})
+    records.push({
+      metadata: null,
+      moduleId: interfaceModuleId('app', appName),
+      name: appName,
+      title: appTitle,
+      type: 'app',
+      version,
+    })
   }
-  for (const view of exposes.views ?? []) records.push(toRecord('views', view))
-  for (const service of exposes.services ?? []) records.push(toRecord('services', service))
+  for (const view of exposes.views ?? []) {
+    records.push({
+      metadata: null,
+      moduleId: interfaceModuleId('panel', view.name),
+      name: view.name,
+      title: view.title ?? view.name,
+      type: 'panel',
+      version,
+    })
+  }
+  for (const service of exposes.services ?? []) {
+    records.push({
+      metadata: null,
+      moduleId: interfaceModuleId('worker', service.name),
+      name: service.name,
+      title: service.title ?? service.name,
+      type: 'worker',
+      version,
+    })
+  }
   return records
 }
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -13,7 +13,16 @@ describe('deriveInterfaces', () => {
   test('maps views to panel interfaces', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel', version: 1},
+      {
+        id: 'test-app-panel-feed',
+        metadata: null,
+        moduleId: 'views/feed',
+        name: 'feed',
+        src: './src/FeedPanel.tsx',
+        title: 'feed',
+        type: 'panel',
+        version: '1',
+      },
     ])
   })
 
@@ -22,15 +31,55 @@ describe('deriveInterfaces', () => {
       services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {name: 'unread', src: './src/service.ts', title: 'unread', type: 'worker', version: 1},
+      {
+        id: 'test-app-worker-unread',
+        metadata: null,
+        moduleId: 'services/unread',
+        name: 'unread',
+        src: './src/service.ts',
+        title: 'unread',
+        type: 'worker',
+        version: '1',
+      },
     ])
   })
 
   test('derives an app interface from entry for an SDK app', () => {
     const app = workbenchApp({entry: './src/App.tsx', name: 'my-app'})
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {name: 'my-app', src: './src/App.tsx', title: 'Test App', type: 'app'},
+      {
+        id: 'my-app-app-my-app',
+        metadata: null,
+        moduleId: 'App',
+        name: 'my-app',
+        src: './src/App.tsx',
+        title: 'Test App',
+        type: 'app',
+      },
     ])
+  })
+
+  test('stamps the moduleId a deploy would, so a local interface resolves like a deployed one', () => {
+    const app = workbenchApp({
+      entry: './src/App.tsx',
+      services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+      views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})?.map((iface) => iface.moduleId)).toEqual([
+      'views/feed',
+      'services/unread',
+      'App',
+    ])
+  })
+
+  test('carries null metadata on every interface (not yet populated)', () => {
+    const app = workbenchApp({
+      entry: './src/App.tsx',
+      views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})?.every((iface) => iface.metadata === null)).toBe(
+      true,
+    )
   })
 
   test('omits the app interface for a dock-only app (no entry)', () => {
@@ -47,10 +96,48 @@ describe('deriveInterfaces', () => {
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel', version: 1},
-      {name: 'unread', src: './src/service.ts', title: 'unread', type: 'worker', version: 1},
-      {name: 'my-app', src: './src/App.tsx', title: 'Test App', type: 'app'},
+      {
+        id: 'my-app-panel-feed',
+        metadata: null,
+        moduleId: 'views/feed',
+        name: 'feed',
+        src: './src/FeedPanel.tsx',
+        title: 'feed',
+        type: 'panel',
+        version: '1',
+      },
+      {
+        id: 'my-app-worker-unread',
+        metadata: null,
+        moduleId: 'services/unread',
+        name: 'unread',
+        src: './src/service.ts',
+        title: 'unread',
+        type: 'worker',
+        version: '1',
+      },
+      {
+        id: 'my-app-app-my-app',
+        metadata: null,
+        moduleId: 'App',
+        name: 'my-app',
+        src: './src/App.tsx',
+        title: 'Test App',
+        type: 'app',
+      },
     ])
+  })
+
+  test('derives a unique id per interface, disambiguating a view and service that share a name', () => {
+    const app = workbenchApp({
+      entry: './src/App.tsx',
+      name: 'my-app',
+      services: [{name: 'sync', src: './src/sync.ts', type: 'worker'}],
+      views: [{name: 'sync', src: './src/SyncPanel.tsx', type: 'panel'}],
+    })
+    const ids = deriveInterfaces(app, {isApp: true})?.map((iface) => iface.id) ?? []
+    expect(ids).toEqual(['my-app-panel-sync', 'my-app-worker-sync', 'my-app-app-my-app'])
+    expect(new Set(ids).size).toBe(ids.length)
   })
 
   test('does not put the config in the interface set', () => {
@@ -63,7 +150,16 @@ describe('deriveInterfaces', () => {
     })
     // only the panel — the config rides deriveConfigs, not interfaces
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
-      {name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel', version: 1},
+      {
+        id: 'test-app-panel-feed',
+        metadata: null,
+        moduleId: 'views/feed',
+        name: 'feed',
+        src: './src/FeedPanel.tsx',
+        title: 'feed',
+        type: 'panel',
+        version: '1',
+      },
     ])
   })
 
@@ -77,7 +173,16 @@ describe('deriveInterfaces', () => {
   test('a studio without entry still derives its panels/workers', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     expect(deriveInterfaces(app, {isApp: false})).toEqual([
-      {name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel', version: 1},
+      {
+        id: 'test-app-panel-feed',
+        metadata: null,
+        moduleId: 'views/feed',
+        name: 'feed',
+        src: './src/FeedPanel.tsx',
+        title: 'feed',
+        type: 'panel',
+        version: '1',
+      },
     ])
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
@@ -165,7 +165,16 @@ describe('startDevServerRegistration', () => {
     await expect(extract(params)).resolves.toEqual({
       configs: [],
       interfaces: [
-        {name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel', version: 1},
+        {
+          id: 'test-app-panel-feed',
+          metadata: null,
+          moduleId: 'views/feed',
+          name: 'feed',
+          src: './src/FeedPanel.tsx',
+          title: 'feed',
+          type: 'panel',
+          version: '1',
+        },
       ],
       manifest,
     })
@@ -205,7 +214,15 @@ describe('startDevServerRegistration', () => {
     expect(mockRegisterDevServer).toHaveBeenCalledWith(
       expect.objectContaining({
         interfaces: expect.arrayContaining([
-          {name: 'test-app', src: './src/App.tsx', title: 'Test App', type: 'app'},
+          {
+            id: 'test-app-app-test-app',
+            metadata: null,
+            moduleId: 'App',
+            name: 'test-app',
+            src: './src/App.tsx',
+            title: 'Test App',
+            type: 'app',
+          },
         ]),
       }),
     )

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -3,6 +3,7 @@ import {hash} from 'node:crypto'
 import {type CliConfig} from '@sanity/cli-core'
 
 import {
+  interfaceModuleId,
   MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION,
   SERVICE_CONTRACT_VERSION,
   VIEW_CONTRACT_VERSION,
@@ -17,13 +18,11 @@ export type DevServerInterface = NonNullable<DevServerManifest['interfaces']>[nu
 export type DevServerConfig = NonNullable<DevServerManifest['configs']>[number]
 
 /**
- * Map a workbench app's declarations to the interface records forwarded on its
- * registry entry: `views` → panels, `services` → workers, `entry` → the
- * navigable `app` view. `src` is the raw source, not a resolved URL. `undefined`
- * for a non-branded app; a studio that declares `entry` is rejected (studio app
- * views are not implemented yet). The config is not an interface — see
- * {@link deriveConfigs}. `version` is the module's contract version; the app
- * view has no versioned contract, so it carries none.
+ * Map a workbench app's declarations to its registry interface records:
+ * `views` → panels, `services` → workers, `entry` → the `app` view. Each mirrors
+ * a deployed record so the workbench loads a local interface like a deployed one.
+ * `undefined` for a non-branded app; a studio that declares `entry` is rejected
+ * (studio app views aren't implemented yet).
  */
 export function deriveInterfaces(
   app: CliConfig['app'],
@@ -35,18 +34,50 @@ export function deriveInterfaces(
     throw new Error('App views for studios are not implemented yet')
   }
 
-  const toInterface = (
-    {name, src, title, type}: {name: string; src: string; title?: string; type: string},
-    version: number,
-  ): DevServerInterface => ({name, src, title: title ?? name, type, version})
+  const interfaceId = (type: string, name: string): string => `${app.name}-${type}-${name}`
 
-  return [
-    ...(app.views ?? []).map((view) => toInterface(view, VIEW_CONTRACT_VERSION)),
-    ...(app.services ?? []).map((service) => toInterface(service, SERVICE_CONTRACT_VERSION)),
-    ...(app.entry === undefined
+  const views = (app.views ?? []).map(
+    (view): DevServerInterface => ({
+      id: interfaceId('panel', view.name),
+      metadata: null,
+      moduleId: interfaceModuleId('panel', view.name),
+      name: view.name,
+      src: view.src,
+      title: view.title ?? view.name,
+      type: 'panel',
+      version: String(VIEW_CONTRACT_VERSION),
+    }),
+  )
+
+  const services = (app.services ?? []).map(
+    (service): DevServerInterface => ({
+      id: interfaceId('worker', service.name),
+      metadata: null,
+      moduleId: interfaceModuleId('worker', service.name),
+      name: service.name,
+      src: service.src,
+      title: service.title ?? service.name,
+      type: 'worker',
+      version: String(SERVICE_CONTRACT_VERSION),
+    }),
+  )
+
+  const appView: DevServerInterface[] =
+    app.entry === undefined
       ? []
-      : [{name: app.name, src: app.entry, title: app.title, type: 'app' as const}]),
-  ]
+      : [
+          {
+            id: interfaceId('app', app.name),
+            metadata: null,
+            moduleId: interfaceModuleId('app', app.name),
+            name: app.name,
+            src: app.entry,
+            title: app.title,
+            type: 'app',
+          },
+        ]
+
+  return [...views, ...services, ...appView]
 }
 
 /**

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -17,6 +17,7 @@ import {
 } from '@sanity/cli-core'
 import {z} from 'zod/mini'
 
+import {AppInterfaceMetadataSchema} from '../../contract.js'
 import {canonicalizeWatchDir} from './canonicalizeWatchDir.js'
 import {getProcessStartTime, isOurProcess} from './processLiveness.js'
 
@@ -34,6 +35,31 @@ const REGISTRY_VERSION = 1
 function ownStartedAt(): string {
   return (getProcessStartTime(process.pid) ?? new Date()).toISOString()
 }
+
+const interfaceBaseFields = {
+  /** CLI-minted for a local interface; a deployed one gets its id from Brett. */
+  id: z.string(),
+  moduleId: z.string(),
+  name: z.string(),
+  /** Raw source vite serves; a deployed interface carries only the `moduleId`. */
+  src: z.string(),
+  title: z.string(),
+  version: z.optional(z.string()),
+}
+
+/**
+ * A forwarded interface, discriminated on `type`. Kept outside the manifest so
+ * the workbench renders local panels and runs workers without a deploy.
+ */
+const devServerInterfaceSchema = z.discriminatedUnion('type', [
+  z.object({
+    ...interfaceBaseFields,
+    metadata: z.nullable(AppInterfaceMetadataSchema),
+    type: z.literal('app'),
+  }),
+  z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('panel')}),
+  z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('worker')}),
+])
 
 const devServerManifestSchema = z.object({
   /**
@@ -68,29 +94,7 @@ const devServerManifestSchema = z.object({
   ),
   host: z.string(),
   id: z.optional(z.string()),
-  /**
-   * Interfaces the app exposes, mapped from the declared `views` (dock panels,
-   * `type: "panel"`) and `services` (background workers,
-   * `type: "worker"`). A service is just an interface, so both live
-   * in this one list. Carried separately from the manifest — interfaces live in
-   * the application service, not the manifest — so the workbench can render
-   * local panels and run local workers without a deploy. `src` is the
-   * declared source file; `title` defaults to `name`. Lenient by design; the
-   * workbench is the authority on the interface shape.
-   */
-  interfaces: z.optional(
-    z.array(
-      z.object({
-        name: z.string(),
-        src: z.string(),
-        title: z.string(),
-        type: z.string(),
-        // Contract version the interface's generated module exports; the app
-        // view has no versioned contract and carries none.
-        version: z.optional(z.number()),
-      }),
-    ),
-  ),
+  interfaces: z.optional(z.array(devServerInterfaceSchema)),
   /**
    * Inlined manifest — either a {@link StudioManifest} or {@link CoreAppManifest},
    * validated against the shared cli-core schemas. The registry stores and

--- a/packages/@sanity/workbench-cli/src/contract.ts
+++ b/packages/@sanity/workbench-cli/src/contract.ts
@@ -40,6 +40,41 @@ export type InterfaceType = keyof typeof VIEW_COMPONENTS
 /** @public */
 export type ServiceType = 'worker'
 
+/**
+ * The `app` interface's dock-placement metadata. Interface metadata is
+ * discriminated on `type`; `app` is the only type with a shape so far.
+ * @internal
+ */
+export const AppInterfaceMetadataSchema = z.object({
+  group: z.optional(z.string()),
+  priority: z.optional(z.number()),
+})
+
+/** @internal */
+export type AppInterfaceMetadata = z.infer<typeof AppInterfaceMetadataSchema>
+
+/**
+ * The module-federation id a build exposes an interface at. Dev stamps the same
+ * id a deploy would, so the workbench loads a local interface like a deployed one.
+ * @internal
+ */
+export function interfaceModuleId(type: string, name: string): string {
+  switch (type) {
+    case 'app': {
+      return 'App'
+    }
+    case 'panel': {
+      return `views/${name}`
+    }
+    case 'worker': {
+      return `services/${name}`
+    }
+    default: {
+      throw new Error(`Cannot derive a moduleId for unknown interface type: ${type}`)
+    }
+  }
+}
+
 // Shared `name` + `src`; `kind` only tailors the validation message.
 function extensionDeclarationFields(kind: 'Field' | 'Service' | 'View') {
   const pattern = /^[a-zA-Z0-9_-]+$/

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -5,6 +5,7 @@ import {getGlobalCliClient} from '@sanity/cli-core'
 import {isStaging} from '@sanity/cli-core/util'
 import FormData from 'form-data'
 
+import {type AppInterfaceMetadata} from '../contract.js'
 import {APP_WORKBENCH_API_VERSION} from './apiVersion.js'
 
 export type ApplicationType = 'coreApp' | 'studio'
@@ -17,19 +18,22 @@ export interface Application {
   type: ApplicationType
 }
 
-/**
- * An interface as Brett stores it: the declared `type` (validated server-side,
- * not here) and the remote-relative `moduleId` the workbench loads it by — the
- * host prepends the app's own id.
- * @internal
- */
-export interface BrettInterface {
+interface BrettInterfaceBase {
   moduleId: string
   name: string
   title: string
-  type: string
   version: string
 }
+
+/**
+ * An interface as Brett stores it, discriminated on `type`. `moduleId` is
+ * remote-relative — the host prepends the app's id. Brett assigns the id.
+ * @internal
+ */
+export type BrettInterface =
+  | (BrettInterfaceBase & {metadata: AppInterfaceMetadata | null; type: 'app'})
+  | (BrettInterfaceBase & {metadata: null; type: 'panel'})
+  | (BrettInterfaceBase & {metadata: null; type: 'worker'})
 
 /** A studio workspace as Brett stores it. */
 export interface BrettWorkspace {


### PR DESCRIPTION
### Description

Align local interfaces with Brett:

- `version` is a string, matching Brett's `InterfaceEntryFields`.
- Every record carries `metadata`, discriminated on `type` so each interface type owns its shape. Only the `app` interface has one (`AppInterfaceMetadata`, i.e. dock placement); `panel`/`worker` are `null`. Metadata is `null` everywhere for now — the shape lands here, the `app` placement wiring comes separately.
- Local dev interfaces now stamp the `moduleId` a deploy would and mint a stable, unique `id` (a deployed interface gets its id from Brett), so the workbench resolves a local interface exactly like a deployed one. `moduleId` derivation is shared via `interfaceModuleId` so dev and deploy can't drift.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the JSON shape written to the dev-server registry and sent on deploy; stricter parsing may ignore older registry files until dev servers restart, but behavior is intended to match Brett’s API contract.
> 
> **Overview**
> **Dev and deploy interface records now match Brett’s shape** so the workbench can treat local and deployed interfaces the same way.
> 
> Deploy payloads from `buildExposes` add **`metadata: null`**, use **`interfaceModuleId`** for federation ids (`App`, `views/{name}`, `services/{name}`), and keep **`version` as a string**. `BrettInterface` is a **discriminated union on `type`**: `app` may carry `AppInterfaceMetadata` (dock `group` / `priority`); panels and workers use **`metadata: null`** for now.
> 
> Local dev forwarding in **`deriveInterfaces`** mirrors deploy: **`moduleId`**, string contract **`version`** for panels/workers, **`metadata: null`**, and a stable CLI **`id`** (`{appName}-{type}-{name}`). The dev-server registry schema validates that richer shape (including optional app metadata).
> 
> Shared **`interfaceModuleId`** in `contract.ts` keeps dev and deploy from drifting on expose paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e78cb9f4605c9b428109c024c99a5abdf85951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->