### PR TITLE
feat(init): signpost sanity new to logged-out users

### DIFF
--- a/.changeset/pr-1581.md
+++ b/.changeset/pr-1581.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(init): signpost sanity new to logged-out users

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -201,7 +201,8 @@ describe('initAction (direct)', () => {
 
     expect(caughtError).toBeInstanceOf(InitError)
     const initError = caughtError as InitError
-    expect(initError.message).toBe(LOGIN_REQUIRED_MESSAGE)
+    expect(initError.message).toContain(LOGIN_REQUIRED_MESSAGE)
+    expect(initError.message).toContain('run `sanity new` to create a project without logging in')
     expect(initError.exitCode).toBe(1)
   })
 })

--- a/packages/@sanity/cli/src/actions/init/__tests__/newCommandBanner.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/newCommandBanner.test.ts
@@ -1,0 +1,42 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {renderNewCommandBanner} from '../newCommandBanner.js'
+
+function render(): string {
+  const log = vi.fn()
+  renderNewCommandBanner({error: vi.fn() as never, log, warn: vi.fn()})
+  return (
+    log.mock.calls
+      .map(([line]) => String(line ?? ''))
+      .join('\n')
+      // eslint-disable-next-line no-control-regex -- strip ANSI styling
+      .replaceAll(/\u001B\[[0-9;]*m/g, '')
+      // eslint-disable-next-line no-control-regex -- strip OSC 8 hyperlink wrappers
+      .replaceAll(/\u001B\]8;;[^\u0007]*\u0007/g, '')
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('#renderNewCommandBanner', () => {
+  test('renders the two-ways-to-start signpost box, blank-line padded', () => {
+    const banner = render()
+
+    expect(banner).toContain('Two ways to start')
+    expect(banner).toContain('sanity init')
+    expect(banner).toContain('sanity new')
+    expect(banner).toContain('claim it within 72 hours')
+    expect(banner).toContain('https://sanity.new')
+    expect(banner).toContain('╭') // boxed — the one-time signpost keeps its box
+    expect(banner.startsWith('\n')).toBe(true)
+    expect(banner.endsWith('\n')).toBe(true)
+  })
+
+  test('ignores the retired SANITY_NEW_BANNER switch', () => {
+    vi.stubEnv('SANITY_NEW_BANNER', '3')
+
+    expect(render()).toContain('Two ways to start')
+  })
+})

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -32,6 +32,7 @@ import {InitError} from './initError.js'
 import {flagOrDefault, shouldPrompt, writeStagingEnvIfNeeded} from './initHelpers.js'
 import {initNextJs} from './initNextJs.js'
 import {initStudio} from './initStudio.js'
+import {renderNewCommandBanner} from './newCommandBanner.js'
 import {getPlan} from './plan/getPlan.js'
 import {createProjectFromName} from './project/createProjectFromName.js'
 import {getProjectDetails} from './project/getProjectDetails.js'
@@ -397,11 +398,18 @@ async function ensureAuthenticated(
   }
 
   if (options.unattended) {
-    throw new InitError(LOGIN_REQUIRED_MESSAGE, exitCodes.RUNTIME_ERROR)
+    throw new InitError(
+      `${LOGIN_REQUIRED_MESSAGE}\n\n` +
+        'Alternatively, run `sanity new` to create a project without logging in — ' +
+        'you can claim it with a Sanity account later. See `sanity new --help`.',
+      exitCodes.RUNTIME_ERROR,
+    )
   }
 
   trace.log({step: 'login'})
   output.warn(LOGIN_REQUIRED_MESSAGE)
+
+  renderNewCommandBanner(output)
 
   try {
     await login({

--- a/packages/@sanity/cli/src/actions/init/newCommandBanner.ts
+++ b/packages/@sanity/cli/src/actions/init/newCommandBanner.ts
@@ -1,0 +1,36 @@
+import {styleText} from 'node:util'
+
+import {boxen} from '@sanity/cli-core/ux'
+
+import {hyperlink as link} from '../../util/terminalLink.js'
+import {type InitContext} from './types.js'
+
+const SANITY_NEW_URL = 'https://sanity.new'
+
+/**
+ * The fork-in-the-road signpost shown before init's interactive login takes over the terminal:
+ * frames `init` and `new` as two equally valid front doors. A one-time boxed moment is
+ * deliberate here — unlike the recurring claim reminders, it renders once per init run, so the
+ * box draws the eye without training anyone to skim past it. (Three prototype treatments
+ * existed behind a `SANITY_NEW_BANNER` env switch during evaluation; UAT standardized on this
+ * one and dropped the switch.)
+ */
+export function renderNewCommandBanner(output: InitContext['output']): void {
+  output.log('')
+  output.log(
+    boxen(
+      `${styleText('bold', 'Two ways to start')}
+
+${styleText('cyan', 'sanity init')}  Log in and set up a Studio ${styleText('dim', "(you're here)")}
+${styleText('cyan', 'sanity new')}   No login — mint a project now, claim it within 72 hours
+
+Learn how it works: ${link(SANITY_NEW_URL, SANITY_NEW_URL)}`,
+      {
+        borderColor: 'cyan',
+        borderStyle: 'round',
+        padding: 1,
+      },
+    ),
+  )
+  output.log('')
+}

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -206,6 +206,7 @@ describe('#init: authentication', () => {
     })
 
     expect(error?.message).toContain(LOGIN_REQUIRED_MESSAGE)
+    expect(error?.message).toContain('run `sanity new` to create a project without logging in')
     expect(error?.oclif?.exit).toBe(1)
   })
 
@@ -213,7 +214,7 @@ describe('#init: authentication', () => {
     mockGetById.mockRejectedValueOnce(createHttpError(401, 'Unauthorized'))
 
     setupInitSuccessMocks()
-    const {error} = await testCommand(
+    const {error, stdout} = await testCommand(
       InitCommand,
       [
         '--dataset=test',
@@ -235,6 +236,8 @@ describe('#init: authentication', () => {
     )
 
     if (error) throw error
+    expect(stdout).toContain('Two ways to start')
+    expect(stdout).toContain('claim it within 72 hours')
     expect(mockLogin).toHaveBeenCalled()
   })
 


### PR DESCRIPTION
### Description

this PR adds a `sanity new` hint to `sanity init`, with attended + unattended support

### Stack

(each PR reviews against its base; merge bottom-up only):

1. `stack/mint-and-claim/a1/01-terminal-presentation`
2. `stack/mint-and-claim/a1/02-mint-core`
3. `stack/mint-and-claim/a1/03-claim-reminders`
4. `stack/mint-and-claim/a1/04-init-signpost` ← this diff
5. `stack/mint-and-claim/a1/05-remint-guardrail`
6. `stack/mint-and-claim/a1/06-ambient-reminder`
7. `stack/mint-and-claim/a1/07-logout-env-token`

### What to review

`actions/init/newCommandBanner.ts` and the unattended not-logged-in path in `initAction.ts`.

### Testing

Layer-scoped unit tests included (test:source ≥ 1:1); every layer validated standalone (full typecheck + targeted tests at each checkout).

<img width="858" height="409" alt="pr1581-init-signpost" src="https://github.com/user-attachments/assets/c3e8632d-e7e6-4142-8078-ea62318f6eab" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI messaging and UX only; authentication behavior is unchanged aside from additional error and stdout text.
> 
> **Overview**
> Logged-out users running **`sanity init`** now see a one-time cyan boxed **"Two ways to start"** signpost after the login-required warning and before interactive login, contrasting **`sanity init`** (log in, set up Studio) with **`sanity new`** (no login, claim within 72 hours) and linking to `https://sanity.new`.
> 
> When **`init`** runs in unattended mode without a session, the **`InitError`** still uses the existing login-required text but adds guidance to use **`sanity new`** instead and points at **`sanity new --help`**.
> 
> New **`renderNewCommandBanner`** helper and unit/integration test updates cover banner content and the extended error copy; a minor **`@sanity/cli`** changeset records the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36dfbdbe6c3fb1d5203286ddbe61ff492330160e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->