### PR TITLE
feat(cli-build): use interface events in cli-build

### DIFF
--- a/.changeset/pr-1585.md
+++ b/.changeset/pr-1585.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+'@sanity/cli': minor
+---
+
+feat(cli-build): Use interface events in cli-build

--- a/.changeset/pr-1585.md
+++ b/.changeset/pr-1585.md
@@ -1,7 +1,6 @@
-<!-- auto-generated -->
 ---
-'@sanity/cli-build': minor
-'@sanity/cli': minor
+'@sanity/cli-build': major
+'@sanity/cli': patch
 ---
 
-feat(cli-build): use interface events in cli-build
+Move all user interactivity (except for a couple of log outputs) out of cli-build so that we can customize how events are handled in the Runtime CLI.

--- a/.changeset/pr-1585.md
+++ b/.changeset/pr-1585.md
@@ -1,7 +1,7 @@
 <!-- auto-generated -->
 ---
-'@sanity/cli-build': major
-'@sanity/cli': patch
+'@sanity/cli-build': minor
+'@sanity/cli': minor
 ---
 
-Move all user interactivity (except for a couple of log outputs) out of cli-build so that we can customize how events are handled in the Runtime CLI.
+feat(cli-build): use interface events in cli-build

--- a/.changeset/pr-1585.md
+++ b/.changeset/pr-1585.md
@@ -1,7 +1,7 @@
 <!-- auto-generated -->
 ---
-'@sanity/cli-build': minor
-'@sanity/cli': minor
+'@sanity/cli-build': major
+'@sanity/cli': patch
 ---
 
-feat(cli-build): use interface events in cli-build
+Move all user interactivity (except for a couple of log outputs) out of cli-build so that we can customize how events are handled in the Runtime CLI.

--- a/.changeset/pr-1585.md
+++ b/.changeset/pr-1585.md
@@ -4,4 +4,4 @@
 '@sanity/cli': minor
 ---
 
-feat(cli-build): Use interface events in cli-build
+feat(cli-build): use interface events in cli-build

--- a/packages/@sanity/cli-build/src/_exports/_internal/build.ts
+++ b/packages/@sanity/cli-build/src/_exports/_internal/build.ts
@@ -1,6 +1,6 @@
-export {buildApp} from '../../actions/build/buildApp.js'
+export {buildApp, type BuildAppEventListener} from '../../actions/build/buildApp.js'
 export {buildStaticFiles} from '../../actions/build/buildStaticFiles.js'
-export {buildStudio} from '../../actions/build/buildStudio.js'
+export {buildStudio, type BuildStudioEventListener} from '../../actions/build/buildStudio.js'
 export {checkRequiredDependencies} from '../../actions/build/checkRequiredDependencies.js'
 export {checkStudioDependencyVersions} from '../../actions/build/checkStudioDependencyVersions.js'
 export {extendViteConfigWithUserConfig, getViteConfig} from '../../actions/build/getViteConfig.js'

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/buildApp.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/buildApp.test.ts
@@ -39,7 +39,6 @@ function buildOptions(
 }
 
 const mockedConfirm = vi.hoisted(() => vi.fn())
-const mockedSelect = vi.hoisted(() => vi.fn())
 const mockedSpinner = vi.hoisted(() => vi.fn())
 const mockGetAppEnvironmentVariables = vi.hoisted(() => vi.fn().mockReturnValue({}))
 const mockedIsInteractive = vi.hoisted(() => vi.fn(() => true))
@@ -82,7 +81,6 @@ vi.mock(import('@sanity/cli-core/ux'), async (importOriginal) => {
   return {
     ...original,
     confirm: mockedConfirm,
-    select: mockedSelect,
     spinner: mockedSpinner,
   }
 })
@@ -100,7 +98,6 @@ describe('#buildApp', () => {
     mockedBuildStaticFiles.mockResolvedValue({chunks: []})
     mockedIsInteractive.mockReturnValue(true)
     mockedConfirm.mockResolvedValue(true)
-    mockedSelect.mockResolvedValue('disable-auto-updates')
     mockedGetLocalPackageVersion.mockResolvedValue('1.0.0')
     mockedResolveWorkbenchApp.mockReturnValue({})
   })
@@ -223,63 +220,55 @@ describe('#buildApp', () => {
   test('should error in unattended mode when prerelease versions are detected', async () => {
     const output = createMockOutput()
 
-    await buildApp(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [],
-          unresolvedPrerelease: [{pkg: '@sanity/sdk-react', version: '1.0.0-alpha.1'}],
-        }),
-        output,
-        unattendedMode: true,
-      }),
-    )
-
-    expect(output.error).toHaveBeenCalledWith(expect.stringContaining('prerelease versions'), {
-      exit: 1,
-    })
-    expect(output.error).toHaveBeenCalledWith(expect.stringContaining('--no-auto-updates'), {
-      exit: 1,
-    })
-    expect(mockedSelect).not.toHaveBeenCalled()
-  })
-
-  test('should exit when user selects "cancel" for prerelease prompt', async () => {
-    const output = createMockOutput()
-
-    mockedSelect.mockResolvedValue('cancel')
+    const onPreReleaseInInteractiveAutoUpdate = vi.fn()
+    const onPreReleaseInNonInteractiveAutoUpdate = vi.fn()
 
     await buildApp(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [],
-          unresolvedPrerelease: [{pkg: '@sanity/sdk-react', version: '1.0.0-alpha.1'}],
-        }),
-        output,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [],
+            unresolvedPrerelease: [{pkg: '@sanity/sdk-react', version: '1.0.0-alpha.1'}],
+          }),
+          output,
+          unattendedMode: true,
+        },
+        {
+          onPreReleaseInInteractiveAutoUpdate,
+          onPreReleaseInNonInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(output.error).toHaveBeenCalledWith('Declined to continue with build', {exit: 1})
+    expect(onPreReleaseInNonInteractiveAutoUpdate).toHaveBeenCalledWith({
+      message: expect.stringContaining('prerelease versions'),
+    })
+    expect(onPreReleaseInInteractiveAutoUpdate).not.toHaveBeenCalled()
   })
 
   test('should build without auto-updates when user selects "disable-auto-updates" for prerelease', async () => {
     const output = createMockOutput()
 
-    mockedSelect.mockResolvedValue('disable-auto-updates')
+    const onPreReleaseInInteractiveAutoUpdate = vi.fn()
 
     await buildApp(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [],
-          unresolvedPrerelease: [{pkg: '@sanity/sdk-react', version: '1.0.0-alpha.1'}],
-        }),
-        output,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [],
+            unresolvedPrerelease: [{pkg: '@sanity/sdk-react', version: '1.0.0-alpha.1'}],
+          }),
+          output,
+        },
+        {
+          onPreReleaseInInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(output.warn).toHaveBeenCalledWith('Auto-updates disabled for this build')
+    expect(onPreReleaseInInteractiveAutoUpdate).toHaveBeenCalled()
     expect(mockedSpinner).toHaveBeenCalledWith('Building Sanity application')
     expect(mockedBuildStaticFiles).toHaveBeenCalled()
   })
@@ -287,22 +276,26 @@ describe('#buildApp', () => {
   test('should skip version mismatch prompt after disabling auto-updates for prerelease', async () => {
     const output = createMockOutput()
 
-    mockedSelect.mockResolvedValue('disable-auto-updates')
+    const onPreReleaseInInteractiveAutoUpdate = vi.fn()
 
     await buildApp(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [{installed: '1.0.0', pkg: '@sanity/sdk', remote: '1.1.0'}],
-          unresolvedPrerelease: [{pkg: '@sanity/sdk-react', version: '1.0.0-alpha.1'}],
-        }),
-        output,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [{installed: '1.0.0', pkg: '@sanity/sdk', remote: '1.1.0'}],
+            unresolvedPrerelease: [{pkg: '@sanity/sdk-react', version: '1.0.0-alpha.1'}],
+          }),
+          output,
+        },
+        {
+          onPreReleaseInInteractiveAutoUpdate,
+        },
+      ),
     )
 
     expect(mockedSpinner).toHaveBeenCalledWith('Building Sanity application')
-    // select should only be called once (for the prerelease prompt), not twice
-    expect(mockedSelect).toHaveBeenCalledTimes(1)
+    expect(onPreReleaseInInteractiveAutoUpdate).toHaveBeenCalled()
     // confirm for version mismatch should not have been called
     expect(mockedConfirm).not.toHaveBeenCalledWith(
       expect.objectContaining({
@@ -358,24 +351,30 @@ describe('#buildApp', () => {
 
     mockedIsInteractive.mockReturnValue(false)
 
+    const onPreReleaseInInteractiveAutoUpdate = vi.fn()
+    const onPreReleaseInNonInteractiveAutoUpdate = vi.fn()
+
     await buildApp(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [],
-          unresolvedPrerelease: [{pkg: '@sanity/sdk-react', version: '1.0.0-alpha.1'}],
-        }),
-        output,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [],
+            unresolvedPrerelease: [{pkg: '@sanity/sdk-react', version: '1.0.0-alpha.1'}],
+          }),
+          output,
+        },
+        {
+          onPreReleaseInInteractiveAutoUpdate,
+          onPreReleaseInNonInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(output.error).toHaveBeenCalledWith(expect.stringContaining('prerelease versions'), {
-      exit: 1,
+    expect(onPreReleaseInNonInteractiveAutoUpdate).toHaveBeenCalledWith({
+      message: expect.stringContaining('prerelease versions'),
     })
-    expect(output.error).toHaveBeenCalledWith(expect.stringContaining('--no-auto-updates'), {
-      exit: 1,
-    })
-    expect(mockedSelect).not.toHaveBeenCalled()
+    expect(onPreReleaseInInteractiveAutoUpdate).not.toHaveBeenCalled()
   })
 
   test('should check appId when auto-updates are ebnabled', async () => {

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/buildApp.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/buildApp.test.ts
@@ -1,10 +1,11 @@
 import {type Output} from '@sanity/cli-core/types'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {buildApp, type BuildOptions} from '../buildApp.js'
+import {buildApp, type BuildAppEventListener, type BuildOptions} from '../buildApp.js'
 
 function buildOptions(
   overrides: Partial<BuildOptions> & Pick<BuildOptions, 'output'>,
+  eventListenerOverrides?: Partial<BuildAppEventListener>,
 ): BuildOptions {
   return {
     appId: undefined,
@@ -18,6 +19,11 @@ function buildOptions(
       return ''
     },
     entry: undefined,
+    eventListener: {
+      async onPreReleaseInInteractiveAutoUpdate() {},
+      onPreReleaseInNonInteractiveAutoUpdate() {},
+      ...eventListenerOverrides,
+    },
     isWorkbenchApp: false,
     minify: true,
     outDir: '/tmp/dist',

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/buildStudio.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/buildStudio.test.ts
@@ -2,11 +2,12 @@ import {type Output} from '@sanity/cli-core/types'
 import {DefinedTelemetryTrace} from '@sanity/telemetry'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {type BuildOptions, buildStudio} from '../buildStudio.js'
+import {type BuildOptions, buildStudio, BuildStudioEventListener} from '../buildStudio.js'
 import {getAutoUpdatesCssUrls, getAutoUpdatesImportMap} from '../getAutoUpdatesImportMap.js'
 
 function buildOptions(
   overrides: Partial<BuildOptions> & Pick<BuildOptions, 'output'>,
+  eventListenerOverrides?: Partial<BuildStudioEventListener>,
 ): BuildOptions {
   return {
     appId: undefined,
@@ -18,6 +19,29 @@ function buildOptions(
     determineBasePath() {
       return ''
     },
+    eventListener: {
+      onBuildEnd() {},
+      onBuildFail() {},
+      onBuildStart() {},
+      onCleanOutputDirEnd() {},
+      onCleanOutputDirStart() {},
+      onIncompatibleDeclaredStyledComponentsVersionRange() {},
+      onIncompatibleInstalledStyledComponentsVersionRange() {},
+      async onInteractiveNonDefaultOutputDir() {
+        return {shouldClean: false}
+      },
+      onInvalidStyledComponentsVersionRange() {},
+      onNoDeclaredStyledComponentsVersion() {},
+      onNoInstalledSanityVersion() {},
+      onNoInstalledStyledComponentsVersion() {},
+      async onPreReleaseInInteractiveAutoUpdate() {},
+      onPreReleaseInNonInteractiveAutoUpdate() {},
+      async onVersionMismatchInInteractiveAutoUpdate() {
+        return {stopBuild: false}
+      },
+      onVersionMismatchInNonInteractiveAutoUpdate() {},
+      ...eventListenerOverrides,
+    },
     isApp: false,
     isWorkbenchApp: false,
     minify: true,
@@ -27,16 +51,12 @@ function buildOptions(
     sourceMap: true,
     stats: true,
     unattendedMode: false,
-    async upgradePackages() {},
     vite: undefined,
     workDir: '/tmp',
     ...overrides,
   }
 }
 
-const mockedSelect = vi.hoisted(() => vi.fn())
-const mockedSpinner = vi.hoisted(() => vi.fn())
-const mockedConfirm = vi.hoisted(() => vi.fn())
 const mockGetStudioEnvironmentVariables = vi.hoisted(() => vi.fn().mockReturnValue({}))
 const mockedIsInteractive = vi.hoisted(() => vi.fn())
 const mockedBuildStaticFiles = vi.hoisted(() => vi.fn())
@@ -87,17 +107,6 @@ vi.mock(import('@sanity/cli-core/util'), () => ({
   isInteractive: mockedIsInteractive,
 }))
 
-vi.mock(import('@sanity/cli-core/ux'), async (importOriginal) => {
-  const original = await importOriginal()
-  mockedSpinner.mockImplementation(original.spinner)
-  return {
-    ...original,
-    confirm: mockedConfirm,
-    select: mockedSelect,
-    spinner: mockedSpinner,
-  }
-})
-
 function createMockOutput(): Output {
   return {
     error: vi.fn(),
@@ -110,8 +119,6 @@ describe('#buildStudio', () => {
   beforeEach(() => {
     mockedBuildStaticFiles.mockResolvedValue({chunks: []})
     mockedIsInteractive.mockReturnValue(true)
-    mockedConfirm.mockResolvedValue(true)
-    mockedSelect.mockResolvedValue('upgrade-and-proceed')
   })
 
   afterEach(() => {
@@ -124,209 +131,215 @@ describe('#buildStudio', () => {
     mockedBuildStaticFiles.mockImplementation(() => {
       throw new Error('build static files error')
     })
+    const onBuildFail = vi.fn()
 
-    await buildStudio(buildOptions({output, unattendedMode: true}))
+    await buildStudio(buildOptions({output, unattendedMode: true}, {onBuildFail}))
 
-    expect(output.error).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to build Sanity Studio'),
-      {exit: 1},
-    )
+    expect(onBuildFail).toHaveBeenCalledWith({
+      message: expect.stringContaining('Failed to build Sanity Studio'),
+    })
   })
 
   test('should prompt for directory cleanup with custom output dir and confirm', async () => {
     const output = createMockOutput()
 
-    const customDir = 'custom-output'
-    await buildStudio(buildOptions({outDir: customDir, output}))
+    const onInteractiveNonDefaultOutputDir = vi.fn().mockResolvedValue({shouldClean: true})
+    const onCleanOutputDirStart = vi.fn()
 
-    expect(mockedConfirm).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining('Do you want to delete the existing directory'),
-      }),
+    const customDir = 'custom-output'
+    await buildStudio(
+      buildOptions(
+        {outDir: customDir, output},
+        {
+          onCleanOutputDirStart,
+          onInteractiveNonDefaultOutputDir,
+        },
+      ),
     )
-    expect(mockedSpinner).toHaveBeenCalledWith('Clean output folder')
+
+    expect(onInteractiveNonDefaultOutputDir).toHaveBeenCalledWith({
+      message: expect.stringContaining('Do you want to delete the existing directory'),
+    })
+    expect(onCleanOutputDirStart).toHaveBeenCalledWith({message: 'Clean output folder'})
     expect(mockedBuildStaticFiles).toHaveBeenCalled()
   })
 
   test('should skip cleanup when user declines directory cleanup prompt', async () => {
     const output = createMockOutput()
 
-    mockedConfirm.mockResolvedValue(false)
+    const onCleanOutputDirStart = vi.fn()
+    const onInteractiveNonDefaultOutputDir = vi.fn().mockResolvedValue({shouldClean: false})
 
     const customDir = 'custom-output'
-    await buildStudio(buildOptions({outDir: customDir, output}))
+    await buildStudio(
+      buildOptions(
+        {outDir: customDir, output},
+        {onCleanOutputDirStart, onInteractiveNonDefaultOutputDir},
+      ),
+    )
 
-    expect(mockedSpinner).not.toHaveBeenCalledWith('Clean output folder')
+    expect(onCleanOutputDirStart).not.toHaveBeenCalled()
     expect(mockedBuildStaticFiles).toHaveBeenCalled()
   })
 
   test('should exit when user selects "cancel" for version diff', async () => {
     const output = createMockOutput()
 
-    mockedSelect.mockResolvedValue('cancel')
+    const onBuildStart = vi.fn()
+    const onVersionMismatchInInteractiveAutoUpdate = vi.fn().mockResolvedValue({stopBuild: true})
 
-    let upgradePackagesCalled = false
     await buildStudio(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
-          unresolvedPrerelease: [],
-        }),
-        output,
-        async upgradePackages() {
-          upgradePackagesCalled = true
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
+            unresolvedPrerelease: [],
+          }),
+          output,
         },
-      }),
+        {
+          onBuildStart,
+          onVersionMismatchInInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(mockedSelect).toHaveBeenCalled()
-    expect(output.error).toHaveBeenCalledWith('Declined to continue with build', {exit: 1})
-    expect(upgradePackagesCalled).toBeFalsy()
+    expect(onVersionMismatchInInteractiveAutoUpdate).toHaveBeenCalled()
+    expect(onBuildStart).not.toHaveBeenCalled()
   })
 
   test('should upgrade packages when user selects "upgrade" only', async () => {
     const output = createMockOutput()
 
-    const mockedUpgradePackages = vi.fn()
-    mockedSelect.mockResolvedValue('upgrade')
+    const onVersionMismatchInInteractiveAutoUpdate = vi.fn().mockResolvedValue({stopBuild: true})
 
     await buildStudio(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
-          unresolvedPrerelease: [],
-        }),
-        output,
-        upgradePackages: mockedUpgradePackages,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
+            unresolvedPrerelease: [],
+          }),
+          output,
+        },
+        {
+          onVersionMismatchInInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(mockedSelect).toHaveBeenCalled()
-    expect(mockedUpgradePackages).toHaveBeenCalledWith(
-      expect.objectContaining({
-        packages: [['sanity', '3.1.0']],
-      }),
-    )
+    expect(onVersionMismatchInInteractiveAutoUpdate).toHaveBeenCalled()
     expect(mockedBuildStaticFiles).not.toHaveBeenCalled()
-  })
-
-  test('should continue without upgrading when user selects "continue"', async () => {
-    const output = createMockOutput()
-
-    const mockedUpgradePackages = vi.fn()
-    mockedSelect.mockResolvedValue('continue')
-
-    await buildStudio(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
-          unresolvedPrerelease: [],
-        }),
-        output,
-      }),
-    )
-
-    expect(mockedUpgradePackages).not.toHaveBeenCalled()
-    expect(mockedBuildStaticFiles).toHaveBeenCalled()
   })
 
   test('should upgrade and build when user selects "upgrade-and-proceed"', async () => {
     const output = createMockOutput()
 
-    const mockedUpgradePackages = vi.fn()
-    mockedSelect.mockResolvedValue('upgrade-and-proceed')
+    const onVersionMismatchInInteractiveAutoUpdate = vi.fn().mockResolvedValue({stopBuild: false})
 
     await buildStudio(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
-          unresolvedPrerelease: [],
-        }),
-        output,
-        upgradePackages: mockedUpgradePackages,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
+            unresolvedPrerelease: [],
+          }),
+          output,
+        },
+        {
+          onVersionMismatchInInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(mockedUpgradePackages).toHaveBeenCalledWith(
-      expect.objectContaining({
-        packages: [['sanity', '3.1.0']],
-      }),
-    )
     expect(mockedBuildStaticFiles).toHaveBeenCalled()
   })
 
   test('should error in unattended mode when prerelease versions are detected', async () => {
     const output = createMockOutput()
 
+    const onPreReleaseInNonInteractiveAutoUpdate = vi.fn()
+    const onPreReleaseInInteractiveAutoUpdate = vi.fn()
+
     await buildStudio(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [],
-          unresolvedPrerelease: [{pkg: 'sanity', version: '5.11.1-alpha.14'}],
-        }),
-        output,
-        unattendedMode: true,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [],
+            unresolvedPrerelease: [{pkg: 'sanity', version: '5.11.1-alpha.14'}],
+          }),
+          output,
+          unattendedMode: true,
+        },
+        {
+          onPreReleaseInInteractiveAutoUpdate,
+          onPreReleaseInNonInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(output.error).toHaveBeenCalledWith(expect.stringContaining('prerelease versions'), {
-      exit: 1,
+    expect(onPreReleaseInNonInteractiveAutoUpdate).toHaveBeenCalledWith({
+      message: expect.stringContaining('prerelease versions'),
     })
-    expect(output.error).toHaveBeenCalledWith(expect.stringContaining('--no-auto-updates'), {
-      exit: 1,
-    })
-    expect(mockedSelect).not.toHaveBeenCalled()
+    expect(onPreReleaseInInteractiveAutoUpdate).not.toHaveBeenCalled()
   })
 
   test('should exit when user selects "cancel" for prerelease prompt', async () => {
     const output = createMockOutput()
 
-    mockedSelect.mockResolvedValue('cancel')
+    const onPreReleaseInInteractiveAutoUpdate = vi.fn()
 
     await buildStudio(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [],
-          unresolvedPrerelease: [{pkg: 'sanity', version: '5.11.1-alpha.14'}],
-        }),
-        output,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [],
+            unresolvedPrerelease: [{pkg: 'sanity', version: '5.11.1-alpha.14'}],
+          }),
+          output,
+        },
+        {
+          onPreReleaseInInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(output.error).toHaveBeenCalledWith('Declined to continue with build', {exit: 1})
+    expect(onPreReleaseInInteractiveAutoUpdate).toHaveBeenCalled()
   })
 
   test('should build without auto-updates when user selects "disable-auto-updates" for prerelease', async () => {
     const output = createMockOutput()
 
-    const mockedUpgradePackages = vi.fn()
-    mockedSelect.mockResolvedValue('disable-auto-updates')
+    const onBuildStart = vi.fn()
+    const onPreReleaseInInteractiveAutoUpdate = vi.fn()
 
     await buildStudio(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [],
-          unresolvedPrerelease: [{pkg: 'sanity', version: '5.11.1-alpha.14'}],
-        }),
-        output,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [],
+            unresolvedPrerelease: [{pkg: 'sanity', version: '5.11.1-alpha.14'}],
+          }),
+          output,
+        },
+        {
+          onBuildStart,
+          onPreReleaseInInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(output.warn).toHaveBeenCalledWith('Auto-updates disabled for this build')
-    expect(mockedSpinner).toHaveBeenCalledWith('Build Sanity Studio')
-
-    // Should not have shown the version mismatch prompt
-    expect(mockedUpgradePackages).not.toHaveBeenCalled()
+    expect(onPreReleaseInInteractiveAutoUpdate).toHaveBeenCalled()
+    expect(onBuildStart).toHaveBeenCalledWith({message: 'Build Sanity Studio'})
   })
 
-  test('outputs included environment variables', async () => {
+  test('outputs include environment variables', async () => {
     const output = createMockOutput()
 
     mockGetStudioEnvironmentVariables.mockImplementation(() => ({
@@ -343,46 +356,63 @@ describe('#buildStudio', () => {
     const output = createMockOutput()
 
     // First select call is for prerelease prompt
-    mockedSelect.mockResolvedValue('disable-auto-updates')
-    const mockedUpgradePackages = vi.fn()
+    const onBuildStart = vi.fn()
+    const onPreReleaseInInteractiveAutoUpdate = vi.fn()
+    const onVersionMismatchInInteractiveAutoUpdate = vi.fn()
 
     await buildStudio(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [{installed: '3.0.0', pkg: '@sanity/vision', remote: '3.1.0'}],
-          unresolvedPrerelease: [{pkg: 'sanity', version: '5.11.1-alpha.14'}],
-        }),
-        output,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [{installed: '3.0.0', pkg: '@sanity/vision', remote: '3.1.0'}],
+            unresolvedPrerelease: [{pkg: 'sanity', version: '5.11.1-alpha.14'}],
+          }),
+          output,
+        },
+        {
+          onBuildStart,
+          onPreReleaseInInteractiveAutoUpdate,
+          onVersionMismatchInInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(mockedSpinner).toHaveBeenCalledWith('Build Sanity Studio')
-    // select should only be called once (for the prerelease prompt), not twice
-    expect(mockedSelect).toHaveBeenCalledTimes(1)
-    expect(mockedUpgradePackages).not.toHaveBeenCalled()
+    expect(onPreReleaseInInteractiveAutoUpdate).toHaveBeenCalled()
+    expect(onBuildStart).toHaveBeenCalledWith({message: 'Build Sanity Studio'})
+    expect(onVersionMismatchInInteractiveAutoUpdate).not.toHaveBeenCalled()
   })
 
   test('should skip version prompt in unattended mode and show warning', async () => {
     const output = createMockOutput()
 
+    const onBuildStart = vi.fn()
+    const onVersionMismatchInNonInteractiveAutoUpdate = vi.fn()
+
     await buildStudio(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
-          unresolvedPrerelease: [],
-        }),
-        output,
-        unattendedMode: true,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
+            unresolvedPrerelease: [],
+          }),
+          output,
+          unattendedMode: true,
+        },
+        {
+          onBuildStart,
+          onVersionMismatchInNonInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(mockedSelect).not.toHaveBeenCalled()
-    expect(output.warn).toHaveBeenCalledWith(
-      expect.stringContaining('local version: 3.0.0, runtime version: 3.1.0'),
-    )
-    expect(mockedSpinner).toHaveBeenCalledWith('Build Sanity Studio')
+    expect(onVersionMismatchInNonInteractiveAutoUpdate).toHaveBeenCalledWith({
+      versionMismatchWarning: expect.stringContaining(
+        'local version: 3.0.0, runtime version: 3.1.0',
+      ),
+    })
+    expect(onBuildStart).toHaveBeenCalledWith({message: 'Build Sanity Studio'})
   })
 
   test('should skip version prompt in non-interactive mode and show warning', async () => {
@@ -390,22 +420,32 @@ describe('#buildStudio', () => {
 
     mockedIsInteractive.mockReturnValue(false)
 
+    const onBuildStart = vi.fn()
+    const onVersionMismatchInNonInteractiveAutoUpdate = vi.fn()
+
     await buildStudio(
-      buildOptions({
-        autoUpdatesEnabled: true,
-        compareDependencyVersions: async () => ({
-          mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
-          unresolvedPrerelease: [],
-        }),
-        output,
-      }),
+      buildOptions(
+        {
+          autoUpdatesEnabled: true,
+          compareDependencyVersions: async () => ({
+            mismatched: [{installed: '3.0.0', pkg: 'sanity', remote: '3.1.0'}],
+            unresolvedPrerelease: [],
+          }),
+          output,
+        },
+        {
+          onBuildStart,
+          onVersionMismatchInNonInteractiveAutoUpdate,
+        },
+      ),
     )
 
-    expect(mockedSelect).not.toHaveBeenCalled()
-    expect(output.warn).toHaveBeenCalledWith(
-      expect.stringContaining('local version: 3.0.0, runtime version: 3.1.0'),
-    )
-    expect(mockedSpinner).toHaveBeenCalledWith('Build Sanity Studio')
+    expect(onVersionMismatchInNonInteractiveAutoUpdate).toHaveBeenCalledWith({
+      versionMismatchWarning: expect.stringContaining(
+        'local version: 3.0.0, runtime version: 3.1.0',
+      ),
+    })
+    expect(onBuildStart).toHaveBeenCalledWith({message: 'Build Sanity Studio'})
   })
 
   test('passes a vision entry with cssFile when @sanity/vision is installed locally', async () => {

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/checkRequiredDependencies.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/checkRequiredDependencies.test.ts
@@ -2,10 +2,12 @@ import {
   getLocalPackageVersion as mockGetLocalPackageVersion,
   readPackageJson as mockReadPackageJson,
 } from '@sanity/cli-test/mocks/cli-core/package-manager'
-import {createMockOutput} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {checkRequiredDependencies} from '../checkRequiredDependencies'
+import {
+  checkRequiredDependencies,
+  CheckRequiredDependenciesOptions,
+} from '../checkRequiredDependencies'
 
 vi.mock('semver', {spy: true})
 
@@ -14,20 +16,35 @@ vi.mock(
   () => import('@sanity/cli-test/mocks/cli-core/package-manager'),
 )
 
-describe('#checkRequiredDependencies', () => {
-  const workDir = '/tmp/test-studio'
-  const mockOutput = createMockOutput()
+const handler = ({message}: {message: string}) => {
+  throw new Error(`Unhandled event: ${message}`)
+}
 
+function buildOptions(
+  isApp: boolean,
+  overrides?: Partial<CheckRequiredDependenciesOptions>,
+): CheckRequiredDependenciesOptions {
+  return {
+    isApp,
+    onIncompatibleDeclaredStyledComponentsVersionRange: handler,
+    onIncompatibleInstalledStyledComponentsVersionRange: handler,
+    onInvalidStyledComponentsVersionRange: handler,
+    onNoDeclaredStyledComponentsVersion: handler,
+    onNoInstalledSanityVersion: handler,
+    onNoInstalledStyledComponentsVersion: handler,
+    workDir: '/tmp/test-studio',
+
+    ...overrides,
+  }
+}
+
+describe('#checkRequiredDependencies', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   test('should return early if the project is an app', async () => {
-    const result = await checkRequiredDependencies({
-      isApp: true,
-      output: mockOutput,
-      workDir,
-    })
+    const result = await checkRequiredDependencies(buildOptions(true))
     expect(result).toEqual({installedSanityVersion: ''})
     expect(mockReadPackageJson).not.toHaveBeenCalled()
   })
@@ -46,14 +63,13 @@ describe('#checkRequiredDependencies', () => {
       return '6.1.15'
     })
 
-    const result = await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
+    const mockNoInstalledSanityVersion = vi.fn()
+    const result = await checkRequiredDependencies(
+      buildOptions(false, {onNoInstalledSanityVersion: mockNoInstalledSanityVersion}),
+    )
 
-    expect(mockOutput.error).toHaveBeenCalledWith('Failed to read the installed sanity version.', {
-      exit: 1,
+    expect(mockNoInstalledSanityVersion).toHaveBeenCalledWith({
+      message: 'Failed to read the installed sanity version.',
     })
     expect(result).toEqual({installedSanityVersion: ''})
   })
@@ -72,16 +88,16 @@ describe('#checkRequiredDependencies', () => {
       return null // styled-components not installed
     })
 
-    const result = await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
-
-    expect(mockOutput.error).toHaveBeenCalledWith(
-      expect.stringContaining('Declared dependency `styled-components` is not installed'),
-      {exit: 1},
+    const mockNoDeclaredStyledComponentsVersion = vi.fn()
+    const result = await checkRequiredDependencies(
+      buildOptions(false, {
+        onNoDeclaredStyledComponentsVersion: mockNoDeclaredStyledComponentsVersion,
+      }),
     )
+
+    expect(mockNoDeclaredStyledComponentsVersion).toHaveBeenCalledWith({
+      message: expect.stringContaining('Declared dependency `styled-components` is not installed'),
+    })
     expect(result).toEqual({installedSanityVersion: '3.0.0'})
   })
 
@@ -94,18 +110,18 @@ describe('#checkRequiredDependencies', () => {
     })
     mockGetLocalPackageVersion.mockResolvedValue('3.0.0') // for sanity
 
-    const result = await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
+    const mockInvalidStyledComponentsVersionRange = vi.fn()
+    const result = await checkRequiredDependencies(
+      buildOptions(false, {
+        onInvalidStyledComponentsVersionRange: mockInvalidStyledComponentsVersionRange,
+      }),
+    )
 
-    expect(mockOutput.error).toHaveBeenCalledWith(
-      expect.stringContaining(
+    expect(mockInvalidStyledComponentsVersionRange).toHaveBeenCalledWith({
+      message: expect.stringContaining(
         'Declared dependency `styled-components` has an invalid version range: `some-invalid-range`',
       ),
-      {exit: 1},
-    )
+    })
     expect(result).toEqual({installedSanityVersion: '3.0.0'})
   })
 
@@ -118,17 +134,16 @@ describe('#checkRequiredDependencies', () => {
     })
     mockGetLocalPackageVersion.mockResolvedValue('6.1.15')
 
-    await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
+    const onIncompatibleDeclaredStyledComponentsVersionRange = vi.fn()
+    await checkRequiredDependencies(
+      buildOptions(false, {onIncompatibleDeclaredStyledComponentsVersionRange}),
+    )
 
-    expect(mockOutput.warn).toHaveBeenCalledWith(
-      expect.stringContaining(
+    expect(onIncompatibleDeclaredStyledComponentsVersionRange).toHaveBeenCalledWith({
+      message: expect.stringContaining(
         'Declared version of styled-components (^5.0.0) is not compatible with the version required by sanity (^6.1.15)',
       ),
-    )
+    })
   })
 
   test('should not warn on complex but valid styled-components version range', async () => {
@@ -140,13 +155,12 @@ describe('#checkRequiredDependencies', () => {
     })
     mockGetLocalPackageVersion.mockResolvedValue('6.1.15')
 
-    await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
+    const onIncompatibleDeclaredStyledComponentsVersionRange = vi.fn()
+    await checkRequiredDependencies(
+      buildOptions(false, {onIncompatibleDeclaredStyledComponentsVersionRange}),
+    )
 
-    expect(mockOutput.warn).not.toHaveBeenCalled()
+    expect(onIncompatibleDeclaredStyledComponentsVersionRange).not.toHaveBeenCalled()
   })
 
   test('should call output.error and return sanity version if styled-components is declared but not installed', async () => {
@@ -163,16 +177,14 @@ describe('#checkRequiredDependencies', () => {
       return '3.0.0' // sanity version
     })
 
-    const result = await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
-
-    expect(mockOutput.error).toHaveBeenCalledWith(
-      expect.stringContaining('Declared dependency `styled-components` is not installed'),
-      {exit: 1},
+    const onNoInstalledStyledComponentsVersion = vi.fn()
+    const result = await checkRequiredDependencies(
+      buildOptions(false, {onNoInstalledStyledComponentsVersion}),
     )
+
+    expect(onNoInstalledStyledComponentsVersion).toHaveBeenCalledWith({
+      message: expect.stringContaining('Declared dependency `styled-components` is not installed'),
+    })
     expect(result).toEqual({installedSanityVersion: '3.0.0'})
   })
 
@@ -190,17 +202,16 @@ describe('#checkRequiredDependencies', () => {
       return '3.0.0' // sanity version
     })
 
-    await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
+    const onIncompatibleInstalledStyledComponentsVersionRange = vi.fn()
+    await checkRequiredDependencies(
+      buildOptions(false, {onIncompatibleInstalledStyledComponentsVersionRange}),
+    )
 
-    expect(mockOutput.warn).toHaveBeenCalledWith(
-      expect.stringContaining(
+    expect(onIncompatibleInstalledStyledComponentsVersionRange).toHaveBeenCalledWith({
+      message: expect.stringContaining(
         'Installed version of styled-components (5.3.6) is not compatible with the version required by sanity (^6.1.15)',
       ),
-    )
+    })
   })
 
   test('should not error on catalog: prefix for styled-components version', async () => {
@@ -216,15 +227,9 @@ describe('#checkRequiredDependencies', () => {
       return null
     })
 
-    const result = await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
+    const result = await checkRequiredDependencies(buildOptions(false))
 
     expect(result).toEqual({installedSanityVersion: '3.2.0'})
-    expect(mockOutput.error).not.toHaveBeenCalled()
-    expect(mockOutput.warn).not.toHaveBeenCalled()
   })
 
   test('should not warn on version comparison when using catalog: prefix', async () => {
@@ -240,15 +245,9 @@ describe('#checkRequiredDependencies', () => {
       return null
     })
 
-    const result = await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
+    const result = await checkRequiredDependencies(buildOptions(false))
 
     expect(result).toEqual({installedSanityVersion: '3.2.0'})
-    expect(mockOutput.error).not.toHaveBeenCalled()
-    expect(mockOutput.warn).not.toHaveBeenCalled()
   })
 
   test('should still warn on incompatible installed version when using catalog: prefix', async () => {
@@ -264,18 +263,16 @@ describe('#checkRequiredDependencies', () => {
       return null
     })
 
-    await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
+    const onIncompatibleInstalledStyledComponentsVersionRange = vi.fn()
+    await checkRequiredDependencies(
+      buildOptions(false, {onIncompatibleInstalledStyledComponentsVersionRange}),
+    )
 
-    expect(mockOutput.error).not.toHaveBeenCalled()
-    expect(mockOutput.warn).toHaveBeenCalledWith(
-      expect.stringContaining(
+    expect(onIncompatibleInstalledStyledComponentsVersionRange).toHaveBeenCalledWith({
+      message: expect.stringContaining(
         'Installed version of styled-components (5.3.6) is not compatible with the version required by sanity (^6.1.15)',
       ),
-    )
+    })
   })
 
   test('should succeed on happy path', async () => {
@@ -292,13 +289,8 @@ describe('#checkRequiredDependencies', () => {
       return null
     })
 
-    const result = await checkRequiredDependencies({
-      isApp: false,
-      output: mockOutput,
-      workDir,
-    })
+    const result = await checkRequiredDependencies(buildOptions(false))
 
     expect(result).toEqual({installedSanityVersion: '3.2.0'})
-    expect(mockOutput.warn).not.toHaveBeenCalled()
   })
 })

--- a/packages/@sanity/cli-build/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildApp.ts
@@ -15,11 +15,13 @@ import {CompareDependencyVersionsResult} from '../../util/compareDependencyVersi
 import {formatModuleSizes, sortModulesBySize} from '../../util/moduleFormatUtils.js'
 import {buildDebug} from './buildDebug.js'
 import {buildStaticFiles} from './buildStaticFiles.js'
+import {BuildEventListener} from './eventListener.js'
 import {getAutoUpdatesCssUrls, getAutoUpdatesImportMap} from './getAutoUpdatesImportMap.js'
 import {getAppEnvironmentVariables} from './getEnvironmentVariables.js'
 import {handlePrereleaseVersions} from './handlePrereleaseVersions.js'
 import {resolveVendorBuildConfig} from './resolveVendorBuildConfig.js'
 
+export type BuildAppEventListener = BuildEventListener
 export interface BuildOptions {
   appId: string | undefined
   appTitle: string | undefined
@@ -30,6 +32,7 @@ export interface BuildOptions {
   ) => Promise<CompareDependencyVersionsResult>
   determineBasePath: () => string
   entry: string | undefined
+  eventListener: BuildAppEventListener
   isWorkbenchApp: boolean
   minify: boolean
   outDir: string | undefined
@@ -55,7 +58,7 @@ export interface BuildOptions {
 export async function buildApp(options: BuildOptions): Promise<void> {
   buildDebug(`Building app`)
 
-  const {appId, determineBasePath, outDir, output, workDir} = options
+  const {appId, determineBasePath, eventListener, outDir, output, workDir} = options
   let {autoUpdatesEnabled} = options
   const unattendedMode = options.unattendedMode
 
@@ -106,7 +109,13 @@ export async function buildApp(options: BuildOptions): Promise<void> {
       await options.compareDependencyVersions(autoUpdatedPackages)
 
     if (unresolvedPrerelease.length > 0) {
-      await handlePrereleaseVersions({output, unattendedMode, unresolvedPrerelease})
+      await handlePrereleaseVersions({
+        onPreReleaseInInteractiveAutoUpdate: eventListener.onPreReleaseInInteractiveAutoUpdate,
+        onPreReleaseInNonInteractiveAutoUpdate:
+          eventListener.onPreReleaseInNonInteractiveAutoUpdate,
+        unattendedMode,
+        unresolvedPrerelease,
+      })
       autoUpdatesImports = {}
       autoUpdatesCssUrls = []
       autoUpdatesEnabled = false

--- a/packages/@sanity/cli-build/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildApp.ts
@@ -32,7 +32,7 @@ export interface BuildOptions {
   ) => Promise<CompareDependencyVersionsResult>
   determineBasePath: () => string
   entry: string | undefined
-  eventListener: BuildAppEventListener
+  eventListener: Partial<BuildAppEventListener>
   isWorkbenchApp: boolean
   minify: boolean
   outDir: string | undefined

--- a/packages/@sanity/cli-build/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildStudio.ts
@@ -53,7 +53,7 @@ export interface BuildOptions {
     packages: {name: string; version: string}[],
   ) => Promise<CompareDependencyVersionsResult>
   determineBasePath: () => string
-  eventListener: BuildStudioEventListener
+  eventListener: Partial<BuildStudioEventListener>
   isApp: boolean
   isWorkbenchApp: boolean
   minify: boolean
@@ -166,16 +166,21 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
         `When using auto updates, we recommend that you test locally with the same versions before deploying. \n\n` +
         `${mismatched.map((mod) => ` - ${mod.pkg} (local version: ${mod.installed}, runtime version: ${mod.remote})`).join('\n')}`
 
+      const {
+        onVersionMismatchInInteractiveAutoUpdate = () => ({stopBuild: true}),
+        onVersionMismatchInNonInteractiveAutoUpdate = () => {},
+      } = eventListener
+
       // If it is non-interactive or in unattended mode, we don't want to prompt
       if (isInteractive() && !unattendedMode) {
-        const {stopBuild} = await eventListener.onVersionMismatchInInteractiveAutoUpdate({
+        const {stopBuild} = await onVersionMismatchInInteractiveAutoUpdate({
           mismatched,
           versionMismatchWarning,
         })
         if (stopBuild) return
       } else {
         // if non-interactive or unattended, just show the warning
-        eventListener.onVersionMismatchInNonInteractiveAutoUpdate({versionMismatchWarning})
+        onVersionMismatchInNonInteractiveAutoUpdate({versionMismatchWarning})
       }
     }
   }
@@ -191,7 +196,8 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
 
   let shouldClean = true
   if (outputDir !== defaultOutputDir && !unattendedMode && isInteractive()) {
-    ;({shouldClean} = await eventListener.onInteractiveNonDefaultOutputDir({
+    const {onInteractiveNonDefaultOutputDir = () => ({shouldClean: true})} = eventListener
+    ;({shouldClean} = await onInteractiveNonDefaultOutputDir({
       message: `Do you want to delete the existing directory (${outputDir}) first?`,
     }))
   }
@@ -204,18 +210,21 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
   }
 
   if (shouldClean) {
+    const {onCleanOutputDirEnd = () => {}, onCleanOutputDirStart = () => {}} = eventListener
     timer.start('cleanOutputFolder')
-    eventListener.onCleanOutputDirStart({message: 'Clean output folder'})
+    onCleanOutputDirStart({message: 'Clean output folder'})
 
     await rm(outputDir, {force: true, recursive: true})
     const cleanDuration = timer.end('cleanOutputFolder')
 
-    eventListener.onCleanOutputDirEnd({
+    onCleanOutputDirEnd({
       message: `Clean output folder (${cleanDuration.toFixed(0)}ms)`,
     })
   }
 
-  eventListener.onBuildStart({message: `Build Sanity Studio`})
+  const {onBuildEnd = () => {}, onBuildFail = () => {}, onBuildStart = () => {}} = eventListener
+
+  onBuildStart({message: `Build Sanity Studio`})
 
   const trace = getCliTelemetry().trace(StudioBuildTrace)
   trace.start()
@@ -254,7 +263,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     })
     const buildDuration = timer.end('bundleStudio')
 
-    eventListener.onBuildEnd({message: `Build Sanity Studio (${buildDuration.toFixed(0)}ms)`})
+    onBuildEnd({message: `Build Sanity Studio (${buildDuration.toFixed(0)}ms)`})
 
     trace.complete()
     if (stats) {
@@ -265,7 +274,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     trace.error(error)
     const message = error instanceof Error ? error.message : String(error)
     buildDebug(`Failed to build Sanity Studio`, {error})
-    eventListener.onBuildFail({message: `Failed to build Sanity Studio: ${message}`})
+    onBuildFail({message: `Failed to build Sanity Studio: ${message}`})
     return
   }
 }

--- a/packages/@sanity/cli-build/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildStudio.ts
@@ -1,33 +1,49 @@
 import {rm} from 'node:fs/promises'
 import path from 'node:path'
-import {styleText} from 'node:util'
 
 import {getLocalPackageVersion} from '@sanity/cli-core/package-manager'
 import {getCliTelemetry} from '@sanity/cli-core/telemetry'
 import {type CliConfig, type Output, type UserViteConfig} from '@sanity/cli-core/types'
 import {isInteractive} from '@sanity/cli-core/util'
-import {
-  confirm,
-  getTimer,
-  logSymbols,
-  select,
-  spinner,
-  type SpinnerInstance,
-} from '@sanity/cli-core/ux'
+import {getTimer, logSymbols} from '@sanity/cli-core/ux'
 import {type WorkbenchExposes} from '@sanity/workbench-cli/build'
 import {parse as semverParse} from 'semver'
 
 import {StudioBuildTrace} from '../../telemetry/build.telemetry.js'
-import {CompareDependencyVersionsResult} from '../../util/compareDependencyVersions.js'
+import {
+  CompareDependencyVersions,
+  CompareDependencyVersionsResult,
+} from '../../util/compareDependencyVersions.js'
 import {formatModuleSizes, sortModulesBySize} from '../../util/moduleFormatUtils.js'
 import {buildDebug} from './buildDebug.js'
 import {buildStaticFiles} from './buildStaticFiles.js'
 import {checkRequiredDependencies} from './checkRequiredDependencies.js'
 import {checkStudioDependencyVersions} from './checkStudioDependencyVersions.js'
+import {type BuildEventListener, type MessageFunc} from './eventListener.js'
 import {getAutoUpdatesCssUrls, getAutoUpdatesImportMap} from './getAutoUpdatesImportMap.js'
 import {getStudioEnvironmentVariables} from './getEnvironmentVariables.js'
 import {handlePrereleaseVersions} from './handlePrereleaseVersions.js'
 import {resolveVendorBuildConfig} from './resolveVendorBuildConfig.js'
+
+export interface BuildStudioEventListener extends BuildEventListener {
+  onBuildEnd: MessageFunc
+  onBuildFail: MessageFunc
+  onBuildStart: MessageFunc
+  onCleanOutputDirEnd: MessageFunc
+  onCleanOutputDirStart: MessageFunc
+  onIncompatibleDeclaredStyledComponentsVersionRange: MessageFunc
+  onIncompatibleInstalledStyledComponentsVersionRange: MessageFunc
+  onInteractiveNonDefaultOutputDir({message}: {message: string}): Promise<{shouldClean: boolean}>
+  onInvalidStyledComponentsVersionRange: MessageFunc
+  onNoDeclaredStyledComponentsVersion: MessageFunc
+  onNoInstalledSanityVersion: MessageFunc
+  onNoInstalledStyledComponentsVersion: MessageFunc
+  onVersionMismatchInInteractiveAutoUpdate(params: {
+    mismatched: CompareDependencyVersions[]
+    versionMismatchWarning: string
+  }): Promise<{stopBuild: boolean}>
+  onVersionMismatchInNonInteractiveAutoUpdate(params: {versionMismatchWarning: string}): void
+}
 
 export interface BuildOptions {
   appId: string | undefined
@@ -37,6 +53,7 @@ export interface BuildOptions {
     packages: {name: string; version: string}[],
   ) => Promise<CompareDependencyVersionsResult>
   determineBasePath: () => string
+  eventListener: BuildStudioEventListener
   isApp: boolean
   isWorkbenchApp: boolean
   minify: boolean
@@ -47,7 +64,6 @@ export interface BuildOptions {
   sourceMap: boolean
   stats: boolean
   unattendedMode: boolean
-  upgradePackages(options: {packages: [name: string, version: string][]}): Promise<void>
   vite: UserViteConfig | undefined
   workDir: string
 
@@ -68,6 +84,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
   const {
     appId,
     determineBasePath,
+    eventListener,
     exposes,
     isApp,
     minify,
@@ -78,7 +95,6 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     sourceMap,
     stats,
     unattendedMode,
-    upgradePackages,
     vite,
     workDir,
   } = options
@@ -91,8 +107,9 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
   // thus we want to exit early
   const {installedSanityVersion} = await checkRequiredDependencies({
     isApp,
-    output,
     workDir,
+
+    ...eventListener,
   })
 
   let autoUpdatesEnabled = options.autoUpdatesEnabled
@@ -132,7 +149,12 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
       await options.compareDependencyVersions(sanityDependencies)
 
     if (unresolvedPrerelease.length > 0) {
-      await handlePrereleaseVersions({output, unattendedMode, unresolvedPrerelease})
+      await handlePrereleaseVersions({
+        unattendedMode,
+        unresolvedPrerelease,
+
+        ...eventListener,
+      })
       autoUpdatesImports = {}
       autoUpdatesCssUrls = []
       autoUpdatesEnabled = false
@@ -146,46 +168,14 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
 
       // If it is non-interactive or in unattended mode, we don't want to prompt
       if (isInteractive() && !unattendedMode) {
-        const choice = await select({
-          choices: [
-            {
-              name: `Upgrade local versions (recommended). You will need to run the build command again`,
-              value: 'upgrade',
-            },
-            {
-              name: `Upgrade and proceed with build`,
-              value: 'upgrade-and-proceed',
-            },
-            {
-              name: `Continue anyway`,
-              value: 'continue',
-            },
-            {name: 'Cancel', value: 'cancel'},
-          ],
-          default: 'upgrade',
-          message: styleText(
-            'yellow',
-            `${logSymbols.warning} ${versionMismatchWarning}\n\nDo you want to upgrade local versions before deploying?`,
-          ),
+        const {stopBuild} = await eventListener.onVersionMismatchInInteractiveAutoUpdate({
+          mismatched,
+          versionMismatchWarning,
         })
-
-        if (choice === 'cancel') {
-          output.error('Declined to continue with build', {exit: 1})
-          return
-        }
-
-        if (choice === 'upgrade' || choice === 'upgrade-and-proceed') {
-          await upgradePackages({
-            packages: mismatched.map((res) => [res.pkg, res.remote]),
-          })
-
-          if (choice === 'upgrade') {
-            return
-          }
-        }
+        if (stopBuild) return
       } else {
         // if non-interactive or unattended, just show the warning
-        output.warn(versionMismatchWarning)
+        eventListener.onVersionMismatchInNonInteractiveAutoUpdate({versionMismatchWarning})
       }
     }
   }
@@ -201,10 +191,9 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
 
   let shouldClean = true
   if (outputDir !== defaultOutputDir && !unattendedMode && isInteractive()) {
-    shouldClean = await confirm({
-      default: true,
+    ;({shouldClean} = await eventListener.onInteractiveNonDefaultOutputDir({
       message: `Do you want to delete the existing directory (${outputDir}) first?`,
-    })
+    }))
   }
 
   // Determine base path for built studio
@@ -214,17 +203,19 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     output.log(`${logSymbols.info} Building with schema extraction enabled`)
   }
 
-  let spin: SpinnerInstance
   if (shouldClean) {
     timer.start('cleanOutputFolder')
-    spin = spinner('Clean output folder').start()
+    eventListener.onCleanOutputDirStart({message: 'Clean output folder'})
+
     await rm(outputDir, {force: true, recursive: true})
     const cleanDuration = timer.end('cleanOutputFolder')
-    spin.text = `Clean output folder (${cleanDuration.toFixed(0)}ms)`
-    spin.succeed()
+
+    eventListener.onCleanOutputDirEnd({
+      message: `Clean output folder (${cleanDuration.toFixed(0)}ms)`,
+    })
   }
 
-  spin = spinner(`Build Sanity Studio`).start()
+  eventListener.onBuildStart({message: `Build Sanity Studio`})
 
   const trace = getCliTelemetry().trace(StudioBuildTrace)
   trace.start()
@@ -263,8 +254,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     })
     const buildDuration = timer.end('bundleStudio')
 
-    spin.text = `Build Sanity Studio (${buildDuration.toFixed(0)}ms)`
-    spin.succeed()
+    eventListener.onBuildEnd({message: `Build Sanity Studio (${buildDuration.toFixed(0)}ms)`})
 
     trace.complete()
     if (stats) {
@@ -272,10 +262,10 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
       output.log(formatModuleSizes(sortModulesBySize(bundle.chunks).slice(0, 15)))
     }
   } catch (error) {
-    spin.fail()
     trace.error(error)
     const message = error instanceof Error ? error.message : String(error)
     buildDebug(`Failed to build Sanity Studio`, {error})
-    output.error(`Failed to build Sanity Studio: ${message}`, {exit: 1})
+    eventListener.onBuildFail({message: `Failed to build Sanity Studio: ${message}`})
+    return
   }
 }

--- a/packages/@sanity/cli-build/src/actions/build/checkRequiredDependencies.ts
+++ b/packages/@sanity/cli-build/src/actions/build/checkRequiredDependencies.ts
@@ -1,9 +1,11 @@
 import path from 'node:path'
 
 import {getLocalPackageVersion, readPackageJson} from '@sanity/cli-core/package-manager'
-import {type Output, type PackageJson} from '@sanity/cli-core/types'
+import {type PackageJson} from '@sanity/cli-core/types'
 import {oneline} from 'oneline'
 import {minVersion, satisfies, type SemVer} from 'semver'
+
+import {type BuildStudioEventListener} from './buildStudio'
 
 const defaultStudioManifestProps: Partial<PackageJson> = {
   name: 'studio',
@@ -14,9 +16,15 @@ interface CheckResult {
   installedSanityVersion: string
 }
 
-interface CheckRequiredDependenciesOptions {
+export interface CheckRequiredDependenciesOptions {
   isApp: boolean
-  output: Output
+  onIncompatibleDeclaredStyledComponentsVersionRange: BuildStudioEventListener['onIncompatibleDeclaredStyledComponentsVersionRange']
+
+  onIncompatibleInstalledStyledComponentsVersionRange: BuildStudioEventListener['onIncompatibleInstalledStyledComponentsVersionRange']
+  onInvalidStyledComponentsVersionRange: BuildStudioEventListener['onInvalidStyledComponentsVersionRange']
+  onNoDeclaredStyledComponentsVersion: BuildStudioEventListener['onNoDeclaredStyledComponentsVersion']
+  onNoInstalledSanityVersion: BuildStudioEventListener['onNoInstalledSanityVersion']
+  onNoInstalledStyledComponentsVersion: BuildStudioEventListener['onNoInstalledStyledComponentsVersion']
   workDir: string
 }
 
@@ -36,7 +44,7 @@ const styledComponentsVersionRange = '^6.1.15'
 export async function checkRequiredDependencies(
   options: CheckRequiredDependenciesOptions,
 ): Promise<CheckResult> {
-  const {isApp, output, workDir: studioPath} = options
+  const {isApp, workDir: studioPath} = options
   // currently there's no check needed for core apps,
   // but this should be removed once they are more mature
   if (isApp) {
@@ -57,7 +65,7 @@ export async function checkRequiredDependencies(
 
   // Retrieve the version of the 'sanity' dependency
   if (!installedSanityVersion) {
-    output.error('Failed to read the installed sanity version.', {exit: 1})
+    options.onNoInstalledSanityVersion({message: 'Failed to read the installed sanity version.'})
     return {installedSanityVersion: ''}
   }
 
@@ -69,13 +77,12 @@ export async function checkRequiredDependencies(
     studioPackageManifest?.devDependencies?.['styled-components']
 
   if (!declaredStyledComponentsVersion) {
-    output.error(
-      oneline`
+    options.onNoDeclaredStyledComponentsVersion({
+      message: oneline`
       Declared dependency \`styled-components\` is not installed - run
       \`npm install\`, \`yarn install\` or \`pnpm install\` to install it before re-running this command.
     `,
-      {exit: 1},
-    )
+    })
     return {installedSanityVersion}
   }
 
@@ -91,13 +98,12 @@ export async function checkRequiredDependencies(
   }
 
   if (!minDeclaredStyledComponentsVersion && !isStyledComponentsVersionRangeInCatalog) {
-    output.error(
-      oneline`
+    options.onInvalidStyledComponentsVersionRange({
+      message: oneline`
       Declared dependency \`styled-components\` has an invalid version range:
       \`${declaredStyledComponentsVersion}\`.
     `,
-      {exit: 1},
-    )
+    })
     return {installedSanityVersion}
   }
 
@@ -112,33 +118,36 @@ export async function checkRequiredDependencies(
     isComparableRange(declaredStyledComponentsVersion) &&
     !satisfies(minDeclaredStyledComponentsVersion!, wantedStyledComponentsVersionRange)
   ) {
-    output.warn(oneline`
+    options.onIncompatibleDeclaredStyledComponentsVersionRange({
+      message: oneline`
       Declared version of styled-components (${declaredStyledComponentsVersion})
       is not compatible with the version required by sanity (${wantedStyledComponentsVersionRange}).
       This might cause problems!
-    `)
+    `,
+    })
   }
 
   // Ensure the studio has _installed_ a version of `styled-components`
   if (!installedStyledComponentsVersion) {
-    output.error(
-      oneline`
+    options.onNoInstalledStyledComponentsVersion({
+      message: oneline`
       Declared dependency \`styled-components\` is not installed - run
       \`npm install\`, \`yarn install\` or \`pnpm install\` to install it before re-running this command.
     `,
-      {exit: 1},
-    )
+    })
     return {installedSanityVersion}
   }
 
   // The studio should have an _installed_ version of `styled-components`, and it should
   // be semver compatible with the version specified in `sanity` peer dependencies.
   if (!satisfies(installedStyledComponentsVersion, wantedStyledComponentsVersionRange)) {
-    output.warn(oneline`
+    options.onIncompatibleInstalledStyledComponentsVersionRange({
+      message: oneline`
       Installed version of styled-components (${installedStyledComponentsVersion})
       is not compatible with the version required by sanity (${wantedStyledComponentsVersionRange}).
       This might cause problems!
-    `)
+    `,
+    })
   }
 
   return {installedSanityVersion}

--- a/packages/@sanity/cli-build/src/actions/build/checkRequiredDependencies.ts
+++ b/packages/@sanity/cli-build/src/actions/build/checkRequiredDependencies.ts
@@ -18,17 +18,19 @@ interface CheckResult {
 
 export interface CheckRequiredDependenciesOptions {
   isApp: boolean
-  onIncompatibleDeclaredStyledComponentsVersionRange: BuildStudioEventListener['onIncompatibleDeclaredStyledComponentsVersionRange']
-
-  onIncompatibleInstalledStyledComponentsVersionRange: BuildStudioEventListener['onIncompatibleInstalledStyledComponentsVersionRange']
-  onInvalidStyledComponentsVersionRange: BuildStudioEventListener['onInvalidStyledComponentsVersionRange']
-  onNoDeclaredStyledComponentsVersion: BuildStudioEventListener['onNoDeclaredStyledComponentsVersion']
-  onNoInstalledSanityVersion: BuildStudioEventListener['onNoInstalledSanityVersion']
-  onNoInstalledStyledComponentsVersion: BuildStudioEventListener['onNoInstalledStyledComponentsVersion']
   workDir: string
+
+  onIncompatibleDeclaredStyledComponentsVersionRange?: BuildStudioEventListener['onIncompatibleDeclaredStyledComponentsVersionRange']
+  onIncompatibleInstalledStyledComponentsVersionRange?: BuildStudioEventListener['onIncompatibleInstalledStyledComponentsVersionRange']
+  onInvalidStyledComponentsVersionRange?: BuildStudioEventListener['onInvalidStyledComponentsVersionRange']
+  onNoDeclaredStyledComponentsVersion?: BuildStudioEventListener['onNoDeclaredStyledComponentsVersion']
+  onNoInstalledSanityVersion?: BuildStudioEventListener['onNoInstalledSanityVersion']
+  onNoInstalledStyledComponentsVersion?: BuildStudioEventListener['onNoInstalledStyledComponentsVersion']
 }
 
 const styledComponentsVersionRange = '^6.1.15'
+
+const noop = async () => {}
 
 /**
  * Checks that the studio has declared and installed the required dependencies
@@ -51,6 +53,15 @@ export async function checkRequiredDependencies(
     return {installedSanityVersion: ''}
   }
 
+  const {
+    onIncompatibleDeclaredStyledComponentsVersionRange = noop,
+    onIncompatibleInstalledStyledComponentsVersionRange = noop,
+    onInvalidStyledComponentsVersionRange = noop,
+    onNoDeclaredStyledComponentsVersion = noop,
+    onNoInstalledSanityVersion = noop,
+    onNoInstalledStyledComponentsVersion = noop,
+  } = options
+
   const [studioPackageManifest, installedStyledComponentsVersion, installedSanityVersion] =
     await Promise.all([
       readPackageJson(path.join(studioPath, 'package.json'), {
@@ -65,7 +76,7 @@ export async function checkRequiredDependencies(
 
   // Retrieve the version of the 'sanity' dependency
   if (!installedSanityVersion) {
-    options.onNoInstalledSanityVersion({message: 'Failed to read the installed sanity version.'})
+    onNoInstalledSanityVersion({message: 'Failed to read the installed sanity version.'})
     return {installedSanityVersion: ''}
   }
 
@@ -77,7 +88,7 @@ export async function checkRequiredDependencies(
     studioPackageManifest?.devDependencies?.['styled-components']
 
   if (!declaredStyledComponentsVersion) {
-    options.onNoDeclaredStyledComponentsVersion({
+    onNoDeclaredStyledComponentsVersion({
       message: oneline`
       Declared dependency \`styled-components\` is not installed - run
       \`npm install\`, \`yarn install\` or \`pnpm install\` to install it before re-running this command.
@@ -98,7 +109,7 @@ export async function checkRequiredDependencies(
   }
 
   if (!minDeclaredStyledComponentsVersion && !isStyledComponentsVersionRangeInCatalog) {
-    options.onInvalidStyledComponentsVersionRange({
+    onInvalidStyledComponentsVersionRange({
       message: oneline`
       Declared dependency \`styled-components\` has an invalid version range:
       \`${declaredStyledComponentsVersion}\`.
@@ -118,7 +129,7 @@ export async function checkRequiredDependencies(
     isComparableRange(declaredStyledComponentsVersion) &&
     !satisfies(minDeclaredStyledComponentsVersion!, wantedStyledComponentsVersionRange)
   ) {
-    options.onIncompatibleDeclaredStyledComponentsVersionRange({
+    onIncompatibleDeclaredStyledComponentsVersionRange({
       message: oneline`
       Declared version of styled-components (${declaredStyledComponentsVersion})
       is not compatible with the version required by sanity (${wantedStyledComponentsVersionRange}).
@@ -129,7 +140,7 @@ export async function checkRequiredDependencies(
 
   // Ensure the studio has _installed_ a version of `styled-components`
   if (!installedStyledComponentsVersion) {
-    options.onNoInstalledStyledComponentsVersion({
+    onNoInstalledStyledComponentsVersion({
       message: oneline`
       Declared dependency \`styled-components\` is not installed - run
       \`npm install\`, \`yarn install\` or \`pnpm install\` to install it before re-running this command.
@@ -141,7 +152,7 @@ export async function checkRequiredDependencies(
   // The studio should have an _installed_ version of `styled-components`, and it should
   // be semver compatible with the version specified in `sanity` peer dependencies.
   if (!satisfies(installedStyledComponentsVersion, wantedStyledComponentsVersionRange)) {
-    options.onIncompatibleInstalledStyledComponentsVersionRange({
+    onIncompatibleInstalledStyledComponentsVersionRange({
       message: oneline`
       Installed version of styled-components (${installedStyledComponentsVersion})
       is not compatible with the version required by sanity (${wantedStyledComponentsVersionRange}).

--- a/packages/@sanity/cli-build/src/actions/build/eventListener.ts
+++ b/packages/@sanity/cli-build/src/actions/build/eventListener.ts
@@ -1,0 +1,6 @@
+export type MessageFunc = ({message}: {message: string}) => void
+
+export interface BuildEventListener {
+  onPreReleaseInInteractiveAutoUpdate(params: {prereleaseMessage: string}): Promise<void>
+  onPreReleaseInNonInteractiveAutoUpdate: MessageFunc
+}

--- a/packages/@sanity/cli-build/src/actions/build/handlePrereleaseVersions.ts
+++ b/packages/@sanity/cli-build/src/actions/build/handlePrereleaseVersions.ts
@@ -1,10 +1,7 @@
-import {styleText} from 'node:util'
-
-import {type Output} from '@sanity/cli-core/types'
 import {isInteractive} from '@sanity/cli-core/util'
-import {select} from '@sanity/cli-core/ux'
 
 import {type UnresolvedPrerelease} from '../../util/compareDependencyVersions.js'
+import {type BuildStudioEventListener} from './buildStudio.js'
 
 /**
  * Handle prerelease versions that cannot be resolved by the auto-updates CDN.
@@ -15,11 +12,13 @@ import {type UnresolvedPrerelease} from '../../util/compareDependencyVersions.js
  * Does not return if the build should be cancelled (exits via `output.error`).
  */
 export async function handlePrereleaseVersions({
-  output,
+  onPreReleaseInInteractiveAutoUpdate,
+  onPreReleaseInNonInteractiveAutoUpdate,
   unattendedMode,
   unresolvedPrerelease,
 }: {
-  output: Output
+  onPreReleaseInInteractiveAutoUpdate: BuildStudioEventListener['onPreReleaseInInteractiveAutoUpdate']
+  onPreReleaseInNonInteractiveAutoUpdate: BuildStudioEventListener['onPreReleaseInNonInteractiveAutoUpdate']
   unattendedMode: boolean
   unresolvedPrerelease: UnresolvedPrerelease[]
 }): Promise<void> {
@@ -30,33 +29,14 @@ export async function handlePrereleaseVersions({
     `switch to a non-prerelease version locally and deploy again.`
 
   if (unattendedMode || !isInteractive()) {
-    output.error(
-      `${prereleaseMessage}\n\n` +
+    onPreReleaseInNonInteractiveAutoUpdate({
+      message:
+        `${prereleaseMessage}\n\n` +
         `Cannot build with auto-updates in unattended mode when using prerelease versions. ` +
         `Either switch to a non-prerelease version, or use --no-auto-updates to build without auto-updates.`,
-      {exit: 1},
-    )
-    // output.error with exit: 1 throws, but TypeScript doesn't know that
+    })
     return
   }
 
-  const choice = await select({
-    choices: [
-      {
-        name: 'Disable auto-updates for this build and continue',
-        value: 'disable-auto-updates',
-      },
-      {name: 'Cancel build', value: 'cancel'},
-    ],
-    default: 'disable-auto-updates',
-    message: styleText('yellow', prereleaseMessage),
-  })
-
-  if (choice === 'cancel') {
-    output.error('Declined to continue with build', {exit: 1})
-    // output.error with exit: 1 throws, but TypeScript doesn't know that
-    return
-  }
-
-  output.warn('Auto-updates disabled for this build')
+  await onPreReleaseInInteractiveAutoUpdate({prereleaseMessage})
 }

--- a/packages/@sanity/cli-build/src/actions/build/handlePrereleaseVersions.ts
+++ b/packages/@sanity/cli-build/src/actions/build/handlePrereleaseVersions.ts
@@ -3,6 +3,8 @@ import {isInteractive} from '@sanity/cli-core/util'
 import {type UnresolvedPrerelease} from '../../util/compareDependencyVersions.js'
 import {type BuildStudioEventListener} from './buildStudio.js'
 
+const noop = async () => {}
+
 /**
  * Handle prerelease versions that cannot be resolved by the auto-updates CDN.
  *
@@ -17,11 +19,14 @@ export async function handlePrereleaseVersions({
   unattendedMode,
   unresolvedPrerelease,
 }: {
-  onPreReleaseInInteractiveAutoUpdate: BuildStudioEventListener['onPreReleaseInInteractiveAutoUpdate']
-  onPreReleaseInNonInteractiveAutoUpdate: BuildStudioEventListener['onPreReleaseInNonInteractiveAutoUpdate']
+  onPreReleaseInInteractiveAutoUpdate?: BuildStudioEventListener['onPreReleaseInInteractiveAutoUpdate']
+  onPreReleaseInNonInteractiveAutoUpdate?: BuildStudioEventListener['onPreReleaseInNonInteractiveAutoUpdate']
   unattendedMode: boolean
   unresolvedPrerelease: UnresolvedPrerelease[]
 }): Promise<void> {
+  onPreReleaseInInteractiveAutoUpdate ??= noop
+  onPreReleaseInNonInteractiveAutoUpdate ??= noop
+
   const prereleaseMessage =
     `The following packages are using prerelease versions not yet available on the auto-updates CDN:\n\n` +
     `${unresolvedPrerelease.map((mod) => ` - ${mod.pkg} (${mod.version})`).join('\n')}\n\n` +

--- a/packages/@sanity/cli/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli/src/actions/build/buildApp.ts
@@ -7,6 +7,7 @@ import {buildAppId, resolveWorkbenchApp} from '@sanity/workbench-cli/build'
 import {getAppId} from '../../util/appId.js'
 import {warnAboutMissingAppId} from '../../util/warnAboutMissingAppId.js'
 import {determineBasePath} from './determineBasePath.js'
+import {preReleaseEventListenerFactory} from './eventListenerFactory.js'
 import {type BuildOptions} from './types.js'
 
 /**
@@ -59,5 +60,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
       ? (options.applicationId ?? (await buildAppId(workbench)))
       : undefined,
     workDir,
+
+    eventListener: preReleaseEventListenerFactory(output),
   })
 }

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -1,7 +1,10 @@
+import {styleText} from 'node:util'
+
 import {
   compareDependencyVersions,
   buildStudio as internalBuildStudio,
 } from '@sanity/cli-build/_internal/build'
+import { logSymbols, select, spinner} from '@sanity/cli-core/ux'
 import {buildAppId, resolveWorkbenchApp} from '@sanity/workbench-cli/build'
 
 import {getAppId} from '../../util/appId.js'
@@ -10,6 +13,10 @@ import {getPackageManagerChoice} from '../../util/packageManager/packageManagerC
 import {upgradePackages} from '../../util/packageManager/upgradePackages.js'
 import {warnAboutMissingAppId} from '../../util/warnAboutMissingAppId.js'
 import {determineBasePath} from './determineBasePath.js'
+import {
+  checkDependenciesEventListenerFactory,
+  preReleaseEventListenerFactory,
+} from './eventListenerFactory.js'
 import {type BuildOptions} from './types.js'
 
 /**
@@ -27,17 +34,8 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
 
   const appId = getAppId(cliConfig)
 
-  const upgradePkgs = async (options: {
-    packages: [name: string, version: string][]
-  }): Promise<void> => {
-    await upgradePackages(
-      {
-        packageManager: (await getPackageManagerChoice(workDir, {interactive: false})).chosen,
-        packages: options.packages,
-      },
-      {output, workDir},
-    )
-  }
+  let cleanOutputDirSpinner: ReturnType<typeof spinner> | undefined
+  let buildSpinner: ReturnType<typeof spinner> | undefined
 
   await internalBuildStudio({
     appId,
@@ -63,7 +61,6 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
     sourceMap: Boolean(flags['source-maps']),
     stats: flags.stats,
     unattendedMode: Boolean(flags.yes),
-    upgradePackages: upgradePkgs,
     vite: cliConfig.vite,
     // Shared with deploy: it passes the resolved application id (minted by the
     // API on a first deploy) to inline; a plain build has none, so it hashes the shape.
@@ -71,5 +68,87 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
       ? (options.applicationId ?? (await buildAppId(workbench)))
       : undefined,
     workDir,
+
+    eventListener: {
+      ...preReleaseEventListenerFactory(output),
+
+      ...checkDependenciesEventListenerFactory(output),
+
+      onBuildEnd({message}) {
+        if (buildSpinner) {
+          buildSpinner.text = message
+          buildSpinner.succeed()
+        }
+      },
+      onBuildFail({message}) {
+        if (buildSpinner) {
+          buildSpinner.fail()
+        }
+
+        output.error(message, {exit: 1})
+      },
+      onBuildStart({message}) {
+        if (!buildSpinner) {
+          buildSpinner = spinner(message).start()
+        }
+      },
+      onCleanOutputDirEnd({message}) {
+        if (cleanOutputDirSpinner) {
+          cleanOutputDirSpinner.text = message
+          cleanOutputDirSpinner.succeed()
+        }
+      },
+      onCleanOutputDirStart({message}) {
+        if (!cleanOutputDirSpinner) {
+          cleanOutputDirSpinner = spinner(message).start()
+        }
+      },
+      async onVersionMismatchInInteractiveAutoUpdate({mismatched, versionMismatchWarning}) {
+        const choice = await select({
+          choices: [
+            {
+              name: `Upgrade local versions (recommended). You will need to run the build command again`,
+              value: 'upgrade',
+            },
+            {
+              name: `Upgrade and proceed with build`,
+              value: 'upgrade-and-proceed',
+            },
+            {
+              name: `Continue anyway`,
+              value: 'continue',
+            },
+            {name: 'Cancel', value: 'cancel'},
+          ],
+          default: 'upgrade',
+          message: styleText(
+            'yellow',
+            `${logSymbols.warning} ${versionMismatchWarning}\n\nDo you want to upgrade local versions before deploying?`,
+          ),
+        })
+
+        if (choice === 'cancel') {
+          output.error('Declined to continue with build', {exit: 1})
+          return {stopBuild: true}
+        }
+
+        if (choice === 'upgrade' || choice === 'upgrade-and-proceed') {
+          await upgradePackages(
+            {
+              packageManager: (await getPackageManagerChoice(workDir, {interactive: false})).chosen,
+              packages: mismatched.map((res) => [res.pkg, res.remote]),
+            },
+            {output, workDir},
+          )
+
+          return {stopBuild: choice === 'upgrade'}
+        }
+
+        return {stopBuild: false}
+      },
+      onVersionMismatchInNonInteractiveAutoUpdate({versionMismatchWarning}) {
+        output.warn(versionMismatchWarning)
+      },
+    },
   })
 }

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -4,7 +4,7 @@ import {
   compareDependencyVersions,
   buildStudio as internalBuildStudio,
 } from '@sanity/cli-build/_internal/build'
-import { logSymbols, select, spinner} from '@sanity/cli-core/ux'
+import {logSymbols, select, spinner} from '@sanity/cli-core/ux'
 import {buildAppId, resolveWorkbenchApp} from '@sanity/workbench-cli/build'
 
 import {getAppId} from '../../util/appId.js'

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -4,7 +4,7 @@ import {
   compareDependencyVersions,
   buildStudio as internalBuildStudio,
 } from '@sanity/cli-build/_internal/build'
-import {logSymbols, select, spinner} from '@sanity/cli-core/ux'
+import {confirm, logSymbols, select, spinner} from '@sanity/cli-core/ux'
 import {buildAppId, resolveWorkbenchApp} from '@sanity/workbench-cli/build'
 
 import {getAppId} from '../../util/appId.js'
@@ -102,6 +102,13 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
         if (!cleanOutputDirSpinner) {
           cleanOutputDirSpinner = spinner(message).start()
         }
+      },
+      async onInteractiveNonDefaultOutputDir({message}: {message: string}) {
+        const shouldClean = await confirm({
+          default: true,
+          message,
+        })
+        return {shouldClean}
       },
       async onVersionMismatchInInteractiveAutoUpdate({mismatched, versionMismatchWarning}) {
         const choice = await select({

--- a/packages/@sanity/cli/src/actions/build/eventListenerFactory.ts
+++ b/packages/@sanity/cli/src/actions/build/eventListenerFactory.ts
@@ -1,0 +1,68 @@
+import {styleText} from 'node:util'
+
+import {Output} from '@sanity/cli-core'
+import {confirm, select} from '@sanity/cli-core/ux'
+
+/**
+ * Creates check dependency event handlers that are shared between buildStudio and startStudioDevServer.
+ */
+export function checkDependenciesEventListenerFactory(output: Output) {
+  return {
+    onIncompatibleDeclaredStyledComponentsVersionRange({message}: {message: string}) {
+      output.warn(message)
+    },
+    onIncompatibleInstalledStyledComponentsVersionRange({message}: {message: string}) {
+      output.warn(message)
+    },
+    async onInteractiveNonDefaultOutputDir({message}: {message: string}) {
+      const shouldClean = await confirm({
+        default: true,
+        message,
+      })
+      return {shouldClean}
+    },
+    onInvalidStyledComponentsVersionRange({message}: {message: string}) {
+      output.error(message, {exit: 1})
+    },
+    onNoDeclaredStyledComponentsVersion({message}: {message: string}) {
+      output.error(message, {exit: 1})
+    },
+    onNoInstalledSanityVersion({message}: {message: string}) {
+      output.error(message, {exit: 1})
+    },
+    onNoInstalledStyledComponentsVersion({message}: {message: string}) {
+      output.error(message, {exit: 1})
+    },
+  }
+}
+
+/**
+ * Creates pre-release event handlers that are shared between buildApp and buildStudio.
+ */
+export function preReleaseEventListenerFactory(output: Output) {
+  return {
+    async onPreReleaseInInteractiveAutoUpdate({prereleaseMessage}: {prereleaseMessage: string}) {
+      const choice = await select({
+        choices: [
+          {
+            name: 'Disable auto-updates for this build and continue',
+            value: 'disable-auto-updates',
+          },
+          {name: 'Cancel build', value: 'cancel'},
+        ],
+        default: 'disable-auto-updates',
+        message: styleText('yellow', prereleaseMessage),
+      })
+
+      if (choice === 'cancel') {
+        output.error('Declined to continue with build', {exit: 1})
+        return
+      }
+
+      output.warn('Auto-updates disabled for this build')
+    },
+    onPreReleaseInNonInteractiveAutoUpdate({message}: {message: string}) {
+      output.error(message, {exit: 1})
+    },
+  }
+}

--- a/packages/@sanity/cli/src/actions/build/eventListenerFactory.ts
+++ b/packages/@sanity/cli/src/actions/build/eventListenerFactory.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Output} from '@sanity/cli-core'
-import {confirm, select} from '@sanity/cli-core/ux'
+import {select} from '@sanity/cli-core/ux'
 
 /**
  * Creates check dependency event handlers that are shared between buildStudio and startStudioDevServer.
@@ -13,13 +13,6 @@ export function checkDependenciesEventListenerFactory(output: Output) {
     },
     onIncompatibleInstalledStyledComponentsVersionRange({message}: {message: string}) {
       output.warn(message)
-    },
-    async onInteractiveNonDefaultOutputDir({message}: {message: string}) {
-      const shouldClean = await confirm({
-        default: true,
-        message,
-      })
-      return {shouldClean}
     },
     onInvalidStyledComponentsVersionRange({message}: {message: string}) {
       output.error(message, {exit: 1})

--- a/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
@@ -16,6 +16,7 @@ import {getProjectById} from '../../../services/projects.js'
 import {getAppId} from '../../../util/appId.js'
 import {getPackageManagerChoice} from '../../../util/packageManager/packageManagerChoice.js'
 import {upgradePackages} from '../../../util/packageManager/upgradePackages.js'
+import {checkDependenciesEventListenerFactory} from '../../build/eventListenerFactory.js'
 import {shouldAutoUpdate} from '../../build/shouldAutoUpdate.js'
 import {devDebug} from '../devDebug.js'
 import {type DevActionOptions, type StartDevServerResult} from '../types.js'
@@ -36,7 +37,10 @@ export async function startStudioDevServer(
   // Check studio dependency versions
   await checkStudioDependencyVersions(workDir, output)
 
-  const {installedSanityVersion} = await checkRequiredDependencies(options)
+  const {installedSanityVersion} = await checkRequiredDependencies({
+    ...options,
+    ...checkDependenciesEventListenerFactory(output),
+  })
 
   // Check if auto-updates are enabled
   const autoUpdatesEnabled = shouldAutoUpdate({cliConfig, flags, output})


### PR DESCRIPTION
### Description

This PR moves all user interactivity (except for a couple of log outputs) out of cli-build so that we can customize how events are handled in the Runtime CLI.

This a breaking change and the interface is pretty ugly but it works and solves two problems.
1. Spinners are started during the build which conflicts with the spinner that is used in the runtime cli.
2. output.error can exit at anytime making clean up impossible

### Testing

Updated all related tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major breaking change to @sanity/cli-build public build APIs; any direct consumers must implement event listeners or builds may silently no-op on errors. Build and auto-update paths are behavior-sensitive but logic is largely moved, not rewritten.
> 
> **Overview**
> **`@sanity/cli-build` no longer drives prompts, spinners, or fatal `output.error` during builds**—callers must supply an `eventListener` on `buildApp` / `buildStudio` and pass dependency-check callbacks into `checkRequiredDependencies`. This is a **major** API change so the Runtime CLI can own UX (avoid nested spinners and abrupt exits that block cleanup).
> 
> Build flows now **emit events** instead of calling `@sanity/cli-core/ux` directly: prerelease auto-update handling, version-mismatch choices (including package upgrades), output-dir cleanup confirmation, clean/build spinner lifecycle, styled-components validation, and build failure reporting. **`upgradePackages` is removed** from internal studio build options; upgrade behavior lives in the studio listener in `@sanity/cli`.
> 
> **`@sanity/cli`** wires the previous behavior back in via `eventListenerFactory` (`preReleaseEventListenerFactory`, `checkDependenciesEventListenerFactory`) and studio-specific handlers for spinners, confirms, selects, and errors. Dev server startup reuses the dependency-check factory when calling `checkRequiredDependencies`. Tests in cli-build assert listener calls instead of mocking UX primitives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2481cfdd1a3dda70d67acbfb52496bda6aa095a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->