### PR TITLE
feat(workbench): serve built apps with `sanity start`

### DIFF
--- a/.changeset/workbench-start-preview.md
+++ b/.changeset/workbench-start-preview.md
@@ -1,0 +1,6 @@
+---
+"@sanity/workbench-cli": patch
+"@sanity/cli": patch
+---
+
+Make `sanity start` serve a built workbench app like a local dev app, rendering it in the workbench from its static federation build.

--- a/packages/@sanity/cli/src/actions/preview/__tests__/previewAction.test.ts
+++ b/packages/@sanity/cli/src/actions/preview/__tests__/previewAction.test.ts
@@ -1,0 +1,81 @@
+import {type CliConfig} from '@sanity/cli-core'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {createMockOutput, workbenchCliConfig} from '../../dev/__tests__/testHelpers.js'
+import {previewAction} from '../previewAction.js'
+
+const mockStartWorkbenchPreview = vi.hoisted(() => vi.fn())
+const mockStartPreviewServer = vi.hoisted(() => vi.fn())
+const mockGetPreviewServerConfig = vi.hoisted(() => vi.fn())
+const mockCheckForDeprecatedAppId = vi.hoisted(() => vi.fn())
+
+// The workbench orchestration lives in workbench-cli and is imported lazily —
+// mock the single entry the action delegates to.
+vi.mock('@sanity/workbench-cli/preview', () => ({
+  startWorkbenchPreview: mockStartWorkbenchPreview,
+}))
+vi.mock('../../../server/previewServer.js', () => ({startPreviewServer: mockStartPreviewServer}))
+vi.mock('../getPreviewServerConfig.js', () => ({
+  getPreviewServerConfig: mockGetPreviewServerConfig,
+}))
+vi.mock('../../../util/appId.js', () => ({
+  checkForDeprecatedAppId: mockCheckForDeprecatedAppId,
+}))
+
+function options(overrides: Partial<Parameters<typeof previewAction>[0]> = {}) {
+  return {
+    cliConfig: {} as CliConfig,
+    flags: {host: undefined, json: undefined, port: undefined},
+    outDir: '/tmp/project/dist',
+    output: createMockOutput(),
+    workDir: '/tmp/project',
+    ...overrides,
+  }
+}
+
+describe('previewAction', () => {
+  beforeEach(() => {
+    mockGetPreviewServerConfig.mockReturnValue({
+      httpHost: 'localhost',
+      httpPort: 3333,
+      root: '/tmp/project/dist',
+      workDir: '/tmp/project',
+    })
+    mockStartPreviewServer.mockResolvedValue({close: vi.fn(), urls: {local: [], network: []}})
+    mockStartWorkbenchPreview.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('serves a plain build with the static preview server and never delegates to the workbench', async () => {
+    await previewAction(options())
+
+    expect(mockStartPreviewServer).toHaveBeenCalled()
+    expect(mockStartWorkbenchPreview).not.toHaveBeenCalled()
+  })
+
+  test('delegates a workbench app to startWorkbenchPreview with the injected CLI-domain pieces', async () => {
+    const previewClose = vi.fn().mockResolvedValue(undefined)
+    mockStartWorkbenchPreview.mockResolvedValue({close: previewClose})
+
+    const result = await previewAction(options({cliConfig: workbenchCliConfig()}))
+
+    expect(mockStartPreviewServer).not.toHaveBeenCalled()
+    expect(mockStartWorkbenchPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cacheDir: expect.stringMatching(/\/vite$/),
+        checkForDeprecatedAppId: expect.any(Function),
+        extractManifest: expect.any(Function),
+        httpHost: 'localhost',
+        httpPort: 3333,
+        // Derived inside the workbench branch via determineIsApp, not passed in.
+        isApp: true,
+        outDir: '/tmp/project/dist',
+        reactStrictMode: expect.any(Boolean),
+      }),
+    )
+    expect(result.close).toBe(previewClose)
+  })
+})

--- a/packages/@sanity/cli/src/actions/preview/previewAction.ts
+++ b/packages/@sanity/cli/src/actions/preview/previewAction.ts
@@ -1,7 +1,14 @@
-import {type CliConfig} from '@sanity/cli-core'
+import {SANITY_CACHE_DIR} from '@sanity/cli-build/_internal/build'
+import {type CliConfig, type Output} from '@sanity/cli-core'
+import {isWorkbenchApp} from '@sanity/workbench-cli'
 
 import {gracefulServerDeath} from '../../server/gracefulServerDeath.js'
-import {startPreviewServer} from '../../server/previewServer.js'
+import {type PreviewServer, startPreviewServer} from '../../server/previewServer.js'
+import {checkForDeprecatedAppId} from '../../util/appId.js'
+import {determineIsApp} from '../../util/determineIsApp.js'
+import {resolveReactStrictMode} from '../../util/resolveReactStrictMode.js'
+import {extractCoreAppManifest} from '../manifest/extractCoreAppManifest.js'
+import {extractStudioManifest} from '../manifest/extractStudioManifest.js'
 import {getPreviewServerConfig} from './getPreviewServerConfig.js'
 import {type PreviewFlags} from './types.js'
 
@@ -9,13 +16,39 @@ interface PreviewActionOptions {
   cliConfig: CliConfig
   flags: PreviewFlags
   outDir: string
+  output: Output
   workDir: string
 }
 
-export async function previewAction(options: PreviewActionOptions) {
-  const {cliConfig, flags, outDir, workDir} = options
+export async function previewAction(
+  options: PreviewActionOptions,
+): Promise<PreviewServer | {close: () => Promise<void>}> {
+  const {cliConfig, flags, outDir, output, workDir} = options
 
   const config = getPreviewServerConfig({cliConfig, flags, rootDir: outDir, workDir})
+
+  if (isWorkbenchApp(cliConfig?.app)) {
+    const isApp = determineIsApp(cliConfig)
+    // Lazy so a non-workbench `sanity start` never loads the package. `doImport`
+    // is path-based and doesn't apply to a bare specifier.
+    // eslint-disable-next-line no-restricted-syntax
+    const {startWorkbenchPreview} = await import('@sanity/workbench-cli/preview')
+    return startWorkbenchPreview({
+      cacheDir: `${SANITY_CACHE_DIR}/vite`,
+      checkForDeprecatedAppId: () => checkForDeprecatedAppId({cliConfig, output}),
+      cliConfig,
+      extractManifest: isApp
+        ? ({workDir: wd}) => extractCoreAppManifest({workDir: wd})
+        : (params) => extractStudioManifest(params),
+      httpHost: config.httpHost,
+      httpPort: config.httpPort,
+      isApp,
+      outDir,
+      output,
+      reactStrictMode: resolveReactStrictMode(cliConfig) ?? false,
+      workDir,
+    })
+  }
 
   try {
     const server = await startPreviewServer(config)

--- a/packages/@sanity/cli/src/commands/preview.ts
+++ b/packages/@sanity/cli/src/commands/preview.ts
@@ -33,7 +33,7 @@ export class PreviewCommand extends SanityCommand<typeof PreviewCommand> {
   }
   static override hiddenAliases: string[] = ['start']
 
-  public async run(): Promise<PreviewServer | void> {
+  public async run(): Promise<PreviewServer | {close: () => Promise<void>} | void> {
     const {args, flags} = await this.parse(PreviewCommand)
 
     const workDir = (await this.getProjectRoot()).directory
@@ -45,7 +45,7 @@ export class PreviewCommand extends SanityCommand<typeof PreviewCommand> {
     const outDir = path.resolve(outputDir || defaultRootDir)
 
     try {
-      return await previewAction({cliConfig, flags, outDir, workDir})
+      return await previewAction({cliConfig, flags, outDir, output: this.output, workDir})
     } catch (error: unknown) {
       const suggestions =
         error instanceof Error && error.name === 'BUILD_NOT_FOUND'

--- a/packages/@sanity/workbench-cli/package.json
+++ b/packages/@sanity/workbench-cli/package.json
@@ -39,6 +39,10 @@
       "source": "./src/_exports/init.ts",
       "default": "./dist/_exports/init.js"
     },
+    "./preview": {
+      "source": "./src/_exports/preview.ts",
+      "default": "./dist/_exports/preview.js"
+    },
     "./undeploy": {
       "source": "./src/_exports/undeploy.ts",
       "default": "./dist/_exports/undeploy.js"

--- a/packages/@sanity/workbench-cli/src/_exports/preview.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/preview.ts
@@ -1,0 +1,4 @@
+export {
+  startWorkbenchPreview,
+  type StartWorkbenchPreviewOptions,
+} from '../actions/preview/startWorkbenchPreview.js'

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/checkBuiltOutput.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/checkBuiltOutput.test.ts
@@ -42,11 +42,13 @@ describe('checkBuiltOutput', () => {
     expect(mockStat).not.toHaveBeenCalledWith(join(testDir, 'index.html'))
   })
 
-  test('throws when the directory does not exist', async () => {
+  test('tags a missing directory as BUILD_NOT_FOUND', async () => {
     mockStat.mockRejectedValueOnce(enoent())
 
-    await expect(checkBuiltOutput(testDir)).rejects.toThrow(`Directory "${testDir}" does not exist`)
+    const err = await checkBuiltOutput(testDir).catch((e) => e)
 
+    expect(err.message).toContain(`Directory "${testDir}" does not exist`)
+    expect(err.name).toBe('BUILD_NOT_FOUND')
     expect(mockStat).toHaveBeenCalledTimes(1)
   })
 
@@ -58,30 +60,38 @@ describe('checkBuiltOutput', () => {
     expect(mockStat).toHaveBeenCalledTimes(1)
   })
 
-  test('re-throws non-ENOENT errors when checking the directory', async () => {
+  test('re-throws non-ENOENT errors when checking the directory, untagged', async () => {
     const permissionError = new Error('Permission denied') as NodeJS.ErrnoException
     permissionError.code = 'EACCES'
     mockStat.mockRejectedValueOnce(permissionError)
 
-    await expect(checkBuiltOutput(testDir)).rejects.toThrow('Permission denied')
+    const err = await checkBuiltOutput(testDir).catch((e) => e)
+
+    expect(err).toBe(permissionError)
+    expect(err.name).not.toBe('BUILD_NOT_FOUND')
   })
 
-  test('throws when mf-manifest.json does not exist', async () => {
+  test('tags a missing mf-manifest.json as BUILD_NOT_FOUND', async () => {
     mockSourceDirExists()
     mockStat.mockRejectedValueOnce(enoent())
 
-    await expect(checkBuiltOutput(testDir)).rejects.toThrow(`"${manifestPath}" does not exist`)
+    const err = await checkBuiltOutput(testDir).catch((e) => e)
 
+    expect(err.message).toContain(`"${manifestPath}" does not exist`)
+    expect(err.name).toBe('BUILD_NOT_FOUND')
     expect(mockStat).toHaveBeenNthCalledWith(2, manifestPath)
   })
 
-  test('re-throws non-ENOENT errors when checking the manifest', async () => {
+  test('re-throws non-ENOENT errors when checking the manifest, untagged', async () => {
     mockSourceDirExists()
 
     const permissionError = new Error('Permission denied') as NodeJS.ErrnoException
     permissionError.code = 'EACCES'
     mockStat.mockRejectedValueOnce(permissionError)
 
-    await expect(checkBuiltOutput(testDir)).rejects.toThrow('Permission denied')
+    const err = await checkBuiltOutput(testDir).catch((e) => e)
+
+    expect(err).toBe(permissionError)
+    expect(err.name).not.toBe('BUILD_NOT_FOUND')
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/deploy/checkBuiltOutput.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/checkBuiltOutput.ts
@@ -2,6 +2,18 @@ import {stat} from 'node:fs/promises'
 import {join} from 'node:path'
 
 /**
+ * A genuinely-missing-build error, named so callers can offer the "run sanity
+ * build" hint (the `preview` command keys off this name, matching how the studio
+ * path keys off a missing `index.html`). Only the missing cases get it — real
+ * I/O failures keep their own name so they surface as themselves.
+ */
+function buildNotFound(message: string): Error {
+  const error = new Error(message)
+  error.name = 'BUILD_NOT_FOUND'
+  return error
+}
+
+/**
  * Throws unless `sourceDir` is a directory holding a federation build.
  * A workbench build always emits a module-federation remote, and may
  * additionally emit a standalone `index.html` SPA (workbench remotes). Either
@@ -15,18 +27,20 @@ export async function checkBuiltOutput(sourceDir: string): Promise<void> {
       throw new Error(`"${sourceDir}" is not a directory`)
     }
   } catch (err) {
-    throw err.code === 'ENOENT' ? new Error(`Directory "${sourceDir}" does not exist`) : err
+    if (err.code === 'ENOENT') throw buildNotFound(`Directory "${sourceDir}" does not exist`)
+    throw err
   }
 
   const manifestPath = join(sourceDir, 'mf-manifest.json')
   try {
     await stat(manifestPath)
   } catch (err) {
-    throw err.code === 'ENOENT'
-      ? new Error(
-          `"${manifestPath}" does not exist. ` +
-            'The deploy directory must contain a federation build created with "sanity build".',
-        )
-      : err
+    if (err.code === 'ENOENT') {
+      throw buildNotFound(
+        `"${manifestPath}" does not exist. ` +
+          'The deploy directory must contain a federation build created with "sanity build".',
+      )
+    }
+    throw err
   }
 }

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
@@ -64,3 +64,32 @@ export function createDevOptions(
     ...overrides,
   }
 }
+
+/** A minimal Vite dev server stand-in — enough of the shape the workbench dev
+ * flow reads (bound address, config, ws channel, lifecycle). */
+export function createMockViteServer({host, port = 3333}: {host?: string; port?: number} = {}) {
+  return {
+    close: vi.fn().mockResolvedValue(),
+    config: {server: {host, port}},
+    httpServer: {address: vi.fn().mockReturnValue({address: '127.0.0.1', family: 'IPv4', port})},
+    listen: vi.fn().mockResolvedValue(),
+    ws: {on: vi.fn(), send: vi.fn()},
+  }
+}
+
+/** A `startWorkbenchDevServer` result — the singleton shell as seen by its callers. */
+export function mockWorkbenchServer(
+  overrides: {
+    httpHost?: string
+    workbenchAvailable?: boolean
+    workbenchPort?: number
+  } = {},
+) {
+  return {
+    close: vi.fn().mockResolvedValue(),
+    httpHost: 'localhost',
+    workbenchAvailable: true,
+    workbenchPort: 3333,
+    ...overrides,
+  }
+}

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
@@ -57,6 +57,7 @@ export function createDevOptions(
     cliConfig: {} as CliConfig,
     httpHost: 'localhost',
     httpPort: 3333,
+    mode: 'development',
     output: createMockOutput(),
     reactStrictMode: false,
     workDir: '/tmp/sanity-project',

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/registry.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/registry.test.ts
@@ -8,6 +8,7 @@ import {
   getRegisteredServers,
   readWorkbenchLock,
   registerDevServer,
+  runRegistryExitCleanupForTesting,
   watchRegistry,
 } from '../registry.js'
 import {FakeFsWatcher} from './devTestHelpers.js'
@@ -344,5 +345,41 @@ describe('readWorkbenchLock', () => {
 
     expect(readWorkbenchLock()).toBeUndefined()
     expect(fsMock.module.existsSync(lockPath())).toBe(false)
+  })
+})
+
+// Vite's own SIGTERM handler can `process.exit()` before the async teardown
+// releases anything, so both the entry and lock also clean up synchronously on
+// the process `exit` event.
+describe('exit backstop', () => {
+  test('removes the registry entry when the process exits without a release', () => {
+    registerDevServer({host: 'localhost', port: 3334, type: 'studio', workDir: '/tmp/project'})
+    expect(fsMock.module.existsSync(manifestPath())).toBe(true)
+
+    runRegistryExitCleanupForTesting()
+
+    expect(fsMock.module.existsSync(manifestPath())).toBe(false)
+  })
+
+  test('removes the workbench lock when the process exits without a release', () => {
+    acquireWorkbenchLock({host: 'localhost', port: 3333})
+    expect(fsMock.module.existsSync(lockPath())).toBe(true)
+
+    runRegistryExitCleanupForTesting()
+
+    expect(fsMock.module.existsSync(lockPath())).toBe(false)
+  })
+
+  test('leaves a lock reacquired by a successor untouched', () => {
+    acquireWorkbenchLock({host: 'localhost', port: 3333})
+    // A different process now owns the lock file.
+    fsMock.files.set(
+      lockPath(),
+      JSON.stringify({host: 'localhost', pid: 4242, port: 3333, startedAt: '', version: 1}),
+    )
+
+    runRegistryExitCleanupForTesting()
+
+    expect(readJson(lockPath()).pid).toBe(4242)
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDev.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDev.test.ts
@@ -1,7 +1,12 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {startWorkbenchDev, type StartWorkbenchDevOptions} from '../startWorkbenchDev.js'
-import {createMockOutput, workbenchCliConfig} from './devTestHelpers.js'
+import {
+  createMockOutput,
+  createMockViteServer,
+  mockWorkbenchServer,
+  workbenchCliConfig,
+} from './devTestHelpers.js'
 
 const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
 const mockStartDevServerRegistration = vi.hoisted(() => vi.fn())
@@ -22,7 +27,7 @@ vi.mock('../startDevServerRegistration.js', () => ({
 function mockAppServer({port = 3334}: {port?: number} = {}) {
   return {
     close: vi.fn().mockResolvedValue(undefined),
-    server: {config: {server: {port}}, httpServer: {address: () => ({port})}},
+    server: createMockViteServer({port}),
     started: true as const,
   }
 }
@@ -61,12 +66,7 @@ function installedSignalHandler(): (signal: NodeJS.Signals) => void {
 
 describe('startWorkbenchDev', () => {
   beforeEach(() => {
-    mockStartWorkbenchDevServer.mockResolvedValue({
-      close: vi.fn().mockResolvedValue(undefined),
-      httpHost: 'localhost',
-      workbenchAvailable: true,
-      workbenchPort: 3333,
-    })
+    mockStartWorkbenchDevServer.mockResolvedValue(mockWorkbenchServer())
     mockStartDevServerRegistration.mockResolvedValue({close: vi.fn().mockResolvedValue(undefined)})
     mockStartAppServer.mockResolvedValue(mockAppServer({port: 3334}))
     mockGetCliConfigUncached.mockResolvedValue(workbenchCliConfig())
@@ -94,12 +94,9 @@ describe('startWorkbenchDev', () => {
     })
 
     test('keeps the configured port and announces the URL when the workbench is unavailable', async () => {
-      mockStartWorkbenchDevServer.mockResolvedValue({
-        close: vi.fn().mockResolvedValue(undefined),
-        httpHost: 'localhost',
-        workbenchAvailable: false,
-        workbenchPort: 3333,
-      })
+      mockStartWorkbenchDevServer.mockResolvedValue(
+        mockWorkbenchServer({workbenchAvailable: false}),
+      )
 
       await run()
 
@@ -116,12 +113,7 @@ describe('startWorkbenchDev', () => {
     })
 
     test('shows the existing lock host in the URL, not the caller host', async () => {
-      mockStartWorkbenchDevServer.mockResolvedValue({
-        close: vi.fn().mockResolvedValue(undefined),
-        httpHost: 'mydev.local',
-        workbenchAvailable: true,
-        workbenchPort: 3333,
-      })
+      mockStartWorkbenchDevServer.mockResolvedValue(mockWorkbenchServer({httpHost: 'mydev.local'}))
       const output = createMockOutput()
 
       await run({output})
@@ -130,12 +122,7 @@ describe('startWorkbenchDev', () => {
     })
 
     test('falls back to localhost for a non-routable bind address', async () => {
-      mockStartWorkbenchDevServer.mockResolvedValue({
-        close: vi.fn().mockResolvedValue(undefined),
-        httpHost: '0.0.0.0',
-        workbenchAvailable: true,
-        workbenchPort: 3333,
-      })
+      mockStartWorkbenchDevServer.mockResolvedValue(mockWorkbenchServer({httpHost: '0.0.0.0'}))
       const output = createMockOutput()
 
       await run({output})
@@ -163,14 +150,9 @@ describe('startWorkbenchDev', () => {
     })
 
     test('tears down both servers and re-throws when registration fails', async () => {
-      const workbenchClose = vi.fn().mockResolvedValue(undefined)
+      const workbench = mockWorkbenchServer()
       const appClose = vi.fn().mockResolvedValue(undefined)
-      mockStartWorkbenchDevServer.mockResolvedValue({
-        close: workbenchClose,
-        httpHost: 'localhost',
-        workbenchAvailable: true,
-        workbenchPort: 3333,
-      })
+      mockStartWorkbenchDevServer.mockResolvedValue(workbench)
       mockStartAppServer.mockResolvedValue({...mockAppServer({port: 3334}), close: appClose})
       const registrationError = new Error('deriveInterfaces failed')
       mockStartDevServerRegistration.mockRejectedValue(registrationError)
@@ -178,7 +160,7 @@ describe('startWorkbenchDev', () => {
       const thrown = await run().catch((err) => err)
 
       expect(thrown).toBe(registrationError)
-      expect(workbenchClose).toHaveBeenCalled()
+      expect(workbench.close).toHaveBeenCalled()
       expect(appClose).toHaveBeenCalled()
     })
 
@@ -193,19 +175,14 @@ describe('startWorkbenchDev', () => {
     })
 
     test('returns a workbench-only close and skips registration when the app server does not start', async () => {
-      const workbenchClose = vi.fn().mockResolvedValue(undefined)
-      mockStartWorkbenchDevServer.mockResolvedValue({
-        close: workbenchClose,
-        httpHost: 'localhost',
-        workbenchAvailable: false,
-        workbenchPort: 3333,
-      })
+      const workbench = mockWorkbenchServer({workbenchAvailable: false})
+      mockStartWorkbenchDevServer.mockResolvedValue(workbench)
       mockStartAppServer.mockResolvedValue({reason: 'missing-organization-id', started: false})
 
       const {close} = await run()
       await close()
 
-      expect(workbenchClose).toHaveBeenCalled()
+      expect(workbench.close).toHaveBeenCalled()
       expect(mockStartDevServerRegistration).not.toHaveBeenCalled()
     })
   })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDev.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDev.test.ts
@@ -85,6 +85,14 @@ describe('startWorkbenchDev', () => {
       )
     })
 
+    test('runs the workbench shell in development mode', async () => {
+      await run()
+
+      expect(mockStartWorkbenchDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({mode: 'development'}),
+      )
+    })
+
     test('keeps the configured port and announces the URL when the workbench is unavailable', async () => {
       mockStartWorkbenchDevServer.mockResolvedValue({
         close: vi.fn().mockResolvedValue(undefined),

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -174,6 +174,34 @@ describe('startWorkbenchDevServer', () => {
       )
     })
 
+    test('development mode forwards the SANITY_INTERNAL_WORKBENCH_REMOTE_URL override', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+      vi.stubEnv('SANITY_INTERNAL_WORKBENCH_REMOTE_URL', 'http://localhost:5173/mf-manifest.json')
+
+      await startWorkbenchDevServer(
+        createDevOptions({cliConfig: federationConfig, mode: 'development'}),
+      )
+
+      expect(mockWriteWorkbenchRuntime).toHaveBeenCalledWith(
+        expect.objectContaining({remoteUrl: expect.stringContaining('localhost:5173')}),
+      )
+    })
+
+    test('preview mode drops the dev override so the deployed workbench UI is used', async () => {
+      mockResolveLocalPackage.mockResolvedValue({})
+      mockCreateServer.mockResolvedValue(createMockServer())
+      vi.stubEnv('SANITY_INTERNAL_WORKBENCH_REMOTE_URL', 'http://localhost:5173/mf-manifest.json')
+
+      await startWorkbenchDevServer(
+        createDevOptions({cliConfig: federationConfig, mode: 'preview'}),
+      )
+
+      expect(mockWriteWorkbenchRuntime).toHaveBeenCalledWith(
+        expect.objectContaining({remoteUrl: undefined}),
+      )
+    })
+
     test('passes organizationId from cliConfig.app.organizationId', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
       mockCreateServer.mockResolvedValue(createMockServer())

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -4,6 +4,7 @@ import {startWorkbenchDevServer} from '../startWorkbenchDevServer.js'
 import {
   createDevOptions,
   createMockOutput,
+  createMockViteServer,
   workbenchApp,
   workbenchCliConfig,
 } from './devTestHelpers.js'
@@ -37,16 +38,6 @@ vi.mock('../registry.js', async (importOriginal) => ({
   readWorkbenchLock: mockReadWorkbenchLock,
   watchRegistry: mockWatchRegistry,
 }))
-
-function createMockServer(port = 3333) {
-  return {
-    close: vi.fn().mockResolvedValue(undefined),
-    config: {server: {port}},
-    httpServer: {address: vi.fn().mockReturnValue({address: '127.0.0.1', family: 'IPv4', port})},
-    listen: vi.fn().mockResolvedValue(undefined),
-    ws: {on: vi.fn(), send: vi.fn()},
-  }
-}
 
 describe('startWorkbenchDevServer', () => {
   beforeEach(() => {
@@ -126,7 +117,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('returns workbenchAvailable: true and close when server starts', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       const result = await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
@@ -137,7 +128,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('returns httpHost and workbenchPort from provided options', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer(4000))
+      mockCreateServer.mockResolvedValue(createMockViteServer({port: 4000}))
 
       const result = await startWorkbenchDevServer(
         createDevOptions({cliConfig: federationConfig, httpHost: '0.0.0.0', httpPort: 4000}),
@@ -150,7 +141,7 @@ describe('startWorkbenchDevServer', () => {
     test('returns actual port when Vite picks an alternative port', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
       // Simulate Vite finding port 3333 occupied and binding to 3334 instead
-      const mockServer = createMockServer(3334)
+      const mockServer = createMockViteServer({port: 3334})
       mockServer.httpServer.address.mockReturnValue({
         address: '127.0.0.1',
         family: 'IPv4',
@@ -165,7 +156,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('passes workDir to writeWorkbenchRuntime', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
@@ -176,7 +167,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('development mode forwards the SANITY_INTERNAL_WORKBENCH_REMOTE_URL override', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
       vi.stubEnv('SANITY_INTERNAL_WORKBENCH_REMOTE_URL', 'http://localhost:5173/mf-manifest.json')
 
       await startWorkbenchDevServer(
@@ -190,7 +181,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('preview mode drops the dev override so the deployed workbench UI is used', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
       vi.stubEnv('SANITY_INTERNAL_WORKBENCH_REMOTE_URL', 'http://localhost:5173/mf-manifest.json')
 
       await startWorkbenchDevServer(
@@ -204,7 +195,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('passes organizationId from cliConfig.app.organizationId', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await startWorkbenchDevServer(
         createDevOptions({
@@ -219,7 +210,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('throws a readable error when neither app.organizationId nor api.projectId is configured', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await expect(
         startWorkbenchDevServer(
@@ -259,7 +250,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('does not register plugin when remoteUrl is not set', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
@@ -275,7 +266,7 @@ describe('startWorkbenchDevServer', () => {
         'https://workbench.example/mf-manifest.json',
       )
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
@@ -297,7 +288,7 @@ describe('startWorkbenchDevServer', () => {
         'https://workbench.example/mf-manifest.json',
       )
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
@@ -314,7 +305,7 @@ describe('startWorkbenchDevServer', () => {
         'https://workbench.example/mf-manifest.json',
       )
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
@@ -331,7 +322,7 @@ describe('startWorkbenchDevServer', () => {
         'https://workbench.example/mf-manifest.json',
       )
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
@@ -347,7 +338,7 @@ describe('startWorkbenchDevServer', () => {
     test('throws when remote URL is set but invalid', async () => {
       vi.stubEnv('SANITY_INTERNAL_WORKBENCH_REMOTE_URL', 'javascript:alert(1)')
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await expect(
         startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig})),
@@ -357,7 +348,7 @@ describe('startWorkbenchDevServer', () => {
     test('releases the lock when server creation throws', async () => {
       vi.stubEnv('SANITY_INTERNAL_WORKBENCH_REMOTE_URL', 'javascript:alert(1)')
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
       const release = vi.fn()
       mockAcquireWorkbenchLock.mockReturnValue({release, updatePort: vi.fn()})
 
@@ -369,7 +360,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('releases the lock when writing runtime files throws', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
       mockWriteWorkbenchRuntime.mockRejectedValue(new Error('EACCES: permission denied'))
       const release = vi.fn()
       mockAcquireWorkbenchLock.mockReturnValue({release, updatePort: vi.fn()})
@@ -386,7 +377,7 @@ describe('startWorkbenchDevServer', () => {
         'http://workbench.example/mf-manifest.json',
       )
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
@@ -406,7 +397,7 @@ describe('startWorkbenchDevServer', () => {
     // injected; the server just forwards the resolved value to the runtime.
     test('forwards the injected reactStrictMode to the runtime template', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await startWorkbenchDevServer(
         createDevOptions({
@@ -428,7 +419,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('warns and returns without close when listen() throws', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockServer.listen.mockRejectedValue(new Error('Port already in use'))
       mockCreateServer.mockResolvedValue(mockServer)
       const output = createMockOutput()
@@ -444,7 +435,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('closes the server before returning when listen() throws', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockServer.listen.mockRejectedValue(new Error('Port already in use'))
       mockCreateServer.mockResolvedValue(mockServer)
 
@@ -496,7 +487,7 @@ describe('startWorkbenchDevServer', () => {
       const mockUpdatePort = vi.fn()
       mockAcquireWorkbenchLock.mockReturnValue({release: vi.fn(), updatePort: mockUpdatePort})
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer(3334))
+      mockCreateServer.mockResolvedValue(createMockViteServer({port: 3334}))
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
@@ -505,7 +496,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('starts watching registry after successful startup', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
 
@@ -514,7 +505,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('watcher callback broadcasts applications via server.ws.send with inlined manifests', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockCreateServer.mockResolvedValue(mockServer)
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
@@ -565,7 +556,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('includes undefined manifest when a registered server has not yet extracted one', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockCreateServer.mockResolvedValue(mockServer)
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
@@ -591,7 +582,7 @@ describe('startWorkbenchDevServer', () => {
       // Workbench needs the projectId on the very first event to resolve a
       // local studio's primary project before the manifest arrives.
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockCreateServer.mockResolvedValue(mockServer)
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
@@ -624,7 +615,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('routes a config-only server (no interfaces) to configs, not applications', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockCreateServer.mockResolvedValue(mockServer)
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
@@ -673,7 +664,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('a config server that also has interfaces lands in both channels', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockCreateServer.mockResolvedValue(mockServer)
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
@@ -705,7 +696,7 @@ describe('startWorkbenchDevServer', () => {
       // exposes; module federation has the old remote-entry cached, so the page
       // must reload to re-fetch it. A soft reconcile would render an empty panel.
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockCreateServer.mockResolvedValue(mockServer)
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
@@ -729,7 +720,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('does not reload on a new app or a manifest-only change', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockCreateServer.mockResolvedValue(mockServer)
 
       await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
@@ -751,7 +742,7 @@ describe('startWorkbenchDevServer', () => {
 
     test('responds to client request with current applications', async () => {
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockCreateServer.mockResolvedValue(mockServer)
       const inlined = {icon: '<svg>inline</svg>', title: 'Title', version: '1'}
       mockGetRegisteredServers.mockReturnValue([
@@ -796,7 +787,7 @@ describe('startWorkbenchDevServer', () => {
       mockAcquireWorkbenchLock.mockReturnValue({release: mockReleaseLock, updatePort: vi.fn()})
       mockWatchRegistry.mockReturnValue({close: mockWatcherClose})
       mockResolveLocalPackage.mockResolvedValue({})
-      mockCreateServer.mockResolvedValue(createMockServer())
+      mockCreateServer.mockResolvedValue(createMockViteServer())
 
       const result = await startWorkbenchDevServer(createDevOptions({cliConfig: federationConfig}))
       await result.close()
@@ -809,7 +800,7 @@ describe('startWorkbenchDevServer', () => {
       const mockReleaseLock = vi.fn()
       mockAcquireWorkbenchLock.mockReturnValue({release: mockReleaseLock, updatePort: vi.fn()})
       mockResolveLocalPackage.mockResolvedValue({})
-      const mockServer = createMockServer()
+      const mockServer = createMockViteServer()
       mockServer.listen.mockRejectedValue(new Error('Port already in use'))
       mockCreateServer.mockResolvedValue(mockServer)
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -21,6 +21,26 @@ import {AppInterfaceMetadataSchema} from '../../contract.js'
 import {canonicalizeWatchDir} from './canonicalizeWatchDir.js'
 import {getProcessStartTime, isOurProcess} from './processLiveness.js'
 
+/**
+ * The dev-server registry: how a running `sanity dev` / `sanity start` process
+ * tells the workbench on this machine "I'm here, load me."
+ *
+ * Two kinds of file under `~/.sanity/dev-servers/` do the coordinating:
+ *
+ *   - `<pid>.json` — one per running app/studio server, holding where it's served
+ *     plus its inlined manifest and interfaces. The workbench reads these to
+ *     discover and render local apps. Written by `registerDevServer`, watched by
+ *     `watchRegistry`.
+ *   - `workbench.lock` — a single machine-wide lock, so only one workbench shell
+ *     runs at a time and later `dev`s register into it instead of starting their
+ *     own. Managed by `acquireWorkbenchLock` / `readWorkbenchLock`.
+ *
+ * Both files belong to the process that created them and must not outlive it.
+ * Three things keep that true: an explicit `release()` on clean shutdown, an
+ * `exit` backstop for abrupt exits (`unlinkOnProcessExit`), and a dead-pid prune
+ * on read (`isOurProcess`) that clears whatever a crashed process left behind.
+ */
+
 const devDebug = subdebug('dev')
 
 /** Bump when the manifest/lock shape changes in a breaking way. */
@@ -132,6 +152,47 @@ function getRegistryDir(): string {
   return join(getSanityDataDir(), 'dev-servers')
 }
 
+// One shared `exit` listener drives every registered cleanup, so N locks/entries
+// don't each add a listener and trip Node's MaxListeners warning.
+const exitCleanups = new Set<() => void>()
+let exitListenerInstalled = false
+
+function runExitCleanups(): void {
+  for (const cleanup of exitCleanups) cleanup()
+}
+
+/** Exercise the exit backstop in tests without terminating the process; not part
+ * of the package's public surface. */
+export const runRegistryExitCleanupForTesting = runExitCleanups
+
+/**
+ * Delete a registry file synchronously on process exit, as a backstop for abrupt
+ * termination. Vite installs its own SIGTERM handler that calls `process.exit()`,
+ * which can outrun the async server teardown and leave the lock or registry entry
+ * behind — a stray dev-server that lingers until the dead-pid prune clears it. The
+ * `exit` event only runs synchronous work, hence `unlinkSync`. `ownedByUs` guards
+ * the shared lock so a successor that reacquired it isn't wiped. Returns a
+ * detacher to call after a clean release.
+ */
+function unlinkOnProcessExit(filePath: string, ownedByUs: () => boolean): () => void {
+  const cleanup = () => {
+    if (!ownedByUs()) return
+    try {
+      unlinkSync(filePath)
+    } catch {
+      // The file may already have been removed during shutdown.
+    }
+  }
+  exitCleanups.add(cleanup)
+
+  if (!exitListenerInstalled) {
+    exitListenerInstalled = true
+    process.once('exit', runExitCleanups)
+  }
+
+  return () => exitCleanups.delete(cleanup)
+}
+
 interface DevServerRegistration {
   /** Remove the registry entry. */
   release: () => void
@@ -170,9 +231,13 @@ export function registerDevServer(
   // without this, the update would re-create the registry entry and leak.
   let released = false
 
+  // The file is pid-named, so it's always ours to remove on exit.
+  const detachExitCleanup = unlinkOnProcessExit(filePath, () => !released)
+
   return {
     release() {
       released = true
+      detachExitCleanup()
       try {
         unlinkSync(filePath)
       } catch {
@@ -367,8 +432,24 @@ export function acquireWorkbenchLock(
   try {
     writeFileSync(lockPath, JSON.stringify(lockData), {flag: 'wx'})
     devDebug('Workbench lock acquired')
+
+    let released = false
+    // Only wipe the lock on exit if it's still ours — a successor that reacquired
+    // it after our own release must not be clobbered.
+    const detachExitCleanup = unlinkOnProcessExit(lockPath, () => {
+      if (released) return false
+      try {
+        const disk = parseLockContents(readFileSync(lockPath, 'utf8'))
+        return disk?.pid === process.pid && disk.startedAt === startedAt
+      } catch {
+        return false
+      }
+    })
+
     return {
       release() {
+        released = true
+        detachExitCleanup()
         try {
           unlinkSync(lockPath)
         } catch {

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -23,7 +23,7 @@ import {getProcessStartTime, isOurProcess} from './processLiveness.js'
 
 /**
  * The dev-server registry: how a running `sanity dev` / `sanity start` process
- * tells the workbench on this machine "I'm here, load me."
+ * advertises itself so the workbench on this machine can find and load it.
  *
  * Two kinds of file under `~/.sanity/dev-servers/` do the coordinating:
  *

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDev.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDev.ts
@@ -95,6 +95,7 @@ export async function startWorkbenchDev(
     cliConfig,
     httpHost,
     httpPort,
+    mode: 'development',
     output,
     reactStrictMode,
     workDir,

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDev.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDev.ts
@@ -2,6 +2,7 @@ import {styleText} from 'node:util'
 
 import {type CliConfig, type Output} from '@sanity/cli-core'
 
+import {createServerLifecycle, toDisplayHost} from '../../util/serverOrchestration.js'
 import {type AppServerResult, startAppServerSupervisor} from './appServerSupervisor.js'
 import {type DevServerManifest} from './registry.js'
 import {startDevServerRegistration} from './startDevServerRegistration.js'
@@ -9,19 +10,6 @@ import {
   startWorkbenchDevServer,
   startWorkbenchRemoteCoordinator,
 } from './startWorkbenchDevServer.js'
-
-/** How long teardown runs before re-raising the signal to force-exit — enough for
- * Vite/watchers to close, short enough not to strand a backgrounded process. */
-const SHUTDOWN_GRACE_MS = 5000
-
-// Bind-only addresses ('0.0.0.0', '::') aren't routable in every browser (notably
-// Windows); the displayed URL falls back to localhost. The bind address is untouched.
-function toDisplayHost(host: string | undefined): string {
-  if (!host || host === '0.0.0.0' || host === '::' || host === '[::]') {
-    return 'localhost'
-  }
-  return host
-}
 
 export interface StartWorkbenchDevOptions {
   /** Resolved app id for the registry entry (the CLI owns id resolution). */
@@ -100,12 +88,7 @@ export async function startWorkbenchDev(
 
   // Unwound in reverse on any failure or on close(): the watcher stops before
   // the app server, and the supervisor waits out an in-flight rebuild.
-  const closers: Array<() => Promise<void>> = []
-  const disposeAll = async () => {
-    for (const close of closers.splice(0).toReversed()) {
-      await close().catch(() => {})
-    }
-  }
+  const {close, closers, installSignalHandlers} = createServerLifecycle()
 
   const workbench = await startWorkbenchDevServer({
     cacheDir,
@@ -123,22 +106,12 @@ export async function startWorkbenchDev(
   const appPort = workbench.workbenchAvailable ? workbench.workbenchPort + 1 : httpPort
   const announceUrl = !workbench.workbenchAvailable
 
-  let closing: Promise<void> | undefined
-  const close = () => {
-    closing ??= (async () => {
-      process.off('SIGINT', onSignal)
-      process.off('SIGTERM', onSignal)
-      await disposeAll()
-    })()
-    return closing
-  }
-
   const supervised = await startAppServerSupervisor({
     cliConfig,
     start: (config) => startAppServer({announceUrl, cliConfig: config, httpPort: appPort}),
     workDir,
   }).catch(async (err) => {
-    await disposeAll()
+    await close()
     throw err
   })
 
@@ -167,7 +140,7 @@ export async function startWorkbenchDev(
   } catch (err) {
     // Registration runs after both servers are up; a failure here would leak the
     // workbench lock and dev servers without this teardown.
-    await disposeAll()
+    await close()
     throw err
   }
 
@@ -180,20 +153,7 @@ export async function startWorkbenchDev(
     )
   }
 
-  // Trapping the signal disables Node's default exit, and a finished teardown
-  // doesn't guarantee an empty event loop (keep-alive sockets, an extraction
-  // worker mid-run) — so re-raise after teardown to restore conventional signal
-  // exit semantics. A backstop timer force-exits if teardown wedges.
-  function onSignal(signal: NodeJS.Signals) {
-    const graceTimer = setTimeout(() => process.kill(process.pid, signal), SHUTDOWN_GRACE_MS)
-    graceTimer.unref()
-    void close().finally(() => {
-      clearTimeout(graceTimer)
-      process.kill(process.pid, signal)
-    })
-  }
-  process.once('SIGINT', onSignal)
-  process.once('SIGTERM', onSignal)
+  installSignalHandlers()
 
   return {close}
 }

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -124,6 +124,9 @@ export interface StartWorkbenchOptions {
   cliConfig: CliConfig
   httpHost: string | undefined
   httpPort: number
+  /** `dev` renders a live app and honors a local workbench-UI override; `preview`
+   * (`sanity start`) previews a build and loads the deployed workbench UI. */
+  mode: 'development' | 'preview'
   output: Output
   /** Wrap the workbench in React StrictMode; the CLI resolves it (unset collapses to `false`). */
   reactStrictMode: boolean
@@ -144,6 +147,7 @@ export async function startWorkbenchDevServer(
     cliConfig,
     httpHost,
     httpPort: workbenchPort,
+    mode,
     output,
     reactStrictMode,
     workDir,
@@ -196,6 +200,7 @@ export async function startWorkbenchDevServer(
       cacheDir,
       cliConfig,
       httpHost,
+      mode,
       output,
       reactStrictMode,
       workbenchPort,
@@ -229,6 +234,7 @@ interface CreateWorkbenchViteServerOptions {
   cacheDir: string
   cliConfig: CliConfig
   httpHost: string | undefined
+  mode: 'development' | 'preview'
   output: Output
   reactStrictMode: boolean
   workbenchPort: number
@@ -243,9 +249,16 @@ interface CreateWorkbenchViteServerResult {
 async function createWorkbenchViteServer(
   options: CreateWorkbenchViteServerOptions,
 ): Promise<CreateWorkbenchViteServerResult | undefined> {
-  const {cacheDir, cliConfig, httpHost, output, reactStrictMode, workbenchPort, workDir} = options
+  const {cacheDir, cliConfig, httpHost, mode, output, reactStrictMode, workbenchPort, workDir} =
+    options
 
-  const remoteUrl = parseRemoteUrl(process.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL)
+  // A production preview loads the deployed workbench UI (render.ts picks it by
+  // environment), so ignore the local dev-server override `.env.development`
+  // sets — nothing is listening there.
+  const remoteUrl =
+    mode === 'preview'
+      ? undefined
+      : parseRemoteUrl(process.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL)
 
   const organizationId = resolveOrganizationId(cliConfig)
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -252,9 +252,9 @@ async function createWorkbenchViteServer(
   const {cacheDir, cliConfig, httpHost, mode, output, reactStrictMode, workbenchPort, workDir} =
     options
 
-  // A production preview loads the deployed workbench UI (render.ts picks it by
-  // environment), so ignore the local dev-server override `.env.development`
-  // sets — nothing is listening there.
+  // `preview` loads `.env.development` (the env hook treats only `build`/`deploy`
+  // as production), which points the workbench UI at a local dev server that
+  // isn't running here. Ignore the override and load the deployed UI instead.
   const remoteUrl =
     mode === 'preview'
       ? undefined

--- a/packages/@sanity/workbench-cli/src/actions/preview/__tests__/serveBuiltApplication.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/__tests__/serveBuiltApplication.test.ts
@@ -38,13 +38,17 @@ describe('serveBuiltApplication', () => {
     vi.clearAllMocks()
   })
 
-  test('re-tags a missing build as BUILD_NOT_FOUND so the command can hint at `sanity build`', async () => {
-    mockCheckBuiltOutput.mockRejectedValue(new Error('mf-manifest.json does not exist'))
+  test('propagates a failed build check and never starts the server', async () => {
+    // checkBuiltOutput owns the BUILD_NOT_FOUND tagging; this just verifies the
+    // error passes through untouched and no server is started.
+    const error = Object.assign(new Error('mf-manifest.json does not exist'), {
+      name: 'BUILD_NOT_FOUND',
+    })
+    mockCheckBuiltOutput.mockRejectedValue(error)
 
     const thrown = await serve().catch((err) => err)
 
-    expect(thrown).toBeInstanceOf(Error)
-    expect(thrown.name).toBe('BUILD_NOT_FOUND')
+    expect(thrown).toBe(error)
     expect(mockPreview).not.toHaveBeenCalled()
   })
 

--- a/packages/@sanity/workbench-cli/src/actions/preview/__tests__/serveBuiltApplication.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/__tests__/serveBuiltApplication.test.ts
@@ -1,6 +1,6 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {serveBuiltRemote} from '../serveBuiltRemote.js'
+import {serveBuiltApplication} from '../serveBuiltApplication.js'
 
 const mockCheckBuiltOutput = vi.hoisted(() => vi.fn())
 const mockPreview = vi.hoisted(() => vi.fn())
@@ -18,7 +18,7 @@ function fakeViteServer({port = 3334}: {port?: number} = {}) {
 }
 
 function serve(overrides: Record<string, unknown> = {}) {
-  return serveBuiltRemote({
+  return serveBuiltApplication({
     cacheDir: '/tmp/.sanity/vite',
     httpHost: 'localhost',
     httpPort: 3334,
@@ -28,7 +28,7 @@ function serve(overrides: Record<string, unknown> = {}) {
   })
 }
 
-describe('serveBuiltRemote', () => {
+describe('serveBuiltApplication', () => {
   beforeEach(() => {
     mockCheckBuiltOutput.mockResolvedValue(undefined)
     mockPreview.mockResolvedValue(fakeViteServer())

--- a/packages/@sanity/workbench-cli/src/actions/preview/__tests__/serveBuiltRemote.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/__tests__/serveBuiltRemote.test.ts
@@ -1,0 +1,71 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {serveBuiltRemote} from '../serveBuiltRemote.js'
+
+const mockCheckBuiltOutput = vi.hoisted(() => vi.fn())
+const mockPreview = vi.hoisted(() => vi.fn())
+
+vi.mock('../../deploy/checkBuiltOutput.js', () => ({checkBuiltOutput: mockCheckBuiltOutput}))
+vi.mock('vite', () => ({preview: mockPreview}))
+
+function fakeViteServer({port = 3334}: {port?: number} = {}) {
+  return {
+    httpServer: {
+      address: () => ({port}),
+      close: (cb: (err?: Error) => void) => cb(),
+    },
+  }
+}
+
+function serve(overrides: Record<string, unknown> = {}) {
+  return serveBuiltRemote({
+    cacheDir: '/tmp/.sanity/vite',
+    httpHost: 'localhost',
+    httpPort: 3334,
+    outDir: '/tmp/project/dist',
+    workDir: '/tmp/project',
+    ...overrides,
+  })
+}
+
+describe('serveBuiltRemote', () => {
+  beforeEach(() => {
+    mockCheckBuiltOutput.mockResolvedValue(undefined)
+    mockPreview.mockResolvedValue(fakeViteServer())
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('re-tags a missing build as BUILD_NOT_FOUND so the command can hint at `sanity build`', async () => {
+    mockCheckBuiltOutput.mockRejectedValue(new Error('mf-manifest.json does not exist'))
+
+    const thrown = await serve().catch((err) => err)
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect(thrown.name).toBe('BUILD_NOT_FOUND')
+    expect(mockPreview).not.toHaveBeenCalled()
+  })
+
+  test('serves the built output at the root and returns the bound address', async () => {
+    mockPreview.mockResolvedValue(fakeViteServer({port: 4009}))
+
+    const server = await serve()
+
+    expect(mockPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        base: '/',
+        build: {outDir: '/tmp/project/dist'},
+        preview: expect.objectContaining({host: 'localhost', port: 3334, strictPort: false}),
+        root: '/tmp/project',
+      }),
+    )
+    expect(server).toMatchObject({host: 'localhost', port: 4009})
+  })
+
+  test('close shuts the http server down', async () => {
+    const server = await serve()
+    await expect(server.close()).resolves.toBeUndefined()
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/preview/__tests__/startWorkbenchPreview.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/__tests__/startWorkbenchPreview.test.ts
@@ -1,6 +1,10 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {createMockOutput, workbenchCliConfig} from '../../dev/__tests__/devTestHelpers.js'
+import {
+  createMockOutput,
+  mockWorkbenchServer,
+  workbenchCliConfig,
+} from '../../dev/__tests__/devTestHelpers.js'
 import {startWorkbenchPreview, type StartWorkbenchPreviewOptions} from '../startWorkbenchPreview.js'
 
 const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
@@ -38,19 +42,9 @@ function run(overrides: Partial<StartWorkbenchPreviewOptions> = {}) {
   })
 }
 
-function workbenchRunning(overrides: Record<string, unknown> = {}) {
-  return {
-    close: vi.fn().mockResolvedValue(undefined),
-    httpHost: 'localhost',
-    workbenchAvailable: true,
-    workbenchPort: 3333,
-    ...overrides,
-  }
-}
-
 describe('startWorkbenchPreview', () => {
   beforeEach(() => {
-    mockStartWorkbenchDevServer.mockResolvedValue(workbenchRunning())
+    mockStartWorkbenchDevServer.mockResolvedValue(mockWorkbenchServer())
     mockServeBuiltApplication.mockResolvedValue({
       close: vi.fn().mockResolvedValue(undefined),
       host: 'localhost',
@@ -75,7 +69,9 @@ describe('startWorkbenchPreview', () => {
     })
 
     test('serves the build on the configured port when no workbench runs', async () => {
-      mockStartWorkbenchDevServer.mockResolvedValue(workbenchRunning({workbenchAvailable: false}))
+      mockStartWorkbenchDevServer.mockResolvedValue(
+        mockWorkbenchServer({workbenchAvailable: false}),
+      )
 
       await run()
 
@@ -118,7 +114,7 @@ describe('startWorkbenchPreview', () => {
 
   describe('teardown', () => {
     test('tears down the workbench and re-throws when the build cannot be served', async () => {
-      const workbench = workbenchRunning()
+      const workbench = mockWorkbenchServer()
       mockStartWorkbenchDevServer.mockResolvedValue(workbench)
       const serveError = new Error('build not found')
       mockServeBuiltApplication.mockRejectedValue(serveError)
@@ -131,7 +127,7 @@ describe('startWorkbenchPreview', () => {
     })
 
     test('tears down both servers and re-throws when registration fails', async () => {
-      const workbench = workbenchRunning()
+      const workbench = mockWorkbenchServer()
       const remoteClose = vi.fn().mockResolvedValue(undefined)
       mockStartWorkbenchDevServer.mockResolvedValue(workbench)
       mockServeBuiltApplication.mockResolvedValue({
@@ -152,7 +148,7 @@ describe('startWorkbenchPreview', () => {
     })
 
     test('close releases the registration and both servers', async () => {
-      const workbench = workbenchRunning()
+      const workbench = mockWorkbenchServer()
       const remoteClose = vi.fn().mockResolvedValue(undefined)
       const release = vi.fn()
       mockStartWorkbenchDevServer.mockResolvedValue(workbench)
@@ -181,7 +177,7 @@ describe('startWorkbenchPreview', () => {
     })
 
     test('shows the existing lock host, not the caller host', async () => {
-      mockStartWorkbenchDevServer.mockResolvedValue(workbenchRunning({httpHost: 'mydev.local'}))
+      mockStartWorkbenchDevServer.mockResolvedValue(mockWorkbenchServer({httpHost: 'mydev.local'}))
       const output = createMockOutput()
 
       await run({output})
@@ -190,7 +186,9 @@ describe('startWorkbenchPreview', () => {
     })
 
     test('announces the build URL directly when no workbench runs', async () => {
-      mockStartWorkbenchDevServer.mockResolvedValue(workbenchRunning({workbenchAvailable: false}))
+      mockStartWorkbenchDevServer.mockResolvedValue(
+        mockWorkbenchServer({workbenchAvailable: false}),
+      )
       mockServeBuiltApplication.mockResolvedValue({
         close: vi.fn().mockResolvedValue(undefined),
         host: 'localhost',

--- a/packages/@sanity/workbench-cli/src/actions/preview/__tests__/startWorkbenchPreview.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/__tests__/startWorkbenchPreview.test.ts
@@ -4,7 +4,7 @@ import {createMockOutput, workbenchCliConfig} from '../../dev/__tests__/devTestH
 import {startWorkbenchPreview, type StartWorkbenchPreviewOptions} from '../startWorkbenchPreview.js'
 
 const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
-const mockServeBuiltRemote = vi.hoisted(() => vi.fn())
+const mockServeBuiltApplication = vi.hoisted(() => vi.fn())
 const mockRegisterDevServer = vi.hoisted(() => vi.fn())
 const mockFindProjectRoot = vi.hoisted(() => vi.fn())
 
@@ -15,7 +15,7 @@ vi.mock('@sanity/cli-core', async (importOriginal) => ({
 vi.mock('../../dev/startWorkbenchDevServer.js', () => ({
   startWorkbenchDevServer: mockStartWorkbenchDevServer,
 }))
-vi.mock('../serveBuiltRemote.js', () => ({serveBuiltRemote: mockServeBuiltRemote}))
+vi.mock('../serveBuiltApplication.js', () => ({serveBuiltApplication: mockServeBuiltApplication}))
 vi.mock('../../dev/registry.js', () => ({registerDevServer: mockRegisterDevServer}))
 
 const mockExtractManifest = vi.hoisted(() => vi.fn())
@@ -51,7 +51,7 @@ function workbenchRunning(overrides: Record<string, unknown> = {}) {
 describe('startWorkbenchPreview', () => {
   beforeEach(() => {
     mockStartWorkbenchDevServer.mockResolvedValue(workbenchRunning())
-    mockServeBuiltRemote.mockResolvedValue({
+    mockServeBuiltApplication.mockResolvedValue({
       close: vi.fn().mockResolvedValue(undefined),
       host: 'localhost',
       port: 3334,
@@ -69,7 +69,9 @@ describe('startWorkbenchPreview', () => {
     test('serves the build on the next port when the workbench claims the configured one', async () => {
       await run()
 
-      expect(mockServeBuiltRemote).toHaveBeenCalledWith(expect.objectContaining({httpPort: 3334}))
+      expect(mockServeBuiltApplication).toHaveBeenCalledWith(
+        expect.objectContaining({httpPort: 3334}),
+      )
     })
 
     test('serves the build on the configured port when no workbench runs', async () => {
@@ -77,7 +79,9 @@ describe('startWorkbenchPreview', () => {
 
       await run()
 
-      expect(mockServeBuiltRemote).toHaveBeenCalledWith(expect.objectContaining({httpPort: 3333}))
+      expect(mockServeBuiltApplication).toHaveBeenCalledWith(
+        expect.objectContaining({httpPort: 3333}),
+      )
     })
 
     test('runs the workbench shell in preview mode', async () => {
@@ -117,7 +121,7 @@ describe('startWorkbenchPreview', () => {
       const workbench = workbenchRunning()
       mockStartWorkbenchDevServer.mockResolvedValue(workbench)
       const serveError = new Error('build not found')
-      mockServeBuiltRemote.mockRejectedValue(serveError)
+      mockServeBuiltApplication.mockRejectedValue(serveError)
 
       const thrown = await run().catch((err) => err)
 
@@ -130,7 +134,11 @@ describe('startWorkbenchPreview', () => {
       const workbench = workbenchRunning()
       const remoteClose = vi.fn().mockResolvedValue(undefined)
       mockStartWorkbenchDevServer.mockResolvedValue(workbench)
-      mockServeBuiltRemote.mockResolvedValue({close: remoteClose, host: 'localhost', port: 3334})
+      mockServeBuiltApplication.mockResolvedValue({
+        close: remoteClose,
+        host: 'localhost',
+        port: 3334,
+      })
       const registrationError = new Error('deriveInterfaces failed')
       mockRegisterDevServer.mockImplementation(() => {
         throw registrationError
@@ -148,7 +156,11 @@ describe('startWorkbenchPreview', () => {
       const remoteClose = vi.fn().mockResolvedValue(undefined)
       const release = vi.fn()
       mockStartWorkbenchDevServer.mockResolvedValue(workbench)
-      mockServeBuiltRemote.mockResolvedValue({close: remoteClose, host: 'localhost', port: 3334})
+      mockServeBuiltApplication.mockResolvedValue({
+        close: remoteClose,
+        host: 'localhost',
+        port: 3334,
+      })
       mockRegisterDevServer.mockReturnValue({release, update: vi.fn()})
 
       const {close} = await run()
@@ -179,7 +191,7 @@ describe('startWorkbenchPreview', () => {
 
     test('announces the build URL directly when no workbench runs', async () => {
       mockStartWorkbenchDevServer.mockResolvedValue(workbenchRunning({workbenchAvailable: false}))
-      mockServeBuiltRemote.mockResolvedValue({
+      mockServeBuiltApplication.mockResolvedValue({
         close: vi.fn().mockResolvedValue(undefined),
         host: 'localhost',
         port: 3333,

--- a/packages/@sanity/workbench-cli/src/actions/preview/__tests__/startWorkbenchPreview.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/__tests__/startWorkbenchPreview.test.ts
@@ -79,6 +79,14 @@ describe('startWorkbenchPreview', () => {
 
       expect(mockServeBuiltRemote).toHaveBeenCalledWith(expect.objectContaining({httpPort: 3333}))
     })
+
+    test('runs the workbench shell in preview mode', async () => {
+      await run()
+
+      expect(mockStartWorkbenchDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({mode: 'preview'}),
+      )
+    })
   })
 
   describe('registration', () => {

--- a/packages/@sanity/workbench-cli/src/actions/preview/__tests__/startWorkbenchPreview.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/__tests__/startWorkbenchPreview.test.ts
@@ -1,0 +1,198 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {createMockOutput, workbenchCliConfig} from '../../dev/__tests__/devTestHelpers.js'
+import {startWorkbenchPreview, type StartWorkbenchPreviewOptions} from '../startWorkbenchPreview.js'
+
+const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
+const mockServeBuiltRemote = vi.hoisted(() => vi.fn())
+const mockRegisterDevServer = vi.hoisted(() => vi.fn())
+const mockFindProjectRoot = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/cli-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
+  findProjectRoot: mockFindProjectRoot,
+}))
+vi.mock('../../dev/startWorkbenchDevServer.js', () => ({
+  startWorkbenchDevServer: mockStartWorkbenchDevServer,
+}))
+vi.mock('../serveBuiltRemote.js', () => ({serveBuiltRemote: mockServeBuiltRemote}))
+vi.mock('../../dev/registry.js', () => ({registerDevServer: mockRegisterDevServer}))
+
+const mockExtractManifest = vi.hoisted(() => vi.fn())
+const mockCheckForDeprecatedAppId = vi.hoisted(() => vi.fn())
+
+function run(overrides: Partial<StartWorkbenchPreviewOptions> = {}) {
+  return startWorkbenchPreview({
+    cacheDir: '/tmp/sanity-project/.sanity/vite',
+    checkForDeprecatedAppId: mockCheckForDeprecatedAppId,
+    cliConfig: workbenchCliConfig(),
+    extractManifest: mockExtractManifest,
+    httpHost: 'localhost',
+    httpPort: 3333,
+    isApp: true,
+    outDir: '/tmp/sanity-project/dist',
+    output: createMockOutput(),
+    reactStrictMode: false,
+    workDir: '/tmp/sanity-project',
+    ...overrides,
+  })
+}
+
+function workbenchRunning(overrides: Record<string, unknown> = {}) {
+  return {
+    close: vi.fn().mockResolvedValue(undefined),
+    httpHost: 'localhost',
+    workbenchAvailable: true,
+    workbenchPort: 3333,
+    ...overrides,
+  }
+}
+
+describe('startWorkbenchPreview', () => {
+  beforeEach(() => {
+    mockStartWorkbenchDevServer.mockResolvedValue(workbenchRunning())
+    mockServeBuiltRemote.mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      host: 'localhost',
+      port: 3334,
+    })
+    mockRegisterDevServer.mockReturnValue({release: vi.fn(), update: vi.fn()})
+    mockFindProjectRoot.mockResolvedValue({path: '/tmp/sanity-project/sanity.cli.ts'})
+    mockExtractManifest.mockResolvedValue({title: 'Test App'})
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('port coordination', () => {
+    test('serves the build on the next port when the workbench claims the configured one', async () => {
+      await run()
+
+      expect(mockServeBuiltRemote).toHaveBeenCalledWith(expect.objectContaining({httpPort: 3334}))
+    })
+
+    test('serves the build on the configured port when no workbench runs', async () => {
+      mockStartWorkbenchDevServer.mockResolvedValue(workbenchRunning({workbenchAvailable: false}))
+
+      await run()
+
+      expect(mockServeBuiltRemote).toHaveBeenCalledWith(expect.objectContaining({httpPort: 3333}))
+    })
+  })
+
+  describe('registration', () => {
+    test('checks the deprecated app id, then registers the built remote with its manifest', async () => {
+      await run()
+
+      expect(mockCheckForDeprecatedAppId).toHaveBeenCalled()
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: 'localhost',
+          id: 'localhost-3334',
+          manifest: {title: 'Test App'},
+          port: 3334,
+          type: 'coreApp',
+        }),
+      )
+    })
+
+    test('registers a studio build as a studio', async () => {
+      await run({isApp: false})
+
+      expect(mockRegisterDevServer).toHaveBeenCalledWith(expect.objectContaining({type: 'studio'}))
+    })
+  })
+
+  describe('teardown', () => {
+    test('tears down the workbench and re-throws when the build cannot be served', async () => {
+      const workbench = workbenchRunning()
+      mockStartWorkbenchDevServer.mockResolvedValue(workbench)
+      const serveError = new Error('build not found')
+      mockServeBuiltRemote.mockRejectedValue(serveError)
+
+      const thrown = await run().catch((err) => err)
+
+      expect(thrown).toBe(serveError)
+      expect(workbench.close).toHaveBeenCalled()
+      expect(mockRegisterDevServer).not.toHaveBeenCalled()
+    })
+
+    test('tears down both servers and re-throws when registration fails', async () => {
+      const workbench = workbenchRunning()
+      const remoteClose = vi.fn().mockResolvedValue(undefined)
+      mockStartWorkbenchDevServer.mockResolvedValue(workbench)
+      mockServeBuiltRemote.mockResolvedValue({close: remoteClose, host: 'localhost', port: 3334})
+      const registrationError = new Error('deriveInterfaces failed')
+      mockRegisterDevServer.mockImplementation(() => {
+        throw registrationError
+      })
+
+      const thrown = await run().catch((err) => err)
+
+      expect(thrown).toBe(registrationError)
+      expect(workbench.close).toHaveBeenCalled()
+      expect(remoteClose).toHaveBeenCalled()
+    })
+
+    test('close releases the registration and both servers', async () => {
+      const workbench = workbenchRunning()
+      const remoteClose = vi.fn().mockResolvedValue(undefined)
+      const release = vi.fn()
+      mockStartWorkbenchDevServer.mockResolvedValue(workbench)
+      mockServeBuiltRemote.mockResolvedValue({close: remoteClose, host: 'localhost', port: 3334})
+      mockRegisterDevServer.mockReturnValue({release, update: vi.fn()})
+
+      const {close} = await run()
+      await close()
+
+      expect(release).toHaveBeenCalled()
+      expect(remoteClose).toHaveBeenCalled()
+      expect(workbench.close).toHaveBeenCalled()
+    })
+  })
+
+  describe('URL announcement', () => {
+    test('logs the workbench URL with the build port when the workbench runs', async () => {
+      const output = createMockOutput()
+      await run({output})
+
+      expect(output.log).toHaveBeenCalledWith(expect.stringContaining('http://localhost:3333'))
+    })
+
+    test('shows the existing lock host, not the caller host', async () => {
+      mockStartWorkbenchDevServer.mockResolvedValue(workbenchRunning({httpHost: 'mydev.local'}))
+      const output = createMockOutput()
+
+      await run({output})
+
+      expect(output.log).toHaveBeenCalledWith(expect.stringContaining('mydev.local:3333'))
+    })
+
+    test('announces the build URL directly when no workbench runs', async () => {
+      mockStartWorkbenchDevServer.mockResolvedValue(workbenchRunning({workbenchAvailable: false}))
+      mockServeBuiltRemote.mockResolvedValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        host: 'localhost',
+        port: 3333,
+      })
+      const output = createMockOutput()
+
+      await run({output})
+
+      expect(output.log).toHaveBeenCalledWith(expect.stringContaining('http://localhost:3333'))
+    })
+  })
+
+  describe('signals', () => {
+    test('registers signal handlers and removes them on close', async () => {
+      const sigintBefore = process.listenerCount('SIGINT')
+
+      const {close} = await run()
+      expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
+
+      await close()
+      expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
+    })
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/preview/serveBuiltApplication.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/serveBuiltApplication.ts
@@ -18,8 +18,9 @@ export interface BuiltApplicationServer {
  * server, so its `mf-manifest.json` + `remote-entry.js` are reachable exactly as
  * a live `sanity dev` remote would be — the workbench then federates it in.
  *
- * A missing federation build is re-tagged `BUILD_NOT_FOUND` so the command
- * surfaces the same "run sanity build" hint the studio preview path shows.
+ * A missing federation build surfaces as `BUILD_NOT_FOUND` (from
+ * `checkBuiltOutput`) so the command shows the same "run sanity build" hint the
+ * studio preview path does; real I/O errors surface as themselves.
  */
 export async function serveBuiltApplication(options: {
   cacheDir: string
@@ -30,12 +31,7 @@ export async function serveBuiltApplication(options: {
 }): Promise<BuiltApplicationServer> {
   const {cacheDir, httpHost, httpPort, outDir, workDir} = options
 
-  try {
-    await checkBuiltOutput(outDir)
-  } catch (err) {
-    if (err instanceof Error) err.name = 'BUILD_NOT_FOUND'
-    throw err
-  }
+  await checkBuiltOutput(outDir)
 
   const config: InlineConfig = {
     // Serve at the root so `mf-manifest.json` and its `publicPath: 'auto'` chunks

--- a/packages/@sanity/workbench-cli/src/actions/preview/serveBuiltApplication.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/serveBuiltApplication.ts
@@ -5,7 +5,7 @@ import {checkBuiltOutput} from '../deploy/checkBuiltOutput.js'
 
 const previewDebug = subdebug('preview')
 
-export interface BuiltRemoteServer {
+export interface BuiltApplicationServer {
   close: () => Promise<void>
   /** Routable host the remote is reachable at, for the registry's remote URL. */
   host: string
@@ -21,13 +21,13 @@ export interface BuiltRemoteServer {
  * A missing federation build is re-tagged `BUILD_NOT_FOUND` so the command
  * surfaces the same "run sanity build" hint the studio preview path shows.
  */
-export async function serveBuiltRemote(options: {
+export async function serveBuiltApplication(options: {
   cacheDir: string
   httpHost: string
   httpPort: number
   outDir: string
   workDir: string
-}): Promise<BuiltRemoteServer> {
+}): Promise<BuiltApplicationServer> {
   const {cacheDir, httpHost, httpPort, outDir, workDir} = options
 
   try {

--- a/packages/@sanity/workbench-cli/src/actions/preview/serveBuiltRemote.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/serveBuiltRemote.ts
@@ -1,0 +1,73 @@
+import {subdebug} from '@sanity/cli-core'
+import {type InlineConfig, preview} from 'vite'
+
+import {checkBuiltOutput} from '../deploy/checkBuiltOutput.js'
+
+const previewDebug = subdebug('preview')
+
+export interface BuiltRemoteServer {
+  close: () => Promise<void>
+  /** Routable host the remote is reachable at, for the registry's remote URL. */
+  host: string
+  /** Port Vite bound — may differ from the requested one under non-strict ports. */
+  port: number
+}
+
+/**
+ * Serve a built workbench app's `dist` as static files over a Vite `preview`
+ * server, so its `mf-manifest.json` + `remote-entry.js` are reachable exactly as
+ * a live `sanity dev` remote would be — the workbench then federates it in.
+ *
+ * A missing federation build is re-tagged `BUILD_NOT_FOUND` so the command
+ * surfaces the same "run sanity build" hint the studio preview path shows.
+ */
+export async function serveBuiltRemote(options: {
+  cacheDir: string
+  httpHost: string
+  httpPort: number
+  outDir: string
+  workDir: string
+}): Promise<BuiltRemoteServer> {
+  const {cacheDir, httpHost, httpPort, outDir, workDir} = options
+
+  try {
+    await checkBuiltOutput(outDir)
+  } catch (err) {
+    if (err instanceof Error) err.name = 'BUILD_NOT_FOUND'
+    throw err
+  }
+
+  const config: InlineConfig = {
+    // Serve at the root so `mf-manifest.json` and its `publicPath: 'auto'` chunks
+    // resolve under the registered remote URL.
+    base: '/',
+    // Needed for vite to serve `outDir` itself rather than `outDir/dist`.
+    build: {outDir},
+    cacheDir,
+    configFile: false,
+    logLevel: 'warn',
+    mode: 'production',
+    preview: {host: httpHost, port: httpPort, strictPort: false},
+    root: workDir,
+  }
+
+  previewDebug('Serving built remote from %s', outDir)
+  const server = await preview(config)
+
+  const addr = server.httpServer.address()
+  const port = typeof addr === 'object' && addr ? addr.port : httpPort
+
+  return {
+    // Drop idle keep-alive sockets so shutdown doesn't stall on a browser that
+    // kept the connection open — otherwise `close` waits out the teardown grace.
+    // `closeAllConnections` isn't on Vite's `HttpServer` type, but is on the
+    // underlying node server (18.2+); the optional call tolerates its absence.
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.httpServer.close((err) => (err ? reject(err) : resolve()))
+        ;(server.httpServer as {closeAllConnections?: () => void}).closeAllConnections?.()
+      }),
+    host: httpHost,
+    port,
+  }
+}

--- a/packages/@sanity/workbench-cli/src/actions/preview/startWorkbenchPreview.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/startWorkbenchPreview.ts
@@ -1,0 +1,124 @@
+import {styleText} from 'node:util'
+
+import {type CliConfig, findProjectRoot, type Output} from '@sanity/cli-core'
+
+import {createServerLifecycle, toDisplayHost} from '../../util/serverOrchestration.js'
+import {deriveConfigs, deriveInterfaces} from '../dev/deriveInterfaces.js'
+import {type DevServerManifest, registerDevServer} from '../dev/registry.js'
+import {startWorkbenchDevServer} from '../dev/startWorkbenchDevServer.js'
+import {serveBuiltRemote} from './serveBuiltRemote.js'
+
+export interface StartWorkbenchPreviewOptions {
+  /** Directory for the workbench Vite server's dependency cache. */
+  cacheDir: string
+  /** CLI-domain `app.id`/`deployment.appId` deprecation check, run before registering. */
+  checkForDeprecatedAppId: () => void
+  cliConfig: CliConfig
+  /** Extract the project manifest to inline into the registry (studio-vs-app handled by the CLI). */
+  extractManifest: (params: {
+    configPath: string
+    workDir: string
+  }) => Promise<DevServerManifest['manifest']>
+  httpHost: string
+  httpPort: number
+  isApp: boolean
+  /** The built `dist` directory to serve as the federation remote. */
+  outDir: string
+  output: Output
+  reactStrictMode: boolean
+  workDir: string
+}
+
+/**
+ * `sanity start` for a workbench app: serve a production build the way dev serves
+ * a live one. The same singleton workbench shell renders it and the same registry
+ * advertises it — only the remote differs, static files from the build output
+ * instead of a live Vite dev server. There's no config watcher or rebuild: a
+ * build is fixed, so nothing re-syncs.
+ *
+ * A running workbench claims the configured port, so the built remote binds the
+ * next one. Without one the remote takes the configured port and announces its
+ * own URL.
+ */
+export async function startWorkbenchPreview(
+  options: StartWorkbenchPreviewOptions,
+): Promise<{close: () => Promise<void>}> {
+  const {
+    cacheDir,
+    checkForDeprecatedAppId,
+    cliConfig,
+    extractManifest,
+    httpHost,
+    httpPort,
+    isApp,
+    outDir,
+    output,
+    reactStrictMode,
+    workDir,
+  } = options
+
+  const {close, closers, installSignalHandlers} = createServerLifecycle()
+
+  const workbench = await startWorkbenchDevServer({
+    cacheDir,
+    cliConfig,
+    httpHost,
+    httpPort,
+    output,
+    reactStrictMode,
+    workDir,
+  })
+  closers.push(workbench.close)
+
+  const remotePort = workbench.workbenchAvailable ? workbench.workbenchPort + 1 : httpPort
+
+  const remote = await serveBuiltRemote({
+    cacheDir,
+    httpHost,
+    httpPort: remotePort,
+    outDir,
+    workDir,
+  }).catch(async (err) => {
+    await close()
+    throw err
+  })
+  closers.push(remote.close)
+
+  try {
+    // Callers provide CLI-only validation and manifest extraction to keep them
+    // out of workbench-cli.
+    checkForDeprecatedAppId()
+    const configPath = (await findProjectRoot(workDir)).path
+    const registration = registerDevServer({
+      configs: deriveConfigs(cliConfig.app),
+      host: remote.host,
+      // A local app is identified by where it's served, matching `sanity dev`.
+      id: `${remote.host}-${remote.port}`,
+      interfaces: deriveInterfaces(cliConfig.app, {isApp}),
+      manifest: await extractManifest({configPath, workDir}),
+      manifestUpdatedAt: new Date().toISOString(),
+      port: remote.port,
+      projectId: cliConfig?.api?.projectId,
+      type: isApp ? 'coreApp' : 'studio',
+      workDir,
+    })
+    closers.push(async () => registration.release())
+  } catch (err) {
+    await close()
+    throw err
+  }
+
+  if (workbench.workbenchAvailable) {
+    const workbenchUrl = `http://${toDisplayHost(workbench.httpHost)}:${workbench.workbenchPort}`
+    output.log(
+      `Workbench preview server started at ${styleText(['blue', 'underline'], workbenchUrl)} (serving build on port ${remote.port})`,
+    )
+  } else {
+    const remoteUrl = `http://${toDisplayHost(remote.host)}:${remote.port}`
+    output.log(`Serving build at ${styleText(['blue', 'underline'], remoteUrl)}`)
+  }
+
+  installSignalHandlers()
+
+  return {close}
+}

--- a/packages/@sanity/workbench-cli/src/actions/preview/startWorkbenchPreview.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/startWorkbenchPreview.ts
@@ -64,6 +64,7 @@ export async function startWorkbenchPreview(
     cliConfig,
     httpHost,
     httpPort,
+    mode: 'preview',
     output,
     reactStrictMode,
     workDir,

--- a/packages/@sanity/workbench-cli/src/actions/preview/startWorkbenchPreview.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/startWorkbenchPreview.ts
@@ -6,7 +6,7 @@ import {createServerLifecycle, toDisplayHost} from '../../util/serverOrchestrati
 import {deriveConfigs, deriveInterfaces} from '../dev/deriveInterfaces.js'
 import {type DevServerManifest, registerDevServer} from '../dev/registry.js'
 import {startWorkbenchDevServer} from '../dev/startWorkbenchDevServer.js'
-import {serveBuiltRemote} from './serveBuiltRemote.js'
+import {serveBuiltApplication} from './serveBuiltApplication.js'
 
 export interface StartWorkbenchPreviewOptions {
   /** Directory for the workbench Vite server's dependency cache. */
@@ -73,7 +73,7 @@ export async function startWorkbenchPreview(
 
   const remotePort = workbench.workbenchAvailable ? workbench.workbenchPort + 1 : httpPort
 
-  const remote = await serveBuiltRemote({
+  const remote = await serveBuiltApplication({
     cacheDir,
     httpHost,
     httpPort: remotePort,

--- a/packages/@sanity/workbench-cli/src/util/__tests__/serverOrchestration.test.ts
+++ b/packages/@sanity/workbench-cli/src/util/__tests__/serverOrchestration.test.ts
@@ -1,0 +1,107 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {createServerLifecycle, toDisplayHost} from '../serverOrchestration.js'
+
+describe('toDisplayHost', () => {
+  test.each(['0.0.0.0', '::', '[::]', undefined, ''])(
+    'falls back to localhost for the non-routable bind address %s',
+    (host) => {
+      expect(toDisplayHost(host)).toBe('localhost')
+    },
+  )
+
+  test('passes a routable host through unchanged', () => {
+    expect(toDisplayHost('mydev.local')).toBe('mydev.local')
+  })
+})
+
+describe('createServerLifecycle', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('runs closers in reverse (LIFO) on close', async () => {
+    const order: number[] = []
+    const {close, closers} = createServerLifecycle()
+    closers.push(
+      async () => void order.push(1),
+      async () => void order.push(2),
+    )
+
+    await close()
+
+    expect(order).toEqual([2, 1])
+  })
+
+  test('swallows a failing closer so the rest still run', async () => {
+    const later = vi.fn().mockResolvedValue(undefined)
+    const {close, closers} = createServerLifecycle()
+    closers.push(later, async () => {
+      throw new Error('boom')
+    })
+
+    await expect(close()).resolves.toBeUndefined()
+    expect(later).toHaveBeenCalledTimes(1)
+  })
+
+  test('close is single-flight — a second call shares the same teardown', async () => {
+    const dispose = vi.fn().mockResolvedValue(undefined)
+    const {close, closers} = createServerLifecycle()
+    closers.push(dispose)
+
+    await Promise.all([close(), close()])
+
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  test('installs signal handlers and removes them on close', async () => {
+    const sigintBefore = process.listenerCount('SIGINT')
+    const sigtermBefore = process.listenerCount('SIGTERM')
+
+    const {close, installSignalHandlers} = createServerLifecycle()
+    installSignalHandlers()
+
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + 1)
+
+    await close()
+
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)
+  })
+
+  test('re-raises the signal once teardown settles so the default exit runs', async () => {
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+    vi.useFakeTimers()
+
+    const dispose = vi.fn().mockResolvedValue(undefined)
+    const {closers, installSignalHandlers} = createServerLifecycle()
+    closers.push(dispose)
+    installSignalHandlers()
+
+    const handler = process.listeners('SIGINT').at(-1) as (signal: NodeJS.Signals) => void
+    handler('SIGINT')
+    await vi.runAllTimersAsync()
+
+    expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGINT')
+    expect(dispose.mock.invocationCallOrder[0]).toBeLessThan(killSpy.mock.invocationCallOrder[0])
+  })
+
+  test('force-exits after the grace period when teardown hangs', async () => {
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+    vi.useFakeTimers()
+
+    const hangingClose = vi.fn(() => new Promise<void>(() => {}))
+    const {closers, installSignalHandlers} = createServerLifecycle()
+    closers.push(hangingClose)
+    installSignalHandlers()
+
+    const handler = process.listeners('SIGTERM').at(-1) as (signal: NodeJS.Signals) => void
+    handler('SIGTERM')
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(hangingClose).toHaveBeenCalled()
+    expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM')
+  })
+})

--- a/packages/@sanity/workbench-cli/src/util/serverOrchestration.ts
+++ b/packages/@sanity/workbench-cli/src/util/serverOrchestration.ts
@@ -1,0 +1,95 @@
+/** How long teardown may run before we stop waiting and force the process to
+ * exit — long enough for Vite servers and watchers to close, short enough not to
+ * strand a backgrounded process. */
+const SHUTDOWN_GRACE_MS = 5000
+
+/**
+ * Map a server's bind address to a host that's safe to show in a URL. Bind-only
+ * addresses ('0.0.0.0', '::') aren't routable in every browser (notably on
+ * Windows), so fall back to localhost for display. The bind address itself is
+ * untouched — this only affects the URL printed to the user.
+ */
+export function toDisplayHost(host: string | undefined): string {
+  if (!host || host === '0.0.0.0' || host === '::' || host === '[::]') {
+    return 'localhost'
+  }
+  return host
+}
+
+export interface ServerLifecycle {
+  /** Tear everything down exactly once and stop listening for signals. Safe to call more than once. */
+  close: () => Promise<void>
+  /**
+   * Shutdown functions, one per server/resource. Push one as each resource
+   * starts; `close` unwinds them in reverse. A throwing closer is swallowed so
+   * one bad teardown can't strand the rest.
+   */
+  closers: Array<() => Promise<void>>
+  /** Begin handling Ctrl-C / kill by tearing down, then re-raising the signal so the process still exits. */
+  installSignalHandlers: () => void
+}
+
+/**
+ * Shuts down a command that runs several long-lived servers at once. Both
+ * `sanity dev` and `sanity start` start a workbench shell, an app remote, and a
+ * registry entry, and every one of them has to be stopped again — on a clean
+ * exit, on a startup error, or when the user presses Ctrl-C.
+ *
+ * How it works:
+ *   - Each server adds its own shutdown function to `closers` as it starts.
+ *   - `close()` runs them in reverse (last started, first stopped), and only
+ *     runs them once no matter how many times it's called.
+ *   - `installSignalHandlers()` makes Ctrl-C / kill trigger that same `close()`.
+ *
+ * Signals need care: Node would normally exit the instant one arrives, but our
+ * shutdown is async. So we catch the signal, run `close()`, and only then send
+ * the signal on again so the process exits with its usual code. A timer is the
+ * escape hatch — if shutdown ever hangs, it forces the exit rather than leaving
+ * the process stuck.
+ */
+export function createServerLifecycle(): ServerLifecycle {
+  const closers: ServerLifecycle['closers'] = []
+
+  const runClosers = async () => {
+    // Reverse order, so each server is stopped before the one it was started on
+    // top of. A closer that throws is ignored so one failure can't block the rest.
+    for (const closeResource of closers.splice(0).toReversed()) {
+      await closeResource().catch(() => {})
+    }
+  }
+
+  // `close` can be called more than once — a startup error and then a Ctrl-C, or
+  // two signals racing. Keep the first call's promise and hand it back to the
+  // rest, so everything is torn down exactly once.
+  let teardown: Promise<void> | undefined
+  const close = () => {
+    teardown ??= (async () => {
+      process.off('SIGINT', onSignal)
+      process.off('SIGTERM', onSignal)
+      await runClosers()
+    })()
+    return teardown
+  }
+
+  function onSignal(signal: NodeJS.Signals) {
+    // Force the exit if shutdown doesn't finish in time, so a wedged server
+    // can't hang the process forever.
+    const graceTimer = setTimeout(() => process.kill(process.pid, signal), SHUTDOWN_GRACE_MS)
+    graceTimer.unref()
+    // Tear down first, then re-send the signal so the process exits with the
+    // code it normally would for this signal.
+    void close().finally(() => {
+      clearTimeout(graceTimer)
+      process.kill(process.pid, signal)
+    })
+  }
+
+  return {
+    close,
+    closers,
+    installSignalHandlers() {
+      process.once('SIGINT', onSignal)
+      process.once('SIGTERM', onSignal)
+    },
+  }
+}


### PR DESCRIPTION
## Problem

`sanity start` (the hidden alias of `sanity preview`) had no workbench support. A built workbench app emits a module-federation remote — `mf-manifest.json`, `remote-entry.js`, `static/` — but no `index.html`, and the existing preview server keys off `index.html`. So there was no way to preview a built workbench app the way `sanity dev` shows a live one.

## How it works

`start` reuses the `dev` topology and only swaps the live app server for the static build:

- `previewAction` spots a workbench app and delegates to `@sanity/workbench-cli/preview` via a lazy import, the same way `devAction` delegates to `/dev`. A plain, non-workbench preview is left untouched.
- `startWorkbenchPreview` brings up the same singleton workbench shell (`startWorkbenchDevServer`, lock-guarded) and registers into the same dev-server registry (`registerDevServer` + `deriveInterfaces`/`deriveConfigs`) with `id: <host>-<port>`. The shell then renders the app exactly like a live `dev` remote.
- The remote is `serveBuiltApplication` — a Vite `preview` server over the built `dist`. There's no config watcher or rebuild supervisor, since a build is fixed.

## Notable pieces to review

> [!WARNING]
> No e2e tests yet: the deployed workbench UI can't load a locally-served build's `mf-manifest.json` cross-origin until saison adds the CORS headers. Covered by unit tests for now.

- `serverOrchestration.ts` (new): the ordered teardown + signal handling shared by `dev` and `start`, pulled out so both unwind their servers the same way.
- `registry.ts` — the synchronous `exit` backstop. Vite installs its own `SIGTERM` handler that calls `process.exit()`, which can beat the async teardown and leave a stray registry entry or workbench lock behind. The backstop removes both on any exit. It also hardens `dev`.
- The `mode` thread (`development`/`preview`). `preview` loads `.env.development`, which points the workbench UI at a local dev server (`localhost:5173`) that isn't running in a production preview. In `preview` the shell drops that override, so the deployed workbench UI loads — picked by `SANITY_INTERNAL_ENV`. `@sanity/workbench` is unchanged.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new multi-server CLI path (ports, registry, locks) shared with dev; behavior is heavily unit-tested but end-to-end preview against the deployed workbench UI is blocked on cross-origin/CORS until upstream headers land.
> 
> **Overview**
> **`sanity start` / `sanity preview`** now supports workbench apps: when the project uses `unstable_defineApp`, `previewAction` lazily delegates to `@sanity/workbench-cli/preview` instead of the static `index.html` preview server. Non-workbench previews are unchanged.
> 
> **Preview flow** mirrors `sanity dev`: start the singleton workbench shell (`startWorkbenchDevServer` with **`mode: 'preview'`**), serve the built `dist` as a module-federation remote via **`serveBuiltApplication`** (Vite `preview` + `checkBuiltOutput`), and **`registerDevServer`** so the shell federates the build like a live dev remote—without config watching or rebuild.
> 
> **Supporting changes:** missing federation output is tagged **`BUILD_NOT_FOUND`** (same “run `sanity build`” hint as studio). **`preview` mode** ignores `SANITY_INTERNAL_WORKBENCH_REMOTE_URL` so the deployed workbench UI loads. **`serverOrchestration`** centralizes multi-server teardown and signal handling for dev and start. The dev-server **registry** gains a synchronous **`process.exit` backstop** so locks and pid manifests are not left behind when Vite exits before async cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e25df3eb9dbc627cc703d61b2853f0f6c7a2bec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->