### PR TITLE
test(workbench): consolidate unit-test mocking into cli-test

### DIFF
--- a/packages/@sanity/cli-test/src/test/createMockOutput.ts
+++ b/packages/@sanity/cli-test/src/test/createMockOutput.ts
@@ -1,0 +1,15 @@
+import {type Output} from '@sanity/cli-core/types'
+import {vi} from 'vitest'
+
+/**
+ * Creates an `Output` implementation backed by vitest mock functions.
+ *
+ * @internal
+ */
+export function createMockOutput(): Output {
+  return {
+    error: vi.fn(() => undefined as never),
+    log: vi.fn(),
+    warn: vi.fn(),
+  }
+}

--- a/packages/@sanity/cli-test/src/test/util.ts
+++ b/packages/@sanity/cli-test/src/test/util.ts
@@ -1,6 +1,7 @@
 // Fast, in-memory export of utilities provided by cli-test. Limit transient dependencies (no OCLIF, no nock, etc.). Dedicated exports for test utilities relying on heavy exports already exist (e.g. test/createTestClient, test/mockApi, test/oclif, test/setupFixtures, etc.)
 export * from './constants.js'
 export * from './createMockHttpServer.js'
+export * from './createMockOutput.js'
 export * from './createMockSpinner.js'
 export * from './createMockWatcher.js'
 export * from './createTestToken.js'

--- a/packages/@sanity/eslint-config-cli/eslint.config.mjs
+++ b/packages/@sanity/eslint-config-cli/eslint.config.mjs
@@ -105,6 +105,7 @@ export default defineConfig(
           devDependencies: [
             '**/*.test.ts',
             '**/*.test.tsx',
+            '**/__tests__/**',
             '**/test/**',
             '**/config-eslint/**',
             '**/vite.config.ts',

--- a/packages/@sanity/workbench-cli/package.json
+++ b/packages/@sanity/workbench-cli/package.json
@@ -73,6 +73,7 @@
     "@eslint/compat": "catalog:",
     "@repo/package.config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
+    "@sanity/cli-test": "workspace:*",
     "@sanity/eslint-config-cli": "workspace:^",
     "@sanity/pkg-utils": "catalog:",
     "@swc/cli": "catalog:",

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployConfig.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployConfig.test.ts
@@ -1,23 +1,23 @@
 import {Readable} from 'node:stream'
 
-import {type Output} from '@sanity/cli-core'
+import * as apiClient from '@sanity/cli-test/mocks/cli-core/apiClient'
+import {createMockOutput} from '@sanity/cli-test/test/util'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {deployConfig, resolveInstallationId, summarizeConfig} from '../deployConfig.js'
 
-const mockGetGlobalCliClient = vi.hoisted(() => vi.fn())
-const mockRequest = vi.hoisted(() => vi.fn())
+const mockRequest = vi.fn()
 
 vi.mock('@sanity/cli-core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@sanity/cli-core')>()),
-  getGlobalCliClient: mockGetGlobalCliClient,
+  ...(await import('@sanity/cli-test/mocks/cli-core/apiClient')),
 }))
 
 // The tarball content is irrelevant here — stub a readable so no build output
 // has to exist on disk.
 vi.mock('tar-fs', () => ({pack: () => Readable.from(['remote'])}))
 
-const output = {error: vi.fn(), log: vi.fn(), warn: vi.fn()} as unknown as Output
+const output = createMockOutput()
 
 /** Answer the installations list with `data`, and the config POST with a record. */
 function stubBrett(data: unknown[]) {
@@ -29,7 +29,7 @@ function stubBrett(data: unknown[]) {
 }
 
 describe('resolveInstallationId', () => {
-  beforeEach(() => mockGetGlobalCliClient.mockResolvedValue({request: mockRequest}))
+  beforeEach(() => apiClient.getGlobalCliClient.mockResolvedValue({request: mockRequest}))
   afterEach(() => {
     vi.clearAllMocks()
     vi.unstubAllEnvs()
@@ -68,7 +68,7 @@ describe('resolveInstallationId', () => {
 })
 
 describe('deployConfig', () => {
-  beforeEach(() => mockGetGlobalCliClient.mockResolvedValue({request: mockRequest}))
+  beforeEach(() => apiClient.getGlobalCliClient.mockResolvedValue({request: mockRequest}))
   afterEach(() => {
     vi.clearAllMocks()
     vi.unstubAllEnvs()
@@ -86,7 +86,7 @@ describe('deployConfig', () => {
       version: '3.99.0',
     })
 
-    expect(mockGetGlobalCliClient).toHaveBeenCalledWith(
+    expect(apiClient.getGlobalCliClient).toHaveBeenCalledWith(
       expect.objectContaining({requireUser: true}),
     )
     const post = mockRequest.mock.calls.find(([arg]) => arg.method === 'POST')?.[0]

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -1,25 +1,24 @@
 import {Readable} from 'node:stream'
 
-import {getGlobalCliClient, type Output} from '@sanity/cli-core'
+import * as apiClient from '@sanity/cli-test/mocks/cli-core/apiClient'
+import {createMockOutput} from '@sanity/cli-test/test/util'
 import FormData from 'form-data'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {type BrettInterface, type BrettWorkspace} from '../../../services/applications.js'
 import {deployCoreApp, deployStudio} from '../deployWorkbenchApp.js'
 
-vi.mock(import('@sanity/cli-core'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  getGlobalCliClient: vi.fn(),
+vi.mock('@sanity/cli-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
+  ...(await import('@sanity/cli-test/mocks/cli-core/apiClient')),
 }))
 
-vi.mock('@sanity/cli-core/ux', () => ({
-  spinner: () => ({start: () => ({clear: vi.fn(), fail: vi.fn(), succeed: vi.fn()})}),
-}))
+vi.mock('@sanity/cli-core/ux', async () => import('@sanity/cli-test/mocks/cli-core/ux'))
 
 vi.mock('tar-fs', () => ({pack: () => ({pipe: () => Readable.from(['tar'])})}))
 
 const mockClient = {request: vi.fn()}
-const output = {error: vi.fn(), log: vi.fn()} as unknown as Output
+const output = createMockOutput()
 const interfaces: BrettInterface[] = [
   {metadata: null, moduleId: 'App', name: 'app', title: 'App', type: 'app', version: '1.0.0'},
 ]
@@ -34,7 +33,7 @@ function appendedFields(): Array<[string, unknown]> {
 let appendSpy: ReturnType<typeof vi.spyOn>
 
 beforeEach(() => {
-  vi.mocked(getGlobalCliClient).mockResolvedValue(mockClient as never)
+  apiClient.getGlobalCliClient.mockResolvedValue(mockClient as never)
   appendSpy = vi.spyOn(FormData.prototype, 'append')
 })
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
@@ -1,8 +1,7 @@
 import {EventEmitter} from 'node:events'
 
-import {type CliConfig, type Output} from '@sanity/cli-core'
-// eslint-disable-next-line import-x/no-extraneous-dependencies
-import {vi} from 'vitest'
+import {type CliConfig} from '@sanity/cli-core'
+import {createMockOutput} from '@sanity/cli-test/test/util'
 
 import {unstable_defineApp} from '../../../defineApp.js'
 import {type StartWorkbenchOptions} from '../startWorkbenchDevServer.js'
@@ -39,14 +38,6 @@ export function workbenchApp(overrides: Record<string, unknown> = {}): CliConfig
 
 export function workbenchCliConfig(overrides: Partial<CliConfig> = {}): CliConfig {
   return {app: workbenchApp(), ...overrides} as CliConfig
-}
-
-export function createMockOutput(): Output {
-  return {
-    error: vi.fn(),
-    log: vi.fn(),
-    warn: vi.fn(),
-  } as unknown as Output
 }
 
 export function createDevOptions(

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -1,7 +1,8 @@
+import {createMockOutput} from '@sanity/cli-test/test/util'
 import {afterEach, beforeEach, describe, expect, type Mock, test, vi} from 'vitest'
 
 import {startDevManifestWatcher} from '../startDevManifestWatcher.js'
-import {createMockOutput, FakeFsWatcher} from './devTestHelpers.js'
+import {FakeFsWatcher} from './devTestHelpers.js'
 
 const mockFindProjectRoot = vi.hoisted(() => vi.fn())
 const mockFsWatch = vi.hoisted(() => vi.fn())

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
@@ -1,7 +1,8 @@
+import {createMockOutput} from '@sanity/cli-test/test/util'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {startDevServerRegistration} from '../startDevServerRegistration.js'
-import {createMockOutput, workbenchApp, workbenchCliConfig} from './devTestHelpers.js'
+import {workbenchApp, workbenchCliConfig} from './devTestHelpers.js'
 
 const mockRegisterDevServer = vi.hoisted(() => vi.fn())
 const mockStartDevManifestWatcher = vi.hoisted(() => vi.fn())

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDev.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDev.test.ts
@@ -1,7 +1,8 @@
+import {createMockOutput} from '@sanity/cli-test/test/util'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {startWorkbenchDev, type StartWorkbenchDevOptions} from '../startWorkbenchDev.js'
-import {createMockOutput, workbenchCliConfig} from './devTestHelpers.js'
+import {workbenchCliConfig} from './devTestHelpers.js'
 
 const mockStartWorkbenchDevServer = vi.hoisted(() => vi.fn())
 const mockStartDevServerRegistration = vi.hoisted(() => vi.fn())

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -1,12 +1,8 @@
+import {createMockOutput} from '@sanity/cli-test/test/util'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {startWorkbenchDevServer} from '../startWorkbenchDevServer.js'
-import {
-  createDevOptions,
-  createMockOutput,
-  workbenchApp,
-  workbenchCliConfig,
-} from './devTestHelpers.js'
+import {createDevOptions, workbenchApp, workbenchCliConfig} from './devTestHelpers.js'
 
 const mockResolveLocalPackage = vi.hoisted(() => vi.fn())
 const mockCreateServer = vi.hoisted(() => vi.fn())

--- a/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
@@ -1,4 +1,5 @@
 import {type CliConfig} from '@sanity/cli-core'
+import * as apiClient from '@sanity/cli-test/mocks/cli-core/apiClient'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {
@@ -9,12 +10,11 @@ import {
 import {type DeployableWorkbenchApp, getWorkbench} from '../../deploy/getWorkbench.js'
 import {createWorkbenchUndeployAdapter} from '../workbenchUndeployAdapter.js'
 
-const mockGetGlobalCliClient = vi.hoisted(() => vi.fn())
-const mockRequest = vi.hoisted(() => vi.fn())
+const mockRequest = vi.fn()
 
 vi.mock('@sanity/cli-core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@sanity/cli-core')>()),
-  getGlobalCliClient: mockGetGlobalCliClient,
+  ...(await import('@sanity/cli-test/mocks/cli-core/apiClient')),
 }))
 
 function workbenchApp(): DeployableWorkbenchApp {
@@ -40,7 +40,7 @@ function mediaLibraryApp(
   return app
 }
 
-beforeEach(() => mockGetGlobalCliClient.mockResolvedValue({request: mockRequest}))
+beforeEach(() => apiClient.getGlobalCliClient.mockResolvedValue({request: mockRequest}))
 afterEach(() => vi.clearAllMocks())
 
 const appAdapter = () =>

--- a/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
+++ b/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
@@ -1,7 +1,7 @@
 import {Readable} from 'node:stream'
 import {type Gzip} from 'node:zlib'
 
-import {getGlobalCliClient} from '@sanity/cli-core'
+import * as apiClient from '@sanity/cli-test/mocks/cli-core/apiClient'
 import FormData from 'form-data'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -15,9 +15,9 @@ import {
   getWorkbenchUrl,
 } from '../applications.js'
 
-vi.mock(import('@sanity/cli-core'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  getGlobalCliClient: vi.fn(),
+vi.mock('@sanity/cli-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
+  ...(await import('@sanity/cli-test/mocks/cli-core/apiClient')),
 }))
 
 const mockClient = {request: vi.fn()}
@@ -37,7 +37,7 @@ function appendedFields(): Array<[string, unknown]> {
 let appendSpy: ReturnType<typeof vi.spyOn>
 
 beforeEach(() => {
-  vi.mocked(getGlobalCliClient).mockResolvedValue(mockClient as never)
+  apiClient.getGlobalCliClient.mockResolvedValue(mockClient as never)
   appendSpy = vi.spyOn(FormData.prototype, 'append')
 })
 
@@ -51,7 +51,7 @@ describe('getApplication', () => {
     mockClient.request.mockResolvedValueOnce({id: 'app_1', title: 'App', type: 'coreApp'})
 
     expect(await getApplication('app_1')).toMatchObject({id: 'app_1'})
-    expect(getGlobalCliClient).toHaveBeenCalledWith({apiVersion: 'vX', requireUser: true})
+    expect(apiClient.getGlobalCliClient).toHaveBeenCalledWith({apiVersion: 'vX', requireUser: true})
     expect(mockClient.request).toHaveBeenCalledWith({uri: '/applications/app_1'})
   })
 

--- a/packages/@sanity/workbench-cli/tsconfig.json
+++ b/packages/@sanity/workbench-cli/tsconfig.json
@@ -6,7 +6,10 @@
     "jsx": "react-jsx",
     "paths": {
       "@sanity/cli-core": ["./node_modules/@sanity/cli-core/src/_exports/index.ts"],
-      "@sanity/cli-core/*": ["./node_modules/@sanity/cli-core/src/_exports/*"]
+      "@sanity/cli-core/*": ["./node_modules/@sanity/cli-core/src/_exports/*"],
+      "@sanity/cli-test": ["./node_modules/@sanity/cli-test/src/index.ts"],
+      "@sanity/cli-test/mocks/*": ["./node_modules/@sanity/cli-test/src/mocks/*"],
+      "@sanity/cli-test/test/*": ["./node_modules/@sanity/cli-test/src/test/*"]
     }
   }
 }

--- a/packages/@sanity/workbench-cli/vitest.config.ts
+++ b/packages/@sanity/workbench-cli/vitest.config.ts
@@ -1,6 +1,7 @@
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  resolve: {tsconfigPaths: true},
   test: {
     coverage: {
       exclude: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1293,6 +1293,9 @@ importers:
       '@repo/tsconfig':
         specifier: workspace:*
         version: link:../../@repo/tsconfig
+      '@sanity/cli-test':
+        specifier: workspace:*
+        version: link:../cli-test
       '@sanity/eslint-config-cli':
         specifier: workspace:^
         version: link:../eslint-config-cli
@@ -4780,8 +4783,8 @@ packages:
       '@sanity/types':
         optional: true
 
-  '@sanity/workbench@0.1.0-alpha.24':
-    resolution: {integrity: sha512-235mR37+z8eg9OQqhUwgkQ4dZnveFHczUTgW2jk81qm1pP6vMlTdEAiKpz1Tq4zU9zRfg2xck51DP1VlkVzdWA==}
+  '@sanity/workbench@0.1.0-alpha.25':
+    resolution: {integrity: sha512-B4TeDPVoLpTm2AlKiRhvwWyiP3Ep3WlYj+uIBl3ZHk2Jg0oLEtJTO7G3JQs9I9e1plx+lBlqxdnXoj02QJcLlQ==}
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
       '@sanity/sdk': ^2.9.0
@@ -13803,10 +13806,9 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 6.5.0-workbench.20260714145319(@types/react@19.2.17)
 
-  '@sanity/workbench@0.1.0-alpha.24(@sanity/sdk@2.15.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4))(react@19.2.7)(xstate@5.32.4)':
+  '@sanity/workbench@0.1.0-alpha.25(@sanity/sdk@2.15.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4))(react@19.2.7)(xstate@5.32.4)':
     dependencies:
       '@module-federation/runtime': 2.7.0
-      '@sanity/message-protocol': 0.23.0
       '@sanity/sdk': 2.15.0(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
       rxjs: 7.8.2
@@ -18194,7 +18196,7 @@ snapshots:
       '@sanity/ui': 3.3.5(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@sanity/util': 6.5.0-workbench.20260714145319(@types/react@19.2.17)
       '@sanity/uuid': 3.0.3
-      '@sanity/workbench': 0.1.0-alpha.24(@sanity/sdk@2.15.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4))(react@19.2.7)(xstate@5.32.4)
+      '@sanity/workbench': 0.1.0-alpha.25(@sanity/sdk@2.15.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4))(react@19.2.7)(xstate@5.32.4)
       '@sentry/react': 10.65.0(react@19.2.7)
       '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-virtual': 3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
### Description

Follow-up from the undeploy stack (SDK-1886), scoped to `@sanity/workbench-cli`. The package hand-rolled test scaffolding that `@sanity/cli-test` already ships: a mock `Output` factory, a partial `ux` mock, and the `getGlobalCliClient` mock triple duplicated across four files.

This adopts the shared exports so there's one source of truth: `createMockOutput` (promoted to `@sanity/cli-test/test/util`), `mocks/cli-core/ux`, and `mocks/cli-core/apiClient`. It also wires `cli-test` into the package — devDependency, tsconfig paths, and vitest `tsconfigPaths`.

### What to review

- `createMockOutput` lands in cli-test (`test/util`) and replaces the `as unknown as Output` casts.
- The four deploy/undeploy/services tests now mock `@sanity/cli-core` by spreading the shared `apiClient` mock instead of hoisting their own `getGlobalCliClient`; `deployWorkbenchApp` also swaps its partial `ux` mock for the shared one.
- `eslint-config-cli` now lets `__tests__/**` import devDependencies — needed by `devTestHelpers.ts`, which isn't a `.test.ts` file.

### Testing

Covered by the existing workbench-cli unit suite; all tests pass. Typecheck, lint, format, and knip are clean (the pre-existing `BrettInterface` type noise on `main` is untouched and out of scope).