### PR TITLE
fix(cli): move --with-token argument to be first in sanity login

### DIFF
--- a/.changeset/swift-houses-nail.md
+++ b/.changeset/swift-houses-nail.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+fix(cli): move --with-token argument to be first in sanity login

--- a/packages/@sanity/cli/README.md
+++ b/packages/@sanity/cli/README.md
@@ -2616,14 +2616,14 @@ Log in to your Sanity account
 
 ```
 USAGE
-  $ sanity login [--open] [--provider <providerId> | --sso <slug> | --with-token] [--sso-provider <name> ]
+  $ sanity login [--with-token | --provider <providerId> | --sso <slug>] [--open] [--sso-provider <name> ]
 
 FLAGS
+  --with-token             Read token from standard input
   --[no-]open              Open a browser window to log in (`--no-open` only prints URL)
   --provider=<providerId>  Log in using a provider ID (google, github, sanity, vercel)
   --sso=<slug>             Log in using Single Sign-On, using the given organization slug
   --sso-provider=<name>    Select a specific SSO provider by name (use with --sso)
-  --with-token             Read token from standard input
 
 DESCRIPTION
   Log in to your Sanity account
@@ -2632,6 +2632,10 @@ EXAMPLES
   Log in using default settings
 
     $ sanity login
+
+  Log in using a token from standard input
+
+    $ sanity login --with-token < token.txt
 
   Login with GitHub provider, but do not open a browser window automatically
 
@@ -2644,10 +2648,6 @@ EXAMPLES
   Log in using a specific SSO provider within an organization
 
     $ sanity login --sso my-organization --sso-provider "Okta SSO"
-
-  Log in using a token from standard input
-
-    $ sanity login --with-token < token.txt
 ```
 
 ## `sanity logout`

--- a/packages/@sanity/cli/src/SanityHelp.ts
+++ b/packages/@sanity/cli/src/SanityHelp.ts
@@ -1,4 +1,4 @@
-import {Command, Help, Interfaces} from '@oclif/core'
+import {Command, CommandHelp, Help, Interfaces} from '@oclif/core'
 import {getBinCommand, getRunningPackageManager} from '@sanity/cli-core/package-manager'
 
 import {topicAliases} from './topicAliases.js'
@@ -48,6 +48,12 @@ export default class SanityHelp extends Help {
 
   protected formatTopic(topic: Interfaces.Topic): string {
     return prefixBinName(super.formatTopic(topic))
+  }
+
+  protected override getCommandHelpClass(command: Command.Loadable): CommandHelp {
+    const commandHelp = super.getCommandHelpClass(command)
+    if (command.id === 'login') commandHelp.opts.flagSortOrder = 'none'
+    return commandHelp
   }
 
   async showHelp(argv: string[]): Promise<void> {

--- a/packages/@sanity/cli/src/SanityHelp.ts
+++ b/packages/@sanity/cli/src/SanityHelp.ts
@@ -52,7 +52,9 @@ export default class SanityHelp extends Help {
 
   protected override getCommandHelpClass(command: Command.Loadable): CommandHelp {
     const commandHelp = super.getCommandHelpClass(command)
-    if (command.id === 'login') commandHelp.opts.flagSortOrder = 'none'
+    if (command.id === 'login') {
+      commandHelp.opts = {...commandHelp.opts, flagSortOrder: 'none'}
+    }
     return commandHelp
   }
 

--- a/packages/@sanity/cli/src/__tests__/SanityHelp.test.ts
+++ b/packages/@sanity/cli/src/__tests__/SanityHelp.test.ts
@@ -17,13 +17,10 @@ class TestSanityHelp extends SanityHelp {
 const testConfig = {topicSeparator: ':'} as Interfaces.Config
 
 describe('getCommandHelpClass', () => {
-  test('preserves flag definition order for login help', () => {
+  test('preserves flag definition order only for login help', () => {
     const help = new TestSanityHelp(testConfig, {flagSortOrder: 'alphabetical'})
-    expect(help.getFlagSortOrder('login')).toBe('none')
-  })
 
-  test('retains the configured flag order for other commands', () => {
-    const help = new TestSanityHelp(testConfig, {flagSortOrder: 'alphabetical'})
+    expect(help.getFlagSortOrder('login')).toBe('none')
     expect(help.getFlagSortOrder('build')).toBe('alphabetical')
   })
 })

--- a/packages/@sanity/cli/src/__tests__/SanityHelp.test.ts
+++ b/packages/@sanity/cli/src/__tests__/SanityHelp.test.ts
@@ -1,10 +1,32 @@
+import {type Command, type Interfaces} from '@oclif/core'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {
+import SanityHelp, {
   prefixBinName,
   replaceInitWithCreateCommand,
   resolveTopicAliasInArgv,
 } from '../SanityHelp.js'
+
+class TestSanityHelp extends SanityHelp {
+  getFlagSortOrder(commandId: string) {
+    const command = {id: commandId} as Command.Loadable
+    return this.getCommandHelpClass(command).opts.flagSortOrder
+  }
+}
+
+const testConfig = {topicSeparator: ':'} as Interfaces.Config
+
+describe('getCommandHelpClass', () => {
+  test('preserves flag definition order for login help', () => {
+    const help = new TestSanityHelp(testConfig, {flagSortOrder: 'alphabetical'})
+    expect(help.getFlagSortOrder('login')).toBe('none')
+  })
+
+  test('retains the configured flag order for other commands', () => {
+    const help = new TestSanityHelp(testConfig, {flagSortOrder: 'alphabetical'})
+    expect(help.getFlagSortOrder('build')).toBe('alphabetical')
+  })
+})
 
 describe('prefixBinName', () => {
   afterEach(() => {

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -220,6 +220,14 @@ describe('#login', {timeout: 10_000}, () => {
     expect(LoginCommand.flags.provider.description).toContain(LOGIN_PROVIDER_IDS.join(', '))
   })
 
+  test('defines --with-token as the first visible flag', () => {
+    const visibleFlags = Object.entries(LoginCommand.flags)
+      .filter(([, flag]) => !flag.hidden)
+      .map(([name]) => name)
+
+    expect(visibleFlags[0]).toBe('with-token')
+  })
+
   describe('Token Login', () => {
     test('stores a valid token', async () => {
       mockedGetCliToken.mockResolvedValue('')

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -15,6 +15,10 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
       description: 'Log in using default settings',
     },
     {
+      command: '<%= config.bin %> <%= command.id %> --with-token < token.txt',
+      description: 'Log in using a token from standard input',
+    },
+    {
       command: '<%= config.bin %> <%= command.id %> --provider github --no-open',
       description: 'Login with GitHub provider, but do not open a browser window automatically',
     },
@@ -27,12 +31,13 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
         '<%= config.bin %> <%= command.id %> --sso my-organization --sso-provider "Okta SSO"',
       description: 'Log in using a specific SSO provider within an organization',
     },
-    {
-      command: '<%= config.bin %> <%= command.id %> --with-token < token.txt',
-      description: 'Log in using a token from standard input',
-    },
   ]
   static override flags = {
+    'with-token': Flags.boolean({
+      description: 'Read token from standard input',
+      exclusive: ['provider', 'sso'],
+    }),
+    // eslint-disable-next-line perfectionist/sort-objects -- Keep token login first in generated usage.
     experimental: Flags.boolean({
       default: false,
       hidden: true,
@@ -56,10 +61,6 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
       dependsOn: ['sso'],
       description: 'Select a specific SSO provider by name (use with --sso)',
       helpValue: '<name>',
-    }),
-    'with-token': Flags.boolean({
-      description: 'Read token from standard input',
-      exclusive: ['provider', 'sso'],
     }),
   } satisfies FlagInput
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and help formatting only; login behavior and auth logic are unchanged.
> 
> **Overview**
> **`sanity login` help now surfaces `--with-token` first** so CI/token-based login is easier to discover in `sanity help login` and the generated CLI README.
> 
> The **`--with-token` flag is defined first** on `LoginCommand`, with an eslint exception so object sort rules do not reorder it. The **token stdin example is moved up** in the command examples. **`SanityHelp` disables alphabetical flag sorting for `login` only** (`flagSortOrder: 'none'`), so USAGE/FLAGS keep definition order while other commands stay alphabetical.
> 
> Tests lock in **login-only help ordering** and **first visible flag is `with-token`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51bfa67ab15c35cfc39afa171d25dfbcea29e205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->