### PR TITLE
feat: declare application visibility from the CLI config

### DIFF
--- a/.changeset/pr-1541.md
+++ b/.changeset/pr-1541.md
@@ -1,0 +1,8 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+'@sanity/workbench-cli': minor
+---
+
+feat: declare application visibility from the CLI config

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -17,7 +17,12 @@ export {
 } from '../config/cli/cliUserConfig.js'
 export {getCliConfig, getCliConfigUncached} from '../config/cli/getCliConfig.js'
 export {getCliConfigSync} from '../config/cli/getCliConfigSync.js'
-export {type CliConfig, type ConfigStore} from '../config/cli/types/cliConfig.js'
+export {
+  APP_VISIBILITIES,
+  type AppVisibility,
+  type CliConfig,
+  type ConfigStore,
+} from '../config/cli/types/cliConfig.js'
 export {type UserViteConfig} from '../config/cli/types/userViteConfig.js'
 export {type ApplicationType, isWorkbenchApp} from '../config/cli/workbenchApp.js'
 export {findProjectRoot} from '../config/findProjectRoot.js'

--- a/packages/@sanity/cli-core/src/config/cli/schemas.ts
+++ b/packages/@sanity/cli-core/src/config/cli/schemas.ts
@@ -1,7 +1,7 @@
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import {z} from 'zod/mini'
 
-import {type CliConfig, type TypeGenConfig} from './types/cliConfig'
+import {APP_VISIBILITIES, type CliConfig, type TypeGenConfig} from './types/cliConfig.js'
 import {type UserViteConfig} from './types/userViteConfig'
 
 /**
@@ -22,6 +22,7 @@ export const cliConfigSchema = z.object({
       id: z.optional(z.string()),
       organizationId: z.optional(z.string()),
       title: z.optional(z.string()),
+      visibility: z.optional(z.enum(APP_VISIBILITIES)),
     }),
   ),
 

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -11,6 +11,15 @@ export interface TypeGenConfig {
 }
 
 /**
+ * Dashboard visibility an application can declare. Mirrors Brett's canonical
+ * `VISIBILITIES` — the source of truth lives in the application service.
+ * @public
+ */
+export const APP_VISIBILITIES = ['default', 'unlisted', 'disabled'] as const
+/** @public */
+export type AppVisibility = (typeof APP_VISIBILITIES)[number]
+
+/**
  * @public
  */
 export interface CliConfig {
@@ -39,6 +48,8 @@ export interface CliConfig {
     priority?: number
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
+    /** Dashboard visibility of the application. Defaults to `default`. */
+    visibility?: AppVisibility
   }
 
   /** @deprecated Use deployment.autoUpdates */

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/createUserApplication.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/createUserApplication.test.ts
@@ -33,6 +33,26 @@ describe('createUserApplication', () => {
     )
     expect(result).toBe(app)
   })
+
+  test('maps visibility to dashboardStatus in the request body', async () => {
+    mockRequest.mockResolvedValue({title: 'My App'} as UserApplication)
+
+    await createUserApplication('org-1', 'My App', 'unlisted')
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({dashboardStatus: 'unlisted'}),
+      }),
+    )
+  })
+
+  test('omits dashboardStatus when visibility is unset', async () => {
+    mockRequest.mockResolvedValue({title: 'My App'} as UserApplication)
+
+    await createUserApplication('org-1', 'My App')
+
+    expect(mockRequest.mock.calls[0]?.[0].body).not.toHaveProperty('dashboardStatus')
+  })
 })
 
 describe('generateAppSlug', () => {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployApp.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployApp.test.ts
@@ -1,9 +1,20 @@
 import {type CliConfig, type Output} from '@sanity/cli-core'
-import {describe, expect, test, vi} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {logAppDeployed} from '../deployApp.js'
+import {
+  updateUserApplication,
+  type UserApplicationResolved,
+} from '../../../services/userApplications.js'
+import {type CoreAppManifest} from '../../manifest/types.js'
+import {logAppDeployed, syncApplicationMetadata} from '../deployApp.js'
 
-const mockOutput = () => ({log: vi.fn()}) as unknown as Output
+vi.mock('../../../services/userApplications.js', () => ({
+  createDeployment: vi.fn(),
+  updateUserApplication: vi.fn(),
+}))
+vi.mock('@sanity/cli-core/ux', async () => import('@sanity/cli-test/mocks/cli-core/ux'))
+
+const mockOutput = () => ({log: vi.fn(), warn: vi.fn()}) as unknown as Output
 
 describe('logAppDeployed', () => {
   test("updating prints the dashboard URL from the deployed app's organization", () => {
@@ -46,5 +57,96 @@ describe('logAppDeployed', () => {
     expect(logged).toContain('Created a new application.')
     expect(logged).toContain('creates another new application')
     expect(logged).toContain("appId: 'app-2'")
+  })
+})
+
+describe('syncApplicationMetadata', () => {
+  const baseApp = {
+    dashboardStatus: 'default',
+    id: 'app-1',
+    organizationId: 'org-1',
+    title: 'My App',
+    type: 'coreApp',
+  } as UserApplicationResolved
+
+  afterEach(() => vi.clearAllMocks())
+
+  test('does not PATCH when nothing changed', async () => {
+    const result = await syncApplicationMetadata({
+      application: baseApp,
+      manifest: undefined,
+      output: mockOutput(),
+      visibility: 'default',
+    })
+
+    expect(updateUserApplication).not.toHaveBeenCalled()
+    expect(result).toBe(baseApp)
+  })
+
+  test('treats an unset dashboardStatus as default, so visibility "default" is a no-op', async () => {
+    await syncApplicationMetadata({
+      application: {...baseApp, dashboardStatus: undefined} as UserApplicationResolved,
+      manifest: undefined,
+      output: mockOutput(),
+      visibility: 'default',
+    })
+
+    expect(updateUserApplication).not.toHaveBeenCalled()
+  })
+
+  test('PATCHes only dashboardStatus when visibility changed', async () => {
+    vi.mocked(updateUserApplication).mockResolvedValue({...baseApp, dashboardStatus: 'unlisted'})
+
+    await syncApplicationMetadata({
+      application: baseApp,
+      manifest: undefined,
+      output: mockOutput(),
+      visibility: 'unlisted',
+    })
+
+    expect(updateUserApplication).toHaveBeenCalledWith({
+      applicationId: 'app-1',
+      appType: 'coreApp',
+      body: {dashboardStatus: 'unlisted'},
+    })
+  })
+
+  test('PATCHes only title when the manifest title changed', async () => {
+    vi.mocked(updateUserApplication).mockResolvedValue({...baseApp, title: 'Renamed'})
+
+    await syncApplicationMetadata({
+      application: baseApp,
+      manifest: {title: 'Renamed', version: '1'} as CoreAppManifest,
+      output: mockOutput(),
+      visibility: undefined,
+    })
+
+    expect(updateUserApplication).toHaveBeenCalledWith({
+      applicationId: 'app-1',
+      appType: 'coreApp',
+      body: {title: 'Renamed'},
+    })
+  })
+
+  test('PATCHes both title and dashboardStatus in one call when both changed', async () => {
+    vi.mocked(updateUserApplication).mockResolvedValue({
+      ...baseApp,
+      dashboardStatus: 'unlisted',
+      title: 'Renamed',
+    })
+
+    await syncApplicationMetadata({
+      application: baseApp,
+      manifest: {title: 'Renamed', version: '1'} as CoreAppManifest,
+      output: mockOutput(),
+      visibility: 'unlisted',
+    })
+
+    expect(updateUserApplication).toHaveBeenCalledTimes(1)
+    expect(updateUserApplication).toHaveBeenCalledWith({
+      applicationId: 'app-1',
+      appType: 'coreApp',
+      body: {dashboardStatus: 'unlisted', title: 'Renamed'},
+    })
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/createUserApplication.ts
+++ b/packages/@sanity/cli/src/actions/deploy/createUserApplication.ts
@@ -1,4 +1,5 @@
 import {CLIError} from '@oclif/core/errors'
+import {type AppVisibility} from '@sanity/cli-core'
 import {input, spinner} from '@sanity/cli-core/ux'
 import {customAlphabet} from 'nanoid'
 
@@ -89,6 +90,7 @@ export async function createStudioUserApplication(options: CreateStudioUserAppli
 export async function createUserApplication(
   organizationId?: string,
   title?: string,
+  visibility?: AppVisibility,
 ): Promise<UserApplicationResolved> {
   if (!organizationId) {
     throw new Error(NO_ORGANIZATION_ID)
@@ -101,10 +103,10 @@ export async function createUserApplication(
       validate: (value: string) => value.length > 0 || 'Title is required',
     }))
 
-  return tryCreateApp(resolvedTitle, organizationId)
+  return tryCreateApp(resolvedTitle, organizationId, visibility)
 }
 
-const tryCreateApp = async (title: string, organizationId: string) => {
+const tryCreateApp = async (title: string, organizationId: string, visibility?: AppVisibility) => {
   // we will likely prepend this with an org ID or other parameter in the future
   const appHost = generateAppSlug()
 
@@ -113,7 +115,13 @@ const tryCreateApp = async (title: string, organizationId: string) => {
   try {
     const response = await createUserApplicationRequest({
       appType: 'coreApp',
-      body: {appHost, title, type: 'coreApp', urlType: 'internal'},
+      body: {
+        appHost,
+        title,
+        type: 'coreApp',
+        urlType: 'internal',
+        ...(visibility ? {dashboardStatus: visibility} : {}),
+      },
       organizationId,
     })
 
@@ -123,7 +131,7 @@ const tryCreateApp = async (title: string, organizationId: string) => {
     // if the name is taken, generate a new one and try again
     if ([402, 409].includes(e?.statusCode)) {
       deployDebug('App host taken, retrying with new host')
-      return tryCreateApp(title, organizationId)
+      return tryCreateApp(title, organizationId, visibility)
     }
 
     spin.fail()

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -2,7 +2,7 @@ import {basename, dirname} from 'node:path'
 import {styleText} from 'node:util'
 import {createGzip} from 'node:zlib'
 
-import {exitCodes} from '@sanity/cli-core'
+import {type AppVisibility, exitCodes} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {getCoreAppUrl} from '@sanity/cli-core/util'
 import {spinner} from '@sanity/cli-core/ux'
@@ -245,6 +245,7 @@ async function runAppDeployment(
       sourceDir,
       title: appTitle,
       version,
+      visibility: workbench.visibility,
     })
     const url = getApplicationUrl({id: applicationId, organizationId, type: 'coreApp'})
     logAppDeployed({
@@ -276,7 +277,12 @@ async function runAppDeployment(
   // resolved application means the deploy target was never resolved.
   if (!application) return
 
-  application = await syncApplicationTitle({application, manifest, output})
+  application = await syncApplicationMetadata({
+    application,
+    manifest,
+    output,
+    visibility: cliConfig.app?.visibility,
+  })
   await shipAppDeployment({application, isAutoUpdating, manifest, sourceDir, version})
   logAppDeployed({
     applicationId: application.id,
@@ -327,7 +333,7 @@ async function resolveAppApplication(
 
   if (!application) {
     deployDebug('No user application found. Creating a new one')
-    application = await createUserApplication(organizationId, title)
+    application = await createUserApplication(organizationId, title, cliConfig.app?.visibility)
     deployDebug('User application created', application)
     return {application, created: true}
   }
@@ -335,39 +341,58 @@ async function resolveAppApplication(
   return {application, created: false}
 }
 
-/** Syncs the application title from the manifest when it has changed. */
-async function syncApplicationTitle({
+/**
+ * Syncs application metadata on redeploy when it has changed: the title from the
+ * manifest and the dashboard visibility from config. Sends a single PATCH with
+ * only the changed fields, and skips the request entirely when nothing changed.
+ */
+export async function syncApplicationMetadata({
   application,
   manifest,
   output,
+  visibility,
 }: {
   application: UserApplicationResolved
   manifest: CoreAppManifest | undefined
   output: DeployAppOptions['output']
+  visibility: AppVisibility | undefined
 }): Promise<UserApplicationResolved> {
   const titleUpdate = resolveTitleUpdate(manifest, application)
-  if (!titleUpdate) return application
+  // Treat an unset server value as `default` so a config of `default` is a no-op.
+  const visibilityChanged =
+    visibility !== undefined && visibility !== (application.dashboardStatus ?? 'default')
 
-  deployDebug('Updating application title from manifest', titleUpdate)
-  output.log(
-    titleUpdate.from
-      ? `Updating title from "${titleUpdate.from}" to "${titleUpdate.to}"`
-      : `Setting application title to "${titleUpdate.to}"`,
-  )
-  const spin = spinner('Updating application title').start()
+  if (!titleUpdate && !visibilityChanged) return application
+
+  if (titleUpdate) {
+    deployDebug('Updating application title from manifest', titleUpdate)
+    output.log(
+      titleUpdate.from
+        ? `Updating title from "${titleUpdate.from}" to "${titleUpdate.to}"`
+        : `Setting application title to "${titleUpdate.to}"`,
+    )
+  }
+  if (visibilityChanged) {
+    output.log(`Setting dashboard visibility to "${visibility}"`)
+  }
+
+  const spin = spinner('Updating application').start()
   try {
     const updated = await updateUserApplication({
       applicationId: application.id,
       appType: 'coreApp',
-      body: {title: titleUpdate.to},
+      body: {
+        ...(titleUpdate ? {title: titleUpdate.to} : {}),
+        ...(visibilityChanged ? {dashboardStatus: visibility} : {}),
+      },
     })
     spin.succeed()
     return updated
   } catch (err) {
     spin.fail()
     const message = getErrorMessage(err)
-    deployDebug('Error updating application title', {message})
-    output.warn(`Error updating application title: ${message}`)
+    deployDebug('Error updating application metadata', {message})
+    output.warn(`Error updating application metadata: ${message}`)
     return application
   }
 }

--- a/packages/@sanity/cli/src/services/__tests__/userApplications.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/userApplications.test.ts
@@ -163,6 +163,20 @@ describe('createUserApplication', () => {
     })
     expect(app).toBe(result)
   })
+
+  test('forwards dashboardStatus in the body when provided', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'new-core-id'})
+
+    await createUserApplication({
+      appType: 'coreApp',
+      body: {appHost: 'my-app', dashboardStatus: 'unlisted', type: 'coreApp', urlType: 'internal'},
+      organizationId: 'org-123',
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({body: expect.objectContaining({dashboardStatus: 'unlisted'})}),
+    )
+  })
 })
 
 describe('createDeployment', () => {
@@ -275,5 +289,19 @@ describe('updateUserApplication', () => {
       uri: '/user-applications/123',
     })
     expect(result).toBe(updated)
+  })
+
+  test('sends dashboardStatus in the PATCH body', async () => {
+    mockClient.request.mockResolvedValueOnce({id: '123'})
+
+    await updateUserApplication({
+      applicationId: '123',
+      appType: 'coreApp',
+      body: {dashboardStatus: 'unlisted'},
+    })
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({body: {dashboardStatus: 'unlisted'}}),
+    )
   })
 })

--- a/packages/@sanity/cli/src/services/userApplications.ts
+++ b/packages/@sanity/cli/src/services/userApplications.ts
@@ -1,7 +1,7 @@
 import {PassThrough} from 'node:stream'
 import {type Gzip} from 'node:zlib'
 
-import {debug, getGlobalCliClient} from '@sanity/cli-core'
+import {type AppVisibility, debug, getGlobalCliClient} from '@sanity/cli-core'
 import FormData from 'form-data'
 import {type StudioManifest} from 'sanity'
 
@@ -32,6 +32,8 @@ export interface UserApplication {
   urlType: 'external' | 'internal'
 
   activeDeployment?: ActiveDeployment | null
+  /** Dashboard visibility. Defaults to `default` server-side when unset. */
+  dashboardStatus?: AppVisibility
 }
 
 /** A core app always belongs to an organization. */
@@ -123,6 +125,7 @@ export async function deleteUserApplication({
 }
 
 interface UpdateUserApplicationBody {
+  dashboardStatus?: AppVisibility
   title?: string
 }
 
@@ -207,6 +210,7 @@ export async function getUserApplications(
 export async function createUserApplication(options: {
   appType: 'coreApp'
   body: Pick<UserApplication, 'appHost' | 'type' | 'urlType'> & {
+    dashboardStatus?: AppVisibility
     title?: string
   }
   organizationId?: string
@@ -214,6 +218,7 @@ export async function createUserApplication(options: {
 export async function createUserApplication(options: {
   appType: 'studio'
   body: Pick<UserApplication, 'appHost' | 'type' | 'urlType'> & {
+    dashboardStatus?: AppVisibility
     title?: string
   }
   projectId: string
@@ -221,6 +226,7 @@ export async function createUserApplication(options: {
 export async function createUserApplication(options: {
   appType: 'coreApp' | 'studio'
   body: Pick<UserApplication, 'appHost' | 'type' | 'urlType'> & {
+    dashboardStatus?: AppVisibility
     title?: string
   }
   organizationId?: string

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -470,7 +470,7 @@ describe('#deploy app', () => {
 
     if (error) throw error
     expect(stdout).toContain('Updating title from "Existing App" to "New Title From Manifest"')
-    expect(stderr).toContain('Updating application title')
+    expect(stderr).toContain('Updating application')
     expect(stdout).toContain('Success! Application deployed')
   })
 
@@ -517,7 +517,7 @@ describe('#deploy app', () => {
     })
 
     if (error) throw error
-    expect(stderr).not.toContain('Updating application title')
+    expect(stderr).not.toContain('Updating application')
     expect(stdout).toContain('Success! Application deployed')
   })
 

--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -1,4 +1,4 @@
-import {type ApplicationType} from '@sanity/cli-core'
+import {type ApplicationType, type AppVisibility} from '@sanity/cli-core'
 import {describe, expect, expectTypeOf, test} from 'vitest'
 
 import {
@@ -54,6 +54,11 @@ describe('unstable_defineApp', () => {
     expectTypeOf<
       Exclude<WorkbenchApp['applicationType'], undefined>
     >().toEqualTypeOf<ApplicationType>()
+  })
+
+  test("cli-core's `AppVisibility` mirror stays in sync with the schema enum", () => {
+    // The schema mirrors `APP_VISIBILITIES` locally to stay lean; this guards drift.
+    expectTypeOf<Exclude<WorkbenchApp['visibility'], undefined>>().toEqualTypeOf<AppVisibility>()
   })
 })
 
@@ -123,6 +128,24 @@ describe('DefineAppInputSchema (build-time validation)', () => {
         name: 'drop-desk',
         organizationId: 'org-1',
         title: 'Drop',
+      }).success,
+    ).toBe(false)
+  })
+
+  test('accepts a valid visibility, rejecting an out-of-set value', () => {
+    const parsed = DefineAppInputSchema.parse({
+      name: 'drop-desk',
+      organizationId: 'org-1',
+      title: 'Drop',
+      visibility: 'unlisted',
+    })
+    expect(parsed.visibility).toBe('unlisted')
+    expect(
+      DefineAppInputSchema.safeParse({
+        name: 'drop-desk',
+        organizationId: 'org-1',
+        title: 'Drop',
+        visibility: 'hidden',
       }).success,
     ).toBe(false)
   })

--- a/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
@@ -32,7 +32,7 @@ describe('resolveWorkbenchApp', () => {
     })
   })
 
-  test('passes through declared views, services, entry, and slug', () => {
+  test('passes through declared views, services, entry, slug, and visibility', () => {
     const config = asConfig(
       unstable_defineApp({
         entry: './src/App.tsx',
@@ -42,6 +42,7 @@ describe('resolveWorkbenchApp', () => {
         slug: 'my-app-host',
         title: 'My App',
         views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],
+        visibility: 'unlisted',
       }),
     )
 
@@ -51,6 +52,7 @@ describe('resolveWorkbenchApp', () => {
       services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
       slug: 'my-app-host',
       views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],
+      visibility: 'unlisted',
     })
   })
 

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
@@ -1,7 +1,7 @@
 import {basename, dirname} from 'node:path'
 import {createGzip} from 'node:zlib'
 
-import {exitCodes, type Output} from '@sanity/cli-core'
+import {type AppVisibility, exitCodes, type Output} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {pack} from 'tar-fs'
 
@@ -28,6 +28,7 @@ export async function deployCoreApp(options: {
   sourceDir: string
   title: string
   version: string
+  visibility?: AppVisibility
 }): Promise<{applicationId: string}> {
   const {
     appId,
@@ -39,6 +40,7 @@ export async function deployCoreApp(options: {
     sourceDir,
     title,
     version,
+    visibility,
   } = options
   const tarball = pack(dirname(sourceDir), {entries: [basename(sourceDir)]}).pipe(createGzip())
 
@@ -59,6 +61,7 @@ export async function deployCoreApp(options: {
       title,
       type: 'coreApp',
       version,
+      visibility,
     })
     spin.succeed()
     return {applicationId: id}

--- a/packages/@sanity/workbench-cli/src/defineApp.ts
+++ b/packages/@sanity/workbench-cli/src/defineApp.ts
@@ -6,6 +6,13 @@ import {ConfigSchema, InterfaceDeclarationSchema, ServiceDeclarationSchema} from
 const APP_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/
 
 /**
+ * Dashboard visibility values. Mirrors `APP_VISIBILITIES` in `@sanity/cli-core`
+ * (which can't be imported here — pulling the barrel into this lean module bloats
+ * the config-load path). Kept in sync by a type test in `defineApp.test.ts`.
+ */
+const APP_VISIBILITIES = ['default', 'unlisted', 'disabled'] as const
+
+/**
  * Internal application discriminator. Sanity-owned singleton apps only;
  * validated by the schema but excluded from the public `DefineAppInput` type.
  */
@@ -105,6 +112,8 @@ export const DefineAppInputSchema = z
           ),
         ),
     ),
+    /** Dashboard visibility of the app. Defaults to `default` when omitted. */
+    visibility: z.optional(z.enum(APP_VISIBILITIES)),
   })
   .check(
     // Studio app views are not implemented yet. A studio that declares `entry`

--- a/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
@@ -4,7 +4,7 @@
 // build their command-specific view on top of this one brand-check +
 // extraction, so the discrimination lives in exactly one place.
 
-import {type CliConfig} from '@sanity/cli-core'
+import {type AppVisibility, type CliConfig} from '@sanity/cli-core'
 
 import {type DefineAppInput, isWorkbenchApp, readConfig, type WorkbenchApp} from './defineApp.js'
 
@@ -39,6 +39,8 @@ export interface ResolvedWorkbenchApp {
   readonly isSingleton?: boolean
   /** Hostname the application is created at on first deploy. */
   readonly slug?: string
+  /** Dashboard visibility declared by the app; `undefined` when unset. */
+  readonly visibility?: AppVisibility
 }
 
 /**
@@ -60,5 +62,6 @@ export function resolveWorkbenchApp(
     services: app.services ?? [],
     slug: app.slug,
     views: app.views ?? [],
+    visibility: app.visibility,
   }
 }

--- a/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
+++ b/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
@@ -98,6 +98,34 @@ describe('createApplication', () => {
     expect(fields.map(([name]) => name)).not.toContain('isSingleton')
   })
 
+  test('appends visibility on create when set, omits it when unset', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'app_1'})
+    await createApplication({
+      interfaces,
+      organizationId: 'org-1',
+      slug: 'abc123',
+      tarball: tarball(),
+      title: 'Drop Desk',
+      type: 'coreApp',
+      version: '1.2.3',
+      visibility: 'unlisted',
+    })
+    expect(appendedFields()).toContainEqual(['visibility', 'unlisted'])
+
+    appendSpy.mockClear()
+    mockClient.request.mockResolvedValueOnce({id: 'app_2'})
+    await createApplication({
+      interfaces,
+      organizationId: 'org-1',
+      slug: 'def456',
+      tarball: tarball(),
+      title: 'Drop Desk',
+      type: 'coreApp',
+      version: '1.2.3',
+    })
+    expect(appendedFields().map(([name]) => name)).not.toContain('visibility')
+  })
+
   test('flags a singleton create when isSingleton is set', async () => {
     mockClient.request.mockResolvedValueOnce({id: 'app_1'})
 

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -1,7 +1,7 @@
 import {PassThrough} from 'node:stream'
 import {type Gzip} from 'node:zlib'
 
-import {getGlobalCliClient} from '@sanity/cli-core'
+import {type AppVisibility, getGlobalCliClient} from '@sanity/cli-core'
 import {isStaging} from '@sanity/cli-core/util'
 import FormData from 'form-data'
 
@@ -84,6 +84,7 @@ export async function createApplication(options: {
   title: string
   type: ApplicationType
   version: string
+  visibility?: AppVisibility
   workspaces?: readonly BrettWorkspace[]
 }): Promise<Application> {
   const {
@@ -96,6 +97,7 @@ export async function createApplication(options: {
     title,
     type,
     version,
+    visibility,
     workspaces,
   } = options
   const formData = new FormData()
@@ -104,6 +106,7 @@ export async function createApplication(options: {
   formData.append('organizationId', organizationId)
   formData.append('slug', slug)
   if (isSingleton !== undefined) formData.append('isSingleton', String(isSingleton))
+  if (visibility) formData.append('visibility', visibility)
   // Studio config is set once, at create — it's immutable on redeploy.
   if (projectId) appendJson(formData, 'config', {studio: {projectId}})
   appendDeploymentParts(formData, {interfaces, tarball, version, workspaces})


### PR DESCRIPTION
### Description

Adds a `visibility` field (`default | unlisted | disabled`) to the app config so an
application can declare its Dashboard visibility, forwarded to the deploy API. Mirrors
the application-side support in sanity-io/brett#478.

It maps to both application APIs:

- Workbench apps (`unstable_defineApp`) send it to Brett `POST /applications` as
  `visibility`, set on create.
- The stable `app` config sends it to `/user-applications` as `dashboardStatus`, set on
  create and kept in sync on redeploy (folded into the existing title sync).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deploy create/update calls against user-applications and Brett, so wrong visibility mapping could affect Dashboard listing; scope is limited to optional metadata with solid unit/integration coverage.
> 
> **Overview**
> Adds optional **`app.visibility`** (`default` | `unlisted` | `disabled`) to CLI config and workbench `unstable_defineApp`, so deploy can set how an app appears in the Dashboard.
> 
> **Plain SDK apps** (`/user-applications`): on create, config visibility is sent as **`dashboardStatus`** when set. On redeploy, title sync is generalized to **`syncApplicationMetadata`**, which PATCHes changed **title** and/or **`dashboardStatus`** in one request and skips the API when nothing changed (missing server status is treated as `default`).
> 
> **Workbench apps** (Brett): **`visibility`** is passed through resolve/deploy and included on **`POST /applications`** create only; redeploy still ships tarball/interfaces only.
> 
> Exports **`APP_VISIBILITIES`** / **`AppVisibility`** from `@sanity/cli-core`; workbench mirrors the enum locally with a type test to avoid drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91097b16900fdec64fe412eccee34220dd5ddfb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->