### PR TITLE
feat(cli): rename tokens add to tokens create

### DIFF
--- a/.changeset/calm-rooms-cheer.md
+++ b/.changeset/calm-rooms-cheer.md
@@ -1,0 +1,7 @@
+---
+"@sanity/cli": minor
+---
+
+feat(cli): rename tokens add to tokens create
+
+Rename the `sanity tokens add` command to `sanity tokens create`, while preserving the old alias for backward compatibility.

--- a/packages/@sanity/cli/README.md
+++ b/packages/@sanity/cli/README.md
@@ -113,7 +113,7 @@ Code for sanity cli
 - [`sanity telemetry disable`](#sanity-telemetry-disable)
 - [`sanity telemetry enable`](#sanity-telemetry-enable)
 - [`sanity telemetry status`](#sanity-telemetry-status)
-- [`sanity tokens add [LABEL]`](#sanity-tokens-add-label)
+- [`sanity tokens create [LABEL]`](#sanity-tokens-create-label)
 - [`sanity tokens delete [TOKENID]`](#sanity-tokens-delete-tokenid)
 - [`sanity tokens list`](#sanity-tokens-list)
 - [`sanity typegen generate`](#sanity-typegen-generate)
@@ -3396,13 +3396,13 @@ EXAMPLES
     $ sanity telemetry telemetry status
 ```
 
-## `sanity tokens add [LABEL]`
+## `sanity tokens create [LABEL]`
 
 Create a new API token for the project
 
 ```
 USAGE
-  $ sanity tokens add [LABEL] [-p <id>] [--json] [--role viewer] [-y]
+  $ sanity tokens create [LABEL] [-p <id>] [--json] [--role viewer] [-y]
 
 ARGUMENTS
   [LABEL]  Label for the new token
@@ -3421,23 +3421,23 @@ DESCRIPTION
 EXAMPLES
   Create a token with a label
 
-    $ sanity tokens add "My API Token"
+    $ sanity tokens create "My API Token"
 
   Create a token with editor role
 
-    $ sanity tokens add "My API Token" --role=editor
+    $ sanity tokens create "My API Token" --role=editor
 
   Create a token in unattended mode
 
-    $ sanity tokens add "CI Token" --role=editor --yes
+    $ sanity tokens create "CI Token" --role=editor --yes
 
   Output token information as JSON
 
-    $ sanity tokens add "API Token" --json
+    $ sanity tokens create "API Token" --json
 
   Create a token for a specific project
 
-    $ sanity tokens add "My Token" --project-id abc123 --role=editor
+    $ sanity tokens create "My Token" --project-id abc123 --role=editor
 ```
 
 ## `sanity tokens delete [TOKENID]`

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/create.test.ts
@@ -2,10 +2,10 @@ import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {input, select} from '@sanity/cli-core/ux'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {TOKENS_API_VERSION} from '../../../actions/tokens/constants.js'
-import {AddTokenCommand} from '../add.js'
+import {CreateTokenCommand} from '../create.js'
 
 vi.mock('@sanity/cli-core/ux', async () => {
   const actual = await vi.importActual<typeof import('@sanity/cli-core/ux')>('@sanity/cli-core/ux')
@@ -32,9 +32,14 @@ const defaultMocks = {
   token: 'test-token',
 }
 
-describe('#tokens:add', () => {
+describe('#tokens:create', () => {
+  beforeEach(() => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+  })
+
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
     const pending = pendingMocks()
     cleanAll()
     expect(pending, 'pending mocks').toEqual([])
@@ -86,8 +91,11 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/tokens',
     }).reply(200, mockToken)
 
-    const {stdout} = await testCommand(AddTokenCommand, ['My Test Token'], {mocks: defaultMocks})
+    const {error, stdout} = await testCommand(CreateTokenCommand, ['My Test Token'], {
+      mocks: defaultMocks,
+    })
 
+    expect(error).toBeUndefined()
     expect(stdout).toContain('API token created')
     expect(stdout).toContain('Label: My Test Token')
     expect(stdout).toContain('ID: token-123')
@@ -142,7 +150,7 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/tokens',
     }).reply(200, mockToken)
 
-    const {stdout} = await testCommand(AddTokenCommand, ['Editor Token', '--role=editor'], {
+    const {stdout} = await testCommand(CreateTokenCommand, ['Editor Token', '--role=editor'], {
       mocks: defaultMocks,
     })
 
@@ -173,7 +181,7 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/tokens',
     }).reply(200, mockToken)
 
-    const {stdout} = await testCommand(AddTokenCommand, ['JSON Token', '--json'], {
+    const {stdout} = await testCommand(CreateTokenCommand, ['JSON Token', '--json'], {
       mocks: defaultMocks,
     })
 
@@ -204,7 +212,7 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/tokens',
     }).reply(200, mockToken)
 
-    const {stdout} = await testCommand(AddTokenCommand, ['Unattended Token', '--yes'], {
+    const {stdout} = await testCommand(CreateTokenCommand, ['Unattended Token', '--yes'], {
       mocks: defaultMocks,
     })
 
@@ -232,7 +240,7 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
-    const {error} = await testCommand(AddTokenCommand, ['Test Token', '--role=invalid'], {
+    const {error} = await testCommand(CreateTokenCommand, ['Test Token', '--role=invalid'], {
       mocks: defaultMocks,
     })
 
@@ -266,7 +274,7 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/tokens',
     }).reply(500, {message: 'Internal Server Error'})
 
-    const {error} = await testCommand(AddTokenCommand, ['Failed Token'], {mocks: defaultMocks})
+    const {error} = await testCommand(CreateTokenCommand, ['Failed Token'], {mocks: defaultMocks})
 
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Token creation failed')
@@ -275,7 +283,7 @@ describe('#tokens:add', () => {
   })
 
   test('throws error when no project ID is found', async () => {
-    const {error} = await testCommand(AddTokenCommand, ['Test Token'], {
+    const {error} = await testCommand(CreateTokenCommand, ['Test Token'], {
       mocks: {
         ...defaultMocks,
         cliConfig: {api: {projectId: undefined}},
@@ -305,7 +313,7 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/roles',
     }).reply(200, mockRoles)
 
-    const {error} = await testCommand(AddTokenCommand, ['Test Token'], {mocks: defaultMocks})
+    const {error} = await testCommand(CreateTokenCommand, ['Test Token'], {mocks: defaultMocks})
 
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('No roles available for tokens')
@@ -352,7 +360,7 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/tokens',
     }).reply(200, mockToken)
 
-    const {stdout} = await testCommand(AddTokenCommand, [], {mocks: defaultMocks})
+    const {stdout} = await testCommand(CreateTokenCommand, [], {mocks: defaultMocks})
 
     expect(mockedInput).toHaveBeenCalledWith({
       message: 'Token label:',
@@ -403,7 +411,7 @@ describe('#tokens:add', () => {
       uri: '/projects/test-project/tokens',
     }).reply(200, mockToken)
 
-    await testCommand(AddTokenCommand, [], {mocks: defaultMocks})
+    await testCommand(CreateTokenCommand, [], {mocks: defaultMocks})
 
     // Test that the validation function correctly rejects empty and whitespace-only strings
     const inputCall = mockedInput.mock.calls[0]
@@ -422,7 +430,7 @@ describe('#tokens:add', () => {
     {args: ['--yes'], description: 'with --yes', isInteractive: true},
     {args: [], description: 'without an interactive terminal', isInteractive: false},
   ])('requires a label in unattended mode $description', async ({args, isInteractive}) => {
-    const {error} = await testCommand(AddTokenCommand, args, {
+    const {error} = await testCommand(CreateTokenCommand, args, {
       mocks: {
         ...defaultMocks,
         cliConfig: {api: {projectId: undefined}},
@@ -437,7 +445,7 @@ describe('#tokens:add', () => {
   })
 
   test('rejects an empty label argument before project lookup', async () => {
-    const {error} = await testCommand(AddTokenCommand, ['   ', '--yes'], {
+    const {error} = await testCommand(CreateTokenCommand, ['   ', '--yes'], {
       mocks: {...defaultMocks, cliConfig: {api: {projectId: undefined}}},
     })
 

--- a/packages/@sanity/cli/src/commands/tokens/create.ts
+++ b/packages/@sanity/cli/src/commands/tokens/create.ts
@@ -7,9 +7,9 @@ import {promptForProject} from '../../prompts/promptForProject.js'
 import {createToken, getTokenRoles} from '../../services/tokens.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
 
-const tokensAddDebug = subdebug('tokens:add')
+const tokensCreateDebug = subdebug('tokens:create')
 
-export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
+export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand> {
   static override args = {
     label: Args.string({
       description: 'Label for the new token',
@@ -44,7 +44,7 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
 
   static override flags = {
     ...getProjectIdFlag({
-      description: 'Project ID to add token to',
+      description: 'Project ID to create token in',
       semantics: 'override',
     }),
     json: Flags.boolean({
@@ -62,10 +62,10 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
     }),
   }
 
-  static override hiddenAliases: string[] = ['token:add']
+  static override hiddenAliases: string[] = ['tokens:add', 'token:add', 'token:create']
 
   public async run(): Promise<void> {
-    const {args, flags} = await this.parse(AddTokenCommand)
+    const {args, flags} = await this.parse(CreateTokenCommand)
     const {label: givenLabel} = args
     const {json, role} = flags
 
@@ -91,7 +91,7 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
       : this.promptForRole(projectId))
 
     try {
-      tokensAddDebug(`Creating token for project ${projectId}`, {
+      tokensCreateDebug(`Creating token for project ${projectId}`, {
         label,
         roleName,
       })
@@ -116,7 +116,7 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
     } catch (error) {
       const err = error as Error
 
-      tokensAddDebug(`Error creating token for project ${projectId}`, err)
+      tokensCreateDebug(`Error creating token for project ${projectId}`, err)
       this.error(`Token creation failed:\n${err.message}`, {exit: 1})
     }
   }
@@ -149,7 +149,7 @@ export class AddTokenCommand extends SanityCommand<typeof AddTokenCommand> {
     const roles = await getTokenRoles(projectId)
     const robotRoles = roles.filter((role) => role.appliesToRobots)
 
-    tokensAddDebug('Robot roles', {robotRoles})
+    tokensCreateDebug('Robot roles', {robotRoles})
 
     if (robotRoles.length === 0) {
       this.error('No roles available for tokens', {exit: 1})


### PR DESCRIPTION
Rename `sanity tokens add` to `sanity tokens create`
Keep `tokens add` as an alias so there's no breaking changes. No plans to remove that ATM.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI command rename only; token creation logic is unchanged and old invocations remain via aliases.
> 
> **Overview**
> Renames the primary CLI entry point from **`sanity tokens add`** to **`sanity tokens create`**, aligning naming with other resource commands while keeping the same behavior (prompts, flags, API calls).
> 
> **Backward compatibility:** `tokens:add`, `token:add`, and `token:create` are registered as **hidden aliases** on `CreateTokenCommand`, so existing scripts using `sanity tokens add` keep working.
> 
> Docs and the changeset are updated to document `tokens create`; tests target `CreateTokenCommand` and stub `SANITY_INTERNAL_ENV` in `beforeEach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cae51cdf9e40fc28fd0ec578d6334453d1d690f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->