### PR TITLE
feat(cli): add sanity projects mint and sanity new for logged-out project minting

### DIFF
--- a/.changeset/pr-1579.md
+++ b/.changeset/pr-1579.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): add sanity projects mint and sanity new for logged-out project minting

--- a/packages/@sanity/cli/src/commands/new.ts
+++ b/packages/@sanity/cli/src/commands/new.ts
@@ -1,0 +1,10 @@
+import {MintProjectCommand} from './projects/mint.js'
+
+/**
+ * Top-level alias for `sanity projects mint`. Subclassing (rather than oclif's `aliases`) gives
+ * `sanity new` its own entry in help output while sharing the entire implementation.
+ */
+export class NewCommand extends MintProjectCommand {
+  // Don't inherit the parent's `project:mint` alias — it must resolve to a single command.
+  static override hiddenAliases: string[] = []
+}

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
@@ -1,0 +1,215 @@
+import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {NewCommand} from '../../new.js'
+import {MintProjectCommand} from '../mint.js'
+
+const mockMintUnclaimedProject = vi.hoisted(() => vi.fn())
+const mockAppendEnvValues = vi.hoisted(() => vi.fn())
+const mockInput = vi.hoisted(() => vi.fn())
+
+vi.mock(
+  '@sanity/cli-core/SanityCommand',
+  () => import('@sanity/cli-test/mocks/cli-core/SanityCommand'),
+)
+vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sanity/cli-core/ux')>()
+  return {
+    ...original,
+    input: mockInput,
+    // Silence the flow spinner — its lifecycle is exercised via the command outcome.
+    spinner: () => ({
+      start: () => ({fail: vi.fn(), stopAndPersist: vi.fn()}),
+    }),
+  }
+})
+vi.mock('../../../services/mintProject.js', () => ({
+  mintUnclaimedProject: mockMintUnclaimedProject,
+}))
+vi.mock('../../../util/envFile.js', () => ({
+  appendEnvValues: mockAppendEnvValues,
+}))
+
+const mockMinted = {
+  apiHost: 'https://abc123.api.sanity.io',
+  claimApiUrl: 'https://api.sanity.io/v1/provision/claim',
+  claimToken: 'claim-token',
+  claimUrl: 'https://www.sanity.io/claim/some-token',
+  datasetName: 'production',
+  expiresAt: '2026-07-18T00:00:00.000Z',
+  resourceId: 'abc123',
+  token: 'sk-robot-token',
+}
+
+const expectedResult = {
+  apiHost: mockMinted.apiHost,
+  claimApiUrl: mockMinted.claimApiUrl,
+  claimToken: mockMinted.claimToken,
+  claimUrl: mockMinted.claimUrl,
+  dataset: mockMinted.datasetName,
+  expiresAt: mockMinted.expiresAt,
+  projectId: mockMinted.resourceId,
+  token: mockMinted.token,
+}
+
+function loggedLines(): string {
+  return vi.mocked(mocks.SanityCmdOutput.log).mock.calls.flat().join('\n')
+}
+
+beforeEach(() => {
+  mockMintUnclaimedProject.mockResolvedValue(mockMinted)
+  mockAppendEnvValues.mockReturnValue({
+    created: true,
+    skippedKeys: [],
+    wroteKeys: ['SANITY_PROJECT_ID', 'SANITY_DATASET', 'SANITY_AUTH_TOKEN'],
+  })
+  // Default to unattended so tests without a name argument never hang on the prompt.
+  mocks.SanityCmdIsUnattended.mockReturnValue(true)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('#projects:mint', () => {
+  test('mints a project with the provided name and narrates the flow', async () => {
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'My New Project'})
+    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+
+    const lines = loggedLines()
+    // The splash renders first: squiggle art plus full link URLs.
+    expect(lines).toContain('@@@@')
+    expect(lines).toContain('https://sanity.new')
+    expect(lines).toContain('https://sanity.io/learn')
+    expect(lines).toContain("Let's get you set up with a Sanity project.")
+    // The --yes hint is redundant when the run is already non-interactive.
+    expect(lines).not.toContain('--yes')
+    expect(lines).toContain(mockMinted.resourceId)
+    expect(lines).toContain(mockMinted.datasetName)
+    expect(lines).toContain(mockMinted.claimUrl)
+    expect(lines).toContain(mockMinted.expiresAt)
+    // Without a TTY the spinner degrades to plain rail lines through the same log sink.
+    expect(lines).toContain('Minting your project...')
+    expect(lines).toContain('Project minted!')
+    expect(lines).toContain('Happy coding!')
+  })
+
+  test('writes credentials and claim context to .env', async () => {
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockAppendEnvValues).toHaveBeenCalledWith(
+      expect.stringMatching(/\.env$/),
+      {
+        SANITY_AUTH_TOKEN: mockMinted.token,
+        SANITY_DATASET: mockMinted.datasetName,
+        SANITY_PROJECT_ID: mockMinted.resourceId,
+      },
+      {banner: expect.arrayContaining([expect.stringContaining(mockMinted.claimUrl)])},
+    )
+    expect(loggedLines()).toContain(
+      'Saved credentials to ./.env as SANITY_PROJECT_ID, SANITY_DATASET, SANITY_AUTH_TOKEN',
+    )
+  })
+
+  test('reports keys it left untouched in an existing .env', async () => {
+    mockAppendEnvValues.mockReturnValue({
+      created: false,
+      skippedKeys: ['SANITY_AUTH_TOKEN'],
+      wroteKeys: ['SANITY_PROJECT_ID', 'SANITY_DATASET'],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('Saved credentials to ./.env as SANITY_PROJECT_ID, SANITY_DATASET')
+    expect(lines).toContain('Left existing SANITY_AUTH_TOKEN in ./.env untouched.')
+  })
+
+  test('shows the token when .env already had one (never silently lost)', async () => {
+    mockAppendEnvValues.mockReturnValue({
+      created: false,
+      skippedKeys: ['SANITY_AUTH_TOKEN'],
+      wroteKeys: ['SANITY_PROJECT_ID', 'SANITY_DATASET'],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('This project’s token (not saved — .env already had one):')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+  })
+
+  test('surfaces the credentials when the .env write fails after a successful mint', async () => {
+    mockAppendEnvValues.mockImplementation(() => {
+      throw new Error('EACCES: permission denied')
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('Save these credentials yourself')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines).toContain(`SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+  })
+
+  test('defaults the display name when unattended and no project name is provided', async () => {
+    await MintProjectCommand.run([])
+
+    expect(mockInput).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'My Sanity project'})
+  })
+
+  test('accepts --yes without a name argument', async () => {
+    await MintProjectCommand.run(['--yes'])
+
+    expect(mockInput).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'My Sanity project'})
+  })
+
+  test('prompts for the project name when attended', async () => {
+    mocks.SanityCmdIsUnattended.mockReturnValue(false)
+    mockInput.mockResolvedValue('Prompted Project')
+
+    await MintProjectCommand.run([])
+
+    expect(mockInput).toHaveBeenCalledWith({
+      default: 'My Sanity project',
+      message: 'Project name',
+    })
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'Prompted Project'})
+    expect(loggedLines()).toContain('--yes')
+  })
+
+  test('returns the structured result for --json output without touching .env', async () => {
+    await expect(MintProjectCommand.run(['My New Project', '--json'])).resolves.toEqual(
+      expectedResult,
+    )
+
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+    expect(mockInput).not.toHaveBeenCalled()
+  })
+
+  test('propagates mint failures', async () => {
+    mockMintUnclaimedProject.mockRejectedValue(new Error('Mint failed (HTTP 429): rate limited'))
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      'Mint failed (HTTP 429): rate limited',
+    )
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+})
+
+describe('#new', () => {
+  test('runs the same mint flow as projects:mint', async () => {
+    await expect(NewCommand.run(['My New Project', '--json'])).resolves.toEqual(expectedResult)
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'My New Project'})
+  })
+
+  test('does not inherit the parent hidden aliases', () => {
+    expect(MintProjectCommand.hiddenAliases).toEqual(['project:mint'])
+    expect(NewCommand.hiddenAliases).toEqual([])
+  })
+})

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -1,0 +1,206 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {styleText} from 'node:util'
+
+import {Args, Flags} from '@oclif/core'
+import {SanityCommand} from '@sanity/cli-core/SanityCommand'
+import {input} from '@sanity/cli-core/ux'
+
+import {mintUnclaimedProject} from '../../services/mintProject.js'
+import {appendEnvValues} from '../../util/envFile.js'
+import {createFlow} from '../../util/flowOutput.js'
+import {renderNewCommandSplash} from '../../util/newCommandSplash.js'
+import {hyperlink} from '../../util/terminalLink.js'
+
+const DEFAULT_PROJECT_NAME = 'My Sanity project'
+
+function hoursUntil(iso: string): number | undefined {
+  const ms = new Date(iso).getTime() - Date.now()
+  return Number.isFinite(ms) && ms > 0 ? Math.round(ms / 3_600_000) : undefined
+}
+
+/**
+ * Machine-readable result of the mint flow, emitted as JSON under `--json`. Carries everything a
+ * downstream agent needs to act on the project before it is claimed: the scoped robot `token`,
+ * the project/dataset identity, the resolved `apiHost`, and the claim handoff (`claimUrl` for a
+ * human, `claimApiUrl` + `claimToken` for programmatic claiming).
+ */
+export interface MintProjectResult {
+  apiHost: string
+  claimApiUrl: string
+  claimToken: string
+  claimUrl: string
+  dataset: string
+  expiresAt: string
+  projectId: string
+  /** Robot token scoped to the freshly minted, unclaimed project. */
+  token: string
+}
+
+export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand> {
+  static override args = {
+    projectName: Args.string({
+      description: 'Display name for the minted project',
+      required: false,
+    }),
+  }
+
+  static override description =
+    'Mint an unclaimed Sanity project without logging in, and claim it later'
+
+  static override enableJsonFlag = true
+
+  static override examples = [
+    {
+      command: '<%= config.bin %> <%= command.id %>',
+      description: 'Interactively mint an unclaimed project',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> "My New Project"',
+      description: 'Mint an unclaimed project named "My New Project"',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --yes',
+      description: 'Mint a project non-interactively with defaults',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --json',
+      description: 'Mint a project and output the token and claim details as JSON',
+    },
+  ]
+
+  static override flags = {
+    yes: Flags.boolean({
+      char: 'y',
+      default: false,
+      description: `Skip prompts and use defaults (project: "${DEFAULT_PROJECT_NAME}")`,
+    }),
+  }
+
+  static override hiddenAliases: string[] = ['project:mint']
+
+  public async run(): Promise<MintProjectResult> {
+    // Under `--json` oclif suppresses `this.log` (which `output.log` is bound to) and prints the
+    // returned `MintProjectResult` instead, so the narrated flow only appears in human runs — the
+    // structured payload owns stdout in JSON mode, and JSON mode leaves the filesystem untouched
+    // (the payload itself carries the credentials).
+    const {output} = this
+    const json = this.jsonEnabled()
+    const flow = createFlow(output.log)
+    // How this command was invoked (`sanity new` vs `sanity projects mint`), for self-referencing copy.
+    const invoked = [this.config.bin, ...(this.id?.split(':') ?? [])].join(' ')
+
+    renderNewCommandSplash(output.log)
+
+    flow.intro("Let's get you set up with a Sanity project.")
+    flow.gap()
+    // Redundant when the run is already non-interactive — only teach the flag when attended.
+    if (!this.isUnattended()) {
+      flow.note(
+        `${styleText('cyan', `${invoked} --yes`)} for a non-interactive flow with defaults.`,
+      )
+      flow.gap()
+    }
+
+    let displayName = this.args.projectName?.trim()
+    if (displayName) {
+      flow.result(`Project name: ${styleText('cyan', displayName)}`)
+      flow.gap()
+    } else if (this.isUnattended()) {
+      displayName = DEFAULT_PROJECT_NAME
+      flow.result(
+        `Project name: ${styleText('cyan', displayName)} ${styleText('dim', '(default)')}`,
+      )
+      flow.gap()
+    } else {
+      // Attended mode: the one decision worth a prompt. `--yes` (or a non-TTY) skips it.
+      displayName =
+        (await input({default: DEFAULT_PROJECT_NAME, message: 'Project name'})).trim() ||
+        DEFAULT_PROJECT_NAME
+    }
+
+    const envPath = path.join(process.cwd(), '.env')
+    if (!json) {
+      flow.note(
+        fs.existsSync(envPath)
+          ? 'Found an existing .env file, adding to it.'
+          : 'No .env file found, creating one.',
+      )
+      flow.gap()
+    }
+
+    const spin = json ? undefined : flow.spin('Minting your project...')
+    let minted
+    try {
+      minted = await mintUnclaimedProject({displayName})
+    } catch (err) {
+      spin?.fail('Minting your project failed.')
+      throw err
+    }
+    spin?.succeed('Project minted!')
+
+    flow.gap()
+    flow.result(`Project ID: ${styleText('cyan', minted.resourceId)}`)
+    flow.result(`Dataset:    ${styleText('cyan', minted.datasetName)}`)
+    flow.gap()
+
+    if (!json) {
+      // The mint already succeeded — a skipped or failed write must never swallow the only copy
+      // of the new credentials. Show anything that didn't land in .env.
+      try {
+        const written = appendEnvValues(
+          envPath,
+          {
+            SANITY_AUTH_TOKEN: minted.token,
+            SANITY_DATASET: minted.datasetName,
+            SANITY_PROJECT_ID: minted.resourceId,
+          },
+          {
+            banner: [
+              `Added by \`${invoked}\` — unclaimed Sanity project, expires ${minted.expiresAt}`,
+              `Claim it to keep it: ${minted.claimUrl}`,
+            ],
+          },
+        )
+        if (written.wroteKeys.length > 0) {
+          flow.highlight(`Saved credentials to ./.env as ${written.wroteKeys.join(', ')}`)
+        }
+        if (written.skippedKeys.length > 0) {
+          flow.note(`Left existing ${written.skippedKeys.join(', ')} in ./.env untouched.`)
+        }
+        if (written.skippedKeys.includes('SANITY_AUTH_TOKEN')) {
+          flow.highlight('This project’s token (not saved — .env already had one):')
+          flow.line(`SANITY_AUTH_TOKEN="${minted.token}"`)
+        }
+      } catch (err) {
+        this.warn(`Couldn't write ./.env (${err instanceof Error ? err.message : err})`)
+        flow.highlight('Save these credentials yourself — they are not stored anywhere else:')
+        flow.line(`SANITY_PROJECT_ID="${minted.resourceId}"`)
+        flow.line(`SANITY_DATASET="${minted.datasetName}"`)
+        flow.line(`SANITY_AUTH_TOKEN="${minted.token}"`)
+      }
+      flow.gap()
+    }
+
+    const hrs = hoursUntil(minted.expiresAt)
+    flow.note(
+      hrs
+        ? `Claim your project within ${styleText('yellow', `~${hrs} hours`)} (by ${minted.expiresAt}) to keep it:`
+        : `Claim your project before ${styleText('yellow', minted.expiresAt)} to keep it:`,
+    )
+    flow.line(hyperlink(styleText('cyan', minted.claimUrl), minted.claimUrl))
+    flow.gap()
+    flow.outro('Happy coding! 🚀')
+
+    return {
+      apiHost: minted.apiHost,
+      claimApiUrl: minted.claimApiUrl,
+      claimToken: minted.claimToken,
+      claimUrl: minted.claimUrl,
+      dataset: minted.datasetName,
+      expiresAt: minted.expiresAt,
+      projectId: minted.resourceId,
+      token: minted.token,
+    }
+  }
+}

--- a/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
@@ -1,0 +1,144 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {mintUnclaimedProject, PROVISION_API_VERSION} from '../mintProject.js'
+
+const mockFetch = vi.fn()
+
+const provisionResponse = {
+  apiHost: 'https://abc123.api.sanity.io',
+  claimToken: 'claim-token',
+  datasetName: 'production',
+  expiresAt: '2026-07-18T00:00:00.000Z',
+  links: {
+    claimApiUrl: 'https://api.sanity.io/v1/provision/claim',
+    claimUrl: 'https://www.sanity.io/claim/some-token',
+  },
+  resourceId: 'abc123',
+  resourceType: 'project',
+  token: 'sk-robot-token',
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch)
+  mockFetch.mockResolvedValue({
+    json: async () => provisionResponse,
+    ok: true,
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+  vi.clearAllMocks()
+})
+
+describe('#mintUnclaimedProject', () => {
+  test('posts display name to the provision endpoint and maps the response', async () => {
+    const minted = await mintUnclaimedProject({displayName: 'My Project'})
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `https://api.sanity.io/${PROVISION_API_VERSION}/provision`,
+      {
+        body: JSON.stringify({displayName: 'My Project', resourceType: 'project'}),
+        headers: {'Content-Type': 'application/json'},
+        method: 'POST',
+      },
+    )
+    expect(minted).toEqual({
+      apiHost: provisionResponse.apiHost,
+      claimApiUrl: provisionResponse.links.claimApiUrl,
+      claimToken: provisionResponse.claimToken,
+      claimUrl: provisionResponse.links.claimUrl,
+      datasetName: provisionResponse.datasetName,
+      expiresAt: provisionResponse.expiresAt,
+      resourceId: provisionResponse.resourceId,
+      token: provisionResponse.token,
+    })
+  })
+
+  test('trims the display name', async () => {
+    await mintUnclaimedProject({displayName: '  Padded  '})
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({displayName: 'Padded', resourceType: 'project'}),
+      }),
+    )
+  })
+
+  test('respects SANITY_API_HOST override, stripping trailing slash', async () => {
+    vi.stubEnv('SANITY_API_HOST', 'https://api.sanity.example/')
+
+    await mintUnclaimedProject({displayName: 'My Project'})
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `https://api.sanity.example/${PROVISION_API_VERSION}/provision`,
+      expect.any(Object),
+    )
+  })
+
+  test.each(['', '   ', 'x'.repeat(81)])('rejects invalid display name %j', async (displayName) => {
+    await expect(mintUnclaimedProject({displayName})).rejects.toThrow(
+      'Display name must be 1-80 characters.',
+    )
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  test('throws with status and body on HTTP error', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: async () => 'provisioning disabled',
+    })
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
+      'Mint failed (HTTP 404): provisioning disabled',
+    )
+  })
+
+  test('falls back to statusText when the error body is unreadable', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => {
+        throw new Error('no body')
+      },
+    })
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
+      'Mint failed (HTTP 500): Internal Server Error',
+    )
+  })
+
+  test('throws when the response has no claim token', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({...provisionResponse, claimToken: undefined}),
+      ok: true,
+    })
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
+      /did not return a claim token/,
+    )
+  })
+
+  test('names every missing field instead of mapping a partial 200 response', async () => {
+    // A 200 is still external input: every mapped field lands in .env or the JSON payload, so
+    // a hole must fail loudly here — not crash on `data.links` or write the literal string
+    // "undefined" as a credential.
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        ...provisionResponse,
+        links: undefined,
+        token: '',
+      }),
+      ok: true,
+    })
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
+      'Mint response is missing claimApiUrl, claimUrl, token',
+    )
+  })
+})

--- a/packages/@sanity/cli/src/services/mintProject.ts
+++ b/packages/@sanity/cli/src/services/mintProject.ts
@@ -1,0 +1,101 @@
+import {subdebug} from '@sanity/cli-core/debug'
+import {isStaging} from '@sanity/cli-core/util'
+
+const debug = subdebug('projects:mint')
+
+/** Provision API version — see the unauthenticated mint-and-claim endpoint. */
+export const PROVISION_API_VERSION = 'v2026-06-23'
+
+export interface MintedProject {
+  /** Project-scoped API host, e.g. `<id>.api.sanity.io`. */
+  apiHost: string
+  /** API endpoint that performs the claim. */
+  claimApiUrl: string
+  /** Token that authorizes claiming ownership of the project. */
+  claimToken: string
+  /** URL the user opens in a browser to claim the project. */
+  claimUrl: string
+  datasetName: string
+  /** ISO timestamp after which the unclaimed project is reclaimed. */
+  expiresAt: string
+  /** The provisioned (unclaimed) project id. */
+  resourceId: string
+  /** Robot token scoped to the freshly minted, unclaimed project. */
+  token: string
+}
+
+interface ProvisionResponse {
+  apiHost: string
+  claimToken: string
+  datasetName: string
+  expiresAt: string
+  links: {claimApiUrl: string; claimUrl: string}
+  resourceId: string
+  resourceType: string
+  token: string
+}
+
+function getProvisionApiBase(): string {
+  const override = process.env.SANITY_API_HOST
+  if (override) return override.replace(/\/$/, '')
+  return isStaging() ? 'https://api.sanity.work' : 'https://api.sanity.io'
+}
+
+/**
+ * Mint an unclaimed Sanity project via the unauthenticated provision endpoint, returning a
+ * scoped robot token and a claim URL:
+ * `POST <apiHost>/<version>/provision` with `{resourceType:'project', displayName}`.
+ */
+export async function mintUnclaimedProject(options: {displayName: string}): Promise<MintedProject> {
+  const displayName = options.displayName.trim()
+  if (!displayName || displayName.length > 80) {
+    throw new Error('Display name must be 1-80 characters.')
+  }
+
+  const url = `${getProvisionApiBase()}/${PROVISION_API_VERSION}/provision`
+  debug('minting unclaimed project at %s', url)
+
+  const response = await fetch(url, {
+    body: JSON.stringify({displayName, resourceType: 'project'}),
+    headers: {'Content-Type': 'application/json'},
+    method: 'POST',
+  })
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(`Mint failed (HTTP ${response.status}): ${body || response.statusText}`)
+  }
+
+  const data = (await response.json()) as ProvisionResponse
+
+  // Mint may 404 (kill switch off) or 429 (rate limited) and return no claim token.
+  if (!data?.claimToken) {
+    throw new Error(
+      'Mint did not return a claim token (provisioning disabled, or rate limited). ' +
+        'See the provision API response.',
+    )
+  }
+
+  // A 200 is still external input: every field below lands in .env or the JSON payload, so a
+  // missing one must fail here by name — not crash on `data.links` or quietly write the
+  // literal string "undefined" as a credential.
+  const minted = {
+    apiHost: data.apiHost,
+    claimApiUrl: data.links?.claimApiUrl,
+    claimToken: data.claimToken,
+    claimUrl: data.links?.claimUrl,
+    datasetName: data.datasetName,
+    expiresAt: data.expiresAt,
+    resourceId: data.resourceId,
+    token: data.token,
+  }
+  const missing = Object.entries(minted)
+    .filter(([, value]) => typeof value !== 'string' || value === '')
+    .map(([key]) => key)
+  if (missing.length > 0) {
+    throw new Error(
+      `Mint response is missing ${missing.join(', ')} — see the provision API response.`,
+    )
+  }
+  return minted as MintedProject
+}

--- a/packages/@sanity/cli/src/util/__tests__/envFile.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/envFile.test.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {afterEach, beforeEach, describe, expect, test} from 'vitest'
+
+import {appendEnvValues} from '../envFile.js'
+
+let dir: string
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sanity-envfile-'))
+})
+
+afterEach(() => {
+  fs.rmSync(dir, {force: true, recursive: true})
+})
+
+describe('appendEnvValues', () => {
+  test('creates the file with banner comments and quoted values', () => {
+    const envPath = path.join(dir, '.env')
+
+    const result = appendEnvValues(
+      envPath,
+      {SANITY_DATASET: 'production', SANITY_PROJECT_ID: 'abc123'},
+      {banner: ['claim me: https://example.com/claim']},
+    )
+
+    expect(result).toEqual({
+      created: true,
+      skippedKeys: [],
+      wroteKeys: ['SANITY_DATASET', 'SANITY_PROJECT_ID'],
+    })
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(
+      '# claim me: https://example.com/claim\n' +
+        'SANITY_DATASET="production"\n' +
+        'SANITY_PROJECT_ID="abc123"\n',
+    )
+  })
+
+  test('appends to an existing file without clobbering its contents', () => {
+    const envPath = path.join(dir, '.env')
+    fs.writeFileSync(envPath, 'OTHER_KEY=other\n')
+
+    const result = appendEnvValues(envPath, {SANITY_PROJECT_ID: 'abc123'})
+
+    expect(result.created).toBe(false)
+    expect(result.wroteKeys).toEqual(['SANITY_PROJECT_ID'])
+    expect(fs.readFileSync(envPath, 'utf8')).toBe('OTHER_KEY=other\n\nSANITY_PROJECT_ID="abc123"\n')
+  })
+
+  test('never overwrites existing keys, including `export`-prefixed ones', () => {
+    const envPath = path.join(dir, '.env')
+    fs.writeFileSync(envPath, 'export SANITY_AUTH_TOKEN=keep-me\nSANITY_PROJECT_ID=existing\n')
+
+    const result = appendEnvValues(envPath, {
+      SANITY_AUTH_TOKEN: 'new-token',
+      SANITY_DATASET: 'production',
+      SANITY_PROJECT_ID: 'abc123',
+    })
+
+    expect(result.skippedKeys).toEqual(['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'])
+    expect(result.wroteKeys).toEqual(['SANITY_DATASET'])
+    const contents = fs.readFileSync(envPath, 'utf8')
+    expect(contents).toContain('export SANITY_AUTH_TOKEN=keep-me')
+    expect(contents).toContain('SANITY_PROJECT_ID=existing')
+    expect(contents).toContain('SANITY_DATASET="production"')
+    expect(contents).not.toContain('new-token')
+  })
+
+  test('a blank template line counts as existing: skipped, never edited', () => {
+    // `SANITY_PROJECT_ID=` with no value — the classic .env.example leftover. Line presence,
+    // not value presence, decides ownership: the writer must not edit or duplicate the line.
+    // (Callers surface the skipped keys' values instead — see the mint flow.)
+    const envPath = path.join(dir, '.env')
+    const original = 'SANITY_PROJECT_ID=\nSANITY_AUTH_TOKEN=""\n'
+    fs.writeFileSync(envPath, original)
+
+    const result = appendEnvValues(envPath, {
+      SANITY_AUTH_TOKEN: 'sk-new',
+      SANITY_DATASET: 'production',
+      SANITY_PROJECT_ID: 'abc123',
+    })
+
+    expect(result).toEqual({
+      created: false,
+      skippedKeys: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'],
+      wroteKeys: ['SANITY_DATASET'],
+    })
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(`${original}\nSANITY_DATASET="production"\n`)
+  })
+
+  test('writes nothing when every key already exists', () => {
+    const envPath = path.join(dir, '.env')
+    const original = 'SANITY_PROJECT_ID=existing'
+    fs.writeFileSync(envPath, original)
+
+    const result = appendEnvValues(envPath, {SANITY_PROJECT_ID: 'abc123'}, {banner: ['unused']})
+
+    expect(result).toEqual({created: false, skippedKeys: ['SANITY_PROJECT_ID'], wroteKeys: []})
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(original)
+  })
+})

--- a/packages/@sanity/cli/src/util/envFile.ts
+++ b/packages/@sanity/cli/src/util/envFile.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs'
+
+export interface EnvWriteResult {
+  /** Whether the file was created by this write (as opposed to appended to). */
+  created: boolean
+  /** Keys already present in the file, left untouched. */
+  skippedKeys: string[]
+  /** Keys appended by this write, in the order given. */
+  wroteKeys: string[]
+}
+
+function hasKey(contents: string, key: string): boolean {
+  return new RegExp(String.raw`^\s*(?:export\s+)?${key}\s*=`, 'm').test(contents)
+}
+
+/**
+ * Append `values` to the dotenv file at `envPath`, creating the file when missing. Keys already
+ * present are never overwritten — the file may hold credentials the user or an agent put there —
+ * they are reported back as `skippedKeys` instead. `banner` lines are written as `#` comments
+ * above the appended block, so context (e.g. a claim URL) survives after the terminal closes.
+ */
+export function appendEnvValues(
+  envPath: string,
+  values: Record<string, string>,
+  options?: {banner?: string[]},
+): EnvWriteResult {
+  const existing = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf8') : undefined
+
+  const wroteKeys = Object.keys(values).filter((key) => !hasKey(existing ?? '', key))
+  const skippedKeys = Object.keys(values).filter((key) => hasKey(existing ?? '', key))
+
+  if (wroteKeys.length > 0) {
+    const banner = (options?.banner ?? []).map((line) => `# ${line}`)
+    const block = [...banner, ...wroteKeys.map((key) => `${key}="${values[key]}"`)].join('\n')
+    const separator = existing ? (existing.endsWith('\n') ? '\n' : '\n\n') : ''
+    fs.appendFileSync(envPath, `${separator}${block}\n`)
+  }
+
+  return {created: existing === undefined, skippedKeys, wroteKeys}
+}


### PR DESCRIPTION
### Description

this PR wires up top-level `sanity new`, aliasing it to `sanity projects mint` to create an unclaimed sanity project via provisioning apis

### Stack

(each PR reviews against its base; merge bottom-up only):

1. `stack/mint-and-claim/a1/01-terminal-presentation`
2. `stack/mint-and-claim/a1/02-mint-core` ← this diff
3. `stack/mint-and-claim/a1/03-claim-reminders`
4. `stack/mint-and-claim/a1/04-init-signpost`
5. `stack/mint-and-claim/a1/05-remint-guardrail`
6. `stack/mint-and-claim/a1/06-ambient-reminder`
7. `stack/mint-and-claim/a1/07-logout-env-token`

### What to review

`commands/projects/mint.ts` end to end, the `services/mintProject.ts` wire contract, and `util/envFile.ts` write semantics.

### Testing

Layer-scoped unit tests included (test:source ≥ 1:1); every layer validated standalone (full typecheck + targeted tests at each checkout).

<img width="857" height="431" alt="pr1579-mint-json-payload" src="https://github.com/user-attachments/assets/f4f0911c-5cdf-4950-80a8-edc426e3e049" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces unauthenticated provisioning and writes robot tokens to `.env`; behavior is guarded by non-destructive env writes and explicit credential fallback, but mishandling tokens or API abuse still matters.
> 
> **Overview**
> Adds **`sanity projects mint`** and a top-level **`sanity new`** alias so users can create an **unclaimed** Sanity project **without logging in**, then claim it later via a browser URL.
> 
> The mint flow calls a new **`mintUnclaimedProject`** service that **POSTs** to the unauthenticated provision API (`v2026-06-23/provision`), validates the response, and returns project id, dataset, robot token, API host, and claim handoff fields. **`--json`** returns that structured payload and skips writing files; interactive runs use the existing splash/flow UI, optional name prompt or **`--yes`** defaults, and a claim deadline note.
> 
> After a successful mint (non-JSON), credentials are appended to **`.env`** via new **`appendEnvValues`**, which **never overwrites** existing keys (including blank template lines); skipped keys and failed writes are surfaced in the terminal so tokens are not lost silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c561aaeeac3bc7bc02ce220601141294576f2d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->