### PR TITLE
fix(cli): honor packageManager field and check package-lock.json last when detecting package manager

### DIFF
--- a/.changeset/eight-radios-wonder.md
+++ b/.changeset/eight-radios-wonder.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+fix(cli): honor packageManager field and check package-lock.json last when detecting package manager

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/preferredPm.test.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {preferredPm} from '../preferredPm.js'
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  },
+}))
+
+const mockExistsSync = vi.mocked(fs.existsSync)
+const mockReadFileSync = vi.mocked(fs.readFileSync)
+
+describe('preferredPm', () => {
+  const projectDir = path.resolve('/project')
+  let files: Map<string, string>
+
+  beforeEach(() => {
+    files = new Map()
+    mockExistsSync.mockImplementation((filePath) => files.has(String(filePath)))
+    mockReadFileSync.mockImplementation((filePath) => {
+      const contents = files.get(String(filePath))
+      if (contents === undefined) throw new Error(`ENOENT: ${String(filePath)}`)
+      return contents
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function addFile(relativePath: string, contents = ''): void {
+    files.set(path.join(projectDir, relativePath), contents)
+  }
+
+  test('prioritizes packageManager over lock files and devEngines', () => {
+    addFile(
+      'package.json',
+      JSON.stringify({
+        devEngines: {packageManager: {name: 'npm'}},
+        packageManager: 'pnpm@9.1.2',
+      }),
+    )
+    addFile('package-lock.json')
+
+    expect(preferredPm(projectDir)).toBe('pnpm')
+  })
+
+  test('supports hashed packageManager versions', () => {
+    addFile(
+      'package.json',
+      JSON.stringify({
+        packageManager: 'yarn@4.1.0+sha224.fd21d9eb5fba020083811af1d4953acc21eeb9f6',
+      }),
+    )
+
+    expect(preferredPm(projectDir)).toBe('yarn')
+  })
+
+  test('falls back from an unknown packageManager to devEngines', () => {
+    addFile(
+      'package.json',
+      JSON.stringify({
+        devEngines: {packageManager: {name: 'bun'}},
+        packageManager: 'unknown@1.0.0',
+      }),
+    )
+
+    expect(preferredPm(projectDir)).toBe('bun')
+  })
+
+  test('supports a single-entry array of devEngines package managers', () => {
+    addFile('package.json', JSON.stringify({devEngines: {packageManager: [{name: 'yarn'}]}}))
+
+    expect(preferredPm(projectDir)).toBe('yarn')
+  })
+
+  test('ignores multiple alternative devEngines package managers', () => {
+    addFile(
+      'package.json',
+      JSON.stringify({devEngines: {packageManager: [{name: 'yarn'}, {name: 'npm'}]}}),
+    )
+    addFile('package-lock.json')
+
+    expect(preferredPm(projectDir)).toBe('npm')
+  })
+
+  test.each([
+    ['a malformed declaration', {packageManager: 'pnpm'}],
+    ['an unknown package manager', {packageManager: {name: 'unknown'}}],
+  ])('ignores %s in devEngines', (_, devEngines) => {
+    addFile('package.json', JSON.stringify({devEngines}))
+    addFile('package-lock.json')
+
+    expect(preferredPm(projectDir)).toBe('npm')
+  })
+
+  test('falls back to lock files when package.json is malformed', () => {
+    addFile('package.json', '{invalid')
+    addFile('pnpm-lock.yaml')
+
+    expect(preferredPm(projectDir)).toBe('pnpm')
+  })
+
+  test('checks npm lock files after other package manager lock files', () => {
+    addFile('package-lock.json')
+    addFile('pnpm-lock.yaml')
+
+    expect(preferredPm(projectDir)).toBe('pnpm')
+  })
+
+  test('detects npm-shrinkwrap.json', () => {
+    addFile('npm-shrinkwrap.json')
+
+    expect(preferredPm(projectDir)).toBe('npm')
+  })
+
+  test('prioritizes a workspace packageManager over a parent pnpm lock file', () => {
+    addFile(
+      'package.json',
+      JSON.stringify({packageManager: 'yarn@4.1.0', workspaces: ['packages/*']}),
+    )
+    addFile('pnpm-lock.yaml')
+    const childDir = path.join(projectDir, 'packages', 'child')
+    files.set(path.join(childDir, 'package.json'), JSON.stringify({name: 'child'}))
+
+    expect(preferredPm(childDir)).toBe('yarn')
+  })
+})

--- a/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
+++ b/packages/@sanity/cli/src/util/packageManager/preferredPm.ts
@@ -11,15 +11,21 @@ import {toForwardSlashes} from '../toForwardSlashes.js'
 type DetectablePackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn'
 
 /**
- * Detects the preferred package manager for a project by examining lock files,
+ * Detects the preferred package manager for a project by examining the corepack
+ * `packageManager` field, the `devEngines.packageManager` declaration, lock files,
  * workspace configurations, and node_modules markers.
  */
 export function preferredPm(pkgPath: string): DetectablePackageManager | null {
+  const fromPackageManagerField = detectFromPackageManagerField(pkgPath)
+  if (fromPackageManagerField) return fromPackageManagerField
+
   const fromLockFile = detectFromLockFile(pkgPath)
   if (fromLockFile) return fromLockFile
 
   const fromParentPnpm = findUp('pnpm-lock.yaml', pkgPath) || findUp('pnpm-workspace.yaml', pkgPath)
-  if (fromParentPnpm) return 'pnpm'
+  if (fromParentPnpm) {
+    return detectFromPackageManagerField(path.dirname(fromParentPnpm)) ?? 'pnpm'
+  }
 
   const fromWorkspace = detectFromWorkspaceRoot(pkgPath)
   if (fromWorkspace) return fromWorkspace
@@ -27,13 +33,59 @@ export function preferredPm(pkgPath: string): DetectablePackageManager | null {
   return detectFromNodeModules(pkgPath)
 }
 
+/**
+ * Detects the package manager from the corepack `packageManager` field in the
+ * package.json at `dir`, e.g. `"pnpm@9.1.2"` or `"yarn@4.1.0+sha224.…"`, falling
+ * back to the `devEngines.packageManager` declaration.
+ */
+function detectFromPackageManagerField(dir: string): DetectablePackageManager | null {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'))
+    const packageManager = manifest?.packageManager
+    if (typeof packageManager === 'string') {
+      const [tool] = packageManager.split('@', 1)
+      if (tool === 'npm' || tool === 'pnpm' || tool === 'yarn' || tool === 'bun') return tool
+    }
+    return detectFromDevEngines(manifest?.devEngines)
+  } catch {
+    // missing or malformed package.json — fall through to other detection strategies
+    return null
+  }
+}
+
+/**
+ * Detects the package manager from a `devEngines.packageManager` declaration
+ * (https://docs.npmjs.com/cli/configuring-npm/package-json#devengines).
+ * The field is an object (`{name: 'pnpm', …}`) or an array of such objects,
+ * where arrays represent alternatives rather than an order of preference. A
+ * single-entry array is unambiguous; arrays with multiple entries are ignored.
+ * Malformed shapes and unknown names are also ignored.
+ */
+function detectFromDevEngines(devEngines: unknown): DetectablePackageManager | null {
+  if (!devEngines || typeof devEngines !== 'object') return null
+  const packageManager = (devEngines as Record<string, unknown>).packageManager
+  if (Array.isArray(packageManager) && packageManager.length !== 1) return null
+  const entry = Array.isArray(packageManager) ? packageManager[0] : packageManager
+  if (!entry || typeof entry !== 'object') return null
+  const name = (entry as Record<string, unknown>).name
+  if (name === 'npm' || name === 'pnpm' || name === 'yarn' || name === 'bun') return name
+  return null
+}
+
 function detectFromLockFile(dir: string): DetectablePackageManager | null {
-  if (fs.existsSync(path.join(dir, 'package-lock.json'))) return 'npm'
   if (fs.existsSync(path.join(dir, 'yarn.lock'))) return 'yarn'
-  if (fs.existsSync(path.join(dir, 'pnpm-lock.yaml'))) return 'pnpm'
-  if (fs.existsSync(path.join(dir, 'shrinkwrap.yaml'))) return 'pnpm'
+  if (
+    fs.existsSync(path.join(dir, 'pnpm-lock.yaml')) ||
+    fs.existsSync(path.join(dir, 'shrinkwrap.yaml'))
+  )
+    return 'pnpm'
   if (fs.existsSync(path.join(dir, 'bun.lockb')) || fs.existsSync(path.join(dir, 'bun.lock')))
     return 'bun'
+  if (
+    fs.existsSync(path.join(dir, 'package-lock.json')) ||
+    fs.existsSync(path.join(dir, 'npm-shrinkwrap.json'))
+  )
+    return 'npm'
   return null
 }
 
@@ -80,7 +132,7 @@ function detectFromWorkspaceRoot(pkgPath: string): DetectablePackageManager | nu
           const matchDir = packageDir === dir ? resolvedPkgPath : packageDir
           const relativePath = toForwardSlashes(path.relative(dir, matchDir))
           if (relativePath === '' || picomatch.isMatch(relativePath, workspaces)) {
-            return detectFromLockFile(dir) ?? 'yarn'
+            return detectFromPackageManagerField(dir) ?? detectFromLockFile(dir) ?? 'yarn'
           }
         }
       } catch {

--- a/packages/@sanity/cli/test/integration/util/packageManager/preferredPm.test.ts
+++ b/packages/@sanity/cli/test/integration/util/packageManager/preferredPm.test.ts
@@ -48,10 +48,151 @@ describe('preferredPm', () => {
       expect(preferredPm(tmpDir)).toBe('bun')
     })
 
-    it('prioritizes package-lock.json over yarn.lock', () => {
+    it('prioritizes yarn.lock over a stray package-lock.json', () => {
       fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
       fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '')
+      expect(preferredPm(tmpDir)).toBe('yarn')
+    })
+
+    it('prioritizes pnpm-lock.yaml over a stray package-lock.json', () => {
+      fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
+      fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('returns npm when package-lock.json is the only lock file', () => {
+      fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
       expect(preferredPm(tmpDir)).toBe('npm')
+    })
+
+    it('returns npm when npm-shrinkwrap.json is the only lock file', () => {
+      fs.writeFileSync(path.join(tmpDir, 'npm-shrinkwrap.json'), '{}')
+      expect(preferredPm(tmpDir)).toBe('npm')
+    })
+
+    it('prioritizes pnpm-lock.yaml over a stray npm-shrinkwrap.json', () => {
+      fs.writeFileSync(path.join(tmpDir, 'npm-shrinkwrap.json'), '{}')
+      fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+  })
+
+  describe('packageManager field detection', () => {
+    it('prioritizes the packageManager field over package-lock.json', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({packageManager: 'pnpm@9.1.2'}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('returns yarn for a packageManager field with a hash suffix', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({
+          packageManager: 'yarn@4.1.0+sha224.fd21d9eb5fba020083811af1d4953acc21eeb9f6',
+        }),
+      )
+      expect(preferredPm(tmpDir)).toBe('yarn')
+    })
+
+    it('returns bun for a bun packageManager field', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({packageManager: 'bun@1.1.0'}),
+      )
+      expect(preferredPm(tmpDir)).toBe('bun')
+    })
+
+    it('ignores a malformed packageManager field and falls back to lock files', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({packageManager: 'not-a-real-pm@1.0.0'}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('accepts a packageManager field without a version', () => {
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({packageManager: 'pnpm'}))
+      fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '')
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('returns the package manager declared in devEngines.packageManager', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({devEngines: {packageManager: {name: 'pnpm'}}}),
+      )
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('prioritizes the packageManager field over devEngines when both are present', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({
+          devEngines: {packageManager: {name: 'yarn'}},
+          packageManager: 'pnpm@9.1.2',
+        }),
+      )
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('prioritizes devEngines.packageManager over package-lock.json', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({devEngines: {packageManager: {name: 'yarn'}}}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
+      expect(preferredPm(tmpDir)).toBe('yarn')
+    })
+
+    it('uses a single entry when devEngines.packageManager is an array', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({devEngines: {packageManager: [{name: 'bun'}]}}),
+      )
+      expect(preferredPm(tmpDir)).toBe('bun')
+    })
+
+    it('ignores multiple alternatives in a devEngines.packageManager array', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({devEngines: {packageManager: [{name: 'bun'}, {name: 'yarn'}]}}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
+      expect(preferredPm(tmpDir)).toBe('npm')
+    })
+
+    it('ignores malformed devEngines shapes and falls back to lock files', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({devEngines: {packageManager: 'pnpm'}}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '')
+      expect(preferredPm(tmpDir)).toBe('yarn')
+    })
+
+    it('ignores unknown devEngines package manager names', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({devEngines: {packageManager: {name: 'not-a-real-pm'}}}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+      expect(preferredPm(tmpDir)).toBe('pnpm')
+    })
+
+    it('prioritizes the workspace root packageManager field over its lock file', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({packageManager: 'yarn@4.1.0', workspaces: ['packages/*']}),
+      )
+      fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+      const childDir = path.join(tmpDir, 'packages', 'child')
+      fs.mkdirSync(childDir, {recursive: true})
+      fs.writeFileSync(path.join(childDir, 'package.json'), JSON.stringify({name: 'child'}))
+      expect(preferredPm(childDir)).toBe('yarn')
     })
   })
 


### PR DESCRIPTION
https://sanity-io.slack.com/archives/C08QMPTJPJQ/p1784756377300309

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI utility change with broad unit/integration test coverage; behavior shifts only affect which package manager commands the CLI runs, not auth or data.
> 
> **Overview**
> Updates **`preferredPm`** in `@sanity/cli` so the Sanity CLI picks the right install tool when projects declare Corepack/npm metadata or have leftover npm lockfiles.
> 
> **`package.json` is consulted first:** corepack **`packageManager`** (including hashed versions) wins over lock files; unknown values fall through to **`devEngines.packageManager`** (single object or one-element array only—multi-entry arrays are ignored). Workspace roots and parent pnpm monorepos use the same field before defaulting to lock-based pnpm.
> 
> **Lock-file heuristics change:** npm is inferred from **`package-lock.json`** / **`npm-shrinkwrap.json`** only after yarn, pnpm, and bun locks, so a stray npm lock no longer overrides the real package manager.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e4be492a04dbd7a2861a98f22742f4f138b529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->