### PR TITLE
refactor(workbench): share one Web Crypto hash helper

### DIFF
--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -1,5 +1,6 @@
 import {type CliConfig} from '@sanity/cli-core'
 
+import {contentHash} from '../../contentHash.js'
 import {
   interfaceModuleId,
   MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION,
@@ -120,15 +121,4 @@ export async function deriveConfigs(app: CliConfig['app']): Promise<DevServerCon
     version: MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION,
   }
   return [{...entry, id: await contentHash(JSON.stringify(entry))}]
-}
-
-/**
- * SHA-256 of a string, as hex, via the Web Crypto API — available in both Node
- * and the browser. `node:crypto` can't be used: the Vite dev server's dep scan
- * pulls this module into the browser graph.
- */
-async function contentHash(input: string): Promise<string> {
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins -- the Web Crypto global is available on our Node target and in the browser
-  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(input))
-  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
 }

--- a/packages/@sanity/workbench-cli/src/appId.ts
+++ b/packages/@sanity/workbench-cli/src/appId.ts
@@ -1,3 +1,4 @@
+import {contentHash} from './contentHash.js'
 import {type ResolvedWorkbenchApp} from './resolveWorkbenchApp.js'
 
 /**
@@ -20,24 +21,25 @@ export function resolveAppId(source: {host: string; port: number}): string {
 /**
  * The `build`/`start` id — a hash of the app's declared shape (its identity, not
  * its code), so the bundle inlined by `sanity build` and the registry entry
- * advertised by `sanity start` resolve to the same id. Hashed with the Web Crypto
- * API rather than `node:crypto` for parity with `resolveAppId`'s browser-safe
- * home. `sanity deploy` resolves its own id from the applications API.
+ * advertised by `sanity start` resolve to the same id. `sanity deploy` resolves
+ * its own id from the applications API.
  */
 export async function buildAppId(app: ResolvedWorkbenchApp): Promise<string> {
-  const canonical = (
-    interfaces: ReadonlyArray<{name: string; src: string; type: string}> | undefined,
-  ): Array<[string, string, string]> =>
-    (interfaces ?? []).map((i): [string, string, string] => [i.type, i.name, i.src]).toSorted()
-  const shape = JSON.stringify({
-    config: app.config ?? null,
-    entry: app.entry ?? null,
-    name: app.name,
-    organizationId: app.organizationId,
-    services: canonical(app.services),
-    views: canonical(app.views),
-  })
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins -- the Web Crypto global is available on our Node target and in the browser
-  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(shape))
-  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+  return contentHash(
+    JSON.stringify({
+      config: app.config ?? null,
+      entry: app.entry ?? null,
+      name: app.name,
+      organizationId: app.organizationId,
+      services: canonicalInterfaces(app.services),
+      views: canonicalInterfaces(app.views),
+    }),
+  )
+}
+
+/** Sort interfaces to `[type, name, src]` tuples so ordering never shifts the id. */
+function canonicalInterfaces(
+  interfaces: ReadonlyArray<{name: string; src: string; type: string}> | undefined,
+): Array<[string, string, string]> {
+  return (interfaces ?? []).map((i): [string, string, string] => [i.type, i.name, i.src]).toSorted()
 }

--- a/packages/@sanity/workbench-cli/src/contentHash.ts
+++ b/packages/@sanity/workbench-cli/src/contentHash.ts
@@ -1,0 +1,10 @@
+/**
+ * SHA-256 of a string, as hex, via the Web Crypto API — available in both Node
+ * and the browser. Its callers (`appId`, `deriveInterfaces`) reach the browser,
+ * so this can't use `node:crypto`.
+ */
+export async function contentHash(input: string): Promise<string> {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins -- the Web Crypto global is available on our Node target and in the browser
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(input))
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+}


### PR DESCRIPTION
### Description

Follow-up to #1575. Bugbot flagged that `buildAppId` (`appId.ts`) and `deriveConfigs` (`deriveInterfaces.ts`) each inlined the same Web Crypto SHA-256 hex digest — two copies that can drift on a future algorithm/encoding change.

Extracts a single `contentHash` helper both call, and hoists `appId.ts`'s `canonical` interface-sort out of `buildAppId` (it closed over nothing). No behavior change — same SHA-256 hex.

### What to review

- `contentHash.ts` — the shared helper (Web Crypto, browser-safe).
- `appId.ts` / `deriveInterfaces.ts` now delegate to it.

### Testing

Existing `appId.test.ts` and `deriveInterfaces.test.ts` cover it; output is unchanged.

### Notes for release

N/A