### PR TITLE
fix(workbench): derive config id with Web Crypto

### DIFF
--- a/.changeset/fix-workbench-crypto-browser.md
+++ b/.changeset/fix-workbench-crypto-browser.md
@@ -1,0 +1,6 @@
+---
+"@sanity/workbench-cli": patch
+"@sanity/cli": patch
+---
+
+Derive workbench app and config ids with the Web Crypto API so `node:crypto` no longer crashes the dev server's browser bundle.

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -55,7 +55,9 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     vite: cliConfig.vite,
     // Shared with deploy: it passes the resolved application id (minted by the
     // API on a first deploy) to inline; a plain build has none, so it hashes the shape.
-    workbenchAppId: workbench ? (options.applicationId ?? buildAppId(workbench)) : undefined,
+    workbenchAppId: workbench
+      ? (options.applicationId ?? (await buildAppId(workbench)))
+      : undefined,
     workDir,
   })
 }

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -67,7 +67,9 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     vite: cliConfig.vite,
     // Shared with deploy: it passes the resolved application id (minted by the
     // API on a first deploy) to inline; a plain build has none, so it hashes the shape.
-    workbenchAppId: workbench ? (options.applicationId ?? buildAppId(workbench)) : undefined,
+    workbenchAppId: workbench
+      ? (options.applicationId ?? (await buildAppId(workbench)))
+      : undefined,
     workDir,
   })
 }

--- a/packages/@sanity/workbench-cli/src/__tests__/appId.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/appId.test.ts
@@ -1,62 +1,59 @@
 import {describe, expect, test} from 'vitest'
 
-import {type BuildAppIdentity, resolveAppId} from '../appId.js'
+import {buildAppId, resolveAppId} from '../appId.js'
+import {type ResolvedWorkbenchApp} from '../resolveWorkbenchApp.js'
 
 describe('resolveAppId', () => {
-  const app: BuildAppIdentity = {
-    entry: './src/App.tsx',
-    exposes: {
-      services: [{name: 'unread', src: './src/worker.ts', type: 'worker'}],
-      views: [{name: 'feed', src: './src/feed.tsx', type: 'panel'}],
-    },
-    name: 'drop-desk',
-    organizationId: 'org-1',
-  }
-
   test('dev: the host and port the server bound', () => {
     expect(resolveAppId({host: 'localhost', port: 3333})).toBe('localhost-3333')
     expect(resolveAppId({host: '0.0.0.0', port: 8080})).toBe('0.0.0.0-8080')
   })
+})
 
-  test('build: deterministic for the same declared shape', () => {
-    expect(resolveAppId({app})).toBe(resolveAppId({app}))
+describe('buildAppId', () => {
+  const app: ResolvedWorkbenchApp = {
+    entry: './src/App.tsx',
+    name: 'drop-desk',
+    organizationId: 'org-1',
+    services: [{name: 'unread', src: './src/worker.ts', type: 'worker'}],
+    slug: 'drop-desk',
+    views: [{name: 'feed', src: './src/feed.tsx', type: 'panel'}],
+  }
+
+  test('deterministic for the same declared shape', async () => {
+    expect(await buildAppId(app)).toBe(await buildAppId(app))
   })
 
-  test('build: ignores interface order', () => {
-    const reordered: BuildAppIdentity = {
+  test('ignores interface order', async () => {
+    const reordered: ResolvedWorkbenchApp = {
       ...app,
-      exposes: {
-        views: [
-          {name: 'b', src: './b.tsx', type: 'panel'},
-          {name: 'a', src: './a.tsx', type: 'panel'},
-        ],
-      },
+      views: [
+        {name: 'b', src: './b.tsx', type: 'panel'},
+        {name: 'a', src: './a.tsx', type: 'panel'},
+      ],
     }
-    const forward: BuildAppIdentity = {
+    const forward: ResolvedWorkbenchApp = {
       ...app,
-      exposes: {
-        views: [
-          {name: 'a', src: './a.tsx', type: 'panel'},
-          {name: 'b', src: './b.tsx', type: 'panel'},
-        ],
-      },
+      views: [
+        {name: 'a', src: './a.tsx', type: 'panel'},
+        {name: 'b', src: './b.tsx', type: 'panel'},
+      ],
     }
-    expect(resolveAppId({app: reordered})).toBe(resolveAppId({app: forward}))
+    expect(await buildAppId(reordered)).toBe(await buildAppId(forward))
   })
 
-  test('build: changes when the declared shape changes', () => {
-    expect(resolveAppId({app})).not.toBe(resolveAppId({app: {...app, name: 'other'}}))
-    expect(resolveAppId({app})).not.toBe(resolveAppId({app: {...app, organizationId: 'org-2'}}))
-    expect(resolveAppId({app})).not.toBe(resolveAppId({app: {...app, entry: './src/Other.tsx'}}))
-    expect(resolveAppId({app})).not.toBe(
-      resolveAppId({
-        app: {...app, exposes: {views: [{name: 'feed', src: './moved.tsx', type: 'panel'}]}},
-      }),
+  test('changes when the declared shape changes', async () => {
+    const base = await buildAppId(app)
+    expect(base).not.toBe(await buildAppId({...app, name: 'other'}))
+    expect(base).not.toBe(await buildAppId({...app, organizationId: 'org-2'}))
+    expect(base).not.toBe(await buildAppId({...app, entry: './src/Other.tsx'}))
+    expect(base).not.toBe(
+      await buildAppId({...app, views: [{name: 'feed', src: './moved.tsx', type: 'panel'}]}),
     )
   })
 
-  test('build: never collides with a dev host-port', () => {
-    const id = resolveAppId({app})
+  test('never collides with a dev host-port', async () => {
+    const id = await buildAppId(app)
     expect(id).not.toBe(resolveAppId({host: 'localhost', port: 3333}))
     expect(id).not.toContain('-')
   })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -188,18 +188,18 @@ describe('deriveInterfaces', () => {
 })
 
 describe('deriveConfigs', () => {
-  test('returns [] for a non-branded app', () => {
-    expect(deriveConfigs({title: 'Plain'} as CliConfig['app'])).toEqual([])
-    expect(deriveConfigs(undefined)).toEqual([])
+  test('returns [] for a non-branded app', async () => {
+    await expect(deriveConfigs({title: 'Plain'} as CliConfig['app'])).resolves.toEqual([])
+    await expect(deriveConfigs(undefined)).resolves.toEqual([])
   })
 
-  test('[] for an app with no config', () => {
-    expect(
+  test('[] for an app with no config', async () => {
+    await expect(
       deriveConfigs(workbenchApp({views: [{name: 'feed', src: './f.tsx', type: 'panel'}]})),
-    ).toEqual([])
+    ).resolves.toEqual([])
   })
 
-  test('forwards the serializable config on the wire, keeping `src` as each field entry', () => {
+  test('forwards the serializable config on the wire, keeping `src` as each field entry', async () => {
     const app = workbenchApp({
       config: {
         appType: 'media-library',
@@ -210,7 +210,7 @@ describe('deriveConfigs', () => {
       },
       isSingleton: true,
     })
-    expect(deriveConfigs(app)).toEqual([
+    await expect(deriveConfigs(app)).resolves.toEqual([
       {
         appType: 'media-library',
         fields: [
@@ -224,7 +224,7 @@ describe('deriveConfigs', () => {
     ])
   })
 
-  test('id is stable for the same config and changes when the config changes', () => {
+  test('id is stable for the same config and changes when the config changes', async () => {
     const config = {
       appType: 'media-library' as const,
       fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
@@ -234,11 +234,11 @@ describe('deriveConfigs', () => {
       config: {...config, fields: [{...config.fields[0]!, title: 'Edited'}]},
       isSingleton: true,
     })
-    expect(deriveConfigs(app)[0]?.id).toBe(deriveConfigs(app)[0]?.id)
-    expect(deriveConfigs(edited)[0]?.id).not.toBe(deriveConfigs(app)[0]?.id)
+    expect((await deriveConfigs(app))[0]?.id).toBe((await deriveConfigs(app))[0]?.id)
+    expect((await deriveConfigs(edited))[0]?.id).not.toBe((await deriveConfigs(app))[0]?.id)
   })
 
-  test("forwards the config's appType discriminator (assigns the singleton, no app id)", () => {
+  test("forwards the config's appType discriminator (assigns the singleton, no app id)", async () => {
     const app = workbenchApp({
       applicationType: 'media-library',
       config: {
@@ -247,17 +247,17 @@ describe('deriveConfigs', () => {
       },
       isSingleton: true,
     })
-    expect(deriveConfigs(app)[0]?.appType).toBe('media-library')
+    expect((await deriveConfigs(app))[0]?.appType).toBe('media-library')
   })
 
-  test('rejects an config on a non-singleton app', () => {
+  test('rejects an config on a non-singleton app', async () => {
     const app = workbenchApp({
       config: {
         appType: 'media-library',
         fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
       },
     })
-    expect(() => deriveConfigs(app)).toThrow(/only supported for singleton apps/)
+    await expect(deriveConfigs(app)).rejects.toThrow(/only supported for singleton apps/)
   })
 })
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -1,5 +1,3 @@
-import {hash} from 'node:crypto'
-
 import {type CliConfig} from '@sanity/cli-core'
 
 import {
@@ -106,7 +104,7 @@ export function deriveConfigEntries(config: DevServerConfig): {name: string; src
  * and the workbench keys change detection on it. `version` is the config
  * contract version the generated module exports, known before the module runs.
  */
-export function deriveConfigs(app: CliConfig['app']): DevServerConfig[] {
+export async function deriveConfigs(app: CliConfig['app']): Promise<DevServerConfig[]> {
   if (!isWorkbenchApp(app)) return []
   const config = readConfig(app)
   if (!config) return []
@@ -121,5 +119,16 @@ export function deriveConfigs(app: CliConfig['app']): DevServerConfig[] {
     moduleName: app.name,
     version: MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION,
   }
-  return [{...entry, id: hash('sha1', JSON.stringify(entry))}]
+  return [{...entry, id: await contentHash(JSON.stringify(entry))}]
+}
+
+/**
+ * SHA-256 of a string, as hex, via the Web Crypto API — available in both Node
+ * and the browser. `node:crypto` can't be used: the Vite dev server's dep scan
+ * pulls this module into the browser graph.
+ */
+async function contentHash(input: string): Promise<string> {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins -- the Web Crypto global is available on our Node target and in the browser
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(input))
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
 }

--- a/packages/@sanity/workbench-cli/src/actions/dev/startDevServerRegistration.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startDevServerRegistration.ts
@@ -63,7 +63,7 @@ export async function startDevServerRegistration(
   // Forwarded alongside (not inside) the manifest so the workbench renders local
   // panels/workers and reads the configs without a deploy.
   const interfaces = deriveInterfaces(cliConfig.app, {isApp})
-  const configs = deriveConfigs(cliConfig.app)
+  const configs = await deriveConfigs(cliConfig.app)
 
   const registration = registerDevServer({
     configs,
@@ -87,7 +87,7 @@ export async function startDevServerRegistration(
     extract: async (params) => {
       const app = (await getCliConfigUncached(params.workDir)).app
       return {
-        configs: deriveConfigs(app),
+        configs: await deriveConfigs(app),
         interfaces: deriveInterfaces(app, {isApp}),
         manifest: await extractManifest(params),
       }

--- a/packages/@sanity/workbench-cli/src/actions/preview/__tests__/startWorkbenchPreview.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/__tests__/startWorkbenchPreview.test.ts
@@ -107,7 +107,7 @@ describe('startWorkbenchPreview', () => {
         expect.objectContaining({
           host: 'localhost',
           // `start` advertises the build id (matching the bundle), not host-port.
-          id: buildAppId(resolveWorkbenchApp(workbenchCliConfig())!),
+          id: await buildAppId(resolveWorkbenchApp(workbenchCliConfig())!),
           manifest: {title: 'Test App'},
           port: 3334,
           type: 'coreApp',

--- a/packages/@sanity/workbench-cli/src/actions/preview/startWorkbenchPreview.ts
+++ b/packages/@sanity/workbench-cli/src/actions/preview/startWorkbenchPreview.ts
@@ -98,12 +98,16 @@ export async function startWorkbenchPreview(
     // Read the id the build inlined so start matches it even for a deploy build
     // (which carries the API id, not the shape hash); fall back for older builds.
     const inlinedId = await readInlinedAppId(outDir)
+    const configs = await deriveConfigs(cliConfig.app)
+    // `start` serves a build, so it advertises the build's inlined id (matching
+    // the bundle's `__SANITY_APP_ID__`), not the dev host-port.
+    const id = workbench
+      ? (inlinedId ?? (await buildAppId(workbench)))
+      : `${remote.host}-${remote.port}`
     const registration = registerDevServer({
-      configs: deriveConfigs(cliConfig.app),
+      configs,
       host: remote.host,
-      // `start` serves a build, so it advertises the build's inlined id (matching
-      // the bundle's `__SANITY_APP_ID__`), not the dev host-port.
-      id: workbench ? (inlinedId ?? buildAppId(workbench)) : `${remote.host}-${remote.port}`,
+      id,
       interfaces: deriveInterfaces(cliConfig.app, {isApp}),
       manifest: await extractManifest({configPath, workDir}),
       manifestUpdatedAt: new Date().toISOString(),

--- a/packages/@sanity/workbench-cli/src/appId.ts
+++ b/packages/@sanity/workbench-cli/src/appId.ts
@@ -1,6 +1,4 @@
-import {hash} from 'node:crypto'
-
-import {type ResolvedWorkbenchApp, type WorkbenchExposes} from './resolveWorkbenchApp.js'
+import {type ResolvedWorkbenchApp} from './resolveWorkbenchApp.js'
 
 /**
  * File the build writes into its output, carrying the id compiled into the
@@ -9,60 +7,37 @@ import {type ResolvedWorkbenchApp, type WorkbenchExposes} from './resolveWorkben
  */
 export const SANITY_APP_ID_FILE = 'sanity-app-id.txt'
 
-/** The declared shape hashed into a build id — the app's identity, not its code. */
-export interface BuildAppIdentity {
-  name: string
-  organizationId: string
-
-  entry?: string
-  exposes?: WorkbenchExposes
-}
-
 /**
- * Mints the id the workbench keys everything on (React keys, panel ownership, the
- * message bus, and the bundle's `__SANITY_APP_ID__`). Each run mode derives it
- * differently so a running dev app, a local build, and a deployed twin can't
- * share one: `sanity dev` uses the bound address, `sanity build`/`start` a hash
- * of the declared shape. `sanity deploy` resolves its own id from the
- * applications API, so it isn't handled here.
+ * The dev id for a workbench app — the address the server bound. `sanity dev`
+ * keys on where the app is served so a running app can't collide with its
+ * deployed twin. Sync and dependency-free: it's re-exported from the package's
+ * browser-facing entry, so it must not pull in `node:crypto`.
  */
-export function resolveAppId(
-  source: {app: BuildAppIdentity} | {host: string; port: number},
-): string {
-  if ('app' in source) {
-    const {app} = source
-    const canonical = (
-      interfaces: ReadonlyArray<{name: string; src: string; type: string}> | undefined,
-    ): Array<[string, string, string]> =>
-      (interfaces ?? []).map((i): [string, string, string] => [i.type, i.name, i.src]).toSorted()
-    return hash(
-      'sha1',
-      JSON.stringify({
-        config: app.exposes?.config ?? null,
-        entry: app.entry ?? null,
-        name: app.name,
-        organizationId: app.organizationId,
-        services: canonical(app.exposes?.services),
-        views: canonical(app.exposes?.views),
-      }),
-      'hex',
-    )
-  }
+export function resolveAppId(source: {host: string; port: number}): string {
   return `${source.host}-${source.port}`
 }
 
 /**
- * The `build`/`start` id for a workbench app — a hash of its declared shape.
- * Shared so the bundle inlined by `sanity build` and the registry entry advertised
- * by `sanity start` resolve to the same id.
+ * The `build`/`start` id — a hash of the app's declared shape (its identity, not
+ * its code), so the bundle inlined by `sanity build` and the registry entry
+ * advertised by `sanity start` resolve to the same id. Hashed with the Web Crypto
+ * API rather than `node:crypto` for parity with `resolveAppId`'s browser-safe
+ * home. `sanity deploy` resolves its own id from the applications API.
  */
-export function buildAppId(app: ResolvedWorkbenchApp): string {
-  return resolveAppId({
-    app: {
-      entry: app.entry,
-      exposes: {config: app.config, services: app.services, views: app.views},
-      name: app.name,
-      organizationId: app.organizationId,
-    },
+export async function buildAppId(app: ResolvedWorkbenchApp): Promise<string> {
+  const canonical = (
+    interfaces: ReadonlyArray<{name: string; src: string; type: string}> | undefined,
+  ): Array<[string, string, string]> =>
+    (interfaces ?? []).map((i): [string, string, string] => [i.type, i.name, i.src]).toSorted()
+  const shape = JSON.stringify({
+    config: app.config ?? null,
+    entry: app.entry ?? null,
+    name: app.name,
+    organizationId: app.organizationId,
+    services: canonical(app.services),
+    views: canonical(app.views),
   })
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins -- the Web Crypto global is available on our Node target and in the browser
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(shape))
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
 }


### PR DESCRIPTION
### Description

`sanity dev` on a workbench app with a config (media library) throws in the browser:

> Uncaught Error: Module "node:crypto" has been externalized for browser compatibility. Cannot access "node:crypto.hash" in client code.

`deriveConfigs` computed the config id with `node:crypto`'s `hash`. That module is dev-server orchestration, but the workbench Vite server's dependency scan pulls it into the browser module graph — and every other node-ish import there is type-only, so `node:crypto` was the one value import that leaked.

The fix derives the id with the Web Crypto API (`crypto.subtle.digest`), which exists in both Node and secure browser contexts. The id is only a local change-detection token — the deployed installation id comes from the applications API — so swapping the algorithm is safe. `deriveConfigs` is now async; its three call sites already run in async contexts.

Introduced by #1540.

### What to review

- `deriveInterfaces.ts`: `deriveConfigs` is async and hashes via the `contentHash` helper.
- The `eslint-disable` on the crypto call — the global is available at runtime on our Node target (>=22.12) and in the browser; `eslint-plugin-n` only flags it against Node's "stable at 23" docs label.

### Testing

Unit tests updated for the now-async `deriveConfigs` (stable id, changes on edit, rejects a non-singleton config).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hashing algorithm for local build/config ids (new hex values for the same app shape) and threads async through build and dev registration; deployed API ids are unaffected.
> 
> **Overview**
> Fixes **`sanity dev`** crashing in the browser when a workbench app declares config (e.g. media library): Vite’s dep scan was pulling **`deriveConfigs`** / **`appId`** into the client graph, and **`node:crypto`** cannot run there.
> 
> **Hashing** for local workbench identity tokens now uses **`globalThis.crypto.subtle.digest` (SHA-256, hex)** instead of **`node:crypto`**, in both **`deriveConfigs`** (config change-detection id) and **`buildAppId`** (build/start shape id). **`resolveAppId`** is narrowed to the sync **host-port** dev id only so the browser-facing export stays free of crypto imports.
> 
> **`deriveConfigs`** and **`buildAppId`** are **async**; dev registration, preview **`start`**, and **`sanity build`** paths **`await`** them. Deployed application ids from the API are unchanged—only locally derived hashes change algorithm (SHA-1 → SHA-256), which is acceptable for these tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2bcbfb638b001ba8599b0d8a5e40b2b9793deea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->