### PR TITLE
fix(workbench): sync app visibility on redeploy

### DIFF
--- a/.changeset/sync-workbench-visibility-on-redeploy.md
+++ b/.changeset/sync-workbench-visibility-on-redeploy.md
@@ -1,0 +1,6 @@
+---
+"@sanity/cli": patch
+"@sanity/workbench-cli": patch
+---
+
+Sync the `visibility` declared in `unstable_defineApp` to workbench apps on redeploy.

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -121,6 +121,18 @@ describe('deployCoreApp', () => {
       uri: '/applications/app_1',
     })
   })
+
+  test('syncs visibility on redeploy when declared', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'}).mockResolvedValueOnce(undefined)
+
+    await deployCoreApp({...coreAppOptions, appId: 'app_1', visibility: 'unlisted'})
+
+    expect(mockClient.request.mock.calls[1][0]).toEqual({
+      body: {title: 'Drop Desk', visibility: 'unlisted'},
+      method: 'PATCH',
+      uri: '/applications/app_1',
+    })
+  })
 })
 
 const studioOptions = {

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
@@ -51,7 +51,11 @@ export async function deployCoreApp(options: {
   try {
     if (appId) {
       await createDeployment({applicationId: appId, interfaces, isAutoUpdating, tarball, version})
-      await updateApplication(appId, {title, ...(icon ? {icon} : {})})
+      await updateApplication(appId, {
+        title,
+        ...(icon ? {icon} : {}),
+        ...(visibility ? {visibility} : {}),
+      })
       spin.succeed()
       return {applicationId: appId}
     }

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -121,12 +121,10 @@ export async function createApplication(options: {
 export interface ApplicationUpdate {
   icon?: string | null
   title?: string
+  visibility?: AppVisibility
 }
 
-/**
- * Patch an application's mutable fields. The deploy endpoint ignores these, so a
- * redeploy syncs the title (and icon) from config here alongside the new deployment.
- */
+// Patch an application's mutable fields.
 export async function updateApplication(
   applicationId: string,
   update: ApplicationUpdate,


### PR DESCRIPTION
### Description

Redeploying a workbench app only synced its title and icon. A `visibility` change in `unstable_defineApp` never took effect after the first deploy — visibility is written once at create and then frozen. Plain core-apps already sync it on redeploy, so this closes that gap.

The configured visibility now rides along in the redeploy PATCH, next to title and icon.

### What to review

`deployCoreApp`'s redeploy branch in `deployWorkbenchApp.ts`, plus the `ApplicationUpdate` type in `applications.ts`. Visibility is only sent when declared, so apps that don't set it are unaffected. Studios have no visibility, so `deployStudio` is untouched.

### Testing

Added a unit test for the visibility sync on redeploy; the existing redeploy tests still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, optional deploy-time API patch in workbench-cli with unit test coverage; no auth or data-path changes.
> 
> **Overview**
> Workbench **core app** redeploys now PATCH **`visibility`** from `unstable_defineApp` together with title and icon, matching behavior that was already correct on first create and for plain core-apps.
> 
> `ApplicationUpdate` gains an optional `visibility` field; redeploy only sends it when configured, so apps without visibility are unchanged. **Studio** deploy is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b008ba20846bf9267ce823e1da8fa307b8691f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->