### PR TITLE
fix(cli): add actionable login guidance

### DIFF
--- a/.changeset/actionable-login-guidance.md
+++ b/.changeset/actionable-login-guidance.md
@@ -1,0 +1,8 @@
+---
+"@sanity/cli": patch
+---
+
+fix(cli): provide actionable login guidance
+
+Show token, provider, and SSO login commands when authentication is required, and list accepted
+provider IDs in `sanity login --help`.

--- a/packages/@sanity/cli/src/actions/auth/__tests__/ensureAuthenticated.test.ts
+++ b/packages/@sanity/cli/src/actions/auth/__tests__/ensureAuthenticated.test.ts
@@ -2,6 +2,7 @@ import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {LoginError} from '../../../errors/LoginError.js'
 import {ensureAuthenticated, validateSession} from '../ensureAuthenticated.js'
+import {LOGIN_REQUIRED_MESSAGE} from '../login/loginInstructions.js'
 
 const mockGetById = vi.hoisted(() => vi.fn())
 const mockGetCliToken = vi.hoisted(() => vi.fn())
@@ -137,6 +138,7 @@ describe('ensureAuthenticated', () => {
 
     expect(user).toEqual(expect.objectContaining({email: 'test@example.com'}))
     expect(mockLogin).not.toHaveBeenCalled()
+    expect(mockOutput.warn).not.toHaveBeenCalled()
   })
 
   test('triggers login when no token exists', async () => {
@@ -152,6 +154,7 @@ describe('ensureAuthenticated', () => {
     const user = await ensureAuthenticated({output: mockOutput, telemetry: mockTelemetry})
 
     expect(mockLogin).toHaveBeenCalledWith({output: mockOutput, telemetry: mockTelemetry})
+    expect(mockOutput.warn).toHaveBeenCalledWith(LOGIN_REQUIRED_MESSAGE)
     expect(user).toEqual(expect.objectContaining({email: 'new@example.com'}))
   })
 

--- a/packages/@sanity/cli/src/actions/auth/ensureAuthenticated.ts
+++ b/packages/@sanity/cli/src/actions/auth/ensureAuthenticated.ts
@@ -10,6 +10,7 @@ import {isHttpError} from '@sanity/client'
 import {LoginError} from '../../errors/LoginError.js'
 import {getCliUser} from '../../services/user.js'
 import {login} from './login/login.js'
+import {LOGIN_REQUIRED_MESSAGE} from './login/loginInstructions.js'
 
 /**
  * Ensure the user is authenticated. Validates the current token via /users/me
@@ -26,6 +27,8 @@ export async function ensureAuthenticated(options: {
 }): Promise<SanityOrgUser> {
   const user = await validateSession()
   if (user) return user
+
+  options.output.warn(LOGIN_REQUIRED_MESSAGE)
 
   try {
     await login({output: options.output, telemetry: options.telemetry})

--- a/packages/@sanity/cli/src/actions/auth/login/loginInstructions.ts
+++ b/packages/@sanity/cli/src/actions/auth/login/loginInstructions.ts
@@ -1,0 +1,13 @@
+export const LOGIN_PROVIDER_IDS = ['google', 'github', 'sanity', 'vercel'] as const
+
+export const LOGIN_REQUIRED_MESSAGE = [
+  'No valid authentication credentials found.',
+  '',
+  'Authenticate with one of these commands:',
+  '  echo "$TOKEN" | sanity login --with-token',
+  '  sanity login --provider <providerId> --no-open',
+  `    Provider IDs: ${LOGIN_PROVIDER_IDS.join(', ')}`,
+  '  sanity login --sso <organizationSlug> --no-open',
+  '',
+  '`--no-open` prints a login URL instead of opening a browser.',
+].join('\n')

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -3,6 +3,7 @@ import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
+import {LOGIN_REQUIRED_MESSAGE} from '../../auth/login/loginInstructions.js'
 import {initAction} from '../initAction.js'
 import {InitError} from '../initError.js'
 import {type InitContext, type InitOptions} from '../types.js'
@@ -200,9 +201,7 @@ describe('initAction (direct)', () => {
 
     expect(caughtError).toBeInstanceOf(InitError)
     const initError = caughtError as InitError
-    expect(initError.message).toBe(
-      'Must be logged in to run this command in unattended mode, run `sanity login`',
-    )
+    expect(initError.message).toBe(LOGIN_REQUIRED_MESSAGE)
     expect(initError.exitCode).toBe(1)
   })
 })

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -20,6 +20,7 @@ import {getProjectDefaults} from '../../util/getProjectDefaults.js'
 import {validateSession} from '../auth/ensureAuthenticated.js'
 import {getProviderName} from '../auth/getProviderName.js'
 import {login} from '../auth/login/login.js'
+import {LOGIN_REQUIRED_MESSAGE} from '../auth/login/loginInstructions.js'
 import {detectAvailableEditors} from '../mcp/detectAvailableEditors.js'
 import {setupMCP} from '../mcp/setupMCP.js'
 import {setupSkills} from '../skills/setupSkills.js'
@@ -396,13 +397,11 @@ async function ensureAuthenticated(
   }
 
   if (options.unattended) {
-    throw new InitError(
-      'Must be logged in to run this command in unattended mode, run `sanity login`',
-      1,
-    )
+    throw new InitError(LOGIN_REQUIRED_MESSAGE, exitCodes.RUNTIME_ERROR)
   }
 
   trace.log({step: 'login'})
+  output.warn(LOGIN_REQUIRED_MESSAGE)
 
   try {
     await login({

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -2,6 +2,7 @@ import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
+import {LOGIN_REQUIRED_MESSAGE} from '../../../actions/auth/login/loginInstructions.js'
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
 import {PROJECTS_API_VERSION} from '../../../services/projects.js'
 import {InitCommand} from '../../init.js'
@@ -204,9 +205,7 @@ describe('#init: authentication', () => {
       },
     })
 
-    expect(error?.message).toContain(
-      'Must be logged in to run this command in unattended mode, run `sanity login`',
-    )
+    expect(error?.message).toContain(LOGIN_REQUIRED_MESSAGE)
     expect(error?.oclif?.exit).toBe(1)
   })
 
@@ -243,7 +242,7 @@ describe('#init: authentication', () => {
     mockGetById.mockRejectedValueOnce(createHttpError(401, 'Unauthorized'))
     mockLogin.mockRejectedValueOnce(new Error('No authentication providers found'))
 
-    const {error} = await testCommand(InitCommand, [], {
+    const {error, stderr} = await testCommand(InitCommand, [], {
       mocks: {
         ...defaultMocks,
         isInteractive: true,
@@ -252,5 +251,7 @@ describe('#init: authentication', () => {
 
     expect(error?.message).toBe('Login failed: No authentication providers found')
     expect(error?.oclif?.exit).toBe(1)
+    expect(stderr).toContain('No valid authentication credentials found')
+    expect(stderr).toContain('sanity login --provider <providerId> --no-open')
   })
 })

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -7,6 +7,7 @@ import open from 'open'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {startServerForTokenCallback} from '../../actions/auth/authServer.js'
+import {LOGIN_PROVIDER_IDS} from '../../actions/auth/login/loginInstructions.js'
 import {AUTH_API_VERSION} from '../../services/auth.js'
 import {USERS_API_VERSION} from '../../services/user.js'
 import {canLaunchBrowser} from '../../util/canLaunchBrowser.js'
@@ -213,6 +214,10 @@ describe('#login', {timeout: 10_000}, () => {
     const pending = pendingMocks()
     cleanAll()
     expect(pending, 'pending mocks').toEqual([])
+  })
+
+  test('documents the supported provider IDs', () => {
+    expect(LoginCommand.flags.provider.description).toContain(LOGIN_PROVIDER_IDS.join(', '))
   })
 
   describe('Token Login', () => {

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -5,6 +5,7 @@ import {type FlagInput} from '@oclif/core/interfaces'
 import {SanityCommand} from '@sanity/cli-core'
 
 import {login} from '../actions/auth/login/login.js'
+import {LOGIN_PROVIDER_IDS} from '../actions/auth/login/loginInstructions.js'
 
 export class LoginCommand extends SanityCommand<typeof LoginCommand> {
   static override description = 'Log in to your Sanity account'
@@ -42,7 +43,7 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
       description: 'Open a browser window to log in (`--no-open` only prints URL)',
     }),
     provider: Flags.string({
-      description: 'Log in using the given provider',
+      description: `Log in using a provider ID (${LOGIN_PROVIDER_IDS.join(', ')})`,
       exclusive: ['sso', 'with-token'],
       helpValue: '<providerId>',
     }),


### PR DESCRIPTION
Make it clearer in unattended mode when you need to login and how to do it

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing messaging and help text only; auth behavior is unchanged aside from clearer errors and warnings.
> 
> **Overview**
> Centralizes **login guidance** in `loginInstructions.ts` and surfaces it whenever the CLI needs credentials.
> 
> When auth is missing or invalid, **`ensureAuthenticated`** and **`init`** now **`warn`** with copy that lists token, `--provider`, and `--sso` login options (including `--no-open`). **`sanity init --yes`** without a session **throws** that same message instead of a one-line “run `sanity login`” hint, using **`exitCodes.RUNTIME_ERROR`**.
> 
> **`sanity login --help`** documents accepted **`--provider`** IDs via **`LOGIN_PROVIDER_IDS`** (`google`, `github`, `sanity`, `vercel`). Tests assert the shared message on stderr/warn paths and on the provider flag description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21368c0bf39e84b0e1a7bcc6ee48995936d3a56a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->