### PR TITLE
docs(workbench): clarify the config payload's appType

### DIFF
--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -90,7 +90,9 @@ const devServerManifestSchema = z.object({
   configs: z.optional(
     z.array(
       z.object({
-        // Identifies the owning app when it has no app id (singletons).
+        // The config's format. The workbench maps it to a slug to match this
+        // config to its app — a local dev server or a deployed installation. An
+        // app id joins it once an org can install several apps of one type.
         appType: z.optional(z.string()),
         fields: z.array(
           z.object({


### PR DESCRIPTION
## Problem

The dev-server config payload's `appType` is documented as "identifies the owning app when it has no app id (singletons)", which undersells the contract with the workbench and doesn't hint at where it's headed.

## Change

Comment-only. Spells out that `appType` is the config's *format*, that the workbench maps it to a slug to match the config to its app (a local dev server or a deployed installation), and that an app id will join it once an org can install several apps of one type. Keeps the CLI and workbench descriptions of the same contract aligned.