### PR TITLE
fix(workbench): pre-bundle interface deps in the dev server

### DIFF
--- a/.changeset/workbench-optimize-deps.md
+++ b/.changeset/workbench-optimize-deps.md
@@ -1,0 +1,6 @@
+---
+"@sanity/workbench-cli": patch
+"@sanity/cli-build": patch
+---
+
+Pre-bundle a workbench app's interface deps at dev startup by scanning the entry, views, services, and config sources, so Vite no longer re-optimizes and full-page reloads mid-session — removing the need for per-app `optimizeDeps.include` lists.

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getViteConfig.test.ts
@@ -14,6 +14,7 @@ import {
 
 const mockExtractSchemaPlugin = vi.hoisted(() => vi.fn())
 const mockWorkbenchVitePlugins = vi.hoisted(() => vi.fn())
+const mockWorkbenchOptimizeDeps = vi.hoisted(() => vi.fn())
 const mockFaviconsPlugin = vi.hoisted(() => vi.fn())
 const mockFaviconsPath = vi.hoisted(() => vi.fn())
 const mockNormalizeBasePaths = vi.hoisted(() => vi.fn())
@@ -30,6 +31,7 @@ vi.mock('@sanity/cli-core/telemetry', () => ({
 }))
 
 vi.mock('@sanity/workbench-cli/build', () => ({
+  workbenchOptimizeDeps: mockWorkbenchOptimizeDeps,
   workbenchVitePlugins: mockWorkbenchVitePlugins,
 }))
 
@@ -91,6 +93,10 @@ describe('#getViteConfig', () => {
   beforeEach(() => {
     mockWorkbenchVitePlugins.mockResolvedValue({
       name: 'sanity/federation',
+    })
+    mockWorkbenchOptimizeDeps.mockReturnValue({
+      entries: ['src/App.tsx'],
+      include: ['react', 'react-dom/client'],
     })
     mockExtractSchemaPlugin.mockReturnValue({
       name: 'sanity/schema-extraction',
@@ -552,6 +558,62 @@ describe('#getViteConfig', () => {
     // Workbench stacks the app server next to the workbench port, so it must
     // be able to drift even when the project is a studio.
     expect(config.server?.strictPort).toBe(false)
+  })
+
+  test('front-loads workbench exposes into optimizeDeps for the dev server', async () => {
+    const config = await getViteConfig({
+      cwd: mockTestCwd,
+      entries: mockEntries,
+      exposes: {views: [{name: 'panel', src: './src/Panel.tsx', type: 'panel'}]},
+      getEnvironmentVariables,
+      isApp: true,
+      isWorkbenchApp: true,
+      mode: 'development' as const,
+      reactCompiler: undefined,
+    })
+
+    // Runtime-relative entry/config resolve to absolute app sources; exposes pass
+    // through so the helper can add each declared view/service/config source.
+    expect(mockWorkbenchOptimizeDeps).toHaveBeenCalledWith({
+      appSources: [join(mockTestCwd, 'src/App'), join(mockTestCwd, 'sanity.config.ts')],
+      cwd: mockTestCwd,
+      exposes: {views: [{name: 'panel', src: './src/Panel.tsx', type: 'panel'}]},
+    })
+    expect(config.optimizeDeps).toEqual({
+      entries: ['src/App.tsx'],
+      include: ['react', 'react-dom/client'],
+    })
+  })
+
+  test('does not set optimizeDeps for non-workbench apps', async () => {
+    const config = await getViteConfig({
+      cwd: mockTestCwd,
+      entries: mockEntries,
+      getEnvironmentVariables,
+      isApp: true,
+      isWorkbenchApp: false,
+      mode: 'development' as const,
+      reactCompiler: undefined,
+    })
+
+    expect(mockWorkbenchOptimizeDeps).not.toHaveBeenCalled()
+    expect(config.optimizeDeps).toBeUndefined()
+  })
+
+  test('does not set optimizeDeps for workbench production builds', async () => {
+    // `optimizeDeps` is a dev-server concern; Vite ignores it at build.
+    const config = await getViteConfig({
+      cwd: mockTestCwd,
+      entries: mockEntries,
+      getEnvironmentVariables,
+      isApp: true,
+      isWorkbenchApp: true,
+      mode: 'production' as const,
+      reactCompiler: undefined,
+    })
+
+    expect(mockWorkbenchOptimizeDeps).not.toHaveBeenCalled()
+    expect(config.optimizeDeps).toBeUndefined()
   })
 
   test('should not require a sanity config for workbench apps', async () => {

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -4,7 +4,11 @@ import babel from '@rolldown/plugin-babel'
 import {findProjectRoot} from '@sanity/cli-core/config'
 import {getCliTelemetry} from '@sanity/cli-core/telemetry'
 import {type CliConfig, type UserViteConfig} from '@sanity/cli-core/types'
-import {type WorkbenchExposes, workbenchVitePlugins} from '@sanity/workbench-cli/build'
+import {
+  type WorkbenchExposes,
+  workbenchOptimizeDeps,
+  workbenchVitePlugins,
+} from '@sanity/workbench-cli/build'
 import viteReact, {reactCompilerPreset} from '@vitejs/plugin-react'
 import {type PluginOptions as ReactCompilerConfig} from 'babel-plugin-react-compiler'
 import debug from 'debug'
@@ -254,6 +258,19 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
         clientFiles: ['./.sanity/runtime/app.js'],
       },
     },
+  }
+
+  // Front-load the deps the federation `exposes` reach only via the host's
+  // dynamic imports, which Vite's dep scanner (crawling from the HTML entry)
+  // otherwise misses — see `workbenchOptimizeDeps`. Dev-server only; Vite
+  // ignores `optimizeDeps` at build. Set before the userland `vite` hook so an
+  // app can still extend the list.
+  if (isWorkbenchApp && mode === 'development') {
+    const runtimeDir = path.join(cwd, '.sanity', 'runtime')
+    const appSources = [entries.relativeEntry, entries.relativeConfigLocation]
+      .filter((relativePath): relativePath is string => relativePath !== null)
+      .map((relativePath) => path.resolve(runtimeDir, relativePath))
+    viteConfig.optimizeDeps = workbenchOptimizeDeps({appSources, cwd, exposes})
   }
 
   // Federation builds don't produce a client bundle — the federation

--- a/packages/@sanity/workbench-cli/src/_exports/build.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/build.ts
@@ -4,5 +4,6 @@
 // deploy-time guards, so it takes the bare `resolveWorkbenchApp` — the guarded
 // view (`getWorkbench`) is the deploy entry's export.
 
+export {workbenchOptimizeDeps} from '../actions/build/vite/optimize-deps.js'
 export {workbenchVitePlugins} from '../actions/build/vite/workbench-vite-plugins.js'
 export {resolveWorkbenchApp, type WorkbenchExposes} from '../resolveWorkbenchApp.js'

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/__tests__/optimize-deps.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/__tests__/optimize-deps.test.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {afterEach, beforeEach, describe, expect, test} from 'vitest'
+
+import {type WorkbenchExposes} from '../../../../resolveWorkbenchApp.js'
+import {workbenchOptimizeDeps} from '../optimize-deps.js'
+
+const cwd = path.resolve('/project')
+
+describe('workbenchOptimizeDeps', () => {
+  test('always pre-bundles the render-contract react deps', () => {
+    const {include} = workbenchOptimizeDeps({appSources: [], cwd})
+
+    expect(include).toEqual(['react', 'react-dom/client'])
+  })
+
+  test('scans the app entry and every exposed view/service/config source', () => {
+    const exposes: WorkbenchExposes = {
+      config: {
+        appType: 'media-library',
+        fields: [{name: 'credit', src: './src/fields/credit.ts', title: 'Credit'}],
+      },
+      services: [{name: 'reminders', src: './src/service.ts', type: 'worker'}],
+      views: [
+        {name: 'favorites', src: './src/FavoritesPanel.tsx', title: 'Favorites', type: 'panel'},
+      ],
+    }
+
+    const {entries} = workbenchOptimizeDeps({
+      appSources: [path.join(cwd, 'src', 'App.tsx')],
+      cwd,
+      exposes,
+    })
+
+    expect(entries).toEqual([
+      'src/App.tsx',
+      'src/FavoritesPanel.tsx',
+      'src/service.ts',
+      'src/fields/credit.ts',
+    ])
+  })
+
+  test('scans a studio config as its app source', () => {
+    const {entries} = workbenchOptimizeDeps({
+      appSources: [path.join(cwd, 'sanity.config.ts')],
+      cwd,
+    })
+
+    expect(entries).toEqual(['sanity.config.ts'])
+  })
+
+  test('returns entries relative to cwd with forward slashes', () => {
+    const {entries} = workbenchOptimizeDeps({
+      appSources: [path.join(cwd, 'src', 'nested', 'App.tsx')],
+      cwd,
+    })
+
+    expect(entries).toEqual(['src/nested/App.tsx'])
+  })
+
+  test('dedupes a source shared by the entry and an exposed view', () => {
+    const {entries} = workbenchOptimizeDeps({
+      appSources: [path.join(cwd, 'src', 'App.tsx')],
+      cwd,
+      exposes: {views: [{name: 'app', src: './src/App.tsx', title: 'App', type: 'panel'}]},
+    })
+
+    expect(entries).toEqual(['src/App.tsx'])
+  })
+
+  test('handles a dock-only app with no app sources', () => {
+    const {entries} = workbenchOptimizeDeps({
+      appSources: [],
+      cwd,
+      exposes: {
+        views: [
+          {name: 'favorites', src: './src/FavoritesPanel.tsx', title: 'Favorites', type: 'panel'},
+        ],
+      },
+    })
+
+    expect(entries).toEqual(['src/FavoritesPanel.tsx'])
+  })
+
+  // `optimizeDeps.entries` is matched against the filesystem, so an
+  // extensionless source (the default `./src/App`) must resolve to its real file
+  // or Vite skips it and its deps go unscanned.
+  describe('extension resolution', () => {
+    let projectDir: string
+
+    beforeEach(() => {
+      projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-optimize-deps-'))
+      fs.mkdirSync(path.join(projectDir, 'src'), {recursive: true})
+    })
+
+    afterEach(() => {
+      fs.rmSync(projectDir, {force: true, recursive: true})
+    })
+
+    test('resolves an extensionless app entry to its on-disk file', () => {
+      fs.writeFileSync(path.join(projectDir, 'src', 'App.tsx'), 'export default {}')
+
+      const {entries} = workbenchOptimizeDeps({
+        appSources: [path.join(projectDir, 'src', 'App')],
+        cwd: projectDir,
+      })
+
+      expect(entries).toEqual(['src/App.tsx'])
+    })
+
+    test('resolves an extensionless interface source to its on-disk file', () => {
+      fs.writeFileSync(path.join(projectDir, 'src', 'service.ts'), 'export default {}')
+
+      const {entries} = workbenchOptimizeDeps({
+        appSources: [],
+        cwd: projectDir,
+        exposes: {services: [{name: 'reminders', src: './src/service', type: 'worker'}]},
+      })
+
+      expect(entries).toEqual(['src/service.ts'])
+    })
+
+    test('leaves an already-extensioned source untouched', () => {
+      fs.writeFileSync(path.join(projectDir, 'src', 'App.tsx'), 'export default {}')
+
+      const {entries} = workbenchOptimizeDeps({
+        appSources: [path.join(projectDir, 'src', 'App.tsx')],
+        cwd: projectDir,
+      })
+
+      expect(entries).toEqual(['src/App.tsx'])
+    })
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/optimize-deps.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/optimize-deps.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {type WorkbenchExposes} from '../../../resolveWorkbenchApp.js'
+
+/**
+ * React APIs only the generated render-contract modules import — the SPA
+ * bootstrap (`getEntryModule`) and every render artifact (`renderRemote`)
+ * `createRoot` from `react-dom/client` and `createElement` from `react`. No
+ * app/interface source imports `react-dom/client` itself, so scanning `entries`
+ * never surfaces it; every workbench app depends on react/react-dom, so both
+ * always resolve.
+ */
+const RENDER_CONTRACT_DEPS = ['react', 'react-dom/client']
+
+/** Extensions an import-style source path may omit, in resolution order. */
+const SOURCE_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js', '.mjs', '.cjs']
+
+/**
+ * Resolve an import-style source path to the file on disk. The app `entry`
+ * defaults to the extensionless `./src/App` (and a user may omit the extension
+ * anywhere), which the runtime imports fine through Vite's resolver — but
+ * `optimizeDeps.entries` is matched against the filesystem, so an extensionless
+ * path never matches and its deps go unscanned. Try the path as-is, then the
+ * common source extensions; fall back to the input so an already-resolved path
+ * (or a genuinely missing one) passes through unchanged.
+ */
+function resolveSourceFile(absPath: string): string {
+  if (fs.existsSync(absPath) && fs.statSync(absPath).isFile()) return absPath
+  for (const extension of SOURCE_EXTENSIONS) {
+    if (fs.existsSync(`${absPath}${extension}`)) return `${absPath}${extension}`
+  }
+  return absPath
+}
+
+/**
+ * Dep pre-bundling inputs for a workbench app's dev server.
+ *
+ * Vite's dep scanner crawls from the app's HTML entry, which reaches only the
+ * app's `entry` (or a studio's config) — never the federation `exposes` (dock
+ * views, worker services, media-library config fields), which the host loads
+ * dynamically at runtime. So a dep imported only by an exposed module (e.g.
+ * `sanity/workbench` in a service or view) escapes the startup scan; Vite
+ * discovers it on first request, re-optimizes, and full-page reloads — which
+ * flakes Playwright in e2e.
+ *
+ * Point `entries` at the source of every interface: the app `entry` (or, for a
+ * studio, its config), plus each view, service, and installation-config source.
+ * `entries` follows real import statements, so it covers whatever those sources
+ * transitively use — correct subpaths and all — with no hand-maintained dep
+ * list, and never crashes on an unresolvable name the way a bad `include` entry
+ * does. Each source is resolved to its on-disk file so an extensionless path
+ * (like the default `./src/App`) still matches `entries`' filesystem glob.
+ *
+ * @param cwd - Project root; `entries` are returned relative to it.
+ * @param appSources - Absolute paths to the app's `entry` and/or studio config.
+ * @param exposes - The app's declared views/services/config.
+ * @internal
+ */
+export function workbenchOptimizeDeps(options: {
+  appSources: readonly string[]
+  cwd: string
+  exposes?: WorkbenchExposes
+}): {entries: string[]; include: string[]} {
+  const {appSources, cwd, exposes} = options
+
+  const interfaceSources = [
+    ...(exposes?.views ?? []).map((view) => view.src),
+    ...(exposes?.services ?? []).map((service) => service.src),
+    ...(exposes?.config?.fields ?? []).map((field) => field.src),
+  ].map((src) => path.resolve(cwd, src))
+
+  const entries = [...appSources, ...interfaceSources].map((absPath) => {
+    const resolved = resolveSourceFile(absPath)
+    return path.relative(cwd, resolved).split(path.sep).join('/')
+  })
+
+  return {
+    entries: [...new Set(entries)],
+    include: [...RENDER_CONTRACT_DEPS],
+  }
+}


### PR DESCRIPTION
### Description

`sanity dev` runs each workbench app as a module-federation remote. Vite's dependency scanner crawls from the app's HTML entry, which reaches only the app's `entry` — never the federation `exposes` (dock views, worker services, media-library config fields) the host loads dynamically. So a dep imported only by an exposed module (e.g. `sanity/workbench` in a service or view) escapes the startup scan; Vite discovers it on first request, re-optimizes, and full-page reloads — which flakes Playwright navigation in e2e.

Each app worked around this with its own `optimizeDeps.include` list in `sanity.cli.ts`, which drifts from real imports and crashes Vite when an entry doesn't resolve in that app.

This moves the fix into the CLI dev server. It points `optimizeDeps.entries` at the source of every interface — the app `entry` (or a studio's config), plus each view, service, and installation-config source — so Vite discovers and pre-bundles whatever those sources actually import. No hand-maintained dep list, correct subpath handling, no crash on an unresolvable name. `react`/`react-dom/client` (imported only by the generated render-contract, never user source) stay pinned via `include`.

Resolves [SDK-1789](https://linear.app/sanity/issue/SDK-1789/move-workbench-optimizedepsinclude-into-the-cli-dev-server).

### What to review

- `workbenchOptimizeDeps` in [optimize-deps.ts](packages/@sanity/workbench-cli/src/actions/build/vite/optimize-deps.ts) and its wiring in `getViteConfig`, gated to workbench apps in dev.
- No effect on non-workbench studios/apps or production builds.

### Testing

Unit tests for the helper and its wiring. Also booted `sanity dev` on the `federated-studio` fixture: Vite honored the entries, pre-bundled deps up front ("scanner found every used dependency", no mid-session reload), and the module-federation setup started cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-server-only Vite config for workbench apps; production and non-workbench paths are explicitly gated off with unit test coverage.
> 
> **Overview**
> Workbench **dev** now sets Vite `optimizeDeps` automatically so federation-exposed views, services, and config fields are scanned at startup—not only the HTML entry path.
> 
> A new **`workbenchOptimizeDeps`** helper builds `entries` from the app entry/studio config plus every declared expose source (with extension resolution for paths like `./src/App`), and pins **`react`** / **`react-dom/client`** via `include` for generated render-contract imports. **`getViteConfig`** applies this only when `isWorkbenchApp` and `mode === 'development'`, before the user `vite` hook so apps can still extend the list; production and non-workbench apps are unchanged.
> 
> This replaces per-app `optimizeDeps.include` workarounds that could drift or crash Vite on bad entries, and aims to stop mid-session re-optimization and full-page reloads (e.g. flaky Playwright).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd85075d6428c2909a6250534ac981cb357910e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->