### PR TITLE
fix(cli): stop sanity logout from sending env tokens to the session endpoint

### DIFF
--- a/.changeset/pr-1584.md
+++ b/.changeset/pr-1584.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(cli): stop sanity logout from sending env tokens to the session endpoint

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -1,7 +1,7 @@
-import {getCliToken, setCliUserConfig} from '@sanity/cli-core'
+import {getCliUserConfig, setCliUserConfig} from '@sanity/cli-core'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {AUTH_API_VERSION} from '../../services/auth.js'
 import {LogoutCommand} from '../logout.js'
@@ -12,7 +12,7 @@ vi.mock('@sanity/cli-core', async () => {
   const actual = await vi.importActual<typeof import('@sanity/cli-core')>('@sanity/cli-core')
   return {
     ...actual,
-    getCliToken: vi.fn(),
+    getCliUserConfig: vi.fn(),
     getUserConfig: vi.fn().mockReturnValue({
       delete: mockConfigStoreDelete,
     }),
@@ -20,10 +20,18 @@ vi.mock('@sanity/cli-core', async () => {
   }
 })
 
-const mockedGetCliToken = vi.mocked(getCliToken)
+const mockedGetCliUserConfig = vi.mocked(getCliUserConfig)
 const mockedSetConfig = vi.mocked(setCliUserConfig)
 
+beforeEach(() => {
+  // The command reads SANITY_AUTH_TOKEN directly — a token inherited from the developer's shell
+  // (e.g. running the suite from a minted directory) must not leak into the no-env-token cases.
+  // An empty stub reads as absent; env-token tests stub their own value over it.
+  vi.stubEnv('SANITY_AUTH_TOKEN', '')
+})
+
 afterEach(() => {
+  vi.unstubAllEnvs()
   vi.clearAllMocks()
   const pending = pendingMocks()
   cleanAll()
@@ -31,8 +39,8 @@ afterEach(() => {
 })
 
 describe('#logout', () => {
-  test('logs out successfully if a token exists', async () => {
-    mockedGetCliToken.mockResolvedValueOnce('test-token')
+  test('logs out successfully if a stored session exists', async () => {
+    mockedGetCliUserConfig.mockReturnValueOnce('test-token')
 
     mockApi({
       apiVersion: AUTH_API_VERSION,
@@ -48,7 +56,7 @@ describe('#logout', () => {
   })
 
   test('logs out successfully when session is expired (401)', async () => {
-    mockedGetCliToken.mockResolvedValueOnce('test-token')
+    mockedGetCliUserConfig.mockReturnValueOnce('test-token')
 
     mockApi({
       apiVersion: AUTH_API_VERSION,
@@ -66,8 +74,8 @@ describe('#logout', () => {
     expect(mockConfigStoreDelete).toHaveBeenCalledWith('telemetryConsent')
   })
 
-  test('shows an error if no token exists', async () => {
-    mockedGetCliToken.mockResolvedValueOnce('')
+  test('shows an error if no credentials exist', async () => {
+    mockedGetCliUserConfig.mockReturnValueOnce(undefined)
 
     const {stdout} = await testCommand(LogoutCommand)
 
@@ -76,19 +84,52 @@ describe('#logout', () => {
     expect(mockConfigStoreDelete).not.toHaveBeenCalled()
   })
 
-  test('throws error on API failure (non-401)', async () => {
-    mockedGetCliToken.mockResolvedValueOnce('test-token')
+  test('env token only: explains it cannot be logged out, calls no API', async () => {
+    vi.stubEnv('SANITY_AUTH_TOKEN', 'sk-robot-token')
+    mockedGetCliUserConfig.mockReturnValueOnce(undefined)
+
+    const {error, stderr, stdout} = await testCommand(LogoutCommand)
+
+    expect(error).toBeUndefined()
+    expect(stderr).toContain('SANITY_AUTH_TOKEN is set in the environment')
+    // oclif wraps warnings, so assert a fragment that fits on one wrapped line.
+    expect(stderr).toContain('Remove that variable')
+    expect(stdout).not.toContain('No login credentials found')
+    expect(mockedSetConfig).not.toHaveBeenCalled()
+    expect(mockConfigStoreDelete).not.toHaveBeenCalled()
+  })
+
+  test('env token plus stored session: warns about the env token and ends the session', async () => {
+    vi.stubEnv('SANITY_AUTH_TOKEN', 'sk-robot-token')
+    mockedGetCliUserConfig.mockReturnValueOnce('session-token')
 
     mockApi({
       apiVersion: AUTH_API_VERSION,
       method: 'post',
       uri: '/auth/logout',
-    }).reply(500, {message: 'Internal Server Error'})
+    }).reply(200)
+
+    const {stderr, stdout} = await testCommand(LogoutCommand)
+
+    expect(stderr).toContain('SANITY_AUTH_TOKEN is set in the environment')
+    expect(stdout).toContain('Logged out successfully')
+    expect(mockedSetConfig).toHaveBeenCalledWith('authToken', undefined)
+  })
+
+  test('surfaces only the status on API failure, never the response body', async () => {
+    mockedGetCliUserConfig.mockReturnValueOnce('test-token')
+
+    mockApi({
+      apiVersion: AUTH_API_VERSION,
+      method: 'post',
+      uri: '/auth/logout',
+    }).reply(500, {message: 'Populus error: something internal'})
 
     const {error} = await testCommand(LogoutCommand)
 
     expect(error).toBeDefined()
-    expect(error?.message).toContain('Failed to logout')
+    expect(error?.message).toContain('Failed to logout (HTTP 500)')
+    expect(error?.message).not.toContain('Populus')
     expect(mockedSetConfig).not.toHaveBeenCalled()
     expect(mockConfigStoreDelete).not.toHaveBeenCalled()
   })

--- a/packages/@sanity/cli/src/commands/logout.ts
+++ b/packages/@sanity/cli/src/commands/logout.ts
@@ -1,6 +1,6 @@
 import {
   exitCodes,
-  getCliToken,
+  getCliUserConfig,
   getUserConfig,
   SanityCommand,
   setCliUserConfig,
@@ -15,14 +15,27 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
   public async run(): Promise<void> {
     await this.parse(LogoutCommand)
 
-    const previousToken = await getCliToken()
-    if (!previousToken) {
-      this.log('No login credentials found')
+    // An env-sourced token (SANITY_AUTH_TOKEN, often loaded from ./.env) is not a login
+    // session: there is nothing server-side to end, and clearing local config would not stop
+    // the next command from picking the variable up again. Robot tokens from `sanity new` make
+    // the session endpoint reject outright — so say what to do instead of calling it.
+    const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
+    if (envToken) {
+      this.warn(
+        'SANITY_AUTH_TOKEN is set in the environment (often via ./.env) — logging out cannot end it. Remove that variable to stop acting as its identity.',
+      )
+    }
+
+    // Target the stored login session directly: `getCliToken()` prefers the env token, which is
+    // exactly the credential `sanity logout` must not send to the session endpoint.
+    const sessionToken = getCliUserConfig('authToken')
+    if (!sessionToken) {
+      if (!envToken) this.log('No login credentials found')
       return
     }
 
     try {
-      await logout()
+      await logout(sessionToken)
 
       this.clearConfig()
     } catch (error) {
@@ -32,6 +45,14 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
       if (isHttpError(error) && error.response.statusCode === 401) {
         this.clearConfig()
         return
+      }
+      // API failure bodies can name internal services — surface only the status, keep the
+      // local credentials so a retry is possible.
+      if (isHttpError(error)) {
+        this.error(
+          `Failed to logout (HTTP ${error.response.statusCode}). Your local session was kept — try again shortly.`,
+          {exit: exitCodes.RUNTIME_ERROR},
+        )
       }
       const err = error instanceof Error ? error : new Error(`${error}`)
       this.error(`Failed to logout: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})


### PR DESCRIPTION
### Description

this PR quashes a pre-existing edge case: `sanity logout` was sending mint-and-claim robot tokens to populus session endpoints, which yielded raw, internal service errors. to address that, we're providing human/agent messaging on handling logout/login, while preserving non-401 api errors

### Stack

(each PR reviews against its base; merge bottom-up only):

1. `stack/mint-and-claim/a1/01-terminal-presentation`
2. `stack/mint-and-claim/a1/02-mint-core`
3. `stack/mint-and-claim/a1/03-claim-reminders`
4. `stack/mint-and-claim/a1/04-init-signpost`
5. `stack/mint-and-claim/a1/05-remint-guardrail`
6. `stack/mint-and-claim/a1/06-ambient-reminder`
7. `stack/mint-and-claim/a1/07-logout-env-token` ← this diff

### What to review

`commands/logout.ts`: the env-token short-circuit and error sanitization.

### Testing

Layer-scoped unit tests included (test:source ≥ 1:1); every layer validated standalone (full typecheck + targeted tests at each checkout).

<img width="1727" height="988" alt="pr1584-logout-env-token-warning" src="https://github.com/user-attachments/assets/60bfb58c-ab6b-4a7c-9a32-ab1abe922c3f" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI authentication and logout API behavior; changes are narrowly scoped with clear user messaging and tests, but mishandling tokens could affect session invalidation.
> 
> **Overview**
> **`sanity logout` no longer uses `getCliToken()`**, which could prefer `SANITY_AUTH_TOKEN` and send robot/env credentials to `/auth/logout`. It now reads the **stored session** via `getCliUserConfig('authToken')` and passes that token explicitly into `logout()`.
> 
> When **`SANITY_AUTH_TOKEN` is set**, the command **warns** that logout cannot end that identity and tells the user to remove the variable. With only an env token and no stored session, it **skips the API** and avoids the misleading “No login credentials” message. If both env and session exist, it still **ends the stored session** after the warning.
> 
> **Non-401 logout failures** now report only **HTTP status** (not response bodies that may leak internal service names) and **leave local credentials** so the user can retry. Tests cover env-only, env+session, and error sanitization, and clear `SANITY_AUTH_TOKEN` in the suite so shell tokens do not affect other cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0bad1e3502b80f8f239a461df7b1c1bb40d34f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->