### PR TITLE
feat(cli): refuse re-minting over a live project; never modify an existing .env

### DIFF
--- a/.changeset/pr-1582.md
+++ b/.changeset/pr-1582.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): refuse re-minting over a live project; never modify an existing .env

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
@@ -5,7 +5,11 @@ import {NewCommand} from '../../new.js'
 import {MintProjectCommand} from '../mint.js'
 
 const mockMintUnclaimedProject = vi.hoisted(() => vi.fn())
+const mockLookupClaimState = vi.hoisted(() => vi.fn())
 const mockRecordMintedProject = vi.hoisted(() => vi.fn())
+const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn())
+const mockForgetMintedProject = vi.hoisted(() => vi.fn())
+const mockReadEnvValues = vi.hoisted(() => vi.fn())
 const mockAppendEnvValues = vi.hoisted(() => vi.fn())
 const mockInput = vi.hoisted(() => vi.fn())
 
@@ -25,13 +29,17 @@ vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
   }
 })
 vi.mock('../../../services/mintProject.js', () => ({
+  lookupClaimState: mockLookupClaimState,
   mintUnclaimedProject: mockMintUnclaimedProject,
 }))
 vi.mock('../../../util/claimNudges.js', () => ({
+  forgetMintedProject: mockForgetMintedProject,
+  getMintedProjectRecord: mockGetMintedProjectRecord,
   recordMintedProject: mockRecordMintedProject,
 }))
 vi.mock('../../../util/envFile.js', () => ({
   appendEnvValues: mockAppendEnvValues,
+  readEnvValues: mockReadEnvValues,
 }))
 
 const mockMinted = {
@@ -56,16 +64,35 @@ const expectedResult = {
   token: mockMinted.token,
 }
 
+/** `.env` contents of a directory that already went through a mint. */
+const existingEnv = {
+  SANITY_AUTH_TOKEN: 'sk-old-token',
+  SANITY_DATASET: 'production',
+  SANITY_PROJECT_ID: 'oldproj',
+}
+
+const existingRecord = {
+  claimToken: 'old-claim-token',
+  claimUrl: 'https://www.sanity.io/claim/old-claim-token',
+  expiresAt: '2099-01-01T00:00:00.000Z',
+  mintedAt: '2026-07-01T00:00:00.000Z',
+  projectId: 'oldproj',
+}
+
 function loggedLines(): string {
   return vi.mocked(mocks.SanityCmdOutput.log).mock.calls.flat().join('\n')
 }
 
 beforeEach(() => {
   mockMintUnclaimedProject.mockResolvedValue(mockMinted)
+  mockLookupClaimState.mockResolvedValue(undefined)
+  mockGetMintedProjectRecord.mockReturnValue(undefined)
+  mockForgetMintedProject.mockReturnValue(true)
+  mockReadEnvValues.mockReturnValue({})
   mockAppendEnvValues.mockReturnValue({
     created: true,
     skippedKeys: [],
-    wroteKeys: ['SANITY_PROJECT_ID', 'SANITY_DATASET', 'SANITY_AUTH_TOKEN'],
+    wroteKeys: ['SANITY_AUTH_TOKEN', 'SANITY_DATASET', 'SANITY_PROJECT_ID'],
   })
   // Default to unattended so tests without a name argument never hang on the prompt.
   mocks.SanityCmdIsUnattended.mockReturnValue(true)
@@ -73,6 +100,9 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks()
+  // oclif's catch sets process.exitCode when a command throws (in JSON mode it swallows the
+  // error after printing the structured payload) — reset so tests never leak a failing code.
+  process.exitCode = undefined
 })
 
 describe('#projects:mint', () => {
@@ -81,6 +111,7 @@ describe('#projects:mint', () => {
 
     expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'My New Project'})
     expect(mockRecordMintedProject).toHaveBeenCalledWith(mockMinted)
+    expect(mockForgetMintedProject).not.toHaveBeenCalled()
     expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
 
     const lines = loggedLines()
@@ -101,7 +132,7 @@ describe('#projects:mint', () => {
     expect(lines).toContain('Happy coding!')
   })
 
-  test('writes credentials and claim context to .env', async () => {
+  test('appends credentials and claim context to .env in a fresh directory', async () => {
     await MintProjectCommand.run(['My New Project'])
 
     expect(mockAppendEnvValues).toHaveBeenCalledWith(
@@ -111,50 +142,48 @@ describe('#projects:mint', () => {
         SANITY_DATASET: mockMinted.datasetName,
         SANITY_PROJECT_ID: mockMinted.resourceId,
       },
-      {banner: expect.arrayContaining([expect.stringContaining(mockMinted.claimUrl)])},
+      expect.objectContaining({
+        banner: expect.arrayContaining([expect.stringContaining(mockMinted.claimUrl)]),
+      }),
     )
     expect(loggedLines()).toContain(
-      'Saved credentials to ./.env as SANITY_PROJECT_ID, SANITY_DATASET, SANITY_AUTH_TOKEN',
+      'Saved credentials to ./.env as SANITY_AUTH_TOKEN, SANITY_DATASET, SANITY_PROJECT_ID',
     )
   })
 
-  test('reports keys it left untouched in an existing .env', async () => {
+  test('hands over the values for keys the writer skipped', async () => {
+    // A template's lone SANITY_DATASET line: the writer never overwrites it, and the flow
+    // prints what the key must read instead of pretending the old value is fine.
+    mockReadEnvValues.mockReturnValue({SANITY_DATASET: 'production'})
     mockAppendEnvValues.mockReturnValue({
       created: false,
-      skippedKeys: ['SANITY_AUTH_TOKEN'],
-      wroteKeys: ['SANITY_PROJECT_ID', 'SANITY_DATASET'],
+      skippedKeys: ['SANITY_DATASET'],
+      wroteKeys: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'],
     })
 
     await MintProjectCommand.run(['My New Project'])
 
     const lines = loggedLines()
-    expect(lines).toContain('Saved credentials to ./.env as SANITY_PROJECT_ID, SANITY_DATASET')
-    expect(lines).toContain('Left existing SANITY_AUTH_TOKEN in ./.env untouched.')
+    expect(lines).toContain('Saved credentials to ./.env as SANITY_AUTH_TOKEN, SANITY_PROJECT_ID')
+    expect(lines).toContain('./.env already has SANITY_DATASET')
+    expect(lines).toContain(`SANITY_DATASET="${mockMinted.datasetName}"`)
   })
 
-  test('shows the token when .env already had one (never silently lost)', async () => {
+  test('blank template leftovers never swallow the token (guard-absent, writer-present)', async () => {
+    // `SANITY_PROJECT_ID=` and `SANITY_AUTH_TOKEN=` lines: blank values are "absent" to the
+    // guard's dotenv read (mint proceeds down the fresh lane) but "present" to the writer's
+    // line check (append skips them). The skipped token's only copy must reach the terminal.
+    mockReadEnvValues.mockReturnValue({})
     mockAppendEnvValues.mockReturnValue({
       created: false,
-      skippedKeys: ['SANITY_AUTH_TOKEN'],
-      wroteKeys: ['SANITY_PROJECT_ID', 'SANITY_DATASET'],
+      skippedKeys: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'],
+      wroteKeys: ['SANITY_DATASET'],
     })
 
     await MintProjectCommand.run(['My New Project'])
 
     const lines = loggedLines()
-    expect(lines).toContain('This project’s token (not saved — .env already had one):')
-    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
-  })
-
-  test('surfaces the credentials when the .env write fails after a successful mint', async () => {
-    mockAppendEnvValues.mockImplementation(() => {
-      throw new Error('EACCES: permission denied')
-    })
-
-    await MintProjectCommand.run(['My New Project'])
-
-    const lines = loggedLines()
-    expect(lines).toContain('Save these credentials yourself')
+    expect(lines).toContain('./.env already has SANITY_AUTH_TOKEN, SANITY_PROJECT_ID')
     expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
     expect(lines).toContain(`SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
   })
@@ -187,11 +216,13 @@ describe('#projects:mint', () => {
     expect(loggedLines()).toContain('--yes')
   })
 
-  test('returns the structured result for --json output without touching .env', async () => {
+  test('returns the structured result for --json output without writing .env', async () => {
     await expect(MintProjectCommand.run(['My New Project', '--json'])).resolves.toEqual(
       expectedResult,
     )
 
+    // The guardrail reads .env even in JSON mode — but JSON mode never writes.
+    expect(mockReadEnvValues).toHaveBeenCalled()
     expect(mockAppendEnvValues).not.toHaveBeenCalled()
     expect(mockInput).not.toHaveBeenCalled()
   })
@@ -203,6 +234,287 @@ describe('#projects:mint', () => {
       'Mint failed (HTTP 429): rate limited',
     )
     expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+})
+
+describe('#projects:mint re-mint guardrail', () => {
+  test('aborts before minting when .env holds a live unclaimed project', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      state: 'claimable',
+    })
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has an unclaimed Sanity project \(oldproj\)/,
+    )
+    expect(mockLookupClaimState).toHaveBeenCalledWith('old-claim-token', expect.anything())
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+
+  test('live refusal omits the expiry clause when the server returns none', async () => {
+    // Server-confirmed claimable with a null expiry: the stale local date must not surface.
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue({
+      ...existingRecord,
+      expiresAt: '2020-01-01T00:00:00.000Z',
+    })
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'claimable'})
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has an unclaimed Sanity project \(oldproj\)\./,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('aborts before minting when the existing project was already claimed', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'claimed'})
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(/already been claimed/)
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('mints past a verified-expired project without --force, printing the new values', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mockRecordMintedProject).toHaveBeenCalledWith(mockMinted)
+    // The dead project's record is dropped once its replacement exists — a re-run must refuse
+    // instead of minting again against the rate cap.
+    expect(mockForgetMintedProject).toHaveBeenCalledWith('oldproj')
+    // .env is never modified: the new values are printed for the user to apply.
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+    const lines = loggedLines()
+    expect(lines).toContain('Found an expired unclaimed project (oldproj)')
+    expect(lines).toContain('Update ./.env yourself')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines).toContain(`SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+  })
+
+  test('a failed ledger drop in the expired lane warns instead of staying silent', async () => {
+    // Unwritable user config (sudo-owned file, sandboxed $HOME): the surviving record would
+    // re-authorize the auto-proceed on every re-run, so the flow must say so — the warning is
+    // what stops a blind agent retry loop from draining the mint budget. Still fail-open.
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
+    mockForgetMintedProject.mockReturnValue(false)
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.warn).toHaveBeenCalledWith(
+      expect.stringContaining('expired project oldproj is still recorded'),
+    )
+  })
+
+  test('--json surfaces a failed ledger drop through the warnings payload', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
+    mockForgetMintedProject.mockReturnValue(false)
+
+    await expect(MintProjectCommand.run(['My New Project', '--json'])).resolves.toEqual({
+      ...expectedResult,
+      warnings: [
+        expect.stringContaining('was not modified'),
+        expect.stringContaining('is still recorded'),
+      ],
+    })
+  })
+
+  test('lookup failure never authorizes the expired auto-proceed, even past local expiry', async () => {
+    // The project may have been claimed since the record was written — a dead lookup plus a
+    // stale local clock is not evidence enough to declare it dead and spend a mint.
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue({
+      ...existingRecord,
+      expiresAt: '2020-01-01T00:00:00.000Z',
+    })
+    mockLookupClaimState.mockResolvedValue(undefined)
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has an unclaimed Sanity project \(oldproj\)\./,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(mockForgetMintedProject).not.toHaveBeenCalled()
+  })
+
+  test('falls back to local expiry when the claim lookup fails: live aborts', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue(undefined)
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has an unclaimed Sanity project/,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('a lone SANITY_DATASET (template leftover) never blocks minting', async () => {
+    // An .env.example copied with a blank project id leaves only the dataset key — it carries
+    // no identity or credential, so the guardrail must let the mint through without --force.
+    mockReadEnvValues.mockReturnValue({SANITY_DATASET: 'production'})
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockLookupClaimState).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mockAppendEnvValues).toHaveBeenCalled()
+  })
+
+  test('aborts when existing credentials cannot be traced to a mint', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has Sanity credentials \(SANITY_AUTH_TOKEN, SANITY_PROJECT_ID\)/,
+    )
+    expect(mockLookupClaimState).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('unbound claimed verdicts fall back to the conservative refusal', async () => {
+    // A stale SANITY_CLAIM_URL whose project was claimed proves nothing about this directory's
+    // credentials — no claimed attribution, no remove-your-token advice, just the generic
+    // refusal with the --force escape.
+    mockReadEnvValues.mockReturnValue({
+      ...existingEnv,
+      SANITY_CLAIM_URL: 'https://www.sanity.io/claim/url-token',
+    })
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'claimed'})
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has Sanity credentials/,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('unbound claim-URL evidence can refuse but never authorizes the auto-proceed', async () => {
+    // A stale/unrelated SANITY_CLAIM_URL beside live credentials: its "expired" verdict is not
+    // proof about SANITY_PROJECT_ID, so minting must not proceed without --force.
+    mockReadEnvValues.mockReturnValue({
+      ...existingEnv,
+      SANITY_CLAIM_URL: 'https://www.sanity.io/claim/unrelated-token',
+    })
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has Sanity credentials/,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(mockForgetMintedProject).not.toHaveBeenCalled()
+  })
+
+  test('surfaces the credentials when the .env write fails after a successful mint', async () => {
+    mockAppendEnvValues.mockImplementation(() => {
+      throw new Error('EACCES: permission denied')
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('Save these credentials yourself')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines).toContain(`SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+  })
+
+  test('recovers the claim token from SANITY_CLAIM_URL when the ledger has no record', async () => {
+    mockReadEnvValues.mockReturnValue({
+      ...existingEnv,
+      SANITY_CLAIM_URL: 'https://www.sanity.io/claim/url-token',
+    })
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+    mockLookupClaimState.mockResolvedValue({
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      state: 'claimable',
+    })
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has an unclaimed Sanity project/,
+    )
+    expect(mockLookupClaimState).toHaveBeenCalledWith('url-token', expect.anything())
+  })
+
+  test('--json refuses a live unclaimed project with a structured error, before minting', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      state: 'claimable',
+    })
+
+    // In JSON mode oclif's catch prints `{"error": …}` and swallows — run resolves undefined.
+    await expect(MintProjectCommand.run(['My New Project', '--json'])).resolves.toBeUndefined()
+
+    expect(process.exitCode).toBe(1)
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+
+  test('--json still mints on verified-expired, warns about the stale .env, writes nothing', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
+
+    await expect(MintProjectCommand.run(['My New Project', '--json'])).resolves.toEqual({
+      ...expectedResult,
+      warnings: [expect.stringContaining('was not modified')],
+    })
+
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+    expect(mockForgetMintedProject).toHaveBeenCalledWith('oldproj')
+  })
+
+  test('--json --force mints without verification, leaves .env alone, and warns', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+
+    await expect(MintProjectCommand.run(['My New Project', '--json', '--force'])).resolves.toEqual({
+      ...expectedResult,
+      warnings: [expect.stringContaining('was not modified')],
+    })
+
+    expect(mockLookupClaimState).not.toHaveBeenCalled()
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+
+  test('--json --force in a bare directory appends nothing and warns about nothing', async () => {
+    mockReadEnvValues.mockReturnValue({})
+
+    await expect(MintProjectCommand.run(['My New Project', '--json', '--force'])).resolves.toEqual(
+      expectedResult,
+    )
+
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+
+  test('--force mints without prompting, leaves .env untouched, prints the new values', async () => {
+    mocks.SanityCmdIsUnattended.mockReturnValue(false)
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+
+    await MintProjectCommand.run(['My New Project', '--force'])
+
+    expect(mockLookupClaimState).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    // The old project may hold real content — its nudges keep running until claimed/expired.
+    expect(mockForgetMintedProject).not.toHaveBeenCalled()
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+    const lines = loggedLines()
+    expect(lines).toContain('--force: minting a new project')
+    expect(lines).toContain('Update ./.env yourself')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
   })
 })
 

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -1,23 +1,69 @@
-import fs from 'node:fs'
 import path from 'node:path'
 import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
+import {exitCodes} from '@sanity/cli-core'
 import {SanityCommand} from '@sanity/cli-core/SanityCommand'
 import {input} from '@sanity/cli-core/ux'
 
-import {mintUnclaimedProject} from '../../services/mintProject.js'
-import {recordMintedProject} from '../../util/claimNudges.js'
-import {appendEnvValues} from '../../util/envFile.js'
+import {lookupClaimState, mintUnclaimedProject} from '../../services/mintProject.js'
+import {
+  forgetMintedProject,
+  getMintedProjectRecord,
+  recordMintedProject,
+} from '../../util/claimNudges.js'
+import {appendEnvValues, readEnvValues} from '../../util/envFile.js'
 import {createFlow} from '../../util/flowOutput.js'
 import {renderNewCommandSplash} from '../../util/newCommandSplash.js'
 import {hyperlink} from '../../util/terminalLink.js'
 
 const DEFAULT_PROJECT_NAME = 'My Sanity project'
 
+/**
+ * Keys whose presence means this directory already has a project identity, credential, or claim
+ * handoff — the things the guardrail exists to protect. `SANITY_DATASET` is deliberately not
+ * here: alone (a common template leftover, e.g. an `.env.example` copied with a blank project
+ * id) it proves nothing and must not block minting. `SANITY_CLAIM_URL` is read (its last path
+ * segment is the claim token, so a directory stays self-contained across machines) but never
+ * written by this CLI — the claim URL travels in the banner comment; agents and other tools may
+ * set the key themselves.
+ */
+const GUARDED_ENV_KEYS = ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'] as const
+
 function hoursUntil(iso: string): number | undefined {
   const ms = new Date(iso).getTime() - Date.now()
   return Number.isFinite(ms) && ms > 0 ? Math.round(ms / 3_600_000) : undefined
+}
+
+function describeExpiry(expiresAt: string | undefined): string {
+  if (!expiresAt) return ''
+  const hrs = hoursUntil(expiresAt)
+  // A past or imminent date gets no clause: stale local records must not decorate a refusal.
+  return hrs ? `, expiring in ~${hrs} hours (${expiresAt})` : ''
+}
+
+/** The claim URL's last path segment is the claim token — the capability the lookup needs. */
+function claimTokenFromClaimUrl(claimUrl: string | undefined): string | undefined {
+  if (!claimUrl) return undefined
+  try {
+    return new URL(claimUrl).pathname.split('/').findLast(Boolean)
+  } catch {
+    return undefined
+  }
+}
+
+/** Outcome of the pre-mint guardrail when minting is allowed to proceed. */
+interface GuardResult {
+  /**
+   * Whether `.env` already held managed keys. The CLI never modifies an existing line, so when
+   * true the new credentials are printed (or carried in the JSON payload) with instructions
+   * instead of written.
+   */
+  hasExistingKeys: boolean
+
+  /** Verified-expired project id the new mint supersedes (drop its ledger record). */
+  expiredProjectId?: string
 }
 
 /**
@@ -36,6 +82,9 @@ export interface MintProjectResult {
   projectId: string
   /** Robot token scoped to the freshly minted, unclaimed project. */
   token: string
+
+  /** Machine-readable cautions, e.g. a stale `.env` deliberately left unmodified. */
+  warnings?: string[]
 }
 
 export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand> {
@@ -65,12 +114,21 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       description: 'Mint a project non-interactively with defaults',
     },
     {
+      command: '<%= config.bin %> <%= command.id %> --force',
+      description: 'Mint a fresh project even if this directory already has one',
+    },
+    {
       command: '<%= config.bin %> <%= command.id %> --json',
       description: 'Mint a project and output the token and claim details as JSON',
     },
   ]
 
   static override flags = {
+    force: Flags.boolean({
+      default: false,
+      description:
+        'Mint a new project even when .env already has Sanity credentials (the file is left untouched — the new values are printed for you to apply)',
+    }),
     yes: Flags.boolean({
       char: 'y',
       default: false,
@@ -83,7 +141,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
   public async run(): Promise<MintProjectResult> {
     // Under `--json` oclif suppresses `this.log` (which `output.log` is bound to) and prints the
     // returned `MintProjectResult` instead, so the narrated flow only appears in human runs — the
-    // structured payload owns stdout in JSON mode, and JSON mode leaves the filesystem untouched
+    // structured payload owns stdout in JSON mode, and JSON mode never *writes* to the filesystem
     // (the payload itself carries the credentials).
     const {output} = this
     const json = this.jsonEnabled()
@@ -91,10 +149,19 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     // How this command was invoked (`sanity new` vs `sanity projects mint`), for self-referencing copy.
     const invoked = [this.config.bin, ...(this.id?.split(':') ?? [])].join(' ')
 
+    const envPath = path.join(process.cwd(), '.env')
+    // Guard before anything interactive: a directory that already has a live project should
+    // abort before the user invests in a name — and before spending a mint against the
+    // provisioning rate cap. This applies to `--json` too: an agent running inside an
+    // already-configured directory is the caller most likely to re-mint in a loop, and oclif
+    // renders the refusal as a structured `{"error": …}` payload (code + suggestions) there.
+    const guard: GuardResult = await this.guardExistingProject(envPath, invoked)
+
     renderNewCommandSplash(output.log)
 
     flow.intro("Let's get you set up with a Sanity project.")
     flow.gap()
+
     // Redundant when the run is already non-interactive — only teach the flag when attended.
     if (!this.isUnattended()) {
       flow.note(
@@ -120,13 +187,16 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
         DEFAULT_PROJECT_NAME
     }
 
-    const envPath = path.join(process.cwd(), '.env')
     if (!json) {
-      flow.note(
-        fs.existsSync(envPath)
-          ? 'Found an existing .env file, adding to it.'
-          : 'No .env file found, creating one.',
-      )
+      if (guard.expiredProjectId) {
+        flow.note(
+          `Found an expired unclaimed project (${guard.expiredProjectId}) in .env — minting a replacement. Your .env is left untouched; new values follow.`,
+        )
+      } else if (guard.hasExistingKeys) {
+        flow.note('--force: minting a new project. Your .env is left untouched; new values follow.')
+      } else {
+        flow.note('No Sanity credentials in .env yet, adding them.')
+      }
       flow.gap()
     }
 
@@ -140,7 +210,9 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     }
     spin?.succeed('Project minted!')
 
-    // Remember the mint so later CLI invocations can nudge toward claiming before expiry.
+    // Remember the mint so later CLI invocations can nudge toward claiming before expiry. A
+    // `--force`-superseded live project keeps its record — it may hold real content, and its
+    // nudges should run until it is claimed or expires.
     recordMintedProject(minted)
 
     flow.gap()
@@ -148,43 +220,83 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     flow.result(`Dataset:    ${styleText('cyan', minted.datasetName)}`)
     flow.gap()
 
-    if (!json) {
-      // The mint already succeeded — a skipped or failed write must never swallow the only copy
-      // of the new credentials. Show anything that didn't land in .env.
+    const envValues = {
+      SANITY_AUTH_TOKEN: minted.token,
+      SANITY_DATASET: minted.datasetName,
+      SANITY_PROJECT_ID: minted.resourceId,
+    }
+    const printEnvValues = () => {
+      flow.line(`SANITY_PROJECT_ID="${minted.resourceId}"`)
+      flow.line(`SANITY_DATASET="${minted.datasetName}"`)
+      flow.line(`SANITY_AUTH_TOKEN="${minted.token}"`)
+    }
+    let warnings: MintProjectResult['warnings']
+
+    if (guard.hasExistingKeys) {
+      // `.env` already holds Sanity values and the CLI never edits an existing line — the file
+      // is user-owned. The new credentials travel by hand: printed in human runs, carried by
+      // the payload in JSON runs.
+      if (json) {
+        warnings = [
+          '.env still holds the previous Sanity values and was not modified (this command ' +
+            'never edits existing lines) — update it from this payload.',
+        ]
+      } else {
+        flow.highlight('Update ./.env yourself — replace the old Sanity values with these:')
+        printEnvValues()
+        flow.gap()
+      }
+      // The superseded verified-expired project's ledger record is dropped now that its
+      // replacement exists — a re-run then refuses (unverifiable credentials) instead of
+      // quietly minting again and again against the rate cap. When the drop fails (an
+      // unwritable user config — e.g. a sudo-owned file, or a sandboxed harness whose $HOME is
+      // read-only), the surviving record would re-authorize the auto-proceed on every re-run,
+      // so say so instead of failing open silently: the warning is what stops a blind retry
+      // loop from draining the mint budget. Still fail-open — the mint succeeded and the
+      // credentials are already delivered above.
+      if (guard.expiredProjectId && !forgetMintedProject(guard.expiredProjectId)) {
+        const notDropped =
+          `Couldn't update the local project registry — expired project ${guard.expiredProjectId} ` +
+          'is still recorded, so re-running this command will mint another project against the rate limit.'
+        if (json) {
+          warnings = [...(warnings ?? []), notDropped]
+        } else {
+          this.output.warn(notDropped)
+        }
+      }
+    } else if (!json) {
+      // Fresh directory: the one lane that writes, and it only ever appends. The mint already
+      // succeeded — an unwritable `.env` (permissions, read-only mount) must never swallow the
+      // only copy of the credentials. Show them and keep going.
       try {
-        const written = appendEnvValues(
-          envPath,
-          {
-            SANITY_AUTH_TOKEN: minted.token,
-            SANITY_DATASET: minted.datasetName,
-            SANITY_PROJECT_ID: minted.resourceId,
-          },
-          {
-            banner: [
-              `Added by \`${invoked}\` — unclaimed Sanity project, expires ${minted.expiresAt}`,
-              `Claim it to keep it: ${minted.claimUrl}`,
-            ],
-          },
-        )
+        const written = appendEnvValues(envPath, envValues, {
+          banner: [
+            `Added by \`${invoked}\` — unclaimed Sanity project, expires ${minted.expiresAt}`,
+            `Claim it to keep it: ${minted.claimUrl}`,
+          ],
+        })
         if (written.wroteKeys.length > 0) {
           flow.highlight(`Saved credentials to ./.env as ${written.wroteKeys.join(', ')}`)
         }
         if (written.skippedKeys.length > 0) {
-          flow.note(`Left existing ${written.skippedKeys.join(', ')} in ./.env untouched.`)
-        }
-        if (written.skippedKeys.includes('SANITY_AUTH_TOKEN')) {
-          flow.highlight('This project’s token (not saved — .env already had one):')
-          flow.line(`SANITY_AUTH_TOKEN="${minted.token}"`)
+          // The guard and the writer see blank lines differently: `SANITY_PROJECT_ID=` is
+          // "absent" to the guard's dotenv read but "present" to the writer's line check, so a
+          // template's blank leftovers land here — and a skipped SANITY_AUTH_TOKEN is the only
+          // copy of the token. The writer never edits an existing line; hand the values over.
+          flow.note(`./.env already has ${written.skippedKeys.join(', ')} — make sure they read:`)
+          for (const key of written.skippedKeys) {
+            flow.line(`${key}="${envValues[key as keyof typeof envValues]}"`)
+          }
         }
       } catch (err) {
         this.warn(`Couldn't write ./.env (${err instanceof Error ? err.message : err})`)
         flow.highlight('Save these credentials yourself — they are not stored anywhere else:')
-        flow.line(`SANITY_PROJECT_ID="${minted.resourceId}"`)
-        flow.line(`SANITY_DATASET="${minted.datasetName}"`)
-        flow.line(`SANITY_AUTH_TOKEN="${minted.token}"`)
+        printEnvValues()
       }
       flow.gap()
     }
+    // Plain `--json` in a fresh directory stays write-free: the payload alone carries the
+    // credentials, and the agent owns its own files.
 
     const hrs = hoursUntil(minted.expiresAt)
     flow.note(
@@ -205,6 +317,96 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       expiresAt: minted.expiresAt,
       projectId: minted.resourceId,
       token: minted.token,
+      ...(warnings ? {warnings} : {}),
     }
+  }
+
+  /**
+   * The re-mint guardrail: minting only proceeds into a directory whose managed `.env` keys are
+   * absent, belong to a verified-expired project, or are explicitly `--force`d. Every other
+   * state aborts before the mint — protecting a live unclaimed project's claim window and the
+   * provisioning rate cap alike. Nothing here is ever destructive: an existing `.env` is never
+   * modified, so proceeding past existing keys only spends a mint — the new credentials are
+   * printed (or carried in the JSON payload) for the caller to apply. Proceeding past a
+   * verified-expired project without `--force` is deliberate: it is the expected recovery path
+   * when an unclaimed project lapses under an agent or low-code integration. The guard applies
+   * under `--json` as well — refusals surface as oclif's structured `{"error": …}` payload with
+   * the `code` and `suggestions` intact.
+   */
+  private async guardExistingProject(envPath: string, invoked: string): Promise<GuardResult> {
+    const existing = readEnvValues(envPath, [...GUARDED_ENV_KEYS])
+    const foundKeys = GUARDED_ENV_KEYS.filter((key) => existing[key] !== undefined)
+    if (foundKeys.length === 0) return {hasExistingKeys: false}
+    if (this.flags.force) {
+      return {hasExistingKeys: true}
+    }
+
+    const projectId = existing.SANITY_PROJECT_ID
+    const record = projectId ? getMintedProjectRecord(projectId) : undefined
+    // The ledger binds its claim token to this project id; a token parsed from
+    // `SANITY_CLAIM_URL` is unbound — nothing proves the URL describes the credentials beside
+    // it. Two lanes therefore demand the bound token: the expired auto-proceed (a stale URL must
+    // never declare this directory's project dead and wave a mint through) and the claimed
+    // refusal (its copy attributes the claim to this directory's project and advises removing
+    // the token — advice unbound evidence can't justify). The live refusal stays open to unbound
+    // evidence: refusing costs nothing, and surfacing the claim URL is the point of carrying it
+    // cross-machine.
+    const boundToken = record?.claimToken
+    const claimToken = boundToken ?? claimTokenFromClaimUrl(existing.SANITY_CLAIM_URL)
+    const lookup = claimToken ? await lookupClaimState(claimToken, {timeoutMs: 3000}) : undefined
+
+    if (lookup?.state === 'expired' && boundToken) {
+      return {expiredProjectId: projectId, hasExistingKeys: true}
+    }
+
+    if (lookup?.state === 'claimed' && boundToken) {
+      throw new CLIError(
+        `This directory's .env points at ${projectId ? `Sanity project ${projectId}` : 'a Sanity project'}, which has already been claimed.`,
+        {
+          code: 'CLAIMED_PROJECT_IN_ENV',
+          exit: exitCodes.RUNTIME_ERROR,
+          suggestions: [
+            'If it is yours: run `sanity login`, then remove SANITY_AUTH_TOKEN from .env to act as yourself',
+            `Mint a fresh project here anyway: \`${invoked} --force\` (.env is left untouched)`,
+          ],
+        },
+      )
+    }
+
+    const claimUrl = record?.claimUrl ?? existing.SANITY_CLAIM_URL
+    if (lookup?.state === 'claimable' || record) {
+      // Live per the server — or the lookup failed, which also refuses: the local clock alone
+      // is never evidence enough to declare a project dead (it may have been claimed since the
+      // record was written, and an unreachable lookup host means the mint POST to the same host
+      // was about to fail anyway). Only a server-verified expiry on a ledger-bound token
+      // auto-proceeds. When the lookup did run, its expiry is the only one worth showing; a
+      // stale local date or a null server expiry means no expiry clause at all.
+      const expiresAt = lookup ? (lookup.expiresAt ?? undefined) : record?.expiresAt
+      throw new CLIError(
+        `This directory already has an unclaimed Sanity project${projectId ? ` (${projectId})` : ''}${describeExpiry(expiresAt ?? undefined)}.`,
+        {
+          code: 'UNCLAIMED_PROJECT_IN_ENV',
+          exit: exitCodes.RUNTIME_ERROR,
+          suggestions: [
+            ...(claimUrl ? [`Claim it to keep it: ${claimUrl}`] : []),
+            `Mint a replacement anyway: \`${invoked} --force\` (the unclaimed project lives on until it expires)`,
+          ],
+        },
+      )
+    }
+
+    // Managed keys are present, but there is no way to verify what they belong to — a
+    // hand-written .env, another machine's mint, or a claimed project whose token was removed.
+    throw new CLIError(
+      `This directory's .env already has Sanity credentials (${foundKeys.join(', ')}).`,
+      {
+        code: 'UNVERIFIED_SANITY_CREDENTIALS',
+        exit: exitCodes.RUNTIME_ERROR,
+        suggestions: [
+          `Mint a fresh project anyway: \`${invoked} --force\` (.env is left untouched)`,
+          'Or run this command in a different directory',
+        ],
+      },
+    )
   }
 }

--- a/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
@@ -3,6 +3,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {lookupClaimState} from '../../services/mintProject.js'
 import {
+  forgetMintedProject,
   recordMintedProject,
   runClaimNudges,
   UNCLAIMED_PROJECTS_CONFIG_KEY,
@@ -111,6 +112,34 @@ describe('#recordMintedProject', () => {
         token: 'x',
       }),
     ).not.toThrow()
+  })
+})
+
+describe('#forgetMintedProject', () => {
+  test('reports success, including when the record is already gone', () => {
+    seedRecord()
+
+    expect(forgetMintedProject('abc123')).toBe(true)
+    expect(storedRecords().abc123).toBeUndefined()
+    // Idempotent: nothing left to forget is still "the ledger no longer holds it".
+    expect(forgetMintedProject('abc123')).toBe(true)
+  })
+
+  test('reports failure on an unwritable config, so callers can surface it', () => {
+    // The expired-recovery lane warns on `false`: a surviving record re-authorizes the
+    // auto-proceed, and a silent failure would let a blind retry loop drain the mint budget.
+    seedRecord()
+    mockGetUserConfig.mockReturnValue({
+      delete: () => {
+        throw new Error('EACCES: permission denied')
+      },
+      get: (key: string) => store[key],
+      set: () => {
+        throw new Error('EACCES: permission denied')
+      },
+    } as never)
+
+    expect(forgetMintedProject('abc123')).toBe(false)
   })
 })
 

--- a/packages/@sanity/cli/src/util/__tests__/envFile.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/envFile.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 import {afterEach, beforeEach, describe, expect, test} from 'vitest'
 
-import {appendEnvValues} from '../envFile.js'
+import {appendEnvValues, readEnvValues} from '../envFile.js'
 
 let dir: string
 
@@ -99,5 +99,42 @@ describe('appendEnvValues', () => {
 
     expect(result).toEqual({created: false, skippedKeys: ['SANITY_PROJECT_ID'], wroteKeys: []})
     expect(fs.readFileSync(envPath, 'utf8')).toBe(original)
+  })
+})
+
+describe('readEnvValues', () => {
+  test('returns an empty object when the file is missing', () => {
+    expect(readEnvValues(path.join(dir, '.env'), ['SANITY_PROJECT_ID'])).toEqual({})
+  })
+
+  test('matches the runtime env grammar: quotes, comments, export, empties, last-wins', () => {
+    // One tripwire for the dotenv dependency: these are the grammar behaviors the guardrail
+    // relies on. If a dotenv major bump ever changes one, this fails before the guard can lie.
+    const envPath = path.join(dir, '.env')
+    fs.writeFileSync(
+      envPath,
+      'SANITY_PROJECT_ID="shadowed"\n' +
+        "SANITY_DATASET='pro#duction' # inline note\n" +
+        'export SANITY_AUTH_TOKEN=sk-token # robot\n' +
+        'SANITY_PROJECT_ID="abc123" # minted 2026-07-22\n' +
+        'SANITY_CLAIM_URL=\n',
+    )
+
+    expect(
+      readEnvValues(envPath, [
+        'SANITY_AUTH_TOKEN',
+        'SANITY_DATASET',
+        'SANITY_PROJECT_ID',
+        'SANITY_CLAIM_URL',
+      ]),
+    ).toEqual({
+      // export prefix accepted, unquoted inline comment stripped:
+      SANITY_AUTH_TOKEN: 'sk-token',
+      // quoted: `#` inside the quotes is data, the comment after them is not:
+      SANITY_DATASET: 'pro#duction',
+      // duplicate keys: the last assignment wins, exactly like the runtime injection:
+      SANITY_PROJECT_ID: 'abc123',
+      // SANITY_CLAIM_URL: empty value → omitted entirely
+    })
   })
 })

--- a/packages/@sanity/cli/src/util/claimNudges.ts
+++ b/packages/@sanity/cli/src/util/claimNudges.ts
@@ -105,6 +105,36 @@ export function recordMintedProject(minted: MintedProject): void {
   }
 }
 
+/** Look up the ledger record for a minted project, if this machine minted it. */
+export function getMintedProjectRecord(projectId: string): UnclaimedProjectRecord | undefined {
+  try {
+    return readRecords()[projectId]
+  } catch (err) {
+    debug('failed to read minted project record: %s', err)
+    return undefined
+  }
+}
+
+/**
+ * Drop a minted project from the ledger — used when a re-mint supersedes a verified-expired
+ * project, so nudges never point at the dead one. Never throws; returns whether the ledger no
+ * longer holds the record. A `false` matters to the expired-recovery lane: the surviving record
+ * re-authorizes the auto-proceed, so a blind re-run spends another mint — callers surface that
+ * instead of looping silently (sandboxed harnesses with a read-only $HOME hit exactly this).
+ */
+export function forgetMintedProject(projectId: string): boolean {
+  try {
+    const records = readRecords()
+    if (!(projectId in records)) return true
+    delete records[projectId]
+    writeRecords(records)
+    return true
+  } catch (err) {
+    debug('failed to forget minted project: %s', err)
+    return false
+  }
+}
+
 /**
  * Compact line rendering, deliberately not a box: developers ad-blind banner boxes the way they
  * gloss over sponsored search results, and a reminder that gets skimmed past protects nothing.

--- a/packages/@sanity/cli/src/util/envFile.ts
+++ b/packages/@sanity/cli/src/util/envFile.ts
@@ -1,5 +1,7 @@
 import fs from 'node:fs'
 
+import {parse as parseDotenv} from 'dotenv'
+
 export interface EnvWriteResult {
   /** Whether the file was created by this write (as opposed to appended to). */
   created: boolean
@@ -14,10 +16,36 @@ function hasKey(contents: string, key: string): boolean {
 }
 
 /**
+ * Read the raw values of `keys` from the dotenv file at `envPath` — a deliberate direct file
+ * read, because `process.env` is only populated from `.env` when a project root exists. Parsing
+ * is delegated to `dotenv` (the same grammar the runtime's env injection ultimately uses via
+ * vite's `loadEnv`), so what the guardrail reads is what a running command would see — quotes,
+ * inline comments, `export` prefixes, multiline values, and duplicate keys (last one wins) all
+ * behave identically in both places. Missing file, missing key, or an empty value → absent from
+ * the result.
+ */
+export function readEnvValues(envPath: string, keys: string[]): Partial<Record<string, string>> {
+  if (!fs.existsSync(envPath)) return {}
+  const parsed = parseDotenv(fs.readFileSync(envPath, 'utf8'))
+
+  const values: Partial<Record<string, string>> = {}
+  for (const key of keys) {
+    const value = parsed[key]?.trim()
+    if (value) values[key] = value
+  }
+  return values
+}
+
+/**
  * Append `values` to the dotenv file at `envPath`, creating the file when missing. Keys already
  * present are never overwritten — the file may hold credentials the user or an agent put there —
  * they are reported back as `skippedKeys` instead. `banner` lines are written as `#` comments
  * above the appended block, so context (e.g. a claim URL) survives after the terminal closes.
+ *
+ * This is deliberately the CLI's *only* `.env` writer: the file is user-owned, so this codebase
+ * never modifies or removes an existing line. When existing values need replacing (a re-mint
+ * over old credentials), the CLI prints the new values and instructions instead of editing —
+ * callers must not work around that by deleting lines first.
  */
 export function appendEnvValues(
   envPath: string,


### PR DESCRIPTION
### Description

this PR adds claim state guardrails around pre-claimed project metadata, most importantly `SANITY_AUTH_TOKEN` management, to keep projects seamlessly auth'd for cli use, and later, studio / mcp server (via non-oauth'd `mcp.sanity.io/mcp`) uses. high level,

- we write-once on successful `sanity projects mint`
- we read and subsequently warn and/or surface directions to humans + agents when `--force` re-minting
- we communicate structured errors when `--json` is present, and human-friendly errors when it's not
- we leverage `dotenv` to avoid rolling our own env parser

### Stack

(each PR reviews against its base; merge bottom-up only):

1. `stack/mint-and-claim/a1/01-terminal-presentation`
2. `stack/mint-and-claim/a1/02-mint-core`
3. `stack/mint-and-claim/a1/03-claim-reminders`
4. `stack/mint-and-claim/a1/04-init-signpost`
5. `stack/mint-and-claim/a1/05-remint-guardrail` ← this diff
6. `stack/mint-and-claim/a1/06-ambient-reminder`
7. `stack/mint-and-claim/a1/07-logout-env-token`

### What to review

The guardrail decision tree in `guardExistingProject` (mint.ts) — the densest logic in the stack. The `.env` write path is unchanged from PR2's append-only writer, now stated as an invariant: existing lines are never edited.

### Testing

Layer-scoped unit tests included (test:source ≥ 1:1); every layer validated standalone (full typecheck + targeted tests at each checkout); the append-only writer property-fuzzed (5,000 cases: prior file content is always a byte-prefix of the result).

<img width="859" height="489" alt="pr1582-force-never-modifies-env" src="https://github.com/user-attachments/assets/5d7e291f-fcb8-449e-94ba-d21aa6cfb6b6" />
<img width="858" height="698" alt="pr1582-guardrail-refusals" src="https://github.com/user-attachments/assets/5d3aa4bc-f5dd-4cfb-b457-2be5757ff29a" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential handling, provisioning rate limits, and a complex guard decision tree; mistakes could block mints or allow unwanted re-mints, but behavior is heavily tested and failures are mostly conservative refusals rather than silent overwrites.
> 
> **Overview**
> **`sanity projects mint` / `sanity new`** now runs a **pre-mint guardrail** that reads `./.env` (via new **`readEnvValues`** / `dotenv`) before prompts or API calls. It blocks accidental re-mints when guarded keys (`SANITY_AUTH_TOKEN`, `SANITY_PROJECT_ID`, `SANITY_CLAIM_URL`) indicate a **live unclaimed**, **already claimed**, or **unverifiable** setup—using **`lookupClaimState`**, the local mint ledger, and optional claim URL parsing—with structured **`CLIError`** codes and **`--json`** refusals. **Server-verified expired** ledger-bound projects can mint a replacement without **`--force`**; **`--force`** skips verification and still mints.
> 
> **`.env` policy is tightened:** existing lines are **never edited**. Fresh dirs still **append-only** write; any dir that already has guarded values gets new credentials **printed** or in the JSON payload plus optional **`warnings`**—including **`--json`**, which never writes files. Skipped append keys now show the **correct values** to set manually. Superseding an expired mint calls **`forgetMintedProject`** (with warnings if the ledger drop fails).
> 
> Supporting changes: **`getMintedProjectRecord`** / **`forgetMintedProject`** in claim nudges, documented append-only invariant on **`appendEnvValues`**, and broad unit tests for the guard decision tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fddabd61a3d518632e340326983140f7a94a7ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->