### PR TITLE
fix(cli): scaffold workbench apps with sanity@latest

### DIFF
--- a/.changeset/init-workbench-sanity-latest.md
+++ b/.changeset/init-workbench-sanity-latest.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+Scaffold workbench apps with `sanity@latest` instead of the `workbench` dist-tag.

--- a/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
@@ -89,9 +89,6 @@ export async function bootstrapLocalTemplate(
     ...(isAppTemplate ? sdkAppDependencies.devDependencies : studioDependencies.devDependencies),
     ...template.dependencies,
     ...template.devDependencies,
-    // `unstable_defineApp` (re-exported via `sanity/cli`) only exists on the
-    // workbench dist-tag of `sanity`.
-    ...(variables.workbench && {sanity: 'workbench'}),
   })
   spin.succeed()
 

--- a/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
@@ -6,8 +6,6 @@ import {type Output} from '@sanity/cli-core'
 import {spinner, spinnerStart, spinnerSucceed} from '@sanity/cli-test/mocks/cli-core/ux'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {resolveLatestVersions} from '../../../../src/util/resolveLatestVersions.js'
-
 vi.mock('../../../../src/util/resolveLatestVersions.js', () => ({
   resolveLatestVersions: vi.fn().mockImplementation(async (deps: Record<string, string>) => {
     const resolved: Record<string, string> = {}
@@ -107,81 +105,6 @@ describe('bootstrapLocalTemplate (workbench)', () => {
   afterEach(async () => {
     await rm(tmp, {force: true, recursive: true})
     vi.clearAllMocks()
-  })
-
-  test('overrides the `sanity` dependency with the `workbench` dist-tag when workbench is enabled', async () => {
-    await bootstrapLocalTemplate({
-      output: makeOutput(),
-      outputPath: tmp,
-      packageName: 'my-studio',
-      templateName: 'clean',
-      useTypeScript: true,
-      variables: {
-        autoUpdates: false,
-        dataset: 'production',
-        organizationId: 'org1',
-        projectId: 'abc123',
-        projectName: 'My Studio',
-        workbench: true,
-      },
-    })
-
-    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
-
-    expect(resolveLatestVersions).toHaveBeenCalledOnce()
-    const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
-    expect(resolvedDeps.sanity).toBe('workbench')
-
-    const pkgJson = JSON.parse(await readFile(path.join(tmp, 'package.json'), 'utf8'))
-    expect(pkgJson.dependencies.sanity).toBe('1.0.0')
-  })
-
-  test('keeps the `sanity` dependency on the `latest` dist-tag when workbench is disabled', async () => {
-    await bootstrapLocalTemplate({
-      output: makeOutput(),
-      outputPath: tmp,
-      packageName: 'my-studio',
-      templateName: 'clean',
-      useTypeScript: true,
-      variables: {
-        autoUpdates: false,
-        dataset: 'production',
-        organizationId: 'org1',
-        projectId: 'abc123',
-        projectName: 'My Studio',
-        workbench: false,
-      },
-    })
-
-    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
-
-    expect(resolveLatestVersions).toHaveBeenCalledOnce()
-    const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
-    expect(resolvedDeps.sanity).toBe('latest')
-  })
-
-  test('overrides the `sanity` devDependency for app templates when workbench is enabled', async () => {
-    await bootstrapLocalTemplate({
-      output: makeOutput(),
-      outputPath: tmp,
-      packageName: 'my-app',
-      templateName: 'app-quickstart',
-      useTypeScript: true,
-      variables: {
-        autoUpdates: false,
-        dataset: 'production',
-        organizationId: 'org1',
-        projectId: 'abc123',
-        projectName: 'my-app',
-        workbench: true,
-      },
-    })
-
-    expect(spinnerSucceed).toHaveBeenCalledTimes(3)
-
-    expect(resolveLatestVersions).toHaveBeenCalledOnce()
-    const resolvedDeps = vi.mocked(resolveLatestVersions).mock.calls[0][0]
-    expect(resolvedDeps.sanity).toBe('workbench')
   })
 
   test('scaffolds a studio sanity.cli.ts branded with unstable_defineApp', async () => {


### PR DESCRIPTION
### Description

`sanity init --unstable--workbench` scaffolded apps by pinning `sanity` to the `workbench` dist-tag (`"sanity": "workbench"` in the generated `package.json`). `unstable_defineApp` now ships on `sanity@latest`, so the special-case is no longer needed.

Drop the override so workbench apps resolve `sanity@latest` like every other template.

### What to review

- [bootstrapLocalTemplate.ts](packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts) — removed the `variables.workbench && {sanity: 'workbench'}` spread. `sanity: 'latest'` is already declared in both `sdkAppDependencies` and `studioDependencies`, so the dep still resolves to a caretified latest version.

### Testing

No test covered the dist-tag override. The change is a pure deletion of a conditional dependency pin; `variables.workbench` is still used for the CLI config templates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small deletion in CLI init dependency resolution with no auth or runtime behavior changes; workbench branding in generated config is untouched.
> 
> **Overview**
> Workbench init (`sanity init --unstable--workbench`) no longer forces the generated `package.json` to depend on the `sanity` **workbench** dist-tag. Dependency resolution now follows the same **`sanity@latest`** path as other templates, since `unstable_defineApp` is available on latest.
> 
> The **`variables.workbench`** flag is unchanged for CLI config (e.g. `unstable_defineApp` in `sanity.cli.ts`). Tests that only asserted the dist-tag override were removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95918b0fae029b11f01d74190728184a3744db97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->