### PR TITLE
feat(cli): ambient claim reminder in minted directories

### DIFF
--- a/.changeset/pr-1583.md
+++ b/.changeset/pr-1583.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): ambient claim reminder in minted directories

--- a/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
@@ -1,6 +1,10 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {mintUnclaimedProject, PROVISION_API_VERSION} from '../mintProject.js'
+import {
+  lookupClaimStateViaProject,
+  mintUnclaimedProject,
+  PROVISION_API_VERSION,
+} from '../mintProject.js'
 
 const mockFetch = vi.fn()
 
@@ -139,6 +143,66 @@ describe('#mintUnclaimedProject', () => {
 
     await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
       'Mint response is missing claimApiUrl, claimUrl, token',
+    )
+  })
+})
+
+describe('#lookupClaimStateViaProject', () => {
+  test('reads the org id from the project host as the robot', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({organizationId: 'oSystemUnclaimed'}),
+      ok: true,
+      status: 200,
+    })
+
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('claimable')
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://abc123.api.sanity.io/v2026-05-04/projects/abc123',
+      expect.objectContaining({headers: {Authorization: 'Bearer sk-robot'}}),
+    )
+  })
+
+  test('a real organization id means the project was claimed', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({organizationId: 'ocREALORG'}),
+      ok: true,
+      status: 200,
+    })
+
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('claimed')
+  })
+
+  test('404 means the project was reaped', async () => {
+    mockFetch.mockResolvedValue({ok: false, status: 404})
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('expired')
+  })
+
+  test('401 fails open — a rejected token is not proof the project is gone', async () => {
+    mockFetch.mockResolvedValue({ok: false, status: 401})
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBeUndefined()
+  })
+
+  test('fails open on other HTTP errors and on network failure', async () => {
+    mockFetch.mockResolvedValue({ok: false, status: 500})
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBeUndefined()
+
+    mockFetch.mockRejectedValue(new Error('offline'))
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBeUndefined()
+  })
+
+  test('honors the SANITY_API_HOST override', async () => {
+    vi.stubEnv('SANITY_API_HOST', 'http://localhost:4321')
+    mockFetch.mockResolvedValue({
+      json: async () => ({organizationId: 'oSystemUnclaimed'}),
+      ok: true,
+      status: 200,
+    })
+
+    await lookupClaimStateViaProject('abc123', 'sk-robot')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:4321/v2026-05-04/projects/abc123',
+      expect.anything(),
     )
   })
 })

--- a/packages/@sanity/cli/src/services/mintProject.ts
+++ b/packages/@sanity/cli/src/services/mintProject.ts
@@ -76,6 +76,46 @@ export async function lookupClaimState(
 }
 
 /**
+ * Claim-state check via the **project-scoped host** as the robot: an `organizationId` of
+ * `oSystemUnclaimed` ⇔ still unclaimed. Authoritative anywhere the robot token exists and —
+ * unlike the provision `lookup`, which draws from the 20/h provisioning budget — free to run on
+ * every render. A 404 means the project is gone: reaped after expiry. A 401 only proves this
+ * token was rejected — the project may be live with the token revoked or rotated — so it fails
+ * open (`undefined`) rather than letting callers erase a possibly-claimable record; a truly
+ * reaped project still resolves via the local clock and the provision lookup's swept-token
+ * contract. Network failures also return `undefined`.
+ */
+export async function lookupClaimStateViaProject(
+  projectId: string,
+  robotToken: string,
+  options?: {timeoutMs?: number},
+): Promise<ClaimState | undefined> {
+  const override = process.env.SANITY_API_HOST
+  const base = override
+    ? override.replace(/\/$/, '')
+    : `https://${projectId}.api.sanity.${isStaging() ? 'work' : 'io'}`
+  const url = `${base}/v2026-05-04/projects/${projectId}`
+  debug('checking claim state via project host at %s', url)
+
+  try {
+    const response = await fetch(url, {
+      headers: {Authorization: `Bearer ${robotToken}`},
+      signal: AbortSignal.timeout(options?.timeoutMs ?? 1500),
+    })
+    if (response.status === 404) return 'expired'
+    if (response.status === 401) return undefined
+    if (!response.ok) return undefined
+
+    const data = (await response.json()) as {organizationId?: string}
+    if (!data.organizationId) return undefined
+    return data.organizationId === 'oSystemUnclaimed' ? 'claimable' : 'claimed'
+  } catch (err) {
+    debug('project claim-state check failed: %s', err)
+    return undefined
+  }
+}
+
+/**
  * Mint an unclaimed Sanity project via the unauthenticated provision endpoint, returning a
  * scoped robot token and a claim URL:
  * `POST <apiHost>/<version>/provision` with `{resourceType:'project', displayName}`.

--- a/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
@@ -1,7 +1,11 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
 import {getUserConfig} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {lookupClaimState} from '../../services/mintProject.js'
+import {lookupClaimState, lookupClaimStateViaProject} from '../../services/mintProject.js'
 import {
   forgetMintedProject,
   recordMintedProject,
@@ -19,10 +23,12 @@ vi.mock(import('@sanity/cli-core'), async (importOriginal) => {
 })
 vi.mock('../../services/mintProject.js', () => ({
   lookupClaimState: vi.fn(),
+  lookupClaimStateViaProject: vi.fn(),
 }))
 
 const mockGetUserConfig = vi.mocked(getUserConfig)
 const mockLookupClaimState = vi.mocked(lookupClaimState)
+const mockLookupViaProject = vi.mocked(lookupClaimStateViaProject)
 
 const HOUR = 3_600_000
 const NOW = new Date('2026-07-15T12:00:00.000Z').getTime()
@@ -47,9 +53,10 @@ function storedRecords(): Record<string, UnclaimedProjectRecord> {
   return (store[UNCLAIMED_PROJECTS_CONFIG_KEY] ?? {}) as Record<string, UnclaimedProjectRecord>
 }
 
-async function run(now = NOW): Promise<string> {
+/** Default cwd has no .env, so the ambient line stays out of waterfall-focused tests. */
+async function run(now = NOW, cwd = '/nonexistent-claim-nudges-cwd'): Promise<string> {
   const write = vi.fn()
-  await runClaimNudges(write, now)
+  await runClaimNudges(write, now, cwd)
   return write.mock.calls.map(([line]) => String(line)).join('\n')
 }
 
@@ -221,6 +228,10 @@ describe('#runClaimNudges', () => {
     expect(first).toContain('expires in about 47 hours')
     expect(first).toContain('https://www.sanity.io/claim/some-token')
     expect(first).not.toContain('╭') // compact lines, never a box
+    // One sentence per line: consequence, cost, and CTA each get their own.
+    expect(first).toMatch(
+      /unless claimed\.\nClaiming is free and keeps everything\.\nClaim it now:/,
+    )
     expect(storedRecords().abc123.lastNudgeTier).toBe(1)
 
     expect(await run()).toBe('')
@@ -375,5 +386,131 @@ describe('#runClaimNudges', () => {
     expect(output).not.toContain('later00')
     expect(storedRecords().sooner0.lastNudgeTier).toBe(3)
     expect(storedRecords().later00.lastNudgeTier).toBeUndefined()
+  })
+})
+
+describe('#runClaimNudges ambient directory reminder', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sanity-nudge-cwd-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, {force: true, recursive: true})
+  })
+
+  test('emits a stateless line on every run in a minted directory', async () => {
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-robot"\n',
+    )
+    // Above every tier threshold, so the waterfall stays silent.
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue('claimable')
+
+    const first = await run(NOW, dir)
+    expect(first).toContain('Unclaimed Sanity project abc123 expires in about 60 hours')
+    expect(first).toContain('https://www.sanity.io/claim/some-token')
+    // Blank-line padded, with the URL on its own line below the sentence.
+    expect(first.startsWith('\n')).toBe(true)
+    expect(first).toMatch(/claim it to keep it:.*\n.*https:\/\/www\.sanity\.io\/claim/)
+    expect(first).not.toContain('╭')
+    // No dedupe marker written — the line repeats on the very next run.
+    expect(storedRecords().abc123.lastNudgeTier).toBeUndefined()
+    expect(await run(NOW, dir)).toBe(first)
+    expect(mockLookupClaimState).not.toHaveBeenCalled()
+  })
+
+  test('yields the slot when a tiered nudge fires in the same invocation', async () => {
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-robot"\n',
+    )
+    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
+
+    const output = await run(NOW, dir)
+
+    expect(output).toContain('⏳ Claim your Sanity project')
+    expect(output).not.toContain('claim it to keep it:')
+  })
+
+  test('stays quiet when the robot token is gone from .env (post-claim handoff)', async () => {
+    // The claim handoff says "login, then remove SANITY_AUTH_TOKEN" — the project id stays
+    // behind. Verification is impossible without the token, so no line renders: a ledger-only
+    // render here would call the freshly claimed project unclaimed on every command.
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+
+    expect(await run(NOW, dir)).toBe('')
+    expect(mockLookupViaProject).not.toHaveBeenCalled()
+  })
+
+  test('stays quiet when the directory points at an unregistered project', async () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="someone-elses"\n')
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+
+    expect(await run(NOW, dir)).toBe('')
+  })
+
+  test('stays quiet in directories without a .env', async () => {
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+
+    expect(await run(NOW, dir)).toBe('')
+  })
+
+  test('verifies every render through the project host when the robot token is present', async () => {
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-robot"\n',
+    )
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue('claimable')
+
+    const output = await run(NOW, dir)
+
+    expect(mockLookupViaProject).toHaveBeenCalledWith('abc123', 'sk-robot')
+    expect(output).toContain('Unclaimed Sanity project abc123')
+  })
+
+  test('claimed per the org read: congratulates once and drops the record', async () => {
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-robot"\n',
+    )
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue('claimed')
+
+    const output = await run(NOW, dir)
+
+    expect(output).toContain('has been claimed')
+    expect(output).not.toContain('claim it to keep it:')
+    expect(storedRecords().abc123).toBeUndefined()
+    expect(await run(NOW, dir)).toBe('')
+  })
+
+  test('expired per the org read: notes it once and drops the record', async () => {
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-robot"\n',
+    )
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue('expired')
+
+    const output = await run(NOW, dir)
+
+    expect(output).toContain('has expired')
+    expect(storedRecords().abc123).toBeUndefined()
+  })
+
+  test('fails open to the ledger when the org read is unavailable', async () => {
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-robot"\n',
+    )
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue(undefined)
+
+    expect(await run(NOW, dir)).toContain('Unclaimed Sanity project abc123')
   })
 })

--- a/packages/@sanity/cli/src/util/claimNudges.ts
+++ b/packages/@sanity/cli/src/util/claimNudges.ts
@@ -1,10 +1,16 @@
+import path from 'node:path'
 import {styleText} from 'node:util'
 
 import {getUserConfig} from '@sanity/cli-core'
 import {subdebug} from '@sanity/cli-core/debug'
 import {logSymbols} from '@sanity/cli-core/ux'
 
-import {lookupClaimState, type MintedProject} from '../services/mintProject.js'
+import {
+  lookupClaimState,
+  lookupClaimStateViaProject,
+  type MintedProject,
+} from '../services/mintProject.js'
+import {readEnvValues} from './envFile.js'
 
 const debug = subdebug('claimNudges')
 
@@ -138,7 +144,8 @@ export function forgetMintedProject(projectId: string): boolean {
 /**
  * Compact line rendering, deliberately not a box: developers ad-blind banner boxes the way they
  * gloss over sponsored search results, and a reminder that gets skimmed past protects nothing.
- * Tiers escalate through color and copy in a constant three-line footprint (plus the agent CTA).
+ * Tiers escalate through color and copy in a constant footprint,
+ * one sentence per line — each line carries exactly one idea.
  */
 function renderNudge(record: UnclaimedProjectRecord, tier: number, msLeft: number): string {
   const timeLeft = humanizeMsLeft(msLeft)
@@ -156,32 +163,57 @@ function renderNudge(record: UnclaimedProjectRecord, tier: number, msLeft: numbe
         : `${urgent ? '🚨' : '⏰'} Project ${record.projectId} expires in ${timeLeft}`
   const body =
     tier === 1
-      ? `It is deleted at ${record.expiresAt} unless claimed. Claiming is free and keeps everything.`
+      ? `It is deleted at ${record.expiresAt} unless claimed.`
       : tier === 2
-        ? `After ${record.expiresAt}, the project and everything in it is deleted. Claiming is free and keeps everything.`
-        : `All content, schema, and tokens in this project are permanently deleted at ${record.expiresAt}. Claiming is free and keeps everything.`
+        ? `After ${record.expiresAt}, the project and everything in it is deleted.`
+        : `All content, schema, and tokens in this project are permanently deleted at ${record.expiresAt}.`
   const bell = tier >= 4 ? '\u0007' : ''
   return (
     bell +
     `${styleText(['bold', urgent ? 'red' : 'yellow'], headline)}\n` +
     `${body}\n` +
-    `Claim it now: ${styleText('cyan', record.claimUrl)}\n` +
+    `Claiming is free and keeps everything.\n` +
+    `Claim it now: ${styleText(['cyan', 'underline'], record.claimUrl)}\n` +
     agentCta
   )
 }
 
 /**
- * Check the registry of minted-but-unclaimed projects and emit at most one reminder for the most
- * urgent project whose nudge tier has advanced since it was last shown. Called from the prerun
- * hook on every CLI invocation; must never throw and stays network-free unless a nudge is due.
+ * The ambient reminder: a single dim line for the project the current directory points at,
+ * emitted on every invocation (no dedupe marker, no network) — deliberately stateless, and
+ * quiet enough that repetition reads as ambient status rather than an alarm to tune out.
+ */
+function renderAmbientLine(record: UnclaimedProjectRecord, msLeft: number): string {
+  // URL on its own line: keeps the human-facing sentence short, and the link easy to spot/click.
+  return (
+    styleText(
+      'dim',
+      `⏳ Unclaimed Sanity project ${record.projectId} expires in ${humanizeMsLeft(msLeft)} — claim it to keep it:`,
+    ) + `\n${styleText(['cyan', 'underline'], record.claimUrl)}`
+  )
+}
+
+/**
+ * Check the registry of minted-but-unclaimed projects and emit at most one reminder per
+ * invocation. Called from the prerun hook on every CLI invocation; must never throw and stays
+ * network-free unless a tiered nudge is due.
  *
- * Before nudging, the claim state is verified against the provision API (fail-open on network
- * errors): claimed projects get a one-time confirmation and are dropped from the registry,
- * expired projects get a one-time notice and are dropped as well.
+ * Two reminder shapes share the single slot, most-urgent first:
+ * 1. The tiered waterfall — a project whose nudge tier advanced since it was last shown, at most
+ *    once per tier. Before nudging, the claim state is verified against the provision API
+ *    (fail-open on network errors): claimed projects get a one-time confirmation and are dropped
+ *    from the registry, expired projects get a one-time notice and are dropped as well.
+ * 2. The ambient line — when nothing else fired and `cwd`'s `.env` holds both a registered
+ *    project and its robot token, one stateless dim line on every invocation. No dedupe, and no
+ *    cached world-state: every render is verified first through the budget-free project-host
+ *    org read, so the line can never call a claimed project unclaimed. Only a network failure
+ *    falls back to the ledger's local expiry data; a missing token skips the line entirely
+ *    (verification would be impossible, and the post-claim handoff removes exactly that token).
  */
 export async function runClaimNudges(
   write: (line: string) => void,
   now: number = Date.now(),
+  cwd: string = process.cwd(),
 ): Promise<void> {
   const records = readRecords()
   const all = Object.values(records)
@@ -189,12 +221,33 @@ export async function runClaimNudges(
 
   // Blank-line padding around every announcement so it never sits flush against the output of
   // the command it rides along with.
-  const announce = (message: string) => write(`\n${message}\n`)
+  let announced = false
+  const announce = (message: string) => {
+    announced = true
+    write(`\n${message}\n`)
+  }
 
   let dirty = false
   // Ids this pass changed — the final write merges exactly these over a fresh read, so records
   // written by another process while this pass awaited a lookup are never clobbered.
   const touched = new Set<string>()
+
+  const announceClaimed = (record: UnclaimedProjectRecord) => {
+    announce(
+      `${logSymbols.success} Sanity project ${record.projectId} has been claimed — it's yours to keep.`,
+    )
+    delete records[record.projectId]
+    touched.add(record.projectId)
+    dirty = true
+  }
+  const announceExpired = (record: UnclaimedProjectRecord) => {
+    announce(
+      `⌛ Unclaimed Sanity project ${record.projectId} has expired. Run \`sanity new\` to mint a new one — where old credentials remain in .env, the guard will walk you through it.`,
+    )
+    delete records[record.projectId]
+    touched.add(record.projectId)
+    dirty = true
+  }
 
   // Locally expired projects: verify against the API before the farewell — the user may have
   // claimed since the last run, and announcing a claimed project as "expired" is worse than no
@@ -206,12 +259,7 @@ export async function runClaimNudges(
     if (new Date(record.expiresAt).getTime() - now > 0) continue
     const lookup = await lookupClaimState(record.claimToken)
     if (lookup?.state === 'claimed') {
-      announce(
-        `${logSymbols.success} Sanity project ${record.projectId} has been claimed — it's yours to keep.`,
-      )
-      delete records[record.projectId]
-      touched.add(record.projectId)
-      dirty = true
+      announceClaimed(record)
     } else if (lookup?.state === 'claimable') {
       if (lookup.expiresAt) {
         records[record.projectId] = {...record, expiresAt: lookup.expiresAt}
@@ -242,19 +290,9 @@ export async function runClaimNudges(
     const lookup = await lookupClaimState(record.claimToken)
 
     if (lookup?.state === 'claimed') {
-      announce(
-        `${logSymbols.success} Sanity project ${record.projectId} has been claimed — it's yours to keep.`,
-      )
-      delete records[record.projectId]
-      touched.add(record.projectId)
-      dirty = true
+      announceClaimed(record)
     } else if (lookup?.state === 'expired') {
-      announce(
-        `⌛ Unclaimed Sanity project ${record.projectId} has expired. Run \`sanity new\` to mint a new one — where old credentials remain in .env, the guard will walk you through it.`,
-      )
-      delete records[record.projectId]
-      touched.add(record.projectId)
-      dirty = true
+      announceExpired(record)
     } else {
       // Claimable — or lookup failed, in which case we fail open on local expiry data. When the
       // server supplied a fresh expiry (window extended or shortened), trust it over the local
@@ -272,6 +310,34 @@ export async function runClaimNudges(
       }
       touched.add(record.projectId)
       dirty = true
+    }
+  }
+
+  // The ambient line for the directory's own project, when the slot is still free.
+  if (!announced) {
+    const env = readEnvValues(path.join(cwd, '.env'), ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'])
+    const record = env.SANITY_PROJECT_ID ? records[env.SANITY_PROJECT_ID] : undefined
+    if (record && env.SANITY_AUTH_TOKEN) {
+      // No token, no line: a minted directory always has the robot token (this CLI wrote it), so
+      // its absence means a hand-edited file or the post-claim handoff ("login, then remove
+      // SANITY_AUTH_TOKEN") — states where verification is impossible and a ledger-only line
+      // could call a claimed project unclaimed. The tiered waterfall still covers real
+      // unclaimed projects; silence here costs nothing.
+      const msLeft = new Date(record.expiresAt).getTime() - now
+      if (msLeft > 0) {
+        // No cached world-state: verify through the project host (budget-free org read with the
+        // directory's own robot token) before rendering, so the line can never call a claimed
+        // project unclaimed. Undefined = network failure → fail open on the ledger.
+        const state = await lookupClaimStateViaProject(record.projectId, env.SANITY_AUTH_TOKEN)
+        if (state === 'claimed') {
+          announceClaimed(record)
+        } else if (state === 'expired') {
+          announceExpired(record)
+        } else {
+          // Announced like every other reminder, so it gets the same blank-line padding.
+          announce(renderAmbientLine(record, msLeft))
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### Description

this PR adds terminal reminders on `sanity` commands run inside a mint-and-claim provisioned directory, containing a `.env` with pre-claimed project metadata. high level,

- we maintain pre-claim project metadata on `~/.config/sanity/config.json` and a project-scoped ledger
- we nudge statelessly whenever possible, and check upstream claim status apis when necessary
- we fallback to ledger data if we can't reach upstreams, ex. when transient failures prevent claim state reconciliation

### Stack

(each PR reviews against its base; merge bottom-up only):

1. `stack/mint-and-claim/a1/01-terminal-presentation`
2. `stack/mint-and-claim/a1/02-mint-core`
3. `stack/mint-and-claim/a1/03-claim-reminders`
4. `stack/mint-and-claim/a1/04-init-signpost`
5. `stack/mint-and-claim/a1/05-remint-guardrail`
6. `stack/mint-and-claim/a1/06-ambient-reminder` ← this diff
7. `stack/mint-and-claim/a1/07-logout-env-token`

### What to review

The ambient block in `runClaimNudges` and `lookupClaimStateViaProject` (the org read) in the mint service.

### Testing

Layer-scoped unit tests included (test:source ≥ 1:1); every layer validated standalone (full typecheck + targeted tests at each checkout).

<img width="858" height="457" alt="pr1583-ambient-reminder" src="https://github.com/user-attachments/assets/eb82fdc2-a50e-4e4b-b38f-a52f4d294420" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX and read-only claim checks on every command in minted dirs; fail-open behavior limits incorrect registry updates.
> 
> **Overview**
> Adds a **stateless ambient reminder** when you run any `sanity` command inside a minted project directory: if `.env` has both `SANITY_PROJECT_ID` and `SANITY_AUTH_TOKEN` and the project is still on the unclaimed ledger, a dim expiry line (with claim URL) prints on every invocation—unless a tiered waterfall nudge already used the single reminder slot.
> 
> Claim state for that line is checked via new **`lookupClaimStateViaProject`**, which hits the project-scoped API with the robot token and treats `organizationId === oSystemUnclaimed` as claimable (404 → expired, 401/network → fail open). That path avoids the provision lookup rate budget used by escalated nudges.
> 
> Tiered nudge copy is split **one sentence per line**; claimed/expired handling is centralized in shared helpers. Unit tests cover the org read and ambient behavior (tier precedence, no token after claim handoff, ledger fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e02db89fc7d3010d8d3beb8528cae3038a277ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->