### PR TITLE
chore: add pre-commit hook to update CLI README

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -14,20 +14,9 @@ on:
       - 'packages/@sanity/cli/src/topicAliases.ts'
       - 'packages/@sanity/cli/src/util/organizationAliases.ts'
       - 'packages/@sanity/cli/src/util/sharedFlags.ts'
-  pull_request:
-    types: [opened, synchronize]
-    paths:
-      - 'packages/@sanity/cli/src/commands/**'
-      - '!packages/@sanity/cli/src/commands/**/__tests__/**'
-      - 'packages/@sanity/cli/oclif.config.js'
-      - 'packages/@sanity/cli/package.json'
-      - 'packages/@sanity/cli/src/SanityHelp.ts'
-      - 'packages/@sanity/cli/src/topicAliases.ts'
-      - 'packages/@sanity/cli/src/util/organizationAliases.ts'
-      - 'packages/@sanity/cli/src/util/sharedFlags.ts'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 permissions:
@@ -35,10 +24,6 @@ permissions:
 
 jobs:
   update-readme:
-    if: >-
-      github.event_name != 'pull_request' ||
-      (github.event.pull_request.head.repo.full_name == github.repository &&
-      !startsWith(github.event.pull_request.head.ref, 'renovate/'))
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -53,7 +38,6 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup Environment
@@ -70,25 +54,7 @@ jobs:
       - name: Format README
         run: npx oxfmt packages/@sanity/cli/README.md
 
-      - name: Commit README to feature branch
-        if: github.event_name == 'pull_request' || github.ref_name != github.event.repository.default_branch
-        env:
-          BRANCH_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          BRANCH_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          git add packages/@sanity/cli/README.md
-          if git diff --cached --quiet; then
-            echo 'CLI README is already up to date'
-            exit 0
-          fi
-
-          git config user.name 'squiggler-app[bot]'
-          git config user.email '265501495+squiggler-app[bot]@users.noreply.github.com'
-          git commit -m 'chore: update CLI README'
-          git push --force-with-lease="${BRANCH_REF}:${BRANCH_SHA}" origin "HEAD:${BRANCH_REF}"
-
       - name: Create Pull Request
-        if: github.ref_name == github.event.repository.default_branch
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - '**'
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -43,10 +43,26 @@ jobs:
         run: pnpm --filter @sanity/cli readme
 
       - name: Format README
-
         run: npx oxfmt packages/@sanity/cli/README.md
 
+      - name: Commit README to feature branch
+        if: github.ref_name != github.event.repository.default_branch
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          git add packages/@sanity/cli/README.md
+          if git diff --cached --quiet; then
+            echo 'CLI README is already up to date'
+            exit 0
+          fi
+
+          git config user.name 'squiggler-app[bot]'
+          git config user.email '265501495+squiggler-app[bot]@users.noreply.github.com'
+          git commit -m 'chore: update CLI README'
+          git push origin "HEAD:${BRANCH_NAME}"
+
       - name: Create Pull Request
+        if: github.ref_name == github.event.repository.default_branch
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -3,8 +3,17 @@ name: Update CLI README
 on:
   workflow_dispatch:
   push:
-    branches:
-      - '**'
+    branches-ignore:
+      - 'renovate/**'
+    paths:
+      - 'packages/@sanity/cli/src/commands/**'
+      - '!packages/@sanity/cli/src/commands/**/__tests__/**'
+      - 'packages/@sanity/cli/oclif.config.js'
+      - 'packages/@sanity/cli/package.json'
+      - 'packages/@sanity/cli/src/SanityHelp.ts'
+      - 'packages/@sanity/cli/src/topicAliases.ts'
+      - 'packages/@sanity/cli/src/util/organizationAliases.ts'
+      - 'packages/@sanity/cli/src/util/sharedFlags.ts'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -47,8 +56,6 @@ jobs:
 
       - name: Commit README to feature branch
         if: github.ref_name != github.event.repository.default_branch
-        env:
-          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           git add packages/@sanity/cli/README.md
           if git diff --cached --quiet; then
@@ -59,7 +66,7 @@ jobs:
           git config user.name 'squiggler-app[bot]'
           git config user.email '265501495+squiggler-app[bot]@users.noreply.github.com'
           git commit -m 'chore: update CLI README'
-          git push origin "HEAD:${BRANCH_NAME}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
 
       - name: Create Pull Request
         if: github.ref_name == github.event.repository.default_branch

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -5,15 +5,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'packages/@sanity/cli/src/commands/**'
-      - '!packages/@sanity/cli/src/commands/**/__tests__/**'
-      - 'packages/@sanity/cli/oclif.config.js'
-      - 'packages/@sanity/cli/package.json'
-      - 'packages/@sanity/cli/src/SanityHelp.ts'
-      - 'packages/@sanity/cli/src/topicAliases.ts'
-      - 'packages/@sanity/cli/src/util/organizationAliases.ts'
-      - 'packages/@sanity/cli/src/util/sharedFlags.ts'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -52,6 +43,7 @@ jobs:
         run: pnpm --filter @sanity/cli readme
 
       - name: Format README
+
         run: npx oxfmt packages/@sanity/cli/README.md
 
       - name: Create Pull Request

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -3,8 +3,19 @@ name: Update CLI README
 on:
   workflow_dispatch:
   push:
-    branches-ignore:
-      - 'renovate/**'
+    branches:
+      - main
+    paths:
+      - 'packages/@sanity/cli/src/commands/**'
+      - '!packages/@sanity/cli/src/commands/**/__tests__/**'
+      - 'packages/@sanity/cli/oclif.config.js'
+      - 'packages/@sanity/cli/package.json'
+      - 'packages/@sanity/cli/src/SanityHelp.ts'
+      - 'packages/@sanity/cli/src/topicAliases.ts'
+      - 'packages/@sanity/cli/src/util/organizationAliases.ts'
+      - 'packages/@sanity/cli/src/util/sharedFlags.ts'
+  pull_request:
+    types: [opened, synchronize]
     paths:
       - 'packages/@sanity/cli/src/commands/**'
       - '!packages/@sanity/cli/src/commands/**/__tests__/**'
@@ -16,7 +27,7 @@ on:
       - 'packages/@sanity/cli/src/util/sharedFlags.ts'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -24,6 +35,10 @@ permissions:
 
 jobs:
   update-readme:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.event.pull_request.head.ref, 'renovate/'))
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -38,6 +53,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup Environment
@@ -55,7 +71,10 @@ jobs:
         run: npx oxfmt packages/@sanity/cli/README.md
 
       - name: Commit README to feature branch
-        if: github.ref_name != github.event.repository.default_branch
+        if: github.event_name == 'pull_request' || github.ref_name != github.event.repository.default_branch
+        env:
+          BRANCH_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          BRANCH_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           git add packages/@sanity/cli/README.md
           if git diff --cached --quiet; then
@@ -66,7 +85,7 @@ jobs:
           git config user.name 'squiggler-app[bot]'
           git config user.email '265501495+squiggler-app[bot]@users.noreply.github.com'
           git commit -m 'chore: update CLI README'
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push --force-with-lease="${BRANCH_REF}:${BRANCH_SHA}" origin "HEAD:${BRANCH_REF}"
 
       - name: Create Pull Request
         if: github.ref_name == github.event.repository.default_branch

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,16 @@
+if ! git diff --cached --quiet -- \
+  packages/@sanity/cli/src/commands \
+  ':(exclude)packages/@sanity/cli/src/commands/**/__tests__/**' \
+  packages/@sanity/cli/oclif.config.js \
+  packages/@sanity/cli/package.json \
+  packages/@sanity/cli/src/SanityHelp.ts \
+  packages/@sanity/cli/src/topicAliases.ts \
+  packages/@sanity/cli/src/util/organizationAliases.ts \
+  packages/@sanity/cli/src/util/sharedFlags.ts
+then
+  pnpm exec turbo run build --filter=@sanity/cli...
+  pnpm --filter @sanity/cli readme
+  git add packages/@sanity/cli/README.md
+fi
+
 npx lint-staged


### PR DESCRIPTION
Instead of this happening:
1. Update some CLI commands in a PR
2. Merge the PR
3. See a PR like #1560 get opened to update the README
4. Merge that PR

Make it like this:
1. Update some CLI commands in a PR
2. Pre-commit hook updates the README
3. Merge the PR

Keeps the CI workflow on `main` untouched, but this should reduce the times where you inadvertently have caused the CLI README to get out of date.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local git hook only; no production runtime or CI behavior change beyond slightly longer commits when CLI sources are touched.
> 
> **Overview**
> Extends **`.husky/pre-commit`** so commits that stage changes under `@sanity/cli` command-related paths (commands, oclif config, help/alias utilities, etc.) automatically **build** `@sanity/cli`, run **`pnpm readme`** (`oclif readme`), and **`git add`** `packages/@sanity/cli/README.md` before the existing **`lint-staged`** step.
> 
> This keeps the CLI README in sync in the same commit instead of relying on a separate post-merge README update PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ffb83bef9b074e04e41b13007dbe397c61bd984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->