### PR TITLE
fix(cli-core): avoid terminating active studio workers

### DIFF
--- a/.changeset/pr-1551.md
+++ b/.changeset/pr-1551.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': patch
+'@sanity/cli': patch
+---
+
+fix(cli-core): avoid terminating active studio workers

--- a/packages/@sanity/cli-core/src/loaders/studio/__tests__/studioWorkerLifecycle.test.ts
+++ b/packages/@sanity/cli-core/src/loaders/studio/__tests__/studioWorkerLifecycle.test.ts
@@ -1,0 +1,172 @@
+import {type MessagePort} from 'node:worker_threads'
+
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {
+  createOneShotWorkerLifecycle,
+  deserializeStudioWorkerError,
+  isStudioWorkerErrorMessage,
+} from '../studioWorkerLifecycle.js'
+
+function createMockParentPort(postMessage = vi.fn()) {
+  return {
+    parentPort: {postMessage} as unknown as MessagePort,
+    postMessage,
+  }
+}
+
+describe('createOneShotWorkerLifecycle', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  test('closes the server before forwarding the task result', async () => {
+    const calls: string[] = []
+    const {parentPort, postMessage} = createMockParentPort(vi.fn(() => calls.push('postMessage')))
+    const closeServer = vi.fn(async () => {
+      calls.push('closeServer')
+    })
+    const lifecycle = createOneShotWorkerLifecycle({
+      closeServer,
+      onCloseError: vi.fn(),
+      parentPort,
+    })
+
+    parentPort.postMessage({type: 'success'})
+    await lifecycle.close()
+
+    expect(calls).toEqual(['closeServer', 'postMessage'])
+    expect(closeServer).toHaveBeenCalledOnce()
+    expect(postMessage).toHaveBeenCalledWith({type: 'success'})
+  })
+
+  test('forwards transfer lists after closing the server', async () => {
+    const {parentPort, postMessage} = createMockParentPort()
+    const lifecycle = createOneShotWorkerLifecycle({
+      closeServer: vi.fn().mockResolvedValue(undefined),
+      onCloseError: vi.fn(),
+      parentPort,
+    })
+    const buffer = new ArrayBuffer(8)
+
+    parentPort.postMessage('result', [buffer])
+    await lifecycle.close()
+
+    expect(postMessage).toHaveBeenCalledWith('result', [buffer])
+  })
+
+  test('uses one close attempt for the result and finalizer', async () => {
+    const {parentPort} = createMockParentPort()
+    const closeServer = vi.fn().mockResolvedValue(undefined)
+    const lifecycle = createOneShotWorkerLifecycle({
+      closeServer,
+      onCloseError: vi.fn(),
+      parentPort,
+    })
+
+    parentPort.postMessage('result')
+    await Promise.all([lifecycle.close(), lifecycle.close()])
+
+    expect(closeServer).toHaveBeenCalledOnce()
+  })
+
+  test('forwards the result when closing the server rejects', async () => {
+    const closeError = new Error('close failed')
+    const onCloseError = vi.fn()
+    const {parentPort, postMessage} = createMockParentPort()
+    const lifecycle = createOneShotWorkerLifecycle({
+      closeServer: vi.fn().mockRejectedValue(closeError),
+      onCloseError,
+      parentPort,
+    })
+
+    parentPort.postMessage('result')
+    await lifecycle.close()
+
+    expect(onCloseError).toHaveBeenCalledWith(closeError)
+    expect(postMessage).toHaveBeenCalledWith('result')
+  })
+
+  test('bounds a hung server close before forwarding the result', async () => {
+    vi.useFakeTimers()
+    const onCloseError = vi.fn()
+    const {parentPort, postMessage} = createMockParentPort()
+    const lifecycle = createOneShotWorkerLifecycle({
+      closeServer: vi.fn(() => new Promise<void>(() => {})),
+      onCloseError,
+      parentPort,
+      timeout: 500,
+    })
+
+    const closePromise = lifecycle.close()
+    parentPort.postMessage('result')
+    await vi.advanceTimersByTimeAsync(500)
+    await closePromise
+
+    expect(onCloseError).toHaveBeenCalledWith(
+      expect.objectContaining({message: 'Vite server close timed out after 500ms'}),
+    )
+    expect(postMessage).toHaveBeenCalledWith('result')
+  })
+
+  test('posts serialized task errors after closing the server', async () => {
+    const calls: string[] = []
+    const {parentPort, postMessage} = createMockParentPort(vi.fn(() => calls.push('postError')))
+    const lifecycle = createOneShotWorkerLifecycle({
+      closeServer: vi.fn(async () => {
+        calls.push('closeServer')
+      }),
+      onCloseError: vi.fn(),
+      parentPort,
+    })
+
+    await lifecycle.postError(new TypeError('invalid config'))
+
+    expect(calls).toEqual(['closeServer', 'postError'])
+    const message: unknown = postMessage.mock.calls[0]?.[0]
+    expect(isStudioWorkerErrorMessage(message)).toBe(true)
+    if (!isStudioWorkerErrorMessage(message)) throw new Error('Expected worker error message')
+
+    const error = deserializeStudioWorkerError(message)
+    expect(error).toMatchObject({
+      cause: expect.objectContaining({message: 'invalid config', name: 'TypeError'}),
+      message: 'Worker error: invalid config',
+    })
+  })
+
+  test('serializes thrown non-error values', async () => {
+    const {parentPort, postMessage} = createMockParentPort()
+    const lifecycle = createOneShotWorkerLifecycle({
+      closeServer: vi.fn().mockResolvedValue(undefined),
+      onCloseError: vi.fn(),
+      parentPort,
+    })
+
+    await lifecycle.postError('invalid config')
+
+    expect(postMessage).toHaveBeenCalledWith({
+      error: {message: 'invalid config', name: 'Error'},
+      type: 'sanity.studioWorker.error',
+    })
+  })
+})
+
+describe('isStudioWorkerErrorMessage', () => {
+  test.each([
+    undefined,
+    null,
+    'error',
+    {},
+    {type: 'different'},
+    {error: null, type: 'sanity.studioWorker.error'},
+    {error: {message: 42, name: 'Error'}, type: 'sanity.studioWorker.error'},
+    {error: {message: 'broken', name: 42}, type: 'sanity.studioWorker.error'},
+    {
+      error: {message: 'broken', name: 'Error', stack: 42},
+      type: 'sanity.studioWorker.error',
+    },
+  ])('rejects malformed values: %o', (value) => {
+    expect(isStudioWorkerErrorMessage(value)).toBe(false)
+  })
+})

--- a/packages/@sanity/cli-core/src/loaders/studio/__tests__/studioWorkerTask.test.ts
+++ b/packages/@sanity/cli-core/src/loaders/studio/__tests__/studioWorkerTask.test.ts
@@ -1,0 +1,135 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {createStudioWorker, studioWorkerTask} from '../studioWorkerTask.js'
+
+const mockPromisifyWorker = vi.hoisted(() => vi.fn())
+const mockWorker = vi.hoisted(() =>
+  vi.fn(function MockWorker() {
+    return {}
+  }),
+)
+
+vi.mock(import('../../../util/promisifyWorker.js'), () => ({
+  promisifyWorker: mockPromisifyWorker,
+}))
+
+vi.mock('node:worker_threads', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:worker_threads')>()),
+  Worker: mockWorker,
+}))
+
+const TASK_URL = new URL('file:///test/example.worker.ts')
+
+describe('studioWorkerTask', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('marks the worker as one-shot and disables forced termination', async () => {
+    mockPromisifyWorker.mockResolvedValue({type: 'success'})
+
+    await studioWorkerTask(TASK_URL, {
+      env: {CUSTOM_ENV: 'value'},
+      name: 'example',
+      studioRootPath: '/studio',
+      timeout: 10_000,
+      workerData: {input: true},
+    })
+
+    expect(mockPromisifyWorker).toHaveBeenCalledWith(
+      expect.objectContaining({pathname: expect.stringContaining('studioWorkerLoader.worker.js')}),
+      {
+        env: {
+          CUSTOM_ENV: 'value',
+          STUDIO_WORKER_ONE_SHOT: '1',
+          STUDIO_WORKER_STUDIO_ROOT_PATH: '/studio',
+          STUDIO_WORKER_TASK_FILE: '/test/example.worker.ts',
+        },
+        name: 'example',
+        terminateOnSettle: false,
+        timeout: 10_000,
+        workerData: {input: true},
+      },
+    )
+  })
+
+  test('returns ordinary task messages', async () => {
+    const result = {type: 'success', value: 42}
+    mockPromisifyWorker.mockResolvedValue(result)
+
+    await expect(
+      studioWorkerTask(TASK_URL, {name: 'example', studioRootPath: '/studio'}),
+    ).resolves.toBe(result)
+  })
+
+  test('rejects with serialized loader errors and preserves their cause', async () => {
+    mockPromisifyWorker.mockResolvedValue({
+      error: {
+        message: 'Invalid studio config',
+        name: 'TypeError',
+        stack: 'TypeError: Invalid studio config',
+      },
+      type: 'sanity.studioWorker.error',
+    })
+
+    const promise = studioWorkerTask(TASK_URL, {name: 'example', studioRootPath: '/studio'})
+
+    await expect(promise).rejects.toMatchObject({
+      cause: expect.objectContaining({
+        message: 'Invalid studio config',
+        name: 'TypeError',
+        stack: 'TypeError: Invalid studio config',
+      }),
+      message: 'Worker error: Invalid studio config',
+    })
+  })
+
+  test('validates the task file name before creating a worker', () => {
+    expect(() =>
+      studioWorkerTask(new URL('file:///test/example.ts'), {
+        name: 'example',
+        studioRootPath: '/studio',
+      }),
+    ).toThrow('Studio worker tasks must include `.worker.(js|ts)` in path')
+    expect(mockPromisifyWorker).not.toHaveBeenCalled()
+  })
+})
+
+describe('createStudioWorker', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('does not mark long-lived workers as one-shot', () => {
+    createStudioWorker(TASK_URL, {
+      env: {CUSTOM_ENV: 'value'},
+      name: 'example',
+      studioRootPath: '/studio',
+      workerData: {input: true},
+    })
+
+    expect(mockWorker).toHaveBeenCalledWith(
+      expect.objectContaining({pathname: expect.stringContaining('studioWorkerLoader.worker.js')}),
+      {
+        env: {
+          CUSTOM_ENV: 'value',
+          STUDIO_WORKER_STUDIO_ROOT_PATH: '/studio',
+          STUDIO_WORKER_TASK_FILE: '/test/example.worker.ts',
+        },
+        name: 'example',
+        studioRootPath: '/studio',
+        workerData: {input: true},
+      },
+    )
+  })
+
+  test('validates the task file name before creating a worker', () => {
+    expect(() =>
+      createStudioWorker(new URL('file:///test/example.ts'), {
+        name: 'example',
+        studioRootPath: '/studio',
+      }),
+    ).toThrow('Studio worker tasks must include `.worker.(js|ts)` in path')
+    expect(mockWorker).not.toHaveBeenCalled()
+  })
+})

--- a/packages/@sanity/cli-core/src/loaders/studio/__tests__/studioWorkerTask.test.ts
+++ b/packages/@sanity/cli-core/src/loaders/studio/__tests__/studioWorkerTask.test.ts
@@ -1,3 +1,5 @@
+import {fileURLToPath} from 'node:url'
+
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {createStudioWorker, studioWorkerTask} from '../studioWorkerTask.js'
@@ -18,7 +20,9 @@ vi.mock('node:worker_threads', async (importOriginal) => ({
   Worker: mockWorker,
 }))
 
-const TASK_URL = new URL('file:///test/example.worker.ts')
+const INVALID_TASK_URL = new URL('example.ts', import.meta.url)
+const TASK_URL = new URL('example.worker.ts', import.meta.url)
+const TASK_PATH = fileURLToPath(TASK_URL)
 
 describe('studioWorkerTask', () => {
   afterEach(() => {
@@ -43,7 +47,7 @@ describe('studioWorkerTask', () => {
           CUSTOM_ENV: 'value',
           STUDIO_WORKER_ONE_SHOT: '1',
           STUDIO_WORKER_STUDIO_ROOT_PATH: '/studio',
-          STUDIO_WORKER_TASK_FILE: '/test/example.worker.ts',
+          STUDIO_WORKER_TASK_FILE: TASK_PATH,
         },
         name: 'example',
         terminateOnSettle: false,
@@ -86,7 +90,7 @@ describe('studioWorkerTask', () => {
 
   test('validates the task file name before creating a worker', () => {
     expect(() =>
-      studioWorkerTask(new URL('file:///test/example.ts'), {
+      studioWorkerTask(INVALID_TASK_URL, {
         name: 'example',
         studioRootPath: '/studio',
       }),
@@ -114,7 +118,7 @@ describe('createStudioWorker', () => {
         env: {
           CUSTOM_ENV: 'value',
           STUDIO_WORKER_STUDIO_ROOT_PATH: '/studio',
-          STUDIO_WORKER_TASK_FILE: '/test/example.worker.ts',
+          STUDIO_WORKER_TASK_FILE: TASK_PATH,
         },
         name: 'example',
         studioRootPath: '/studio',
@@ -125,7 +129,7 @@ describe('createStudioWorker', () => {
 
   test('validates the task file name before creating a worker', () => {
     expect(() =>
-      createStudioWorker(new URL('file:///test/example.ts'), {
+      createStudioWorker(INVALID_TASK_URL, {
         name: 'example',
         studioRootPath: '/studio',
       }),

--- a/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLifecycle.ts
+++ b/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLifecycle.ts
@@ -100,6 +100,8 @@ export function isStudioWorkerErrorMessage(value: unknown): value is StudioWorke
 function closeServerWithTimeout(closeServer: () => Promise<void>, timeout: number): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const timeoutId = setTimeout(() => {
+      // Vite does not expose cancellation for close(); stop waiting while the
+      // unrefed worker lets the still-pending close finish with process teardown.
       reject(new Error(`Vite server close timed out after ${timeout}ms`))
     }, timeout)
 

--- a/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLifecycle.ts
+++ b/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLifecycle.ts
@@ -1,0 +1,140 @@
+import {type MessagePort} from 'node:worker_threads'
+
+export const DEFAULT_STUDIO_WORKER_CLOSE_TIMEOUT = 5000
+
+const STUDIO_WORKER_ERROR_MARKER = 'sanity.studioWorker.error'
+
+interface SerializedStudioWorkerError {
+  message: string
+  name: string
+
+  stack?: string
+}
+
+export interface StudioWorkerErrorMessage {
+  error: SerializedStudioWorkerError
+  type: typeof STUDIO_WORKER_ERROR_MARKER
+}
+
+interface OneShotWorkerLifecycle {
+  close: () => Promise<void>
+  postError: (error: unknown) => Promise<void>
+}
+
+interface OneShotWorkerLifecycleOptions {
+  closeServer: () => Promise<void>
+  onCloseError: (error: unknown) => void
+  parentPort: MessagePort
+
+  timeout?: number
+}
+
+/**
+ * Defers messages from a one-shot studio worker until its Vite server has had
+ * a bounded opportunity to close. Closing is single-flight so the task's final
+ * message and the loader's finalizer can safely request it at the same time.
+ */
+export function createOneShotWorkerLifecycle(
+  options: OneShotWorkerLifecycleOptions,
+): OneShotWorkerLifecycle {
+  const {
+    closeServer,
+    onCloseError,
+    parentPort,
+    timeout = DEFAULT_STUDIO_WORKER_CLOSE_TIMEOUT,
+  } = options
+  let closePromise: Promise<void> | undefined
+
+  const close = () => {
+    closePromise ??= closeServerWithTimeout(closeServer, timeout).catch((error) => {
+      onCloseError(error)
+    })
+    return closePromise
+  }
+
+  const originalPostMessage = parentPort.postMessage.bind(parentPort)
+  parentPort.postMessage = (...args: Parameters<MessagePort['postMessage']>) => {
+    void close().then(() => originalPostMessage(...args))
+  }
+
+  return {
+    close,
+    async postError(error) {
+      await close()
+      originalPostMessage(serializeStudioWorkerError(error))
+    },
+  }
+}
+
+export function deserializeStudioWorkerError(message: StudioWorkerErrorMessage): Error {
+  const cause = new Error(message.error.message)
+  cause.name = message.error.name
+  if (message.error.stack) cause.stack = message.error.stack
+
+  return new Error(`Worker error: ${message.error.message}`, {cause})
+}
+
+export function isStudioWorkerErrorMessage(value: unknown): value is StudioWorkerErrorMessage {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('type' in value) ||
+    value.type !== STUDIO_WORKER_ERROR_MARKER ||
+    !('error' in value) ||
+    typeof value.error !== 'object' ||
+    value.error === null
+  ) {
+    return false
+  }
+
+  const {error} = value
+  return (
+    'message' in error &&
+    typeof error.message === 'string' &&
+    'name' in error &&
+    typeof error.name === 'string' &&
+    (!('stack' in error) || error.stack === undefined || typeof error.stack === 'string')
+  )
+}
+
+function closeServerWithTimeout(closeServer: () => Promise<void>, timeout: number): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`Vite server close timed out after ${timeout}ms`))
+    }, timeout)
+
+    void Promise.resolve()
+      .then(closeServer)
+      .then(
+        () => {
+          clearTimeout(timeoutId)
+          resolve()
+        },
+        (error: unknown) => {
+          clearTimeout(timeoutId)
+          reject(error)
+        },
+      )
+  })
+}
+
+function serializeStudioWorkerError(error: unknown): StudioWorkerErrorMessage {
+  if (error instanceof Error) {
+    return {
+      error: {
+        message: error.message,
+        name: error.name,
+        ...(error.stack ? {stack: error.stack} : {}),
+      },
+      type: STUDIO_WORKER_ERROR_MARKER,
+    }
+  }
+
+  return {
+    error: {
+      message: String(error),
+      name: 'Error',
+    },
+    type: STUDIO_WORKER_ERROR_MARKER,
+  }
+}

--- a/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLifecycle.ts
+++ b/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLifecycle.ts
@@ -1,6 +1,6 @@
 import {type MessagePort} from 'node:worker_threads'
 
-export const DEFAULT_STUDIO_WORKER_CLOSE_TIMEOUT = 5000
+const DEFAULT_STUDIO_WORKER_CLOSE_TIMEOUT = 5000
 
 const STUDIO_WORKER_ERROR_MARKER = 'sanity.studioWorker.error'
 

--- a/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLoader.worker.ts
+++ b/packages/@sanity/cli-core/src/loaders/studio/studioWorkerLoader.worker.ts
@@ -1,4 +1,4 @@
-import {isMainThread} from 'node:worker_threads'
+import {isMainThread, parentPort} from 'node:worker_threads'
 
 import {createServer, type InlineConfig, loadEnv, mergeConfig} from 'vite'
 import {ViteNodeRunner} from 'vite-node/client'
@@ -12,6 +12,7 @@ import {isNotFoundError} from '../../errors/NotFoundError.js'
 import {getStudioEnvironmentVariables} from '../../util/environment/getStudioEnvironmentVariables.js'
 import {setupBrowserStubs} from '../../util/environment/setupBrowserStubs.js' // TODO: this imports jsdom!!! Unpacked Size (module + dependencies): 26 MB
 import {isRecord} from '../../util/isRecord.js'
+import {createOneShotWorkerLifecycle} from './studioWorkerLifecycle.js'
 
 if (isMainThread) {
   throw new Error('Should be child of thread, not the main thread')
@@ -126,58 +127,77 @@ debug('Creating Vite server with config: %o', viteConfig)
 // We include the inject plugin in order to provide the stubs for the undefined global APIs.
 const server = await createServer(viteConfig)
 
-// Bit of a hack, but seems necessary based on the `node-vite` binary implementation
-await server.pluginContainer.buildStart({})
+const lifecycle =
+  process.env.STUDIO_WORKER_ONE_SHOT === '1' && parentPort
+    ? createOneShotWorkerLifecycle({
+        closeServer: () => server.close(),
+        onCloseError: (error) => debug('Failed to close Vite server: %o', error),
+        parentPort,
+      })
+    : undefined
 
-// Load environment variables from `.env` files in the same way as Vite does.
-// Note that Sanity also provides environment variables through `process.env.*` for compat reasons,
-// and so we need to do the same here.
-// Load ALL env vars from .env files (not just studio-prefixed ones) so non-Sanity-prefixed
-// vars (e.g. NEXT_PUBLIC_*, VITE_*) are available via process.env at runtime.
-// The ??= on the next line prevents overwriting existing process.env values.
-const env = loadEnv(server.config.mode, server.config.envDir, '')
-for (const key in env) {
-  process.env[key] ??= env[key]
+try {
+  // Bit of a hack, but seems necessary based on the `node-vite` binary implementation
+  await server.pluginContainer.buildStart({})
+
+  // Load environment variables from `.env` files in the same way as Vite does.
+  // Note that Sanity also provides environment variables through `process.env.*` for compat reasons,
+  // and so we need to do the same here.
+  // Load ALL env vars from .env files (not just studio-prefixed ones) so non-Sanity-prefixed
+  // vars (e.g. NEXT_PUBLIC_*, VITE_*) are available via process.env at runtime.
+  // The ??= on the next line prevents overwriting existing process.env values.
+  const env = loadEnv(server.config.mode, server.config.envDir, '')
+  for (const key in env) {
+    process.env[key] ??= env[key]
+  }
+
+  // Now we're providing the glue that ensures node-specific loading and execution works.
+  const node = new ViteNodeServer(server)
+
+  // Should make it easier to debug any crashes in the imported code…
+  installSourcemapsSupport({
+    getSourceMap: (source) => node.getSourceMap(source),
+  })
+
+  const runner = new ViteNodeRunner({
+    base: server.config.base,
+    async fetchModule(id) {
+      // Vite's SSR transform externalizes https:// imports, so Node's ESM loader
+      // would reject them. We fetch the module over HTTP and run it through Vite's
+      // SSR transform to rewrite ESM export/import syntax to the __vite_ssr_*
+      // format that ViteNodeRunner expects.
+      if (isHttpsUrl(id)) {
+        const {code: rawCode} = await fetchHttpModule(id)
+        const result = await server.ssrTransform(rawCode, null, id)
+        return {code: result?.code || rawCode}
+      }
+      return node.fetchModule(id)
+    },
+    resolveId(id, importer) {
+      // Prevent vite-node from trying to resolve HTTP URLs through Node's resolver
+      if (isHttpsUrl(id)) return {id}
+      // Resolve any import from an HTTP-fetched module against the remote origin
+      // (e.g. esm.sh returns `export * from '/pkg@1.0/es2022/pkg.mjs'`)
+      if (importer && isHttpsUrl(importer)) {
+        return {id: new URL(id, importer).href}
+      }
+      return node.resolveId(id, importer)
+    },
+    root: server.config.root,
+  })
+
+  // Copied from `vite-node` - it appears that this applies the `define` config from
+  // vite, but it also takes a surprisingly long time to execute. Not clear at this
+  // point why this is, so we should investigate whether it's necessary or not.
+  await runner.executeId('/@vite/env')
+
+  await runner.executeId(workerScriptPath)
+} catch (error) {
+  if (!lifecycle) {
+    throw error
+  }
+
+  await lifecycle.postError(error)
+} finally {
+  await lifecycle?.close()
 }
-
-// Now we're providing the glue that ensures node-specific loading and execution works.
-const node = new ViteNodeServer(server)
-
-// Should make it easier to debug any crashes in the imported code…
-installSourcemapsSupport({
-  getSourceMap: (source) => node.getSourceMap(source),
-})
-
-const runner = new ViteNodeRunner({
-  base: server.config.base,
-  async fetchModule(id) {
-    // Vite's SSR transform externalizes https:// imports, so Node's ESM loader
-    // would reject them. We fetch the module over HTTP and run it through Vite's
-    // SSR transform to rewrite ESM export/import syntax to the __vite_ssr_*
-    // format that ViteNodeRunner expects.
-    if (isHttpsUrl(id)) {
-      const {code: rawCode} = await fetchHttpModule(id)
-      const result = await server.ssrTransform(rawCode, null, id)
-      return {code: result?.code || rawCode}
-    }
-    return node.fetchModule(id)
-  },
-  resolveId(id, importer) {
-    // Prevent vite-node from trying to resolve HTTP URLs through Node's resolver
-    if (isHttpsUrl(id)) return {id}
-    // Resolve any import from an HTTP-fetched module against the remote origin
-    // (e.g. esm.sh returns `export * from '/pkg@1.0/es2022/pkg.mjs'`)
-    if (importer && isHttpsUrl(importer)) {
-      return {id: new URL(id, importer).href}
-    }
-    return node.resolveId(id, importer)
-  },
-  root: server.config.root,
-})
-
-// Copied from `vite-node` - it appears that this applies the `define` config from
-// vite, but it also takes a surprisingly long time to execute. Not clear at this
-// point why this is, so we should investigate whether it's necessary or not.
-await runner.executeId('/@vite/env')
-
-await runner.executeId(workerScriptPath)

--- a/packages/@sanity/cli-core/src/loaders/studio/studioWorkerTask.ts
+++ b/packages/@sanity/cli-core/src/loaders/studio/studioWorkerTask.ts
@@ -4,6 +4,11 @@ import {Worker, type WorkerOptions} from 'node:worker_threads'
 import {type RequireProps} from '../../types.js'
 import {isRecord} from '../../util/isRecord.js'
 import {promisifyWorker} from '../../util/promisifyWorker.js'
+import {
+  deserializeStudioWorkerError,
+  isStudioWorkerErrorMessage,
+  type StudioWorkerErrorMessage,
+} from './studioWorkerLifecycle.js'
 
 /**
  * Options for the studio worker task
@@ -13,7 +18,7 @@ import {promisifyWorker} from '../../util/promisifyWorker.js'
 interface StudioWorkerTaskOptions extends RequireProps<WorkerOptions, 'name'> {
   studioRootPath: string
 
-  /** Optional timeout in milliseconds. If the worker does not respond within this time, it will be terminated and the promise rejected. */
+  /** Optional timeout in milliseconds. If the worker does not respond within this time, the promise is rejected. */
   timeout?: number
 }
 
@@ -56,14 +61,27 @@ export function studioWorkerTask<T = unknown>(
   }
 
   const {studioRootPath, timeout, ...workerOptions} = options
-  return promisifyWorker<T>(new URL('studioWorkerLoader.worker.js', import.meta.url), {
-    ...workerOptions,
-    env: {
-      ...(isRecord(workerOptions.env) ? workerOptions.env : process.env),
-      STUDIO_WORKER_STUDIO_ROOT_PATH: studioRootPath,
-      STUDIO_WORKER_TASK_FILE: normalizedFilePath,
+  const workerPromise = promisifyWorker<StudioWorkerErrorMessage | T>(
+    new URL('studioWorkerLoader.worker.js', import.meta.url),
+    {
+      ...workerOptions,
+      env: {
+        ...(isRecord(workerOptions.env) ? workerOptions.env : process.env),
+        STUDIO_WORKER_ONE_SHOT: '1',
+        STUDIO_WORKER_STUDIO_ROOT_PATH: studioRootPath,
+        STUDIO_WORKER_TASK_FILE: normalizedFilePath,
+      },
+      terminateOnSettle: false,
+      timeout,
     },
-    timeout,
+  )
+
+  return workerPromise.then((result) => {
+    if (isStudioWorkerErrorMessage(result)) {
+      throw deserializeStudioWorkerError(result)
+    }
+
+    return result
   })
 }
 

--- a/packages/@sanity/cli-core/src/util/__tests__/promisifyWorker.test.ts
+++ b/packages/@sanity/cli-core/src/util/__tests__/promisifyWorker.test.ts
@@ -18,6 +18,7 @@ function createMockWorker() {
       for (const key of Object.keys(listeners)) delete listeners[key]
     }),
     terminate: vi.fn(),
+    unref: vi.fn(),
   }
 }
 
@@ -114,6 +115,20 @@ describe('promisifyWorker', () => {
     expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
   })
 
+  test('unrefs without terminating when forced termination is disabled', async () => {
+    const promise = promisifyWorker(TEST_WORKER_URL, {
+      name: 'test',
+      terminateOnSettle: false,
+    })
+
+    lastCreatedWorker.emit('message', 'data')
+    await promise
+
+    expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.terminate).not.toHaveBeenCalled()
+    expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
+  })
+
   test('removes all listeners after receiving a message', async () => {
     const promise = promisifyWorker(TEST_WORKER_URL, {name: 'test'})
 
@@ -144,6 +159,23 @@ describe('promisifyWorker', () => {
     expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
     expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
   })
+
+  test.each(['error', 'messageerror'])(
+    'unrefs without terminating after a worker %s',
+    async (event) => {
+      const promise = promisifyWorker(TEST_WORKER_URL, {
+        name: 'test',
+        terminateOnSettle: false,
+      })
+
+      lastCreatedWorker.emit(event, new Error('fail'))
+      await promise.catch(() => {})
+
+      expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
+      expect(lastCreatedWorker.terminate).not.toHaveBeenCalled()
+      expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
+    },
+  )
 
   test('resolves with only the first message when multiple are emitted', async () => {
     const promise = promisifyWorker(TEST_WORKER_URL, {name: 'test'})
@@ -202,6 +234,23 @@ describe('promisifyWorker', () => {
     await expect(promise).rejects.toThrow('Worker timed out after 500ms')
 
     expect(lastCreatedWorker.terminate).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
+  })
+
+  test('unrefs without terminating when the timeout expires and forced termination is disabled', async () => {
+    vi.useFakeTimers()
+
+    const promise = promisifyWorker(TEST_WORKER_URL, {
+      name: 'test',
+      terminateOnSettle: false,
+      timeout: 500,
+    })
+
+    vi.advanceTimersByTime(500)
+
+    await expect(promise).rejects.toThrow('Worker timed out after 500ms')
+    expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.terminate).not.toHaveBeenCalled()
     expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
   })
 

--- a/packages/@sanity/cli-core/src/util/__tests__/promisifyWorker.test.ts
+++ b/packages/@sanity/cli-core/src/util/__tests__/promisifyWorker.test.ts
@@ -12,7 +12,12 @@ function createMockWorker() {
       listeners[event].push(cb)
     }),
     emit(event: string, ...args: unknown[]) {
-      for (const cb of listeners[event] ?? []) cb(...args)
+      const callbacks = listeners[event] ?? []
+      if (event === 'error' && callbacks.length === 0) {
+        const [error] = args
+        throw error instanceof Error ? error : new Error(String(error))
+      }
+      for (const cb of callbacks) cb(...args)
     },
     removeAllListeners: vi.fn(() => {
       for (const key of Object.keys(listeners)) delete listeners[key]

--- a/packages/@sanity/cli-core/src/util/__tests__/promisifyWorker.test.ts
+++ b/packages/@sanity/cli-core/src/util/__tests__/promisifyWorker.test.ts
@@ -127,6 +127,11 @@ describe('promisifyWorker', () => {
     expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
     expect(lastCreatedWorker.terminate).not.toHaveBeenCalled()
     expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.addListener).toHaveBeenLastCalledWith('error', expect.any(Function))
+
+    lastCreatedWorker.emit('error', new Error('late worker failure'))
+    expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
   })
 
   test('removes all listeners after receiving a message', async () => {
@@ -252,6 +257,7 @@ describe('promisifyWorker', () => {
     expect(lastCreatedWorker.unref).toHaveBeenCalledOnce()
     expect(lastCreatedWorker.terminate).not.toHaveBeenCalled()
     expect(lastCreatedWorker.removeAllListeners).toHaveBeenCalledOnce()
+    expect(lastCreatedWorker.addListener).toHaveBeenLastCalledWith('error', expect.any(Function))
   })
 
   test('cleans up timer after an error', async () => {

--- a/packages/@sanity/cli-core/src/util/promisifyWorker.ts
+++ b/packages/@sanity/cli-core/src/util/promisifyWorker.ts
@@ -45,7 +45,7 @@ export function promisifyWorker<T = unknown>(
       timeoutId = setTimeout(() => {
         settled = true
         reject(new Error(`Worker timed out after ${timeout}ms`))
-        cleanup()
+        cleanup(false)
       }, timeout)
     }
 
@@ -83,9 +83,13 @@ export function promisifyWorker<T = unknown>(
       cleanup()
     })
 
-    function cleanup() {
+    function cleanup(deferTermination = true) {
       if (terminateOnSettle) {
-        setImmediate(() => void worker.terminate())
+        if (deferTermination) {
+          setImmediate(() => void worker.terminate())
+        } else {
+          void worker.terminate()
+        }
       } else {
         worker.unref()
       }

--- a/packages/@sanity/cli-core/src/util/promisifyWorker.ts
+++ b/packages/@sanity/cli-core/src/util/promisifyWorker.ts
@@ -5,7 +5,13 @@ import {subdebug} from '../_exports/debug.js'
 const debug = subdebug('promisifyWorker')
 
 interface PromisifyWorkerOptions extends WorkerOptions {
-  /** Optional timeout in milliseconds. If the worker does not respond within this time, it will be terminated and the promise rejected. */
+  /**
+   * Whether to forcibly terminate the worker after settling. Disable this for
+   * workers that host native addons which must tear down with the process.
+   */
+  terminateOnSettle?: boolean
+
+  /** Optional timeout in milliseconds. If the worker does not respond within this time, the promise is rejected. */
   timeout?: number
 }
 
@@ -13,7 +19,8 @@ interface PromisifyWorkerOptions extends WorkerOptions {
  * Creates a Node.js Worker from the given file path and options, and wraps it
  * in a Promise that resolves with the first message the worker sends, and
  * rejects on error, message deserialization failure, or non-zero exit code.
- * The worker is terminated after a message or error is received.
+ * By default, the worker is terminated after a message or error is received.
+ * Callers can instead unref it and allow natural process teardown.
  *
  * @param filePath - URL to the worker file
  * @param options - Options to pass to the Worker constructor
@@ -25,7 +32,7 @@ export function promisifyWorker<T = unknown>(
   filePath: URL,
   options?: PromisifyWorkerOptions,
 ): Promise<T> {
-  const {timeout, ...workerOptions} = options ?? {}
+  const {terminateOnSettle = true, timeout, ...workerOptions} = options ?? {}
   const worker = new Worker(filePath, workerOptions)
 
   const fileName = `[${filePath.pathname}]`
@@ -38,8 +45,7 @@ export function promisifyWorker<T = unknown>(
       timeoutId = setTimeout(() => {
         settled = true
         reject(new Error(`Worker timed out after ${timeout}ms`))
-        void worker.terminate()
-        worker.removeAllListeners()
+        cleanup()
       }, timeout)
     }
 
@@ -78,7 +84,11 @@ export function promisifyWorker<T = unknown>(
     })
 
     function cleanup() {
-      setImmediate(() => worker.terminate())
+      if (terminateOnSettle) {
+        setImmediate(() => void worker.terminate())
+      } else {
+        worker.unref()
+      }
       worker.removeAllListeners()
     }
   })

--- a/packages/@sanity/cli-core/src/util/promisifyWorker.ts
+++ b/packages/@sanity/cli-core/src/util/promisifyWorker.ts
@@ -4,10 +4,16 @@ import {subdebug} from '../_exports/debug.js'
 
 const debug = subdebug('promisifyWorker')
 
+function onDetachedWorkerError(err: Error) {
+  debug(`Detached worker error: ${err.message}`, err)
+}
+
 interface PromisifyWorkerOptions extends WorkerOptions {
   /**
    * Whether to forcibly terminate the worker after settling. Disable this for
-   * workers that host native addons which must tear down with the process.
+   * workers that host native addons which must tear down with the process. A
+   * disabled worker is unrefed and may continue running until the process exits,
+   * including after a timeout.
    */
   terminateOnSettle?: boolean
 
@@ -90,10 +96,15 @@ export function promisifyWorker<T = unknown>(
         } else {
           void worker.terminate()
         }
-      } else {
-        worker.unref()
+        worker.removeAllListeners()
+        return
       }
+
+      worker.unref()
       worker.removeAllListeners()
+      // A detached worker may still fail before process teardown. Keep an error
+      // listener so EventEmitter does not rethrow it in the parent process.
+      worker.addListener('error', onDetachedWorkerError)
     }
   })
 }

--- a/packages/@sanity/cli/test/integration/commands/schemas/validate.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/schemas/validate.test.ts
@@ -67,4 +67,19 @@ describe('#schema:validate', {timeout: 60 * 1000}, () => {
     expect(stdout).toContain('A type with name "post" is already defined in the schema')
     expect(error?.oclif?.exit).toBe(1)
   })
+
+  test('should surface errors thrown while loading the studio config', async () => {
+    const cwd = await testFixture('basic-studio')
+    process.chdir(cwd)
+
+    const configPath = join(cwd, 'sanity.config.ts')
+    const content = await readFile(configPath, 'utf8')
+    await writeFile(configPath, `throw new TypeError('Invalid studio config')\n${content}`)
+
+    const {error, stderr} = await testCommand(SchemaValidate, [])
+
+    expect(stderr).toContain('Validating schema')
+    expect(error?.message).toContain('Worker error: Invalid studio config')
+    expect(error?.oclif?.exit).toBe(1)
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes #1511 and AIGRO-5193. Related to sanity-io/sanity#13537 and the worker-race component reported in #1304.

One-shot Studio workers now close their Vite server before reporting a result, forward setup/task errors after cleanup, and unref instead of forcibly terminating workers with live Rolldown native threads. Detached workers retain an error listener so late failures cannot crash the parent process. Long-lived Studio workers retain their existing lifecycle.

### What to review

- Bounded, single-flight Vite shutdown and error forwarding in the Studio worker loader
- `terminateOnSettle: false` usage is limited to one-shot Studio tasks
- Regression coverage for close ordering, timeout/rejection handling, late worker errors, thrown config errors, and long-lived workers

### Testing

- 46/46 targeted worker lifecycle unit tests pass
- Targeted coverage: 100% statements/functions/lines and 90.38% branches
- 311/311 `@sanity/cli-core` unit tests pass
- 3009/3009 full unit tests pass (7 skipped)
- 26/26 schema deploy/extract integration tests pass with a test auth token
- 5/5 schema validate integration tests pass, including a real thrown-config worker error
- Type checking, lint, dependency/export checks, and CLI build pass
- Standalone `schema extract` exits successfully and writes a valid 18-entry schema array

### Notes for release

Fix silent SIGABRT crashes in schema deploy, extract, validate, and Studio builds caused by terminating active Rolldown worker threads.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0589407c-e5d5-4bfc-a6a8-3855895f78e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0589407c-e5d5-4bfc-a6a8-3855895f78e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

