### PR TITLE
refactor: use exitCodes enum everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,9 +180,9 @@ catch (error: any) { }
 
 Commands use a small set of exit codes aligned with oclif defaults and Unix convention.
 
-- **0 - Success**: Command completed normally. Implicit when `run()` returns without throwing. Only use `this.exit(0)` when you need to short-circuit early on a successful path.
-- **1 - Runtime error**: Something went wrong during execution that is not the user's fault. API failures, network errors, missing project config, file system errors, unexpected state. Use `this.output.error(message, {exit: 1})`.
-- **2 - Usage error**: The user provided invalid input to the CLI itself. Bad arguments, unknown flags, invalid flag values, failing input validation. This is oclif's default for `this.output.error()` and all parse errors, so omitting the `exit` option also gives you 2. Use `this.output.error(message, {exit: 2})` or `this.output.error(message)`.
+- **0 - Success**: Command completed normally. Implicit when `run()` returns without throwing. Only use `this.exit(exitCodes.SUCCESS)` when you need to short-circuit early on a successful path.
+- **1 - Runtime error**: Something went wrong during execution that is not the user's fault. API failures, network errors, missing project config, file system errors, unexpected state. Use `this.output.error(message, {exit: exitCodes.RUNTIME_ERROR})`.
+- **2 - Usage error**: The user provided invalid input to the CLI itself. Bad arguments, unknown flags, invalid flag values, failing input validation. This is oclif's default for `this.output.error()` and all parse errors, so omitting the `exit` option also gives you 2. Use `this.output.error(message, {exit: exitCodes.USAGE_ERROR})` or `this.output.error(message)`.
 - **3 - User abort**: The user declined a confirmation prompt or otherwise chose not to proceed. The command didn't fail, but it also didn't complete its intended action. Use `this.exit(exitCodes.USER_ABORT)`. Import `exitCodes` from `@sanity/cli-core`.
 - **130 - User abort (signal)**: The user cancelled via Ctrl+C or dismissed a prompt without answering. Handled automatically by `SanityCommand.catch()` - commands should not set this manually.
 
@@ -197,7 +197,7 @@ Commands use a small set of exit codes aligned with oclif defaults and Unix conv
 
 ### In Practice
 
-- For `this.output.error()`: pass `{exit: 1}` for runtime errors, `{exit: 2}` (or omit) for usage errors.
+- For `this.output.error()`: pass `{exit: exitCodes.RUNTIME_ERROR}` for runtime errors, `{exit: exitCodes.USAGE_ERROR}` (or omit) for usage errors.
 - For user-declined prompts: `this.exit(exitCodes.USER_ABORT)` after logging a message like "Deploy cancelled."
 - For custom error classes extending `CLIError`: set `exit` in the constructor options.
 - For `this.exit()`: only use for early termination (exit 0 for success, exit 1 for programmatic failure like `doctor` checks failing).
@@ -379,7 +379,7 @@ Sanity CLI commands all extend from the `SanityCommand` class, which provides se
 ### Basic Command Structure
 
 ```typescript
-import {getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 import {Args, Flags, type FlagInput} from '@oclif/core'
 
 const debug = subdebug('namespace:command')
@@ -430,7 +430,7 @@ export class MyCommand extends SanityCommand<typeof MyCommand> {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
       debug('Operation failed', error)
-      this.output.error(`Failed: ${message}`, {exit: 1})
+      this.output.error(`Failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }
@@ -439,7 +439,7 @@ export class MyCommand extends SanityCommand<typeof MyCommand> {
 ### Error Handling Pattern
 
 ```typescript
-import {subdebug} from '@sanity/cli-core'
+import {exitCodes, subdebug} from '@sanity/cli-core'
 
 const debug = subdebug('feature:action')
 
@@ -452,7 +452,7 @@ try {
 
   // Show user-friendly message
   const message = error instanceof Error ? error.message : 'Unknown error'
-  this.output.error(`User-facing message: ${message}`, {exit: 1})
+  this.output.error(`User-facing message: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
 }
 ```
 

--- a/packages/@sanity/cli/src/commands/backups/disable.ts
+++ b/packages/@sanity/cli/src/commands/backups/disable.ts
@@ -64,11 +64,11 @@ export class DisableBackupCommand extends SanityCommand<typeof DisableBackupComm
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       disableBackupDebug(`Failed to list datasets: ${message}`, error)
-      this.error(`Failed to list datasets: ${message}`, {exit: 1})
+      this.error(`Failed to list datasets: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (datasets.length === 0) {
-      this.error('No datasets found in this project.', {exit: 1})
+      this.error('No datasets found in this project.', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (dataset) {
@@ -93,7 +93,7 @@ export class DisableBackupCommand extends SanityCommand<typeof DisableBackupComm
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       disableBackupDebug(`Failed to disable backup for dataset`, error)
-      this.error(`Disabling dataset backup failed: ${message}`, {exit: 1})
+      this.error(`Disabling dataset backup failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -111,7 +111,7 @@ export class DisableBackupCommand extends SanityCommand<typeof DisableBackupComm
     } catch (error) {
       const err = error as Error
       disableBackupDebug(`Error fetching datasets`, err)
-      this.error(`Failed to fetch datasets:\n${err.message}`, {exit: 1})
+      this.error(`Failed to fetch datasets:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/backups/download.ts
+++ b/packages/@sanity/cli/src/commands/backups/download.ts
@@ -130,11 +130,11 @@ export class DownloadBackupCommand extends SanityCommand<typeof DownloadBackupCo
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       backupDownloadDebug(`Failed to list datasets: ${message}`, error)
-      this.error(`Failed to list datasets: ${message}`, {exit: 1})
+      this.error(`Failed to list datasets: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (datasets.length === 0) {
-      this.error('No datasets found in this project.', {exit: 1})
+      this.error('No datasets found in this project.', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (dataset) {
@@ -230,7 +230,7 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
       progressSpinner.fail()
       const message = error instanceof Error ? error.message : String(error)
       backupDownloadDebug(`Downloading dataset backup failed: ${message}`, error)
-      this.error(`Downloading dataset backup failed: ${message}`, {exit: 1})
+      this.error(`Downloading dataset backup failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     docOutStream.end()
@@ -247,7 +247,7 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
       progressSpinner.fail()
       const message = err instanceof Error ? err.message : String(err)
       backupDownloadDebug(`Archiving backup failed: ${message}`, err)
-      this.error(`Archiving backup failed: ${message}`, {exit: 1})
+      this.error(`Archiving backup failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     progressSpinner.set({
@@ -286,7 +286,7 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
   ): Promise<DownloadBackupOptions> {
     const err = validateDatasetName(datasetName)
     if (err) {
-      this.error(err, {exit: 1})
+      this.error(err, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const backupId = String(
@@ -354,7 +354,7 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
       })
 
       if (!response?.backups?.length) {
-        this.error('No backups found', {exit: 1})
+        this.error('No backups found', {exit: exitCodes.RUNTIME_ERROR})
       }
 
       const backupIdChoices = response.backups.map((backup: BackupItem) => ({
@@ -374,7 +374,7 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       backupDownloadDebug(`Failed to fetch backups for dataset ${datasetName}: ${message}`, err)
-      this.error(`Failed to fetch backups for dataset ${datasetName}: ${message}`, {exit: 1})
+      this.error(`Failed to fetch backups for dataset ${datasetName}: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/backups/download.ts
+++ b/packages/@sanity/cli/src/commands/backups/download.ts
@@ -374,7 +374,9 @@ ${styleText('bold', 'backupId')}: ${styleText('cyan', opts.backupId)}`,
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       backupDownloadDebug(`Failed to fetch backups for dataset ${datasetName}: ${message}`, err)
-      this.error(`Failed to fetch backups for dataset ${datasetName}: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Failed to fetch backups for dataset ${datasetName}: ${message}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/backups/enable.ts
+++ b/packages/@sanity/cli/src/commands/backups/enable.ts
@@ -97,7 +97,9 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
           enableBackupDebug(`Failed to create dataset ${newDatasetName}: ${message}`, error)
-          this.error(`Failed to create dataset ${newDatasetName}: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
+          this.error(`Failed to create dataset ${newDatasetName}: ${message}`, {
+            exit: exitCodes.RUNTIME_ERROR,
+          })
         }
       }
     }

--- a/packages/@sanity/cli/src/commands/backups/enable.ts
+++ b/packages/@sanity/cli/src/commands/backups/enable.ts
@@ -65,13 +65,13 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       enableBackupDebug(`Failed to list datasets: ${message}`, error)
-      this.error(`Failed to list datasets: ${message}`, {exit: 1})
+      this.error(`Failed to list datasets: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const hasProduction = datasets.some((dataset) => dataset.name === 'production')
 
     if (datasets.length === 0) {
-      this.error('No datasets found in this project.', {exit: 1})
+      this.error('No datasets found in this project.', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (dataset) {
@@ -97,7 +97,7 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
           enableBackupDebug(`Failed to create dataset ${newDatasetName}: ${message}`, error)
-          this.error(`Failed to create dataset ${newDatasetName}: ${message}`, {exit: 1})
+          this.error(`Failed to create dataset ${newDatasetName}: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
         }
       }
     }
@@ -120,7 +120,7 @@ export class EnableBackupCommand extends SanityCommand<typeof EnableBackupComman
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       enableBackupDebug(`Failed to enable backup for dataset`, error)
-      this.error(`Enabling dataset backup failed: ${message}`, {exit: 1})
+      this.error(`Enabling dataset backup failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/backups/list.ts
+++ b/packages/@sanity/cli/src/commands/backups/list.ts
@@ -118,7 +118,9 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
           this.error('--after date must be before --before', {exit: exitCodes.RUNTIME_ERROR})
         }
       } catch (err) {
-        this.error(`Parsing date flags: ${err instanceof Error ? err.message : err}`, {exit: exitCodes.RUNTIME_ERROR})
+        this.error(`Parsing date flags: ${err instanceof Error ? err.message : err}`, {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
     }
 

--- a/packages/@sanity/cli/src/commands/backups/list.ts
+++ b/packages/@sanity/cli/src/commands/backups/list.ts
@@ -91,11 +91,11 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       listBackupDebug(`Failed to list datasets: ${message}`, error)
-      this.error(`Failed to list datasets: ${message}`, {exit: 1})
+      this.error(`Failed to list datasets: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (datasets.length === 0) {
-      this.error('No datasets found in this project.', {exit: 1})
+      this.error('No datasets found in this project.', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (dataset) {
@@ -115,17 +115,17 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
         const parsedAfter = this.processDateFlag(flags.after, 'after')
 
         if (parsedAfter && parsedBefore && isAfter(parsedAfter, parsedBefore)) {
-          this.error('--after date must be before --before', {exit: 1})
+          this.error('--after date must be before --before', {exit: exitCodes.RUNTIME_ERROR})
         }
       } catch (err) {
-        this.error(`Parsing date flags: ${err instanceof Error ? err.message : err}`, {exit: 1})
+        this.error(`Parsing date flags: ${err instanceof Error ? err.message : err}`, {exit: exitCodes.RUNTIME_ERROR})
       }
     }
 
     // Validate limit flag
     if (flags.limit < 1 || flags.limit > Number.MAX_SAFE_INTEGER) {
       this.error(`Parsing --limit: must be an integer between 1 and ${Number.MAX_SAFE_INTEGER}`, {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     }
 
@@ -180,7 +180,7 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       listBackupDebug(`Failed to list backups for dataset ${dataset}:`, error)
-      this.error(`List dataset backup failed: ${message}`, {exit: 1})
+      this.error(`List dataset backup failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -208,7 +208,7 @@ export class ListBackupCommand extends SanityCommand<typeof ListBackupCommand> {
     } catch (error) {
       listBackupDebug(`Error selecting dataset`, error)
       this.error(`Failed to select dataset:\n${error instanceof Error ? error.message : error}`, {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     }
   }

--- a/packages/@sanity/cli/src/commands/codemod.ts
+++ b/packages/@sanity/cli/src/commands/codemod.ts
@@ -3,7 +3,7 @@ import {existsSync} from 'node:fs'
 import path from 'node:path'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {codemods} from '../actions/codemods/index.js'
 import {type CodeMod} from '../actions/codemods/types.js'
@@ -66,7 +66,7 @@ export class CodemodCommand extends SanityCommand<typeof CodemodCommand> {
     // Verify that mod exists
     const mod = normalizedMods.get(codemodName.toLowerCase())
     if (!mod) {
-      this.error(`Codemod with name "${codemodName}" not found`, {exit: 1})
+      this.error(`Codemod with name "${codemodName}" not found`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     // Verify if there is any verification defined, and user has not opted out of it
@@ -76,7 +76,7 @@ export class CodemodCommand extends SanityCommand<typeof CodemodCommand> {
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error))
         codemodeDebug('Verification failed: %s', err.message)
-        this.error(`Verification failed: ${err.message}`, {exit: 1})
+        this.error(`Verification failed: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
       }
     }
 
@@ -133,12 +133,12 @@ export class CodemodCommand extends SanityCommand<typeof CodemodCommand> {
     try {
       const npxHelp = execSync('npx --help', {encoding: 'utf8'})
       if (!npxHelp.includes('npm')) {
-        this.error('Not the npx we expected', {exit: 1})
+        this.error('Not the npx we expected', {exit: exitCodes.RUNTIME_ERROR})
       }
     } catch {
       this.error(
         `Failed to run "npx" - required to run codemods. Do you have a recent version of npm installed?`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
   }

--- a/packages/@sanity/cli/src/commands/cors/add.ts
+++ b/packages/@sanity/cli/src/commands/cors/add.ts
@@ -123,7 +123,7 @@ export class Add extends SanityCommand<typeof Add> {
       const err = error as Error
 
       addCorsDebug(`Error adding CORS origin`, err)
-      this.error(`CORS origin addition failed:\n${err.message}`, {exit: 1})
+      this.error(`CORS origin addition failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 

--- a/packages/@sanity/cli/src/commands/cors/delete.ts
+++ b/packages/@sanity/cli/src/commands/cors/delete.ts
@@ -67,7 +67,7 @@ export class Delete extends SanityCommand<typeof Delete> {
     } catch (error) {
       const err = error as Error
       deleteCorsDebug(`Error deleting CORS origin ${originId} for project ${projectId}`, err)
-      this.error(`Origin deletion failed:\n${err.message}`, {exit: 1})
+      this.error(`Origin deletion failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -81,11 +81,11 @@ export class Delete extends SanityCommand<typeof Delete> {
     } catch (error) {
       const err = error as Error
       deleteCorsDebug(`Error fetching CORS origins for project ${projectId}`, err)
-      this.error(`Failed to fetch CORS origins:\n${err.message}`, {exit: 1})
+      this.error(`Failed to fetch CORS origins:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (origins.length === 0) {
-      this.error('No CORS origins configured for this project.', {exit: 1})
+      this.error('No CORS origins configured for this project.', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     // If origin is specified, find it in the list
@@ -96,7 +96,7 @@ export class Delete extends SanityCommand<typeof Delete> {
       )
 
       if (!selectedOrigin) {
-        this.error(`Origin "${specifiedOrigin}" not found`, {exit: 1})
+        this.error(`Origin "${specifiedOrigin}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       return selectedOrigin.id

--- a/packages/@sanity/cli/src/commands/cors/list.ts
+++ b/packages/@sanity/cli/src/commands/cors/list.ts
@@ -1,4 +1,4 @@
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {type CorsOrigin, listCorsOrigins} from '../../services/cors.js'
@@ -43,7 +43,7 @@ export class List extends SanityCommand<typeof List> {
       const err = error as Error
 
       listCorsDebug(`Error fetching CORS origins for project ${projectId}`, err)
-      this.error(`CORS origins list retrieval failed:\n${err.message}`, {exit: 1})
+      this.error(`CORS origins list retrieval failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (origins.length === 0) {

--- a/packages/@sanity/cli/src/commands/cors/list.ts
+++ b/packages/@sanity/cli/src/commands/cors/list.ts
@@ -43,7 +43,9 @@ export class List extends SanityCommand<typeof List> {
       const err = error as Error
 
       listCorsDebug(`Error fetching CORS origins for project ${projectId}`, err)
-      this.error(`CORS origins list retrieval failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`CORS origins list retrieval failed:\n${err.message}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     if (origins.length === 0) {

--- a/packages/@sanity/cli/src/commands/datasets/alias/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/create.ts
@@ -122,7 +122,9 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
       }
 
       if (existingAliases.includes(aliasName)) {
-        this.error(`Dataset alias "${aliasOutputName}" already exists`, {exit: exitCodes.RUNTIME_ERROR})
+        this.error(`Dataset alias "${aliasOutputName}" already exists`, {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
 
       const targetDataset =

--- a/packages/@sanity/cli/src/commands/datasets/alias/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/create.ts
@@ -95,11 +95,11 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
       canCreateAlias = features.includes('advancedDatasetManagement')
     } catch (error) {
       createAliasDebug(`Error getting project features`, error)
-      this.error('Failed to get project features', {exit: 1})
+      this.error('Failed to get project features', {exit: exitCodes.RUNTIME_ERROR})
     }
     if (!canCreateAlias) {
       this.error('This project cannot create a dataset alias - see https://www.sanity.io/pricing', {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     }
 
@@ -122,7 +122,7 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
       }
 
       if (existingAliases.includes(aliasName)) {
-        this.error(`Dataset alias "${aliasOutputName}" already exists`, {exit: 1})
+        this.error(`Dataset alias "${aliasOutputName}" already exists`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       const targetDataset =
@@ -132,7 +132,7 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
       if (targetDataset && !datasets.includes(targetDataset)) {
         this.error(
           `Dataset "${targetDataset}" does not exist. Available datasets: ${datasets.join(', ')}`,
-          {exit: 1},
+          {exit: exitCodes.RUNTIME_ERROR},
         )
       }
 
@@ -145,7 +145,7 @@ export class CreateAliasCommand extends SanityCommand<typeof CreateAliasCommand>
       createAliasDebug(`Error creating dataset alias`, error)
       this.error(
         `Dataset alias creation failed: ${error instanceof Error ? error.message : String(error)}`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
   }

--- a/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/delete.ts
@@ -72,7 +72,7 @@ export class DeleteAliasCommand extends SanityCommand<typeof DeleteAliasCommand>
 
       if (!existingAlias) {
         this.error(`Dataset alias "${displayName}" does not exist`, {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         })
       }
 
@@ -95,7 +95,7 @@ export class DeleteAliasCommand extends SanityCommand<typeof DeleteAliasCommand>
       const errorMessage = error instanceof Error ? error.message : String(error)
 
       deleteAliasDebug(`Error deleting dataset alias ${args.aliasName}`, error)
-      this.error(`Dataset alias deletion failed: ${errorMessage}`, {exit: 1})
+      this.error(`Dataset alias deletion failed: ${errorMessage}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 

--- a/packages/@sanity/cli/src/commands/datasets/alias/link.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/link.ts
@@ -147,7 +147,9 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
       }
 
       if (existingAlias.datasetName === targetDataset) {
-        this.error(`Dataset alias ${displayName} already linked to ${targetDataset}`, {exit: exitCodes.RUNTIME_ERROR})
+        this.error(`Dataset alias ${displayName} already linked to ${targetDataset}`, {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
 
       if (existingAlias.datasetName && !force) {

--- a/packages/@sanity/cli/src/commands/datasets/alias/link.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/link.ts
@@ -123,7 +123,7 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
         const availableAliases = aliases.map((a) => `~${a.name}`).join(', ')
         this.error(
           `Dataset alias "${displayName}" does not exist. Available aliases: ${availableAliases}`,
-          {exit: 1},
+          {exit: exitCodes.RUNTIME_ERROR},
         )
       }
 
@@ -136,18 +136,18 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
           : null)
 
       if (!targetDataset) {
-        this.error('No datasets available to link to', {exit: 1})
+        this.error('No datasets available to link to', {exit: exitCodes.RUNTIME_ERROR})
       }
 
       if (!datasets.includes(targetDataset)) {
         this.error(
           `Dataset "${targetDataset}" does not exist. Available datasets: ${datasets.join(', ')}`,
-          {exit: 1},
+          {exit: exitCodes.RUNTIME_ERROR},
         )
       }
 
       if (existingAlias.datasetName === targetDataset) {
-        this.error(`Dataset alias ${displayName} already linked to ${targetDataset}`, {exit: 1})
+        this.error(`Dataset alias ${displayName} already linked to ${targetDataset}`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       if (existingAlias.datasetName && !force) {
@@ -169,7 +169,7 @@ export class LinkAliasCommand extends SanityCommand<typeof LinkAliasCommand> {
       linkAliasDebug(`Error linking dataset alias`, error)
       this.error(
         `Dataset alias linking failed: ${error instanceof Error ? error.message : String(error)}`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
   }

--- a/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
@@ -92,11 +92,11 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
       // get the current alias from the remote alias list
       const linkedAlias = aliases.find((elem) => elem.name === apiName)
       if (!linkedAlias) {
-        this.error(`Dataset alias "${displayName}" does not exist`, {exit: 1})
+        this.error(`Dataset alias "${displayName}" does not exist`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       if (!linkedAlias.datasetName) {
-        this.error(`Dataset alias "${displayName}" is not linked to a dataset`, {exit: 1})
+        this.error(`Dataset alias "${displayName}" is not linked to a dataset`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       if (force) {
@@ -117,7 +117,7 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
       unlinkAliasDebug('Error unlinking dataset alias', error)
       this.error(
         `Dataset alias unlink failed: ${error instanceof Error ? error.message : String(error)}`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
   }

--- a/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
+++ b/packages/@sanity/cli/src/commands/datasets/alias/unlink.ts
@@ -96,7 +96,9 @@ export class UnlinkAliasCommand extends SanityCommand<typeof UnlinkAliasCommand>
       }
 
       if (!linkedAlias.datasetName) {
-        this.error(`Dataset alias "${displayName}" is not linked to a dataset`, {exit: exitCodes.RUNTIME_ERROR})
+        this.error(`Dataset alias "${displayName}" is not linked to a dataset`, {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
 
       if (force) {

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -242,7 +242,9 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to attach to copy job: %s', message, error)
-      return this.output.error(`Failed to attach to copy job: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
+      return this.output.error(`Failed to attach to copy job: ${message}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 
@@ -271,7 +273,9 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to fetch datasets: %s', message, error)
-      return this.output.error(`Failed to fetch datasets: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
+      return this.output.error(`Failed to fetch datasets: ${message}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     const datasetNames = new Set(datasetsResponse.map((ds) => ds.name))
@@ -284,7 +288,9 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     }
 
     if (!datasetNames.has(sourceDataset)) {
-      return this.output.error(`Source dataset "${sourceDataset}" doesn't exist`, {exit: exitCodes.RUNTIME_ERROR})
+      return this.output.error(`Source dataset "${sourceDataset}" doesn't exist`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     // Get and validate target dataset
@@ -301,7 +307,9 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     }
 
     if (datasetNames.has(targetDataset)) {
-      return this.output.error(`Target dataset "${targetDataset}" already exists`, {exit: exitCodes.RUNTIME_ERROR})
+      return this.output.error(`Target dataset "${targetDataset}" already exists`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     // Start the copy job
@@ -335,7 +343,9 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Dataset copying failed: %s', message, error)
-      return this.output.error(`Dataset copying failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
+      return this.output.error(`Dataset copying failed: ${message}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 
@@ -361,7 +371,9 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to list dataset copy jobs: %s', message, error)
-      return this.output.error(`Failed to list dataset copy jobs: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
+      return this.output.error(`Failed to list dataset copy jobs: ${message}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -233,7 +233,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     copyDatasetDebug('Attaching to copy job %s', jobId)
 
     if (jobId.trim() === '') {
-      return this.output.error('Please supply a valid jobId', {exit: 1})
+      return this.output.error('Please supply a valid jobId', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     try {
@@ -242,7 +242,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to attach to copy job: %s', message, error)
-      return this.output.error(`Failed to attach to copy job: ${message}`, {exit: 1})
+      return this.output.error(`Failed to attach to copy job: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -271,7 +271,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to fetch datasets: %s', message, error)
-      return this.output.error(`Failed to fetch datasets: ${message}`, {exit: 1})
+      return this.output.error(`Failed to fetch datasets: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const datasetNames = new Set(datasetsResponse.map((ds) => ds.name))
@@ -284,7 +284,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     }
 
     if (!datasetNames.has(sourceDataset)) {
-      return this.output.error(`Source dataset "${sourceDataset}" doesn't exist`, {exit: 1})
+      return this.output.error(`Source dataset "${sourceDataset}" doesn't exist`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     // Get and validate target dataset
@@ -301,7 +301,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     }
 
     if (datasetNames.has(targetDataset)) {
-      return this.output.error(`Target dataset "${targetDataset}" already exists`, {exit: 1})
+      return this.output.error(`Target dataset "${targetDataset}" already exists`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     // Start the copy job
@@ -335,7 +335,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Dataset copying failed: %s', message, error)
-      return this.output.error(`Dataset copying failed: ${message}`, {exit: 1})
+      return this.output.error(`Dataset copying failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -361,7 +361,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       copyDatasetDebug('Failed to list dataset copy jobs: %s', message, error)
-      return this.output.error(`Failed to list dataset copy jobs: ${message}`, {exit: 1})
+      return this.output.error(`Failed to list dataset copy jobs: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 

--- a/packages/@sanity/cli/src/commands/datasets/create.ts
+++ b/packages/@sanity/cli/src/commands/datasets/create.ts
@@ -104,11 +104,11 @@ export class CreateDatasetCommand extends SanityCommand<typeof CreateDatasetComm
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       createDatasetDebug(`Failed to fetch project data: ${message}`, error)
-      this.error(`Failed to fetch project data: ${message}`, {exit: 1})
+      this.error(`Failed to fetch project data: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (datasets.includes(datasetName)) {
-      this.error(`Dataset "${datasetName}" already exists`, {exit: 1})
+      this.error(`Dataset "${datasetName}" already exists`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const canCreatePrivate = projectFeatures.includes('privateDataset')
@@ -127,7 +127,7 @@ export class CreateDatasetCommand extends SanityCommand<typeof CreateDatasetComm
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      this.error(`Failed to create dataset: ${message}`, {exit: 1})
+      this.error(`Failed to create dataset: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/datasets/delete.ts
+++ b/packages/@sanity/cli/src/commands/datasets/delete.ts
@@ -83,7 +83,7 @@ export class DeleteDatasetCommand extends SanityCommand<typeof DeleteDatasetComm
       } catch (error) {
         const err = error instanceof Error ? error : new Error(`${error}`)
         deleteDatasetDebug(`Error getting project ${projectId}`, err)
-        this.error(`Project retrieval failed: ${err.message}`, {exit: 1})
+        this.error(`Project retrieval failed: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       await input({
@@ -104,7 +104,7 @@ export class DeleteDatasetCommand extends SanityCommand<typeof DeleteDatasetComm
     } catch (error) {
       const err = error instanceof Error ? error : new Error(`${error}`)
       deleteDatasetDebug(`Error deleting dataset ${datasetName}`, err)
-      this.error(`Dataset deletion failed: ${err.message}`, {exit: 1})
+      this.error(`Dataset deletion failed: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/disable.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/disable.ts
@@ -2,7 +2,7 @@ import {styleText} from 'node:util'
 
 import {Args} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {resolveDataset} from '../../../actions/dataset/resolveDataset.js'
 import {promptForProject} from '../../../prompts/promptForProject.js'
@@ -64,7 +64,7 @@ export class DatasetEmbeddingsDisableCommand extends SanityCommand<
       if (error instanceof CLIError) throw error
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to resolve dataset: ${message}`, error)
-      this.error(message, {exit: 1})
+      this.error(message, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     try {
@@ -72,7 +72,7 @@ export class DatasetEmbeddingsDisableCommand extends SanityCommand<
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to disable embeddings: ${message}`, error)
-      this.error(`Failed to disable embeddings: ${message}`, {exit: 1})
+      this.error(`Failed to disable embeddings: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     this.log(styleText('green', `Disabled embeddings for dataset ${dataset}.`))

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/enable.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/enable.ts
@@ -87,7 +87,7 @@ export class DatasetEmbeddingsEnableCommand extends SanityCommand<
       if (error instanceof CLIError) throw error
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to resolve dataset: ${message}`, error)
-      this.error(message, {exit: 1})
+      this.error(message, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (projection) {
@@ -104,7 +104,7 @@ export class DatasetEmbeddingsEnableCommand extends SanityCommand<
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to enable embeddings: ${message}`, error)
-      this.error(`Failed to enable embeddings: ${message}`, {exit: 1})
+      this.error(`Failed to enable embeddings: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     this.log(styleText('green', `Embeddings enabled for dataset ${dataset}.`))
@@ -134,7 +134,7 @@ export class DatasetEmbeddingsEnableCommand extends SanityCommand<
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         spin.fail('Failed while waiting for embeddings.')
-        this.error(`Failed while waiting for embeddings: ${message}`, {exit: 1})
+        this.error(`Failed while waiting for embeddings: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
       }
       debug(`Poll status: ${settings.status}, next interval: ${Math.round(interval)}ms`)
 
@@ -145,13 +145,13 @@ export class DatasetEmbeddingsEnableCommand extends SanityCommand<
 
       if (settings.status !== 'updating') {
         spin.fail(`Unexpected status: ${settings.status}`)
-        this.error(`Embeddings entered unexpected status: ${settings.status}`, {exit: 1})
+        this.error(`Embeddings entered unexpected status: ${settings.status}`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       spin.text = 'Still processing...'
     }
 
     spin.fail('Timed out waiting for embeddings.')
-    this.error('Timed out. Check status with: sanity dataset embeddings status', {exit: 1})
+    this.error('Timed out. Check status with: sanity dataset embeddings status', {exit: exitCodes.RUNTIME_ERROR})
   }
 }

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/enable.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/enable.ts
@@ -134,7 +134,9 @@ export class DatasetEmbeddingsEnableCommand extends SanityCommand<
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         spin.fail('Failed while waiting for embeddings.')
-        this.error(`Failed while waiting for embeddings: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
+        this.error(`Failed while waiting for embeddings: ${message}`, {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
       debug(`Poll status: ${settings.status}, next interval: ${Math.round(interval)}ms`)
 
@@ -145,13 +147,17 @@ export class DatasetEmbeddingsEnableCommand extends SanityCommand<
 
       if (settings.status !== 'updating') {
         spin.fail(`Unexpected status: ${settings.status}`)
-        this.error(`Embeddings entered unexpected status: ${settings.status}`, {exit: exitCodes.RUNTIME_ERROR})
+        this.error(`Embeddings entered unexpected status: ${settings.status}`, {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
 
       spin.text = 'Still processing...'
     }
 
     spin.fail('Timed out waiting for embeddings.')
-    this.error('Timed out. Check status with: sanity dataset embeddings status', {exit: exitCodes.RUNTIME_ERROR})
+    this.error('Timed out. Check status with: sanity dataset embeddings status', {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   }
 }

--- a/packages/@sanity/cli/src/commands/datasets/embeddings/status.ts
+++ b/packages/@sanity/cli/src/commands/datasets/embeddings/status.ts
@@ -1,6 +1,6 @@
 import {Args} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {resolveDataset} from '../../../actions/dataset/resolveDataset.js'
 import {promptForProject} from '../../../prompts/promptForProject.js'
@@ -59,7 +59,7 @@ export class DatasetEmbeddingsStatusCommand extends SanityCommand<
       if (error instanceof CLIError) throw error
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to resolve dataset: ${message}`, error)
-      this.error(message, {exit: 1})
+      this.error(message, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     try {
@@ -74,7 +74,7 @@ export class DatasetEmbeddingsStatusCommand extends SanityCommand<
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       debug(`Failed to get embeddings settings: ${message}`, error)
-      this.error(`Failed to get embeddings settings: ${message}`, {exit: 1})
+      this.error(`Failed to get embeddings settings: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/datasets/export.ts
+++ b/packages/@sanity/cli/src/commands/datasets/export.ts
@@ -130,7 +130,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
     } catch (error) {
       exportDebug('Error listing datasets', error)
       this.error(`Failed to list datasets:\n${error instanceof Error ? error.message : error}`, {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     }
 
@@ -179,7 +179,7 @@ export class DatasetExportCommand extends SanityCommand<typeof DatasetExportComm
 
     // Verify existence of dataset before trying to export from it
     if (!datasets.some((set) => set.name === dataset)) {
-      this.error(`Dataset with name "${dataset}" not found`, {exit: 1})
+      this.error(`Dataset with name "${dataset}" not found`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     this.log(
@@ -204,7 +204,7 @@ dataset: ${dataset.padEnd(46)}`,
 
     const outputPath = await this.getOutputPath(destinationPath, dataset, flags)
     if (!outputPath) {
-      this.error('Cancelled', {exit: 1})
+      this.error('Cancelled', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     // Prepare export options
@@ -233,7 +233,7 @@ dataset: ${dataset.padEnd(46)}`,
       fail()
       const err = error instanceof Error ? error : new Error(String(error))
       exportDebug('Export failed', err)
-      this.error(`Export failed: ${err.message}`, {exit: 1})
+      this.error(`Export failed: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -293,12 +293,12 @@ dataset: ${dataset.padEnd(46)}`,
           this.error(
             `Permission denied: Cannot create directory "${createPath}". Please check write permissions.`,
             {
-              exit: 1,
+              exit: exitCodes.RUNTIME_ERROR,
             },
           )
         } else {
           this.error(`Failed to create directory "${createPath}": ${err.message}`, {
-            exit: 1,
+            exit: exitCodes.RUNTIME_ERROR,
           })
         }
       }

--- a/packages/@sanity/cli/src/commands/datasets/import.ts
+++ b/packages/@sanity/cli/src/commands/datasets/import.ts
@@ -294,7 +294,9 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
             `Import failed due to unicode replacement characters in the data.\n${(err as Error).message}\n\nIf you are certain you want to proceed with the import despite potentially corrupt data, re-run the import with the \`--allow-replacement-characters\` flag set.`,
             {exit: exitCodes.RUNTIME_ERROR},
           )
-        : this.output.error((err as Error).stack || (err as Error).message, {exit: exitCodes.RUNTIME_ERROR})
+        : this.output.error((err as Error).stack || (err as Error).message, {
+            exit: exitCodes.RUNTIME_ERROR,
+          })
     }
   }
 

--- a/packages/@sanity/cli/src/commands/datasets/import.ts
+++ b/packages/@sanity/cli/src/commands/datasets/import.ts
@@ -219,7 +219,7 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
           const message = error instanceof Error ? error.message : String(error)
           importDebug(`Failed to create dataset ${newDatasetName}: ${message}`, error)
           return this.output.error(`Failed to create dataset ${newDatasetName}: ${message}`, {
-            exit: 1,
+            exit: exitCodes.RUNTIME_ERROR,
           })
         }
       }
@@ -292,9 +292,9 @@ export class ImportDatasetCommand extends SanityCommand<typeof ImportDatasetComm
       return (err as Error).name === 'ReplacementCharError'
         ? this.output.error(
             `Import failed due to unicode replacement characters in the data.\n${(err as Error).message}\n\nIf you are certain you want to proceed with the import despite potentially corrupt data, re-run the import with the \`--allow-replacement-characters\` flag set.`,
-            {exit: 1},
+            {exit: exitCodes.RUNTIME_ERROR},
           )
-        : this.output.error((err as Error).stack || (err as Error).message, {exit: 1})
+        : this.output.error((err as Error).stack || (err as Error).message, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 

--- a/packages/@sanity/cli/src/commands/datasets/list.ts
+++ b/packages/@sanity/cli/src/commands/datasets/list.ts
@@ -1,4 +1,4 @@
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {listDatasetAliases, listDatasets} from '../../services/datasets.js'
@@ -45,7 +45,7 @@ export class ListDatasetCommand extends SanityCommand<typeof ListDatasetCommand>
     if (datasets.status === 'rejected') {
       const err = datasets.reason as Error
       listDatasetDebug(`Error listing datasets for project ${projectId}`, err)
-      this.error(`Dataset list retrieval failed: ${err.message}`, {exit: 1})
+      this.error(`Dataset list retrieval failed: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const datasetList = datasets.value

--- a/packages/@sanity/cli/src/commands/datasets/visibility/get.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/get.ts
@@ -58,12 +58,12 @@ export class DatasetVisibilityGetCommand extends SanityCommand<typeof DatasetVis
       getDebug(`Error listing datasets`, error)
       this.error(
         `Failed to list datasets: ${error instanceof Error ? error.message : String(error)}`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
 
     if (!current) {
-      this.error(`Dataset not found: ${dataset}`, {exit: 1})
+      this.error(`Dataset not found: ${dataset}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     this.log(current.aclMode)

--- a/packages/@sanity/cli/src/commands/datasets/visibility/set.ts
+++ b/packages/@sanity/cli/src/commands/datasets/visibility/set.ts
@@ -70,13 +70,13 @@ export class DatasetVisibilitySetCommand extends SanityCommand<typeof DatasetVis
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       setDatasetVisibilityDebug(`Failed to list datasets: ${message}`, error)
-      this.error(`Failed to list datasets: ${message}`, {exit: 1})
+      this.error(`Failed to list datasets: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const current = datasets.find((curr: {name: string}) => curr.name === dataset)
 
     if (!current) {
-      this.error(`Dataset "${dataset}" not found`, {exit: 1})
+      this.error(`Dataset "${dataset}" not found`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (current.aclMode === mode) {
@@ -99,7 +99,7 @@ export class DatasetVisibilitySetCommand extends SanityCommand<typeof DatasetVis
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       setDatasetVisibilityDebug(`Failed to edit dataset: ${message}`, error)
-      this.error(`Failed to edit dataset: ${message}`, {exit: 1})
+      this.error(`Failed to edit dataset: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
     this.log('Dataset visibility changed')
   }

--- a/packages/@sanity/cli/src/commands/deploy.ts
+++ b/packages/@sanity/cli/src/commands/deploy.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 
 import {deployApp} from '../actions/deploy/deployApp.js'
@@ -126,7 +126,7 @@ export class DeployCommand extends SanityCommand<typeof DeployCommand> {
           }))
 
         if (!shouldProceed) {
-          this.output.error('Cancelled.', {exit: 1})
+          this.output.error('Cancelled.', {exit: exitCodes.RUNTIME_ERROR})
         }
       }
 

--- a/packages/@sanity/cli/src/commands/dev.ts
+++ b/packages/@sanity/cli/src/commands/dev.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Flags} from '@oclif/core'
-import {type CliConfig, SanityCommand} from '@sanity/cli-core'
+import {type CliConfig, exitCodes, SanityCommand} from '@sanity/cli-core'
 import {isWorkbenchApp} from '@sanity/workbench-cli'
 
 import {devAction} from '../actions/dev/devAction.js'
@@ -81,7 +81,7 @@ export class DevCommand extends SanityCommand<typeof DevCommand> {
       this.output.error(
         styleText(['red', 'bgBlack'], `Failed to start dev server: ${error.message}`),
         {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         },
       )
     }

--- a/packages/@sanity/cli/src/commands/docs/read.ts
+++ b/packages/@sanity/cli/src/commands/docs/read.ts
@@ -119,7 +119,7 @@ export class DocsReadCommand extends SanityCommand<typeof DocsReadCommand> {
       this.log(content)
     } catch (error) {
       this.error(error instanceof Error ? error.message : 'Failed to read article', {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     }
   }

--- a/packages/@sanity/cli/src/commands/docs/search.ts
+++ b/packages/@sanity/cli/src/commands/docs/search.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
-import {isInteractive, SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, isInteractive, SanityCommand, subdebug} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 
 import {readDoc, searchDocs, type SearchResult} from '../../services/docs.js'
@@ -66,7 +66,7 @@ export class DocsSearchCommand extends SanityCommand<typeof DocsSearchCommand> {
           ? error.message
           : 'The documentation search API is currently unavailable. Please try again later.'
       this.error(message, {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     }
 
@@ -114,7 +114,7 @@ export class DocsSearchCommand extends SanityCommand<typeof DocsSearchCommand> {
           this.error(
             `Failed to read article: ${error instanceof Error ? error.message : 'Unknown error'}`,
             {
-              exit: 1,
+              exit: exitCodes.RUNTIME_ERROR,
             },
           )
         }

--- a/packages/@sanity/cli/src/commands/doctor.ts
+++ b/packages/@sanity/cli/src/commands/doctor.ts
@@ -69,7 +69,9 @@ export class DoctorCommand extends SanityCommand<typeof DoctorCommand> {
     try {
       checks = getChecks(argv)
     } catch (err) {
-      return this.output.error(err instanceof Error ? err.message : String(err), {exit: exitCodes.USAGE_ERROR})
+      return this.output.error(err instanceof Error ? err.message : String(err), {
+        exit: exitCodes.USAGE_ERROR,
+      })
     }
     const cwd = process.cwd()
 

--- a/packages/@sanity/cli/src/commands/doctor.ts
+++ b/packages/@sanity/cli/src/commands/doctor.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 import {logSymbols} from '@sanity/cli-core/ux'
 
 import {type DoctorCheckName, doctorChecks, KNOWN_CHECKS} from '../actions/doctor/checks/index.js'
@@ -69,7 +69,7 @@ export class DoctorCommand extends SanityCommand<typeof DoctorCommand> {
     try {
       checks = getChecks(argv)
     } catch (err) {
-      return this.output.error(err instanceof Error ? err.message : String(err), {exit: 2})
+      return this.output.error(err instanceof Error ? err.message : String(err), {exit: exitCodes.USAGE_ERROR})
     }
     const cwd = process.cwd()
 
@@ -91,7 +91,7 @@ export class DoctorCommand extends SanityCommand<typeof DoctorCommand> {
 
     // Exit with error code if any checks failed
     if (results.summary.errors > 0) {
-      return this.exit(1)
+      return this.exit(exitCodes.RUNTIME_ERROR)
     }
   }
 

--- a/packages/@sanity/cli/src/commands/documents/create.ts
+++ b/packages/@sanity/cli/src/commands/documents/create.ts
@@ -152,7 +152,7 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
       } catch (error) {
         const err = error as Error
         createDocumentDebug(`Error creating documents from file ${file}`, err)
-        this.error(`Failed to create documents: ${err.message}`, {exit: 1})
+        this.error(`Failed to create documents: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
       }
     }
 
@@ -216,7 +216,7 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
     } catch (error) {
       const err = error as Error
       createDocumentDebug('Error in editor workflow', err)
-      this.error(`Failed to create documents: ${err.message}`, {exit: 1})
+      this.error(`Failed to create documents: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -297,7 +297,7 @@ export class CreateDocumentCommand extends SanityCommand<typeof CreateDocumentCo
       if (error.message.includes('already exists')) {
         errorMessage += '\nPerhaps you want to use `--replace` or `--missing`?'
       }
-      this.error(errorMessage, {exit: 1})
+      this.error(errorMessage, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 

--- a/packages/@sanity/cli/src/commands/documents/delete.ts
+++ b/packages/@sanity/cli/src/commands/documents/delete.ts
@@ -64,7 +64,7 @@ export class DeleteDocumentCommand extends SanityCommand<typeof DeleteDocumentCo
     const ids = [id, ...argv.slice(1)].filter(Boolean) as string[]
 
     if (ids.length === 0) {
-      this.error('Document ID must be specified', {exit: 1})
+      this.error('Document ID must be specified', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     // Get project configuration (may not exist when running outside a project directory)
@@ -105,7 +105,7 @@ export class DeleteDocumentCommand extends SanityCommand<typeof DeleteDocumentCo
         this.error(
           `${notFound.length === 1 ? 'Document' : 'Documents'} not found: ${notFound.join(', ')}`,
           {
-            exit: 1,
+            exit: exitCodes.RUNTIME_ERROR,
           },
         )
       }
@@ -115,7 +115,7 @@ export class DeleteDocumentCommand extends SanityCommand<typeof DeleteDocumentCo
       this.error(
         `Failed to delete ${ids.length} ${ids.length === 1 ? 'document' : 'documents'}: ${err.message}`,
         {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         },
       )
     }

--- a/packages/@sanity/cli/src/commands/documents/get.ts
+++ b/packages/@sanity/cli/src/commands/documents/get.ts
@@ -85,7 +85,9 @@ export class GetDocumentCommand extends SanityCommand<typeof GetDocumentCommand>
       const doc = await projectClient.getDocument(documentId)
 
       if (!doc) {
-        this.error(`Document "${documentId}" not found in dataset "${targetDataset}"`, {exit: exitCodes.RUNTIME_ERROR})
+        this.error(`Document "${documentId}" not found in dataset "${targetDataset}"`, {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
 
       // Output the document

--- a/packages/@sanity/cli/src/commands/documents/get.ts
+++ b/packages/@sanity/cli/src/commands/documents/get.ts
@@ -85,7 +85,7 @@ export class GetDocumentCommand extends SanityCommand<typeof GetDocumentCommand>
       const doc = await projectClient.getDocument(documentId)
 
       if (!doc) {
-        this.error(`Document "${documentId}" not found in dataset "${targetDataset}"`, {exit: 1})
+        this.error(`Document "${documentId}" not found in dataset "${targetDataset}"`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       // Output the document
@@ -98,7 +98,7 @@ export class GetDocumentCommand extends SanityCommand<typeof GetDocumentCommand>
       const err = error as Error
 
       getDocumentDebug(`Error fetching document ${documentId}`, err)
-      this.error(`Failed to fetch document: ${err.message}`, {exit: 1})
+      this.error(`Failed to fetch document: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/documents/query.ts
+++ b/packages/@sanity/cli/src/commands/documents/query.ts
@@ -108,7 +108,7 @@ export class QueryDocumentCommand extends SanityCommand<typeof QueryDocumentComm
       const docs = await projectClient.fetch(query)
 
       if (!docs) {
-        this.error('Query returned no results', {exit: 1})
+        this.error('Query returned no results', {exit: exitCodes.RUNTIME_ERROR})
       }
 
       // Output the query results
@@ -127,7 +127,7 @@ export class QueryDocumentCommand extends SanityCommand<typeof QueryDocumentComm
         ? `Invalid GROQ query syntax: ${err.message}`
         : `Failed to run query: ${err.message}`
 
-      this.error(`${errorMsg}\nQuery: ${query}`, {exit: 1})
+      this.error(`${errorMsg}\nQuery: ${query}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/documents/validate.ts
+++ b/packages/@sanity/cli/src/commands/documents/validate.ts
@@ -109,7 +109,7 @@ export class ValidateDocumentsCommand extends SanityCommand<typeof ValidateDocum
       if (err instanceof ProjectRootNotFoundError) {
         return this.output.error(
           'This command must be run from within a Sanity project directory (requires studio schema for validation)',
-          {exit: 1},
+          {exit: exitCodes.RUNTIME_ERROR},
         )
       }
       throw err
@@ -200,10 +200,10 @@ export class ValidateDocumentsCommand extends SanityCommand<typeof ValidateDocum
       })
 
       if (overallLevel === 'error') {
-        return this.exit(1)
+        return this.exit(exitCodes.RUNTIME_ERROR)
       }
     } catch (err) {
-      return this.output.error(err instanceof Error ? err.message : String(err), {exit: 1})
+      return this.output.error(err instanceof Error ? err.message : String(err), {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/documents/validate.ts
+++ b/packages/@sanity/cli/src/commands/documents/validate.ts
@@ -203,7 +203,9 @@ export class ValidateDocumentsCommand extends SanityCommand<typeof ValidateDocum
         return this.exit(exitCodes.RUNTIME_ERROR)
       }
     } catch (err) {
-      return this.output.error(err instanceof Error ? err.message : String(err), {exit: exitCodes.RUNTIME_ERROR})
+      return this.output.error(err instanceof Error ? err.message : String(err), {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/graphql/deploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/deploy.ts
@@ -125,11 +125,11 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
       if (error instanceof SchemaError) {
         debug('Schema validation errors: %O', error.problemGroups)
         error.print(this.output)
-        this.error('Fix the schema errors above and try again', {exit: 1})
+        this.error('Fix the schema errors above and try again', {exit: exitCodes.RUNTIME_ERROR})
       }
       debug('Failed to resolve GraphQL APIs: %O', error)
       const message = error instanceof Error ? error.message : String(error)
-      this.error(`Failed to resolve GraphQL APIs: ${message}`, {exit: 1})
+      this.error(`Failed to resolve GraphQL APIs: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const hasMultipleApis = flags.api ? flags.api.length > 1 : apiDefs.length > 1
@@ -172,7 +172,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
 
     for (const apiId of onlyApis || []) {
       if (!apiDefs.some((apiDef) => apiDef.id === apiId)) {
-        this.error(`GraphQL API with id "${apiId}" not found`, {exit: 1})
+        this.error(`GraphQL API with id "${apiId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
     }
 
@@ -187,7 +187,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
       const {apiName} = this.getApiIdentifiers(apiDef, datasetFlag, tagFlag)
       if (apiNames.has(apiName)) {
         this.error(`Multiple GraphQL APIs with the same dataset and tag found (${apiName})`, {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         })
       }
 
@@ -195,12 +195,12 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
         if (!apiIdRegex.test(apiDef.id)) {
           this.error(
             `Invalid GraphQL API id "${apiDef.id}" - only a-z, 0-9, underscore and dashes are allowed`,
-            {exit: 1},
+            {exit: exitCodes.RUNTIME_ERROR},
           )
         }
 
         if (apiIds.has(apiDef.id)) {
-          this.error(`Multiple GraphQL APIs with the same ID found (${apiDef.id})`, {exit: 1})
+          this.error(`Multiple GraphQL APIs with the same ID found (${apiDef.id})`, {exit: exitCodes.RUNTIME_ERROR})
         }
 
         apiIds.add(apiDef.id)
@@ -266,7 +266,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
       } catch (err) {
         debug('Failed to get current GraphQL schema properties', err)
         spin.fail()
-        this.error('Failed to get current GraphQL schema properties', {exit: 1})
+        this.error('Failed to get current GraphQL schema properties', {exit: exitCodes.RUNTIME_ERROR})
       }
 
       // CLI flag takes precedence over configuration
@@ -289,7 +289,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
 
       if (!this.isRecognizedApiGeneration(generation)) {
         spin.fail()
-        this.error(`Unknown API generation "${generation}" for API at index ${index}`, {exit: 1})
+        this.error(`Unknown API generation "${generation}" for API at index ${index}`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       const enablePlayground = await this.shouldEnablePlayground({
@@ -308,7 +308,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
         debug('Failed to generate schema', err)
         spin.fail()
         const message = err instanceof Error ? err.message : 'Unknown error'
-        this.error(`Failed to generate schema: ${message}`, {exit: 1})
+        this.error(`Failed to generate schema: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       let valid: ValidationResponse | undefined
@@ -324,7 +324,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
         debug('validateGraphQLAPI error', err)
         const validationError = get(err, 'response.body.validationError')
         spin.fail()
-        this.error(validationError ?? 'Failed to validate GraphQL API', {exit: 1})
+        this.error(validationError ?? 'Failed to validate GraphQL API', {exit: exitCodes.RUNTIME_ERROR})
       }
 
       // when the result is not valid and there are breaking changes afoot!
@@ -413,12 +413,12 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
       } catch (error) {
         spin.fail()
         debug('Failed to deploy GraphQL API', error)
-        this.error('Failed to deploy GraphQL API', {exit: 1})
+        this.error('Failed to deploy GraphQL API', {exit: exitCodes.RUNTIME_ERROR})
       }
     }
 
     if (hasErrors) {
-      this.exit(1)
+      this.exit(exitCodes.RUNTIME_ERROR)
     }
   }
 
@@ -448,7 +448,7 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
     const {validationError} = valid
     if (validationError) {
       spin.fail()
-      this.error(`GraphQL schema is not valid:\n\n${validationError}`, {exit: 1})
+      this.error(`GraphQL schema is not valid:\n\n${validationError}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const {breakingChanges, dangerousChanges} = this.filterChanges(valid)

--- a/packages/@sanity/cli/src/commands/graphql/deploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/deploy.ts
@@ -200,7 +200,9 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
         }
 
         if (apiIds.has(apiDef.id)) {
-          this.error(`Multiple GraphQL APIs with the same ID found (${apiDef.id})`, {exit: exitCodes.RUNTIME_ERROR})
+          this.error(`Multiple GraphQL APIs with the same ID found (${apiDef.id})`, {
+            exit: exitCodes.RUNTIME_ERROR,
+          })
         }
 
         apiIds.add(apiDef.id)
@@ -266,7 +268,9 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
       } catch (err) {
         debug('Failed to get current GraphQL schema properties', err)
         spin.fail()
-        this.error('Failed to get current GraphQL schema properties', {exit: exitCodes.RUNTIME_ERROR})
+        this.error('Failed to get current GraphQL schema properties', {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
 
       // CLI flag takes precedence over configuration
@@ -289,7 +293,9 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
 
       if (!this.isRecognizedApiGeneration(generation)) {
         spin.fail()
-        this.error(`Unknown API generation "${generation}" for API at index ${index}`, {exit: exitCodes.RUNTIME_ERROR})
+        this.error(`Unknown API generation "${generation}" for API at index ${index}`, {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
 
       const enablePlayground = await this.shouldEnablePlayground({
@@ -324,7 +330,9 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
         debug('validateGraphQLAPI error', err)
         const validationError = get(err, 'response.body.validationError')
         spin.fail()
-        this.error(validationError ?? 'Failed to validate GraphQL API', {exit: exitCodes.RUNTIME_ERROR})
+        this.error(validationError ?? 'Failed to validate GraphQL API', {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
 
       // when the result is not valid and there are breaking changes afoot!
@@ -448,7 +456,9 @@ export class GraphQLDeployCommand extends SanityCommand<typeof GraphQLDeployComm
     const {validationError} = valid
     if (validationError) {
       spin.fail()
-      this.error(`GraphQL schema is not valid:\n\n${validationError}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`GraphQL schema is not valid:\n\n${validationError}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     const {breakingChanges, dangerousChanges} = this.filterChanges(valid)

--- a/packages/@sanity/cli/src/commands/graphql/list.ts
+++ b/packages/@sanity/cli/src/commands/graphql/list.ts
@@ -1,6 +1,6 @@
 import {styleText} from 'node:util'
 
-import {getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {
@@ -46,7 +46,7 @@ export class List extends SanityCommand<typeof List> {
       const message = error instanceof Error ? error.message : String(error)
 
       listGraphQLDebug(`Error fetching GraphQL endpoints for project ${projectId}`, error)
-      this.error(`GraphQL endpoints list retrieval failed:\n${message}`, {exit: 1})
+      this.error(`GraphQL endpoints list retrieval failed:\n${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (!endpoints || endpoints.length === 0) {

--- a/packages/@sanity/cli/src/commands/graphql/list.ts
+++ b/packages/@sanity/cli/src/commands/graphql/list.ts
@@ -46,7 +46,9 @@ export class List extends SanityCommand<typeof List> {
       const message = error instanceof Error ? error.message : String(error)
 
       listGraphQLDebug(`Error fetching GraphQL endpoints for project ${projectId}`, error)
-      this.error(`GraphQL endpoints list retrieval failed:\n${message}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`GraphQL endpoints list retrieval failed:\n${message}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     if (!endpoints || endpoints.length === 0) {

--- a/packages/@sanity/cli/src/commands/graphql/undeploy.ts
+++ b/packages/@sanity/cli/src/commands/graphql/undeploy.ts
@@ -82,7 +82,7 @@ export class Undeploy extends SanityCommand<typeof Undeploy> {
       const apiDef = apiDefs.find((def) => def.id === apiFlag)
 
       if (!apiDef) {
-        this.error(`GraphQL API "${apiFlag}" not found`, {exit: 1})
+        this.error(`GraphQL API "${apiFlag}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       projectId = apiDef.projectId
@@ -161,7 +161,7 @@ export class Undeploy extends SanityCommand<typeof Undeploy> {
     } catch (error) {
       const err = error instanceof Error ? error : new Error(`${error}`)
       undeployGraphqlDebug(`Error deleting GraphQL API for ${dataset}/${tag}`, err)
-      this.error(`GraphQL API deletion failed:\n${err.message}`, {exit: 1})
+      this.error(`GraphQL API deletion failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/hooks/attempt.ts
+++ b/packages/@sanity/cli/src/commands/hooks/attempt.ts
@@ -1,5 +1,5 @@
 import {Args} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {formatFailure} from '../../actions/hook/formatFailure.js'
 import {type DeliveryAttempt} from '../../actions/hook/types.js'
@@ -55,7 +55,7 @@ export class AttemptHookCommand extends SanityCommand<typeof AttemptHookCommand>
     } catch (error) {
       const err = error as Error
       attemptDebug(`Error fetching hook attempt ${attemptId}`, err)
-      this.error(`Hook attempt retrieval failed:\n${err.message}`, {exit: 1})
+      this.error(`Hook attempt retrieval failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const {createdAt, failureReason, inProgress, resultBody, resultCode} = attempt

--- a/packages/@sanity/cli/src/commands/hooks/create.ts
+++ b/packages/@sanity/cli/src/commands/hooks/create.ts
@@ -1,4 +1,4 @@
-import {getSanityUrl, SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, getSanityUrl, SanityCommand, subdebug} from '@sanity/cli-core'
 import open from 'open'
 
 import {promptForProject} from '../../prompts/promptForProject.js'
@@ -41,7 +41,7 @@ export class CreateHookCommand extends SanityCommand<typeof CreateHookCommand> {
     } catch (error) {
       const err = error as Error
       createHookDebug(`Error fetching project info for project ${projectId}`, err)
-      this.error(`Failed to fetch project information:\n${err.message}`, {exit: 1})
+      this.error(`Failed to fetch project information:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const organizationId = projectInfo.organizationId || 'personal'
@@ -61,7 +61,7 @@ export class CreateHookCommand extends SanityCommand<typeof CreateHookCommand> {
     } catch (error) {
       const err = error as Error
       createHookDebug('Error opening browser', err)
-      this.error(`Failed to open browser:\n${err.message}`, {exit: 1})
+      this.error(`Failed to open browser:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/hooks/create.ts
+++ b/packages/@sanity/cli/src/commands/hooks/create.ts
@@ -41,7 +41,9 @@ export class CreateHookCommand extends SanityCommand<typeof CreateHookCommand> {
     } catch (error) {
       const err = error as Error
       createHookDebug(`Error fetching project info for project ${projectId}`, err)
-      this.error(`Failed to fetch project information:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Failed to fetch project information:\n${err.message}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     const organizationId = projectInfo.organizationId || 'personal'

--- a/packages/@sanity/cli/src/commands/hooks/delete.ts
+++ b/packages/@sanity/cli/src/commands/hooks/delete.ts
@@ -69,7 +69,7 @@ export class Delete extends SanityCommand<typeof Delete> {
     } catch (error) {
       const err = error as Error
       deleteHookDebug(`Error deleting hook ${hookId} for project ${projectId}`, err)
-      this.error(`Hook deletion failed:\n${err.message}`, {exit: 1})
+      this.error(`Hook deletion failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -83,11 +83,11 @@ export class Delete extends SanityCommand<typeof Delete> {
     } catch (error) {
       const err = error as Error
       deleteHookDebug(`Error fetching hooks for project ${projectId}`, err)
-      this.error(`Failed to fetch hooks:\n${err.message}`, {exit: 1})
+      this.error(`Failed to fetch hooks:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (hooks.length === 0) {
-      this.error('No hooks configured for this project.', {exit: 1})
+      this.error('No hooks configured for this project.', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     // If hook name is specified, find it in the list
@@ -96,7 +96,7 @@ export class Delete extends SanityCommand<typeof Delete> {
       const selectedHook = hooks.find((hook) => hook.name.toLowerCase() === specifiedNameLower)
 
       if (!selectedHook) {
-        this.error(`Hook with name "${specifiedName}" not found`, {exit: 1})
+        this.error(`Hook with name "${specifiedName}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       return selectedHook.id

--- a/packages/@sanity/cli/src/commands/hooks/list.ts
+++ b/packages/@sanity/cli/src/commands/hooks/list.ts
@@ -1,4 +1,4 @@
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {type Hook} from '../../actions/hook/types'
 import {promptForProject} from '../../prompts/promptForProject.js'
@@ -45,7 +45,7 @@ export class List extends SanityCommand<typeof List> {
       const err = error as Error
 
       listHookDebug(`Error fetching hooks for project ${projectId}`, err)
-      this.error(`Hook list retrieval failed:\n${err.message}`, {exit: 1})
+      this.error(`Hook list retrieval failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     for (const hook of hooks) {

--- a/packages/@sanity/cli/src/commands/hooks/logs.ts
+++ b/packages/@sanity/cli/src/commands/hooks/logs.ts
@@ -73,11 +73,11 @@ export class LogsHookCommand extends SanityCommand<typeof LogsHookCommand> {
     } catch (error) {
       const err = error as Error
       logsHookDebug(`Error fetching hooks for project ${projectId}`, err)
-      this.error(`Hook list retrieval failed:\n${err.message}`, {exit: 1})
+      this.error(`Hook list retrieval failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (hooks.length === 0) {
-      this.error('No hooks currently registered', {exit: 1})
+      this.error('No hooks currently registered', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     // If hook name is provided, find that specific hook
@@ -85,7 +85,7 @@ export class LogsHookCommand extends SanityCommand<typeof LogsHookCommand> {
     if (args.name) {
       selectedHook = hooks.find((hook) => hook.name.toLowerCase() === args.name?.toLowerCase())
       if (!selectedHook) {
-        this.error(`Hook with name "${args.name}" not found`, {exit: 1})
+        this.error(`Hook with name "${args.name}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
     } else if (hooks.length === 1) {
       // If only one hook exists, use that
@@ -104,7 +104,7 @@ export class LogsHookCommand extends SanityCommand<typeof LogsHookCommand> {
     }
 
     if (!selectedHook) {
-      this.error('No hook selected', {exit: 1})
+      this.error('No hook selected', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     // Fetch messages and attempts for the selected hook
@@ -124,7 +124,7 @@ export class LogsHookCommand extends SanityCommand<typeof LogsHookCommand> {
     } catch (error) {
       const err = error as Error
       logsHookDebug(`Error fetching logs for hook ${selectedHook.id}`, err)
-      this.error(`Hook logs retrieval failed:\n${err.message}`, {exit: 1})
+      this.error(`Hook logs retrieval failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     // Group attempts by message ID

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -2,7 +2,7 @@ import {text} from 'node:stream/consumers'
 
 import {Command, Flags} from '@oclif/core'
 import {type FlagInput} from '@oclif/core/interfaces'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 
 import {login} from '../actions/auth/login/login.js'
 import {LOGIN_PROVIDER_IDS} from '../actions/auth/login/loginInstructions.js'
@@ -80,7 +80,7 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
       this.log('Login successful')
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      this.error(`Login failed: ${message}`, {exit: 1})
+      this.error(`Login failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/logout.ts
+++ b/packages/@sanity/cli/src/commands/logout.ts
@@ -1,4 +1,10 @@
-import {exitCodes, getCliToken, getUserConfig, SanityCommand, setCliUserConfig} from '@sanity/cli-core'
+import {
+  exitCodes,
+  getCliToken,
+  getUserConfig,
+  SanityCommand,
+  setCliUserConfig,
+} from '@sanity/cli-core'
 import {isHttpError} from '@sanity/client'
 
 import {logout} from '../services/auth.js'

--- a/packages/@sanity/cli/src/commands/logout.ts
+++ b/packages/@sanity/cli/src/commands/logout.ts
@@ -1,4 +1,4 @@
-import {getCliToken, getUserConfig, SanityCommand, setCliUserConfig} from '@sanity/cli-core'
+import {exitCodes, getCliToken, getUserConfig, SanityCommand, setCliUserConfig} from '@sanity/cli-core'
 import {isHttpError} from '@sanity/client'
 
 import {logout} from '../services/auth.js'
@@ -28,7 +28,7 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
         return
       }
       const err = error instanceof Error ? error : new Error(`${error}`)
-      this.error(`Failed to logout: ${err.message}`, {exit: 1})
+      this.error(`Failed to logout: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 

--- a/packages/@sanity/cli/src/commands/manifest/extract.ts
+++ b/packages/@sanity/cli/src/commands/manifest/extract.ts
@@ -1,6 +1,6 @@
 import {Flags} from '@oclif/core'
 import {formatSchemaValidation, SchemaExtractionError} from '@sanity/cli-build/_internal/extract'
-import {findProjectRoot, SanityCommand} from '@sanity/cli-core'
+import {exitCodes, findProjectRoot, SanityCommand} from '@sanity/cli-core'
 
 import {manifestDebug} from '../../actions/manifest/debug.js'
 import {extractManifest} from '../../actions/manifest/extractManifest.js'
@@ -50,12 +50,12 @@ export class ExtractManifestCommand extends SanityCommand<typeof ExtractManifest
         error.validation.length > 0
       ) {
         this.output.log(formatSchemaValidation(error.validation))
-        this.exit(1)
+        this.exit(exitCodes.RUNTIME_ERROR)
       }
 
       this.error(
         `Failed to extract manifest:\n${error instanceof Error ? error.message : String(error)}`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
   }

--- a/packages/@sanity/cli/src/commands/mcp/configure.ts
+++ b/packages/@sanity/cli/src/commands/mcp/configure.ts
@@ -1,4 +1,4 @@
-import {isInteractive, SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, isInteractive, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage, toError} from '@sanity/cli-core/errors'
 
 import {ensureAuthenticated} from '../../actions/auth/ensureAuthenticated.js'
@@ -32,11 +32,11 @@ export class ConfigureMcpCommand extends SanityCommand<typeof ConfigureMcpComman
       if (error instanceof LoginError) {
         this.error(
           `Failed to verify authentication credentials: ${error.message}. Try running \`sanity login\`.`,
-          {exit: 1},
+          {exit: exitCodes.RUNTIME_ERROR},
         )
       }
 
-      this.error(`Failed to check authentication: ${getErrorMessage(error)}`, {exit: 1})
+      this.error(`Failed to check authentication: ${getErrorMessage(error)}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     try {
@@ -59,7 +59,7 @@ export class ConfigureMcpCommand extends SanityCommand<typeof ConfigureMcpComman
       }
     } catch (error) {
       trace.error(toError(error))
-      this.error(getErrorMessage(error), {exit: 1})
+      this.error(getErrorMessage(error), {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/mcp/configure.ts
+++ b/packages/@sanity/cli/src/commands/mcp/configure.ts
@@ -36,7 +36,9 @@ export class ConfigureMcpCommand extends SanityCommand<typeof ConfigureMcpComman
         )
       }
 
-      this.error(`Failed to check authentication: ${getErrorMessage(error)}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Failed to check authentication: ${getErrorMessage(error)}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     try {

--- a/packages/@sanity/cli/src/commands/media/create-aspect.ts
+++ b/packages/@sanity/cli/src/commands/media/create-aspect.ts
@@ -32,7 +32,7 @@ export class MediaCreateAspectCommand extends SanityCommand<typeof MediaCreateAs
     const cliConfig = await this.getCliConfig()
     const mediaLibrary = getMediaLibraryConfig(cliConfig)
     if (mediaLibrary?.aspectsPath === undefined) {
-      this.error(NO_MEDIA_LIBRARY_ASPECTS_PATH, {exit: 1})
+      this.error(NO_MEDIA_LIBRARY_ASPECTS_PATH, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const title =
@@ -68,7 +68,7 @@ export class MediaCreateAspectCommand extends SanityCommand<typeof MediaCreateAs
       )
       if (destinationPathExists) {
         this.error(`A file already exists at ${styleText('bold', relativeDestinationPath)}`, {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         })
       }
 
@@ -97,7 +97,7 @@ export class MediaCreateAspectCommand extends SanityCommand<typeof MediaCreateAs
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       createAspectDebug('Failed to create aspect', error)
-      this.error(`Failed to create aspect: ${message}`, {exit: 1})
+      this.error(`Failed to create aspect: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/media/delete-aspect.ts
+++ b/packages/@sanity/cli/src/commands/media/delete-aspect.ts
@@ -109,7 +109,7 @@ export class MediaDeleteAspectCommand extends SanityCommand<typeof MediaDeleteAs
         styleText('bold', 'Failed to delete aspect') +
           `\n  - ${aspectName}\n\n${styleText('red', err.message)}`,
         {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         },
       )
     }

--- a/packages/@sanity/cli/src/commands/media/deploy-aspect.ts
+++ b/packages/@sanity/cli/src/commands/media/deploy-aspect.ts
@@ -84,7 +84,7 @@ export class MediaDeployAspectCommand extends SanityCommand<typeof MediaDeployAs
       if (err instanceof ProjectRootNotFoundError) {
         this.error(
           'This command must be run from within a Sanity project directory (requires media library configuration)',
-          {exit: 1},
+          {exit: exitCodes.RUNTIME_ERROR},
         )
       }
       throw err
@@ -92,7 +92,7 @@ export class MediaDeployAspectCommand extends SanityCommand<typeof MediaDeployAs
     const mediaLibrary = getMediaLibraryConfig(cliConfig)
 
     if (!mediaLibrary?.aspectsPath) {
-      this.error(NO_MEDIA_LIBRARY_ASPECTS_PATH, {exit: 1})
+      this.error(NO_MEDIA_LIBRARY_ASPECTS_PATH, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const projectId = await this.getProjectId({fallback: () => promptForProject({})})
@@ -143,7 +143,7 @@ export class MediaDeployAspectCommand extends SanityCommand<typeof MediaDeployAs
       // Check if we found the requested aspect (when not using --all)
       if (!all && result.valid.length === 0 && result.invalid.length === 0) {
         this.log()
-        this.error(`Could not find aspect: ${styleText('bold', aspectName ?? '')}`, {exit: 1})
+        this.error(`Could not find aspect: ${styleText('bold', aspectName ?? '')}`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       // Deploy valid aspects
@@ -186,7 +186,7 @@ export class MediaDeployAspectCommand extends SanityCommand<typeof MediaDeployAs
       this.error(
         styleText('bold', 'Failed to deploy aspects') + `\n\n${styleText('red', err.message)}`,
         {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         },
       )
     }

--- a/packages/@sanity/cli/src/commands/media/deploy-aspect.ts
+++ b/packages/@sanity/cli/src/commands/media/deploy-aspect.ts
@@ -143,7 +143,9 @@ export class MediaDeployAspectCommand extends SanityCommand<typeof MediaDeployAs
       // Check if we found the requested aspect (when not using --all)
       if (!all && result.valid.length === 0 && result.invalid.length === 0) {
         this.log()
-        this.error(`Could not find aspect: ${styleText('bold', aspectName ?? '')}`, {exit: exitCodes.RUNTIME_ERROR})
+        this.error(`Could not find aspect: ${styleText('bold', aspectName ?? '')}`, {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
 
       // Deploy valid aspects

--- a/packages/@sanity/cli/src/commands/media/export.ts
+++ b/packages/@sanity/cli/src/commands/media/export.ts
@@ -113,7 +113,9 @@ export class MediaExportCommand extends SanityCommand<typeof MediaExportCommand>
     }
 
     if (!mediaLibraries.some((library) => library.id === mediaLibraryId)) {
-      this.error(`Media library with id "${mediaLibraryId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Media library with id "${mediaLibraryId}" not found`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     this.log(

--- a/packages/@sanity/cli/src/commands/media/export.ts
+++ b/packages/@sanity/cli/src/commands/media/export.ts
@@ -83,13 +83,13 @@ export class MediaExportCommand extends SanityCommand<typeof MediaExportCommand>
       this.error(
         `Failed to list media libraries:\n${error instanceof Error ? error.message : error}`,
         {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         },
       )
     }
 
     if (mediaLibraries.length === 0) {
-      this.error('No active media libraries found in this project', {exit: 1})
+      this.error('No active media libraries found in this project', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     let mediaLibraryId = flags['media-library-id']
@@ -106,14 +106,14 @@ export class MediaExportCommand extends SanityCommand<typeof MediaExportCommand>
         this.error(
           `Failed to select media library:\n${error instanceof Error ? error.message : error}`,
           {
-            exit: 1,
+            exit: exitCodes.RUNTIME_ERROR,
           },
         )
       }
     }
 
     if (!mediaLibraries.some((library) => library.id === mediaLibraryId)) {
-      this.error(`Media library with id "${mediaLibraryId}" not found`, {exit: 1})
+      this.error(`Media library with id "${mediaLibraryId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     this.log(
@@ -137,7 +137,7 @@ mediaLibraryId: ${mediaLibraryId.padEnd(37)}`,
 
     const outputPath = await this.getOutputPath(destinationPath, mediaLibraryId, flags)
     if (!outputPath) {
-      this.error('Cancelled', {exit: 1})
+      this.error('Cancelled', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const {fail, onProgress, succeed} = this.createProgressHandler()
@@ -159,7 +159,7 @@ mediaLibraryId: ${mediaLibraryId.padEnd(37)}`,
       fail()
       const err = error instanceof Error ? error : new Error(String(error))
       exportDebug('Export failed', err)
-      this.error(`Export failed: ${err.message}`, {exit: 1})
+      this.error(`Export failed: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -212,7 +212,7 @@ mediaLibraryId: ${mediaLibraryId.padEnd(37)}`,
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error))
         this.error(`Failed to create directory "${createPath}": ${err.message}`, {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         })
       }
     }

--- a/packages/@sanity/cli/src/commands/media/import.ts
+++ b/packages/@sanity/cli/src/commands/media/import.ts
@@ -70,13 +70,13 @@ export class MediaImportCommand extends SanityCommand<typeof MediaImportCommand>
       this.error(
         `Failed to list media libraries:\n${error instanceof Error ? error.message : error}`,
         {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         },
       )
     }
 
     if (mediaLibraries.length === 0) {
-      this.error('No active media libraries found in this project', {exit: 1})
+      this.error('No active media libraries found in this project', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     let mediaLibraryId = flags['media-library-id']
@@ -93,14 +93,14 @@ export class MediaImportCommand extends SanityCommand<typeof MediaImportCommand>
         this.error(
           `Failed to select media library:\n${error instanceof Error ? error.message : error}`,
           {
-            exit: 1,
+            exit: exitCodes.RUNTIME_ERROR,
           },
         )
       }
     }
 
     if (!mediaLibraries.some((library) => library.id === mediaLibraryId)) {
-      this.error(`Media library with id "${mediaLibraryId}" not found`, {exit: 1})
+      this.error(`Media library with id "${mediaLibraryId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const projectClient = await getProjectCliClient({
@@ -165,10 +165,10 @@ export class MediaImportCommand extends SanityCommand<typeof MediaImportCommand>
       process.once('SIGINT', () => {
         subscription.unsubscribe()
         spin.fail('Import interrupted.')
-        process.exit(130)
+        process.exit(exitCodes.SIGINT)
       })
     }).catch((error) => {
-      this.error(styleText('red', error.message), {exit: 1})
+      this.error(styleText('red', error.message), {exit: exitCodes.RUNTIME_ERROR})
     })
   }
 

--- a/packages/@sanity/cli/src/commands/media/import.ts
+++ b/packages/@sanity/cli/src/commands/media/import.ts
@@ -100,7 +100,9 @@ export class MediaImportCommand extends SanityCommand<typeof MediaImportCommand>
     }
 
     if (!mediaLibraries.some((library) => library.id === mediaLibraryId)) {
-      this.error(`Media library with id "${mediaLibraryId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Media library with id "${mediaLibraryId}" not found`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     const projectClient = await getProjectCliClient({

--- a/packages/@sanity/cli/src/commands/migrations/create.ts
+++ b/packages/@sanity/cli/src/commands/migrations/create.ts
@@ -137,7 +137,9 @@ export class CreateMigrationCommand extends SanityCommand<typeof CreateMigration
       await mkdir(destDir, {recursive: true})
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      this.error(`Failed to create migration directory: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Failed to create migration directory: ${message}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     try {

--- a/packages/@sanity/cli/src/commands/migrations/create.ts
+++ b/packages/@sanity/cli/src/commands/migrations/create.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import {styleText} from 'node:util'
 
 import {Args} from '@oclif/core'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 import {confirm, input, select} from '@sanity/cli-core/ux'
 
 import {MIGRATIONS_DIRECTORY} from '../../actions/migration/constants.js'
@@ -77,7 +77,7 @@ export class CreateMigrationCommand extends SanityCommand<typeof CreateMigration
         `Could not derive a valid migration name from title ${JSON.stringify(
           title,
         )}. Use a title that contains at least one letter or number.`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
 
@@ -137,14 +137,14 @@ export class CreateMigrationCommand extends SanityCommand<typeof CreateMigration
       await mkdir(destDir, {recursive: true})
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      this.error(`Failed to create migration directory: ${message}`, {exit: 1})
+      this.error(`Failed to create migration directory: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     try {
       await writeFile(definitionFile, renderedTemplate)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      this.error(`Failed to create migration file: ${message}`, {exit: 1})
+      this.error(`Failed to create migration file: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     return true

--- a/packages/@sanity/cli/src/commands/migrations/list.ts
+++ b/packages/@sanity/cli/src/commands/migrations/list.ts
@@ -1,6 +1,6 @@
 import {styleText} from 'node:util'
 
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {Table} from 'console-table-printer'
 
 import {resolveMigrations} from '../../actions/migration/resolveMigrations.js'
@@ -59,7 +59,7 @@ export class ListMigrationCommand extends SanityCommand<typeof ListMigrationComm
       this.error(
         `List migrations failed: ${error instanceof Error ? error.message : String(error)}`,
         {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         },
       )
     }

--- a/packages/@sanity/cli/src/commands/migrations/run.ts
+++ b/packages/@sanity/cli/src/commands/migrations/run.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
-import {getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, getProjectCliClient, SanityCommand, subdebug} from '@sanity/cli-core'
 import {confirm, spinner} from '@sanity/cli-core/ux'
 import {
   type APIConfig,
@@ -117,7 +117,7 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
           this.error(
             `Failed to list migrations: ${error instanceof Error ? error.message : String(error)}`,
-            {exit: 1},
+            {exit: exitCodes.RUNTIME_ERROR},
           )
         }
       }
@@ -127,7 +127,7 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
         this.log(
           `Run ${styleText('green', '`sanity migration create <NAME>`')} to create a new migration`,
         )
-        this.exit(1)
+        this.exit(exitCodes.RUNTIME_ERROR)
       }
 
       const table = new Table({
@@ -144,7 +144,7 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
       table.printTable()
       this.log('\nRun `sanity migration run <ID>` to run a migration')
 
-      this.exit(1)
+      this.exit(exitCodes.RUNTIME_ERROR)
     }
 
     const cliConfig = await this.getCliConfig()
@@ -158,20 +158,20 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
     const apiVersion = ensureApiVersionFormat(flags['api-version'] ?? DEFAULT_API_VERSION)
 
     if ((dataset && !project) || (project && !dataset)) {
-      this.error('If either --dataset or --project is provided, both must be provided', {exit: 1})
+      this.error('If either --dataset or --project is provided, both must be provided', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (!project && !projectId) {
       this.error(
         'sanity.cli.js does not contain a project identifier ("api.projectId") and no --project option was provided.',
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
 
     if (!dataset && !datasetFromConfig) {
       this.error(
         'sanity.cli.js does not contain a dataset identifier ("api.dataset") and no --dataset option was provided.',
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
 
@@ -184,7 +184,7 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
         `Found multiple migrations for "${id}" in ${styleText('cyan', migrationsDirectoryPath)}: \n - ${candidates
           .map((candidate) => path.relative(migrationsDirectoryPath, candidate.absolutePath))
           .join('\n - ')}`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
 
@@ -195,7 +195,7 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
  Tried the following files:\n - ${candidates
    .map((candidate) => path.relative(migrationsDirectoryPath, candidate.absolutePath))
    .join('\n - ')}`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
 
@@ -206,7 +206,7 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
       this.error(
         'Named "up"/"down" migration exports are not supported at this time, please export your migration as the default export',
         {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         },
       )
     }
@@ -214,19 +214,19 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
     const migration: Migration = mod.default
 
     if (fromExport && !dry) {
-      this.error('Can only dry run migrations from a dataset export file', {exit: 1})
+      this.error('Can only dry run migrations from a dataset export file', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const concurrency = flags.concurrency
     if (concurrency !== undefined) {
       if (concurrency > MAX_MUTATION_CONCURRENCY) {
         this.error(`Concurrency exceeds the maximum allowed value of ${MAX_MUTATION_CONCURRENCY}`, {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         })
       }
 
       if (concurrency < 1) {
-        this.error(`Concurrency must be a positive number, got ${concurrency}`, {exit: 1})
+        this.error(`Concurrency must be a positive number, got ${concurrency}`, {exit: exitCodes.RUNTIME_ERROR})
       }
     }
 
@@ -360,7 +360,7 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
 
     if (!response) {
       runMigrationDebug('User aborted migration')
-      this.exit(1)
+      this.exit(exitCodes.RUNTIME_ERROR)
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/migrations/run.ts
+++ b/packages/@sanity/cli/src/commands/migrations/run.ts
@@ -158,7 +158,9 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
     const apiVersion = ensureApiVersionFormat(flags['api-version'] ?? DEFAULT_API_VERSION)
 
     if ((dataset && !project) || (project && !dataset)) {
-      this.error('If either --dataset or --project is provided, both must be provided', {exit: exitCodes.RUNTIME_ERROR})
+      this.error('If either --dataset or --project is provided, both must be provided', {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     if (!project && !projectId) {
@@ -214,7 +216,9 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
     const migration: Migration = mod.default
 
     if (fromExport && !dry) {
-      this.error('Can only dry run migrations from a dataset export file', {exit: exitCodes.RUNTIME_ERROR})
+      this.error('Can only dry run migrations from a dataset export file', {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     const concurrency = flags.concurrency
@@ -226,7 +230,9 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
       }
 
       if (concurrency < 1) {
-        this.error(`Concurrency must be a positive number, got ${concurrency}`, {exit: exitCodes.RUNTIME_ERROR})
+        this.error(`Concurrency must be a positive number, got ${concurrency}`, {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
     }
 

--- a/packages/@sanity/cli/src/commands/openapi/get.ts
+++ b/packages/@sanity/cli/src/commands/openapi/get.ts
@@ -1,5 +1,5 @@
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import open from 'open'
 
 const getOpenapiDebug = subdebug('openapi:get')
@@ -65,11 +65,11 @@ export class GetOpenApiCommand extends SanityCommand<typeof GetOpenApiCommand> {
       getOpenapiDebug(`Error fetching OpenAPI spec ${slug}`, error)
 
       if (error instanceof Response && error.status === 404) {
-        this.error(`OpenAPI specification not found. ${slug}`, {exit: 1})
+        this.error(`OpenAPI specification not found. ${slug}`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       this.error('The OpenAPI service is currently unavailable. Please try again later.', {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     }
   }

--- a/packages/@sanity/cli/src/commands/openapi/list.ts
+++ b/packages/@sanity/cli/src/commands/openapi/list.ts
@@ -1,5 +1,5 @@
 import {Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import open from 'open'
 
 interface OpenAPISpec {
@@ -56,7 +56,7 @@ export class ListOpenApiCommand extends SanityCommand<typeof ListOpenApiCommand>
       listOpenapiDebug('Error fetching OpenAPI specs', error)
 
       this.error('The OpenAPI service is currently unavailable. Please try again later.', {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     }
 

--- a/packages/@sanity/cli/src/commands/organizations/create.ts
+++ b/packages/@sanity/cli/src/commands/organizations/create.ts
@@ -53,7 +53,9 @@ export class CreateOrganizationCommand extends SanityCommand<typeof CreateOrgani
     let name: string
     if (nameFlag === undefined) {
       if (this.isUnattended()) {
-        this.error('Organization name is required. Provide it with the --name flag.', {exit: exitCodes.RUNTIME_ERROR})
+        this.error('Organization name is required. Provide it with the --name flag.', {
+          exit: exitCodes.RUNTIME_ERROR,
+        })
       }
       name = await promptForOrganizationName()
     } else {

--- a/packages/@sanity/cli/src/commands/organizations/create.ts
+++ b/packages/@sanity/cli/src/commands/organizations/create.ts
@@ -1,6 +1,6 @@
 import {Flags} from '@oclif/core'
 import {type FlagInput} from '@oclif/core/interfaces'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {spinner} from '@sanity/cli-core/ux'
 
@@ -47,20 +47,20 @@ export class CreateOrganizationCommand extends SanityCommand<typeof CreateOrgani
 
     const defaultRole = defaultRoleFlag?.trim()
     if (defaultRole === '') {
-      this.error('Default role cannot be empty', {exit: 1})
+      this.error('Default role cannot be empty', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     let name: string
     if (nameFlag === undefined) {
       if (this.isUnattended()) {
-        this.error('Organization name is required. Provide it with the --name flag.', {exit: 1})
+        this.error('Organization name is required. Provide it with the --name flag.', {exit: exitCodes.RUNTIME_ERROR})
       }
       name = await promptForOrganizationName()
     } else {
       const trimmedName = nameFlag.trim()
       const validation = validateOrganizationName(trimmedName)
       if (validation !== true) {
-        this.error(validation, {exit: 1})
+        this.error(validation, {exit: exitCodes.RUNTIME_ERROR})
       }
       name = trimmedName
     }
@@ -75,7 +75,7 @@ export class CreateOrganizationCommand extends SanityCommand<typeof CreateOrgani
       spin.fail()
       createOrgDebug('Error creating organization', error)
       this.error(`Failed to create organization: ${getErrorMessage(error)}`, {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     }
   }

--- a/packages/@sanity/cli/src/commands/organizations/delete.ts
+++ b/packages/@sanity/cli/src/commands/organizations/delete.ts
@@ -2,7 +2,7 @@ import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
 import {type FlagInput} from '@oclif/core/interfaces'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {input, logSymbols, spinner} from '@sanity/cli-core/ux'
 import {isHttpError} from '@sanity/client'
@@ -61,9 +61,9 @@ export class DeleteOrganizationCommand extends SanityCommand<typeof DeleteOrgani
       spin.fail()
       deleteOrgDebug('Error deleting organization', error)
       if (isHttpError(error) && error.statusCode === 404) {
-        this.error(`Organization "${organizationId}" not found`, {exit: 1})
+        this.error(`Organization "${organizationId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
-      this.error(`Failed to delete organization: ${getErrorMessage(error)}`, {exit: 1})
+      this.error(`Failed to delete organization: ${getErrorMessage(error)}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -76,9 +76,9 @@ export class DeleteOrganizationCommand extends SanityCommand<typeof DeleteOrgani
       const err = error instanceof Error ? error : new Error(`${error}`)
       deleteOrgDebug(`Error getting organization ${organizationId}`, err)
       if (isHttpError(error) && error.statusCode === 404) {
-        this.error(`Organization "${organizationId}" not found`, {exit: 1})
+        this.error(`Organization "${organizationId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
-      this.error(`Organization retrieval failed: ${err.message}`, {exit: 1})
+      this.error(`Organization retrieval failed: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     this.log(
@@ -103,7 +103,7 @@ export class DeleteOrganizationCommand extends SanityCommand<typeof DeleteOrgani
     } catch (error) {
       const err = error instanceof Error ? error : new Error(`${error}`)
       deleteOrgDebug(`User cancelled`, err)
-      this.error(`User cancelled`, {exit: 1})
+      this.error(`User cancelled`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/organizations/delete.ts
+++ b/packages/@sanity/cli/src/commands/organizations/delete.ts
@@ -63,7 +63,9 @@ export class DeleteOrganizationCommand extends SanityCommand<typeof DeleteOrgani
       if (isHttpError(error) && error.statusCode === 404) {
         this.error(`Organization "${organizationId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
-      this.error(`Failed to delete organization: ${getErrorMessage(error)}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Failed to delete organization: ${getErrorMessage(error)}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 

--- a/packages/@sanity/cli/src/commands/organizations/get.ts
+++ b/packages/@sanity/cli/src/commands/organizations/get.ts
@@ -1,5 +1,5 @@
 import {Args} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {isHttpError} from '@sanity/client'
 
@@ -36,9 +36,9 @@ export class GetOrganizationCommand extends SanityCommand<typeof GetOrganization
     } catch (error) {
       getOrgDebug('Error getting organization', error)
       if (isHttpError(error) && error.statusCode === 404) {
-        this.error(`Organization "${organizationId}" not found`, {exit: 1})
+        this.error(`Organization "${organizationId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
-      this.error(`Failed to get organization: ${getErrorMessage(error)}`, {exit: 1})
+      this.error(`Failed to get organization: ${getErrorMessage(error)}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     this.log(`ID:           ${org.id}`)

--- a/packages/@sanity/cli/src/commands/organizations/get.ts
+++ b/packages/@sanity/cli/src/commands/organizations/get.ts
@@ -38,7 +38,9 @@ export class GetOrganizationCommand extends SanityCommand<typeof GetOrganization
       if (isHttpError(error) && error.statusCode === 404) {
         this.error(`Organization "${organizationId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
-      this.error(`Failed to get organization: ${getErrorMessage(error)}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Failed to get organization: ${getErrorMessage(error)}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     this.log(`ID:           ${org.id}`)

--- a/packages/@sanity/cli/src/commands/organizations/list.ts
+++ b/packages/@sanity/cli/src/commands/organizations/list.ts
@@ -1,4 +1,4 @@
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {Table} from 'console-table-printer'
 
@@ -25,7 +25,7 @@ export class ListOrganizationsCommand extends SanityCommand<typeof ListOrganizat
       organizations = await listOrganizations()
     } catch (error) {
       listOrgsDebug('Error listing organizations', error)
-      this.error(`Failed to list organizations: ${getErrorMessage(error)}`, {exit: 1})
+      this.error(`Failed to list organizations: ${getErrorMessage(error)}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (organizations.length === 0) {

--- a/packages/@sanity/cli/src/commands/organizations/list.ts
+++ b/packages/@sanity/cli/src/commands/organizations/list.ts
@@ -25,7 +25,9 @@ export class ListOrganizationsCommand extends SanityCommand<typeof ListOrganizat
       organizations = await listOrganizations()
     } catch (error) {
       listOrgsDebug('Error listing organizations', error)
-      this.error(`Failed to list organizations: ${getErrorMessage(error)}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Failed to list organizations: ${getErrorMessage(error)}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     if (organizations.length === 0) {

--- a/packages/@sanity/cli/src/commands/organizations/update.ts
+++ b/packages/@sanity/cli/src/commands/organizations/update.ts
@@ -1,6 +1,6 @@
 import {Args, Flags} from '@oclif/core'
 import {type FlagInput} from '@oclif/core/interfaces'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {spinner} from '@sanity/cli-core/ux'
 import {isHttpError} from '@sanity/client'
@@ -68,7 +68,7 @@ export class UpdateOrganizationCommand extends SanityCommand<typeof UpdateOrgani
       const trimmedName = name.trim()
       const validation = validateOrganizationName(trimmedName)
       if (validation !== true) {
-        this.error(validation, {exit: 1})
+        this.error(validation, {exit: exitCodes.RUNTIME_ERROR})
       }
       params.name = trimmedName
     }
@@ -76,14 +76,14 @@ export class UpdateOrganizationCommand extends SanityCommand<typeof UpdateOrgani
       const trimmedSlug = slug.trim()
       const slugValidation = validateOrganizationSlug(trimmedSlug)
       if (slugValidation !== true) {
-        this.error(slugValidation, {exit: 1})
+        this.error(slugValidation, {exit: exitCodes.RUNTIME_ERROR})
       }
       params.slug = trimmedSlug
     }
     if (defaultRole !== undefined) {
       const trimmedRole = defaultRole.trim()
       if (trimmedRole === '') {
-        this.error('Default role cannot be empty', {exit: 1})
+        this.error('Default role cannot be empty', {exit: exitCodes.RUNTIME_ERROR})
       }
       params.defaultRoleName = trimmedRole
     }
@@ -97,9 +97,9 @@ export class UpdateOrganizationCommand extends SanityCommand<typeof UpdateOrgani
       spin.fail()
       updateOrgDebug('Error updating organization', error)
       if (isHttpError(error) && error.statusCode === 404) {
-        this.error(`Organization "${organizationId}" not found`, {exit: 1})
+        this.error(`Organization "${organizationId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
-      this.error(`Failed to update organization: ${getErrorMessage(error)}`, {exit: 1})
+      this.error(`Failed to update organization: ${getErrorMessage(error)}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/organizations/update.ts
+++ b/packages/@sanity/cli/src/commands/organizations/update.ts
@@ -99,7 +99,9 @@ export class UpdateOrganizationCommand extends SanityCommand<typeof UpdateOrgani
       if (isHttpError(error) && error.statusCode === 404) {
         this.error(`Organization "${organizationId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
-      this.error(`Failed to update organization: ${getErrorMessage(error)}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Failed to update organization: ${getErrorMessage(error)}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/preview.ts
+++ b/packages/@sanity/cli/src/commands/preview.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import {Args, Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 
 import {previewAction} from '../actions/preview/previewAction.js'
 import {type PreviewServer} from '../server/previewServer.js'
@@ -57,7 +57,7 @@ export class PreviewCommand extends SanityCommand<typeof PreviewCommand> {
 
       const message = error instanceof Error ? error.message : String(error)
       this.output.error(`Failed to start preview server: ${message}`, {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
         suggestions,
       })
     }

--- a/packages/@sanity/cli/src/commands/projects/create.ts
+++ b/packages/@sanity/cli/src/commands/projects/create.ts
@@ -139,7 +139,9 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
     } catch (error) {
       spin.fail()
       debug(`Failed to create project: ${error}`)
-      return this.output.error(`Failed to create project: ${error}`, {exit: exitCodes.RUNTIME_ERROR})
+      return this.output.error(`Failed to create project: ${error}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
 
     let newDataset: DatasetResponse | undefined

--- a/packages/@sanity/cli/src/commands/projects/create.ts
+++ b/packages/@sanity/cli/src/commands/projects/create.ts
@@ -122,7 +122,7 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
       const errorText = organization
         ? `Failed to retrieve organization ${organization}`
         : 'Failed to retrieve an organization'
-      return this.output.error(`${errorText}: ${error}`, {exit: 1})
+      return this.output.error(`${errorText}: ${error}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const spin = spinner('Creating project').start()
@@ -139,7 +139,7 @@ export class CreateProjectCommand extends SanityCommand<typeof CreateProjectComm
     } catch (error) {
       spin.fail()
       debug(`Failed to create project: ${error}`)
-      return this.output.error(`Failed to create project: ${error}`, {exit: 1})
+      return this.output.error(`Failed to create project: ${error}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     let newDataset: DatasetResponse | undefined

--- a/packages/@sanity/cli/src/commands/projects/list.ts
+++ b/packages/@sanity/cli/src/commands/projects/list.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import size from 'lodash-es/size.js'
 import sortBy from 'lodash-es/sortBy.js'
 
@@ -72,7 +72,7 @@ export class List extends SanityCommand<typeof List> {
       for (const row of rows) this.log(printRow(row))
     } catch (error) {
       projectsDebug('Error listing projects', error)
-      this.error('Failed to list projects', {exit: 1})
+      this.error('Failed to list projects', {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/schemas/delete.ts
+++ b/packages/@sanity/cli/src/commands/schemas/delete.ts
@@ -108,13 +108,13 @@ export class DeleteSchemaCommand extends SanityCommand<typeof DeleteSchemaComman
       })
     } catch (error) {
       if (error instanceof CLIError) {
-        this.error(error.message, {exit: 1})
+        this.error(error.message, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       deleteSchemaDebug('Error deleting schemas', error)
       this.error(
         `Failed to delete schemas: ${error instanceof Error ? error.message : String(error)}`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
   }

--- a/packages/@sanity/cli/src/commands/schemas/deploy.ts
+++ b/packages/@sanity/cli/src/commands/schemas/deploy.ts
@@ -92,12 +92,12 @@ export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaComman
         error.validation.length > 0
       ) {
         this.output.log(formatSchemaValidation(error.validation))
-        this.exit(1)
+        this.exit(exitCodes.RUNTIME_ERROR)
       }
 
       schemasDeployDebug('Failed to deploy schemas', error)
       const errorMessage = error instanceof Error ? error.message : String(error)
-      this.error(`Failed to deploy schemas:\n${errorMessage}`, {exit: 1})
+      this.error(`Failed to deploy schemas:\n${errorMessage}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/schemas/list.ts
+++ b/packages/@sanity/cli/src/commands/schemas/list.ts
@@ -83,7 +83,7 @@ export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
       schemasListDebug('Failed to list schemas', error)
 
       const errorMessage = error instanceof Error ? error.message : String(error)
-      this.error(`Failed to list schemas:\n${errorMessage}`, {exit: 1})
+      this.error(`Failed to list schemas:\n${errorMessage}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/schemas/validate.ts
+++ b/packages/@sanity/cli/src/commands/schemas/validate.ts
@@ -1,5 +1,6 @@
 import {Flags} from '@oclif/core'
 import {subdebug} from '@sanity/cli-core/debug'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {SanityCommand} from '@sanity/cli-core/SanityCommand'
 
 import {validateAction} from '../../actions/schema/validateAction.js'
@@ -71,7 +72,7 @@ export class SchemaValidate extends SanityCommand<typeof SchemaValidate> {
       debug('Error validating schema', error)
       return this.output.error(
         `Error validating schema: ${error instanceof Error ? error.message : String(error)}`,
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     }
   }

--- a/packages/@sanity/cli/src/commands/skills/install.ts
+++ b/packages/@sanity/cli/src/commands/skills/install.ts
@@ -1,4 +1,4 @@
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage, toError} from '@sanity/cli-core/errors'
 
 import {configureSkills} from '../../actions/skills/configureSkills.js'
@@ -37,7 +37,7 @@ export class InstallSkillsCommand extends SanityCommand<typeof InstallSkillsComm
     } catch (error) {
       debug('Skills installation failed: %O', error)
       trace.error(toError(error))
-      this.error(getErrorMessage(error), {exit: 1})
+      this.error(getErrorMessage(error), {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/telemetry/disable.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/disable.ts
@@ -1,6 +1,6 @@
 import {Command} from '@oclif/core'
 import {type FlagInput} from '@oclif/core/interfaces'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 
 import {setConsent} from '../../actions/telemetry/setConsent.js'
 import {telemetryLearnMoreMessage} from '../../actions/telemetry/telemetryLearnMoreMessage.js'
@@ -33,7 +33,7 @@ export class Disable extends SanityCommand<typeof Disable> {
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An unknown error occurred'
-      this.output.error(message, {exit: 1})
+      this.output.error(message, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/telemetry/enable.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/enable.ts
@@ -1,6 +1,6 @@
 import {Command} from '@oclif/core'
 import {type FlagInput} from '@oclif/core/interfaces'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 
 import {setConsent} from '../../actions/telemetry/setConsent.js'
 import {telemetryLearnMoreMessage} from '../../actions/telemetry/telemetryLearnMoreMessage.js'
@@ -33,7 +33,7 @@ export class Enable extends SanityCommand<typeof Enable> {
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An unknown error occurred'
-      return this.output.error(message, {exit: 1})
+      return this.output.error(message, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/tokens/create.ts
+++ b/packages/@sanity/cli/src/commands/tokens/create.ts
@@ -117,7 +117,7 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       const err = error as Error
 
       tokensCreateDebug(`Error creating token for project ${projectId}`, err)
-      this.error(`Token creation failed:\n${err.message}`, {exit: 1})
+      this.error(`Token creation failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
@@ -152,7 +152,7 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
     tokensCreateDebug('Robot roles', {robotRoles})
 
     if (robotRoles.length === 0) {
-      this.error('No roles available for tokens', {exit: 1})
+      this.error('No roles available for tokens', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const selectedRoleName = await select({

--- a/packages/@sanity/cli/src/commands/tokens/delete.ts
+++ b/packages/@sanity/cli/src/commands/tokens/delete.ts
@@ -112,12 +112,12 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
       this.log('API token deleted')
     } catch (error) {
       if (error instanceof ClientError && error.response.statusCode === 404) {
-        this.error(`Token with ID "${tokenId}" not found`, {exit: 1})
+        this.error(`Token with ID "${tokenId}" not found`, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       const err = error as Error
       deleteTokenDebug(`Error deleting token`, err)
-      this.error(`Token deletion failed:\n${err.message}`, {exit: 1})
+      this.error(`Token deletion failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 

--- a/packages/@sanity/cli/src/commands/tokens/list.ts
+++ b/packages/@sanity/cli/src/commands/tokens/list.ts
@@ -1,5 +1,5 @@
 import {Flags} from '@oclif/core'
-import {SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {Table} from 'console-table-printer'
 
@@ -58,7 +58,7 @@ export class TokensListCommand extends SanityCommand<typeof TokensListCommand> {
     } catch (error) {
       const message = getErrorMessage(error)
       listTokenDebug(`Error fetching tokens for project ${projectId}`, error)
-      this.error(`Token list retrieval failed:\n${message}`, {exit: 1})
+      this.error(`Token list retrieval failed:\n${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
 
     if (outputJson) {

--- a/packages/@sanity/cli/src/commands/users/invite.ts
+++ b/packages/@sanity/cli/src/commands/users/invite.ts
@@ -98,7 +98,7 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
       roles = (await getProjectRoles(projectId)).filter((role) => role.appliesToUsers)
     } catch (error) {
       usersInviteDebug('Error fetching roles', error)
-      this.error('Error fetching roles', {exit: 1})
+      this.error('Error fetching roles', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     const email = normalizedEmail || (await this.promptForEmail())
@@ -119,10 +119,10 @@ export class UsersInviteCommand extends SanityCommand<typeof UsersInviteCommand>
     } catch (error) {
       usersInviteDebug(`Error inviting user`, error)
       if ((error as Error & {statusCode: number}).statusCode === 402) {
-        this.error(QUOTA_ERROR_MESSAGE, {exit: 1})
+        this.error(QUOTA_ERROR_MESSAGE, {exit: exitCodes.RUNTIME_ERROR})
       }
 
-      this.error(`Error inviting user`, {exit: 1})
+      this.error(`Error inviting user`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 


### PR DESCRIPTION
Instead of using a mix of the `exitCodes` enum and hardcoded constants, standardize on using the enum for everything. Was brought up in #1500 during review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with identical exit code values; low risk aside from tests that may still assert `{exit: 1}` instead of `exitCodes.RUNTIME_ERROR`.
> 
> **Overview**
> **Standardizes CLI exit handling** by replacing literal `0`, `1`, `2`, and `130` with the shared `exitCodes` constants from `@sanity/cli-core` across command implementations.
> 
> `this.error()`, `this.output.error()`, `this.exit()`, and `process.exit()` now reference names like `exitCodes.RUNTIME_ERROR`, `exitCodes.USAGE_ERROR`, and `exitCodes.SIGINT` instead of magic numbers. **CONTRIBUTING.md** and the command examples are updated to document and demonstrate the same pattern.
> 
> Exit **semantics are unchanged** (still 0/1/2/3/130); this is naming and consistency only, with broader import of `exitCodes` where it was missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9372603fa1cf7e71d83a76452272e3f6ec3710a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->