### PR TITLE
feat(cli): add clack-style flow output, splash, and terminal hyperlink utilities

### DIFF
--- a/.changeset/pr-1578.md
+++ b/.changeset/pr-1578.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): add clack-style flow output, splash, and terminal hyperlink utilities

--- a/packages/@sanity/cli/src/util/__tests__/flowOutput.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/flowOutput.test.ts
@@ -1,0 +1,57 @@
+import {afterEach, describe, expect, test} from 'vitest'
+
+import {createFlow} from '../flowOutput.js'
+
+/* eslint-disable no-control-regex */
+const stripAnsi = (line: string) => line.replaceAll(/\u001B\[[0-9;]*m/g, '')
+/* eslint-enable no-control-regex */
+
+const originalStderrIsTTY = process.stderr.isTTY
+
+afterEach(() => {
+  process.stderr.isTTY = originalStderrIsTTY
+})
+
+function collect() {
+  const lines: string[] = []
+  const flow = createFlow((message = '') => lines.push(message))
+  return {flow, plain: () => lines.map((line) => stripAnsi(line))}
+}
+
+describe('createFlow', () => {
+  test('renders the rail glyphs for each emitter', () => {
+    const {flow, plain} = collect()
+    flow.intro('hello')
+    flow.note('working')
+    flow.result('done thing')
+    flow.line('detail')
+    flow.highlight('remember this')
+    flow.gap()
+    flow.outro('bye')
+    expect(plain()).toEqual([
+      '┌  hello',
+      '●  working',
+      '◇  done thing',
+      '│  detail',
+      '◆  remember this',
+      '│',
+      '└  bye',
+    ])
+  })
+
+  test('spin degrades to plain rail lines without a TTY and persists success as a result line', () => {
+    process.stderr.isTTY = false
+    const {flow, plain} = collect()
+    const spin = flow.spin('minting')
+    spin.succeed('minted')
+    expect(plain()).toEqual(['●  minting', '◇  minted'])
+  })
+
+  test('spin failure persists a failure line without a TTY', () => {
+    process.stderr.isTTY = false
+    const {flow, plain} = collect()
+    const spin = flow.spin('minting')
+    spin.fail('mint failed')
+    expect(plain()).toEqual(['●  minting', '✖  mint failed'])
+  })
+})

--- a/packages/@sanity/cli/src/util/__tests__/newCommandSplash.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/newCommandSplash.test.ts
@@ -1,0 +1,64 @@
+import {afterEach, describe, expect, test} from 'vitest'
+
+import {renderNewCommandSplash} from '../newCommandSplash.js'
+
+/* eslint-disable no-control-regex */
+const stripAnsi = (line: string) =>
+  line.replaceAll(/\u001B\]8;;[^\u0007]*\u0007/g, '').replaceAll(/\u001B\[[0-9;]*m/g, '')
+/* eslint-enable no-control-regex */
+
+const originalColumns = process.stdout.columns
+
+afterEach(() => {
+  process.stdout.columns = originalColumns
+})
+
+function render() {
+  const lines: string[] = []
+  renderNewCommandSplash((message = '') => lines.push(message))
+  return lines.map((line) => stripAnsi(line))
+}
+
+describe('renderNewCommandSplash', () => {
+  test('decides hyperlink support at render time, not module load', () => {
+    // OSC 8 emission must track stdout's state when the splash renders — a frozen module-load
+    // decision would bake in whatever isTTY was during import.
+    const originalIsTTY = process.stdout.isTTY
+    try {
+      process.stdout.isTTY = true
+      process.stdout.columns = 0
+      const raw: string[] = []
+      renderNewCommandSplash((message = '') => raw.push(message))
+      expect(raw.join('\n')).toContain('\u001B]8;;')
+    } finally {
+      process.stdout.isTTY = originalIsTTY
+    }
+  })
+
+  test('renders links beside the art when width is unknown (pipes, agents)', () => {
+    process.stdout.columns = 0
+    const lines = render()
+    expect(lines[0]).toBe('')
+    expect(lines.at(-1)).toBe('')
+    expect(lines.some((line) => line.includes('@@@') && line.includes('https://sanity.new'))).toBe(
+      true,
+    )
+    expect(lines.some((line) => line.includes('https://sanity.io/learn'))).toBe(true)
+  })
+
+  test('renders links below the art when the longest link would not fit beside it', () => {
+    // 66-69 columns: wider than the old +20 fudge, narrower than column + longest link (24).
+    process.stdout.columns = 68
+    const lines = render()
+    expect(lines.some((line) => line.includes('@@@') && line.includes('https://'))).toBe(false)
+    expect(lines.filter((line) => line.startsWith('   https://'))).toHaveLength(2)
+  })
+
+  test('renders links below the art on narrow terminals', () => {
+    process.stdout.columns = 40
+    const lines = render()
+    const linkLines = lines.filter((line) => line.startsWith('   https://'))
+    expect(linkLines).toEqual(['   https://sanity.new', '   https://sanity.io/learn'])
+    expect(lines.some((line) => line.includes('@@@') && line.includes('https://'))).toBe(false)
+  })
+})

--- a/packages/@sanity/cli/src/util/__tests__/terminalLink.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/terminalLink.test.ts
@@ -1,0 +1,24 @@
+import {afterEach, describe, expect, test} from 'vitest'
+
+import {hyperlink} from '../terminalLink.js'
+
+const originalIsTTY = process.stdout.isTTY
+
+afterEach(() => {
+  process.stdout.isTTY = originalIsTTY
+})
+
+describe('hyperlink', () => {
+  test('wraps text in an OSC 8 hyperlink when stdout is a TTY', () => {
+    process.stdout.isTTY = true
+    const result = hyperlink('claim it', 'https://example.com/claim')
+    expect(result).toContain('\u001B]8;;https://example.com/claim\u0007')
+    expect(result).toContain('claim it')
+    expect(result.endsWith('\u001B]8;;\u0007')).toBe(true)
+  })
+
+  test('returns bare text with no escape bytes when stdout is piped', () => {
+    process.stdout.isTTY = false
+    expect(hyperlink('claim it', 'https://example.com/claim')).toBe('claim it')
+  })
+})

--- a/packages/@sanity/cli/src/util/flowOutput.ts
+++ b/packages/@sanity/cli/src/util/flowOutput.ts
@@ -1,0 +1,98 @@
+import {styleText} from 'node:util'
+
+import {spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
+
+/** Sink for flow lines — matches the `Output['log']` shape commands already carry. */
+type LogFn = (message?: string) => void
+
+/**
+ * Orbiting-moon frames so the in-flight glyph reads as part of the rail's `◇`/`◆` family. The
+ * trailing space matches the rail's two-space gutter (ora renders `<frame> <text>`).
+ */
+const SPINNER_FRAMES = ['◐ ', '◓ ', '◑ ', '◒ ']
+
+function rail(glyph: string): string {
+  return styleText('gray', glyph)
+}
+
+/**
+ * A clack-style narrated flow (the visual language of `neon-new`, `create-astro`, etc.): a dimmed
+ * left rail (`┌ │ └`) with per-step glyphs — `●` for things happening behind the scenes, `◇` for
+ * produced values, `◆` for outcomes worth remembering — so a multi-step command reads as one
+ * connected story, equally in a TTY and as raw text in an agent's message stream.
+ *
+ * Emitters never insert blank rail lines on their own; callers compose spacing with `gap()`.
+ */
+export interface Flow {
+  /** `│` — a blank rail line separating steps. */
+  gap(): void
+  /** `◆` — an outcome the user should act on or remember. */
+  highlight(text: string): void
+  /** `┌` — opening line of the story. */
+  intro(text: string): void
+  /** `│  <text>` — a continuation line belonging to the previous step. */
+  line(text: string): void
+  /** `●` — a step happening behind the scenes, or a tip. */
+  note(text: string): void
+  /** `└` — closing line of the story. */
+  outro(text: string): void
+  /** `◇` — a completed step or produced value. */
+  result(text: string): void
+  /**
+   * An in-flight step. Resolve it with `succeed(text)` (persists as a `◇` line) or `fail(text)`;
+   * renders on stderr so machine-readable stdout is never corrupted.
+   */
+  spin(text: string): {fail(text: string): void; succeed(text: string): void}
+}
+
+/** Create a {@link Flow} that writes rail lines through `log`. */
+export function createFlow(log: LogFn): Flow {
+  return {
+    gap() {
+      log(rail('│'))
+    },
+    highlight(text: string) {
+      log(`${styleText('green', '◆')}  ${text}`)
+    },
+    intro(text: string) {
+      log(`${rail('┌')}  ${text}`)
+    },
+    line(text: string) {
+      log(`${rail('│')}  ${text}`)
+    },
+    note(text: string) {
+      log(`${rail('●')}  ${text}`)
+    },
+    outro(text: string) {
+      log(`${rail('└')}  ${text}`)
+    },
+    result(text: string) {
+      log(`${rail('◇')}  ${text}`)
+    },
+    spin(text: string) {
+      // Without a TTY (CI, agents reading the stream) an animated spinner is noise on stderr that
+      // interleaves badly with the stdout rail — degrade to plain rail lines instead. Same for a
+      // zero-width pty (some CI/agent harnesses): ora's line-wrapping re-renders in a hot loop
+      // there, starving the event loop.
+      if (!process.stderr.isTTY || !process.stderr.columns) {
+        this.note(text)
+        return {
+          fail: (failText: string) => log(`${styleText('red', '✖')}  ${failText}`),
+          succeed: (successText: string) => log(`${rail('◇')}  ${successText}`),
+        }
+      }
+      const spin: SpinnerInstance = spinner({
+        spinner: {frames: SPINNER_FRAMES, interval: 120},
+        text,
+      }).start()
+      return {
+        fail(failText: string) {
+          spin.stopAndPersist({symbol: `${styleText('red', '✖')} `, text: failText})
+        },
+        succeed(successText: string) {
+          spin.stopAndPersist({symbol: `${rail('◇')} `, text: successText})
+        },
+      }
+    },
+  }
+}

--- a/packages/@sanity/cli/src/util/newCommandSplash.ts
+++ b/packages/@sanity/cli/src/util/newCommandSplash.ts
@@ -1,0 +1,66 @@
+import {styleText} from 'node:util'
+
+import {hyperlink} from './terminalLink.js'
+
+/** Sink for splash lines — matches the `Output['log']` shape commands already carry. */
+type LogFn = (message?: string) => void
+
+/** The Sanity squiggle, as terminal-safe ASCII art. */
+const ART = [
+  '          -          #:      @@@@',
+  '         @@@      @@@@@    -@@@=   @@@',
+  '       @@@@   %@@@@@@.    @@@@ %@@@@@@',
+  '      @@@% @@@@@@@#     %@@@@@@@@@-',
+  '    @@@@@@@@@@@@@      @@@@@@@@.',
+  '   @@@@@@@= @@@#     @@@@@@@        @@@@@',
+  '   @@@@   @@@@    @@@@@@         @@@@@@@',
+  '         @@@@ @@@@@@@@        @@@@@@@@',
+  '       +@@@@@@@@@@@@@      @@@@@@@@@@',
+  '      @@@@@@@@ @@@@     @@@@@@ @@@@',
+  '     @@@@@%  *@@@%  .@@@@@%  .@@@@ .@@@@',
+  '      .-    @@@@ .@@@@@%    #@@@.@@@@@@@@',
+  '          *@@@@@@@@@%      @@@@@@@@#@@@@',
+  '         @@@@@@@@        #@@@@@@#  @@@@',
+  '       @@@@@@@           @@@@#    @@@@',
+  '      #@@@@               *      @@@+',
+  '                                  =',
+]
+
+// Full URLs, no tree branching — the visible text doubles as the link target, so terminals'
+// native URL detection works alongside the OSC 8 hyperlink. Built per render, not at module
+// load: `hyperlink` decides OSC 8 support at call time, and freezing that decision at import
+// would bake in whatever stdout happened to be during module init.
+const LINK_URLS = ['https://sanity.new', 'https://sanity.io/learn']
+const renderLinks = () => LINK_URLS.map((url) => hyperlink(styleText('cyan', url), url))
+
+/** Art row the link tree starts on when rendered to the right of the squiggle. */
+const LINKS_START_ROW = 5
+
+/** Column the link tree starts in — a little breathing room past the widest art row. */
+const LINKS_COLUMN = Math.max(...ART.map((line) => line.length)) + 5
+
+/** Visible width of the widest link — the side-by-side layout must fit column + this. */
+const LINKS_WIDTH = Math.max(...LINK_URLS.map((url) => url.length))
+
+/**
+ * Neon.new-style splash: the Sanity squiggle with a small tree of relevant links beside it,
+ * padded with blank lines on both ends. On terminals too narrow for the side-by-side layout the
+ * links render below the art instead; without a TTY (agents, pipes) width is unknown and the
+ * side-by-side layout is used, since the reader is not wrapping lines visually.
+ */
+export function renderNewCommandSplash(log: LogFn): void {
+  const columns = process.stdout.columns
+  const sideBySide = !columns || columns >= LINKS_COLUMN + LINKS_WIDTH
+  const links = renderLinks()
+
+  log('')
+  for (const [row, line] of ART.entries()) {
+    const link = sideBySide ? links[row - LINKS_START_ROW] : undefined
+    log(link ? `${styleText('cyan', line.padEnd(LINKS_COLUMN))}${link}` : styleText('cyan', line))
+  }
+  if (!sideBySide) {
+    log('')
+    for (const link of links) log(`   ${link}`)
+  }
+  log('')
+}

--- a/packages/@sanity/cli/src/util/terminalLink.ts
+++ b/packages/@sanity/cli/src/util/terminalLink.ts
@@ -1,0 +1,13 @@
+import {styleText} from 'node:util'
+
+/**
+ * Wrap `text` in an OSC 8 terminal hyperlink to `url`. Only emits the escape sequence when
+ * stdout is a TTY — piped output (agents, logs) gets the bare text, no escape bytes. Terminals
+ * without OSC 8 support ignore the sequence and render the (underlined) text
+ * unchanged; `text` may already carry ANSI color styling.
+ */
+export function hyperlink(text: string, url: string): string {
+  return process.stdout.isTTY
+    ? `\u001B]8;;${url}\u0007${styleText('underline', text)}\u001B]8;;\u0007`
+    : text
+}


### PR DESCRIPTION
### Description

this PR adds `sanity new` ux via clack-style rail, similar to `npx neon-new`

### Stack

(each PR reviews against its base; merge bottom-up only):

1. `stack/mint-and-claim/a1/01-terminal-presentation` ← this diff
2. `stack/mint-and-claim/a1/02-mint-core`
3. `stack/mint-and-claim/a1/03-claim-reminders`
4. `stack/mint-and-claim/a1/04-init-signpost`
5. `stack/mint-and-claim/a1/05-remint-guardrail`
6. `stack/mint-and-claim/a1/06-ambient-reminder`
7. `stack/mint-and-claim/a1/07-logout-env-token`

### What to review

Rendering shapes in the three utils and their tests; no behavior beyond presentation.

### Testing

Layer-scoped unit tests included (test:source ≥ 1:1); every layer validated standalone (full typecheck + targeted tests at each checkout). 

<img width="853" height="820" alt="pr1578-clack-splash-flow" src="https://github.com/user-attachments/assets/d5266ead-a64f-4a56-9182-93909990192a" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated util modules with no production call sites yet; only affects future CLI UX output.
> 
> **Overview**
> Adds **presentation-only** terminal helpers under `@sanity/cli` (no command wiring yet), plus a minor changeset.
> 
> **`createFlow`** builds a clack-style narrated CLI flow: dim left rail with step glyphs (`intro` / `note` / `result` / `highlight` / `gap` / `outro`), optional **`spin`** via `@sanity/cli-core/ux` that falls back to plain rail lines when stderr is not a TTY or has zero columns.
> 
> **`hyperlink`** emits OSC 8 links only when stdout is a TTY; piped output stays plain text.
> 
> **`renderNewCommandSplash`** prints cyan ASCII Sanity art with `sanity.new` and learn URLs—beside the art when width allows (or when width is unknown), otherwise indented below on narrow terminals. Hyperlinks are resolved at render time, not module load.
> 
> Vitest covers rail glyphs, spinner degradation, hyperlink TTY behavior, and splash layout edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86182cd2a029c1e74b522fc35bbe0d95f03444c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->