### PR TITLE
fix: link to project members page when projectUserNotFoundError is thrown

### DIFF
--- a/.changeset/heavy-carrots-knock.md
+++ b/.changeset/heavy-carrots-knock.md
@@ -1,0 +1,7 @@
+---
+"@sanity/cli-core": patch
+---
+
+fix: link to project members page when projectUserNotFoundError is thrown
+
+`projectUserNotFoundError` errors now include a link to the project members page, where you can update access to the project to resolve the error.

--- a/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
@@ -272,8 +272,12 @@ describe('authErrors middleware', () => {
 
     expect(onErrorHandler).toBeDefined()
 
-    const error = new Error('Unauthorized') as Error & {response: {body: {statusCode: number}}}
-    error.response = {body: {statusCode: 401}}
+    const error = new Error('Unauthorized') as Error & {
+      response: {body: Record<string, never>}
+      statusCode: number
+    }
+    error.response = {body: {}}
+    error.statusCode = 401
 
     mockIsHttpError.mockReturnValue(true)
 
@@ -286,6 +290,50 @@ describe('authErrors middleware', () => {
     expect(result!.message).toContain('sanity login')
     expect(result!.message).toContain('https://help.sanity.io/cli-errors')
     expect(mockGenerateHelpUrl).toHaveBeenCalledWith('cli-errors')
+  })
+
+  test('links to project members for projectUserNotFoundError', async () => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+
+    let onErrorHandler: ((err: Error | null) => Error | null) | undefined
+    const mockRequester = {
+      use: mockRequesterUse.mockImplementation((middleware: {onError?: typeof onErrorHandler}) => {
+        onErrorHandler = middleware.onError
+      }),
+    }
+    mockRequesterClone.mockReturnValue(mockRequester)
+    mockCreateClient.mockResolvedValue({})
+    mockGetCliToken.mockResolvedValue('stored-token')
+
+    await getProjectCliClient({
+      apiVersion: '2021-06-07',
+      projectId: 'test-project',
+    })
+
+    expect(onErrorHandler).toBeDefined()
+
+    const error = new Error('Project user not found') as Error & {
+      response: {
+        body: {error: {type: string}}
+      }
+      statusCode: number
+    }
+    error.response = {
+      body: {
+        error: {type: 'projectUserNotFoundError'},
+      },
+    }
+    error.statusCode = 401
+
+    mockIsHttpError.mockReturnValue(true)
+
+    const result = onErrorHandler!(error)
+
+    expect(result).toBe(error)
+    expect(result?.message).toBe(
+      'Project user not found. Add this account as a project member: https://www.sanity.io/manage/project/test-project/members.',
+    )
+    expect(result?.message).not.toContain('sanity login')
   })
 
   test('returns non-401 HTTP errors unchanged', async () => {
@@ -301,8 +349,12 @@ describe('authErrors middleware', () => {
 
     await getGlobalCliClient({apiVersion: '2021-06-07'})
 
-    const error = new Error('Not Found') as Error & {response: {body: {statusCode: number}}}
-    error.response = {body: {statusCode: 404}}
+    const error = new Error('Not Found') as Error & {
+      response: {body: Record<string, never>}
+      statusCode: number
+    }
+    error.response = {body: {}}
+    error.statusCode = 404
 
     mockIsHttpError.mockReturnValue(true)
 

--- a/packages/@sanity/cli-core/src/apiClient.ts
+++ b/packages/@sanity/cli-core/src/apiClient.ts
@@ -12,6 +12,7 @@ import {
 
 import {getCliToken} from './config/cli/cliUserConfig.js'
 import {generateHelpUrl} from './util/generateHelpUrl.js'
+import {getSanityUrl} from './util/getSanityUrl.js'
 
 const apiHosts: Record<string, string | undefined> = {
   staging: 'https://api.sanity.work',
@@ -126,7 +127,7 @@ export async function getProjectCliClient({
   ...config
 }: ProjectCliClientOptions): Promise<SanityClient> {
   const requester = defaultRequester.clone()
-  requester.use(authErrors())
+  requester.use(authErrors(config.projectId))
 
   const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production'
 
@@ -160,21 +161,40 @@ export async function getProjectCliClient({
  * @returns get-it middleware with `onError` handler
  * @internal
  */
-function authErrors() {
+function authErrors(projectId?: string) {
   return {
     onError: (err: Error | null) => {
       if (!err || !isReqResError(err)) {
         return err
       }
 
-      const statusCode = isHttpError(err) && err.response.body.statusCode
+      const statusCode = isHttpError(err) && err.statusCode
       if (statusCode === 401) {
+        if (projectId && isProjectUserNotFoundError(err.response.body)) {
+          err.message = `${err.message}. Add this account as a project member: ${getSanityUrl(`/manage/project/${encodeURIComponent(projectId)}/members`)}.`
+          return err
+        }
+
         err.message = `${err.message}. You may need to login again with ${styleText('cyan', 'sanity login')}.\nFor more information, see ${generateHelpUrl('cli-errors')}.`
       }
 
       return err
     },
   }
+}
+
+function isProjectUserNotFoundError(
+  body: unknown,
+): body is {error: {type: 'projectUserNotFoundError'}} {
+  if (typeof body !== 'object' || body === null || !('error' in body)) return false
+
+  const {error} = body
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'type' in error &&
+    error.type === 'projectUserNotFoundError'
+  )
 }
 
 function isReqResError(err: Error): err is ClientError | ServerError {


### PR DESCRIPTION
When a `projectUserNotFoundError` error is thrown, we now include a link to the page where you can update what members have access to the project. This makes it clearer what the next steps are to resolve the error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI error-message handling with a type guard; no auth or API behavior changes beyond clearer 401 messaging for one error type.
> 
> **Overview**
> **Project-scoped CLI API errors** now distinguish `projectUserNotFoundError` from a generic 401: instead of suggesting `sanity login`, the message points users to the **project members** page for that `projectId` (via `getSanityUrl`).
> 
> The `authErrors` middleware takes an optional `projectId` (passed from `getProjectCliClient` only); global clients keep the existing login/help flow. **401 detection** is aligned with `@sanity/client` by reading `err.statusCode` rather than `response.body.statusCode`. Tests cover the new message and updated error shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb868a54ddb757cb1ef9ee6fe52142bfae83d4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->