### PR TITLE
fix(workbench): validate app config at build, dev, and deploy

### DIFF
--- a/.changeset/pr-1590.md
+++ b/.changeset/pr-1590.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/workbench-cli': patch
+---
+
+fix(workbench): validate app config at build, dev, and deploy

--- a/fixtures/federated-studio/sanity.cli.ts
+++ b/fixtures/federated-studio/sanity.cli.ts
@@ -10,6 +10,8 @@ export default defineCliConfig({
   app: unstable_defineApp({
     name: 'federated-studio',
     organizationId: 'oSyH1iET5',
+    slug: 'federated-studio',
+    title: 'Federated Studio',
   }),
   deployment: {
     autoUpdates: true,

--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -2,6 +2,7 @@ import {type ApplicationType, type AppVisibility} from '@sanity/cli-core'
 import {describe, expect, expectTypeOf, test} from 'vitest'
 
 import {
+  type DefineAppInput,
   DefineAppInputSchema,
   type DefineAppResult,
   type DockGroup,
@@ -232,6 +233,34 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     expect(dupes.error?.issues[0]?.message).toMatch(/unique/)
   })
 
+  test('rejects declaring both an entry and panel views', () => {
+    const result = DefineAppInputSchema.safeParse(
+      validInput({
+        entry: './src/App.tsx',
+        views: [{name: 'feed', src: './src/panel.tsx', type: 'panel'}],
+      }),
+    )
+    expect(result.success).toBe(false)
+    expect(result.error?.issues.some((issue) => /cannot expose both/.test(issue.message))).toBe(
+      true,
+    )
+  })
+
+  test('rejects more than one panel view', () => {
+    const result = DefineAppInputSchema.safeParse(
+      validInput({
+        views: [
+          {name: 'feed', src: './src/a.tsx', type: 'panel'},
+          {name: 'inbox', src: './src/b.tsx', type: 'panel'},
+        ],
+      }),
+    )
+    expect(result.success).toBe(false)
+    expect(result.error?.issues.some((issue) => /at most one panel view/.test(issue.message))).toBe(
+      true,
+    )
+  })
+
   test('rejects `entry` on a studio with a not-yet-implemented error', () => {
     const result = DefineAppInputSchema.safeParse(
       validInput({applicationType: 'studio', entry: './src/App.tsx'}),
@@ -270,6 +299,23 @@ describe('type surface', () => {
     expectTypeOf<DefineAppResult>().not.toHaveProperty('applicationType')
     expectTypeOf<DefineAppResult>().not.toHaveProperty('isSingleton')
     expectTypeOf<DefineAppResult>().not.toHaveProperty('config')
+  })
+})
+
+describe('interface union (entry vs views)', () => {
+  type Base = {name: string; organizationId: string; slug: string; title: string}
+  type PanelView = {name: string; src: string; type: 'panel'}
+
+  test('allows an app entry without panel views', () => {
+    expectTypeOf<Base & {entry: string}>().toExtend<DefineAppInput>()
+  })
+
+  test('allows panel views without an app entry', () => {
+    expectTypeOf<Base & {views: PanelView[]}>().toExtend<DefineAppInput>()
+  })
+
+  test('rejects declaring an app entry and panel views together', () => {
+    expectTypeOf<Base & {entry: string; views: PanelView[]}>().not.toExtend<DefineAppInput>()
   })
 })
 

--- a/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
@@ -1,7 +1,7 @@
 import {type CliConfig} from '@sanity/cli-core'
 import {describe, expect, test} from 'vitest'
 
-import {unstable_defineApp, unstable_defineMediaLibrary} from '../defineApp.js'
+import {type DefineAppInput, unstable_defineApp, unstable_defineMediaLibrary} from '../defineApp.js'
 import {resolveWorkbenchApp} from '../resolveWorkbenchApp.js'
 
 const asConfig = (app: unknown) => ({app}) as CliConfig
@@ -39,7 +39,7 @@ describe('resolveWorkbenchApp', () => {
     })
   })
 
-  test('passes through declared views, services, entry, slug, and visibility', () => {
+  test('passes through a declared app entry, services, slug, and visibility', () => {
     const config = asConfig(
       unstable_defineApp({
         entry: './src/App.tsx',
@@ -48,19 +48,49 @@ describe('resolveWorkbenchApp', () => {
         services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
         slug: 'my-app-host',
         title: 'My App',
-        views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],
         visibility: 'unlisted',
       }),
     )
 
-    const resolved = resolveWorkbenchApp(config)
-    expect(resolved).toMatchObject({
+    expect(resolveWorkbenchApp(config)).toMatchObject({
       entry: './src/App.tsx',
       services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
       slug: 'my-app-host',
-      views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],
       visibility: 'unlisted',
     })
+  })
+
+  test('passes through declared panel views and services', () => {
+    const config = asConfig(
+      unstable_defineApp({
+        name: 'my-app',
+        organizationId: 'org-123',
+        services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
+        slug: 'my-app-host',
+        title: 'My App',
+        views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],
+      }),
+    )
+
+    expect(resolveWorkbenchApp(config)).toMatchObject({
+      services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
+      views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],
+    })
+  })
+
+  test('throws when an app declares both an entry and panel views', () => {
+    const config = asConfig(
+      unstable_defineApp({
+        entry: './src/App.tsx',
+        name: 'my-app',
+        organizationId: 'org-123',
+        slug: 'my-app',
+        title: 'My App',
+        views: [{name: 'feed', src: './src/Feed.tsx', type: 'panel'}],
+      } as unknown as DefineAppInput),
+    )
+
+    expect(() => resolveWorkbenchApp(config)).toThrow('cannot expose both an app view')
   })
 
   test('resolves a media library singleton and its config', () => {
@@ -89,6 +119,7 @@ describe('resolveWorkbenchApp', () => {
         config: {appType: 'media-library', fields: []},
         name: 'my-app',
         organizationId: 'org-123',
+        slug: 'my-app',
         title: 'My App',
       }),
     )

--- a/packages/@sanity/workbench-cli/src/__tests__/validateWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/validateWorkbenchApp.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, test} from 'vitest'
+
+import {formatWorkbenchAppErrors, validateWorkbenchApp} from '../validateWorkbenchApp.js'
+
+/** A minimal valid app; spread overrides to vary the fields under test. */
+const app = (overrides: Record<string, unknown> = {}) => ({
+  name: 'test-app',
+  organizationId: 'org-1',
+  slug: 'test-app',
+  title: 'Test App',
+  ...overrides,
+})
+
+const panel = {name: 'feed', src: './src/Feed.tsx', type: 'panel'}
+
+describe('validateWorkbenchApp', () => {
+  test('returns no errors for a valid app', () => {
+    expect(validateWorkbenchApp(app({views: [panel]}))).toEqual([])
+  })
+
+  test('validates the whole input, not just interfaces', () => {
+    expect(validateWorkbenchApp(app({name: 'bad name!'}))).toContainEqual(
+      expect.stringMatching(/name: App `name` must match/),
+    )
+  })
+
+  test('reports the app-view / panel exclusion', () => {
+    expect(validateWorkbenchApp(app({entry: './src/App.tsx', views: [panel]}))).toContainEqual(
+      expect.stringContaining('cannot expose both an app view (`entry`) and panel views'),
+    )
+  })
+
+  test('reports more than one panel view', () => {
+    expect(
+      validateWorkbenchApp(
+        app({views: [panel, {name: 'inbox', src: './src/Inbox.tsx', type: 'panel'}]}),
+      ),
+    ).toContainEqual(expect.stringContaining('at most one panel view'))
+  })
+
+  test('locates a malformed declaration', () => {
+    expect(validateWorkbenchApp(app({views: [{...panel, name: 'views/feed'}]}))).toContainEqual(
+      expect.stringMatching(/views\.0\.name: View `name` must match/),
+    )
+  })
+
+  test('collects every error at once so they can be fixed together', () => {
+    const errors = validateWorkbenchApp(
+      app({
+        entry: './src/App.tsx',
+        name: 'bad!',
+        views: [panel, {name: 'inbox', src: './src/Inbox.tsx', type: 'panel'}],
+      }),
+    )
+    expect(errors).toContainEqual(expect.stringMatching(/name: App `name` must match/))
+    expect(errors).toContainEqual(expect.stringContaining('cannot expose both an app view'))
+    expect(errors).toContainEqual(expect.stringContaining('at most one panel view'))
+  })
+})
+
+describe('formatWorkbenchAppErrors', () => {
+  test('renders every error as a single message', () => {
+    expect(formatWorkbenchAppErrors(['first', 'second'])).toBe(
+      'Invalid workbench app config:\n  - first\n  - second',
+    )
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/getWorkbench.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/getWorkbench.test.ts
@@ -16,6 +16,7 @@ function workbench(overrides: Partial<DefineAppInput> = {}) {
   const app = unstable_defineApp({
     name: 'test-app',
     organizationId: 'org-id',
+    slug: 'test-app',
     title: 'Test App',
     ...overrides,
   })
@@ -42,13 +43,16 @@ describe('getWorkbench', () => {
 
   test('exposes the declared interfaces off the branded app', () => {
     const resolved = workbench({
-      entry: './src/App.tsx',
-      services: [{name: 'services/sync', src: './src/sync.ts', type: 'worker'}],
-      views: [{name: 'views/panel', src: './src/panel.tsx', type: 'panel'}],
+      services: [{name: 'sync', src: './src/sync.ts', type: 'worker'}],
+      views: [{name: 'panel', src: './src/panel.tsx', type: 'panel'}],
     })
-    expect(resolved.entry).toBe('./src/App.tsx')
     expect(resolved.views).toHaveLength(1)
     expect(resolved.services).toHaveLength(1)
+  })
+
+  test('exposes an entry app off the branded app', () => {
+    const resolved = workbench({entry: './src/App.tsx'})
+    expect(resolved.entry).toBe('./src/App.tsx')
   })
 
   test('exposes the config off a branded media library', () => {
@@ -85,7 +89,7 @@ describe('assertDeployable', () => {
   test('passes when the app declares a view', () => {
     expect(() =>
       workbench({
-        views: [{name: 'views/panel', src: './src/panel.tsx', type: 'panel'}],
+        views: [{name: 'panel', src: './src/panel.tsx', type: 'panel'}],
       }).assertDeployable(),
     ).not.toThrow()
   })
@@ -93,7 +97,7 @@ describe('assertDeployable', () => {
   test('passes when the app declares a service', () => {
     expect(() =>
       workbench({
-        services: [{name: 'services/sync', src: './src/sync.ts', type: 'worker'}],
+        services: [{name: 'sync', src: './src/sync.ts', type: 'worker'}],
       }).assertDeployable(),
     ).not.toThrow()
   })
@@ -128,7 +132,7 @@ describe('deploySingletonConfig / hasInterfaces', () => {
 
   test('a non-singleton app never deploys a config, and reports its interfaces', () => {
     const resolved = workbench({
-      views: [{name: 'views/panel', src: './src/panel.tsx', type: 'panel'}],
+      views: [{name: 'panel', src: './src/panel.tsx', type: 'panel'}],
     })
     expect(resolved.deploySingletonConfig).toBe(false)
     expect(resolved.hasInterfaces).toBe(true)

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -60,13 +60,20 @@ describe('deriveInterfaces', () => {
   })
 
   test('stamps the moduleId a deploy would, so a local interface resolves like a deployed one', () => {
-    const app = workbenchApp({
-      entry: './src/App.tsx',
+    const panelApp = workbenchApp({
       services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
     })
-    expect(deriveInterfaces(app, {isApp: true})?.map((iface) => iface.moduleId)).toEqual([
+    expect(deriveInterfaces(panelApp, {isApp: true})?.map((iface) => iface.moduleId)).toEqual([
       'views/feed',
+      'services/unread',
+    ])
+
+    const entryApp = workbenchApp({
+      entry: './src/App.tsx',
+      services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+    })
+    expect(deriveInterfaces(entryApp, {isApp: true})?.map((iface) => iface.moduleId)).toEqual([
       'services/unread',
       'App',
     ])
@@ -75,7 +82,7 @@ describe('deriveInterfaces', () => {
   test('carries null metadata on every interface (not yet populated)', () => {
     const app = workbenchApp({
       entry: './src/App.tsx',
-      views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
+      services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
     })
     expect(deriveInterfaces(app, {isApp: true})?.every((iface) => iface.metadata === null)).toBe(
       true,
@@ -88,9 +95,8 @@ describe('deriveInterfaces', () => {
     expect(result?.some((iface) => iface.type === 'app')).toBe(false)
   })
 
-  test('combines views, services, and the app view (in that order)', () => {
+  test('orders a panel view ahead of services', () => {
     const app = workbenchApp({
-      entry: './src/App.tsx',
       name: 'my-app',
       services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
@@ -116,6 +122,26 @@ describe('deriveInterfaces', () => {
         type: 'worker',
         version: '1',
       },
+    ])
+  })
+
+  test('places the app view after services', () => {
+    const app = workbenchApp({
+      entry: './src/App.tsx',
+      name: 'my-app',
+      services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {
+        id: 'my-app-worker-unread',
+        metadata: null,
+        moduleId: 'services/unread',
+        name: 'unread',
+        src: './src/service.ts',
+        title: 'unread',
+        type: 'worker',
+        version: '1',
+      },
       {
         id: 'my-app-app-my-app',
         metadata: null,
@@ -130,14 +156,26 @@ describe('deriveInterfaces', () => {
 
   test('derives a unique id per interface, disambiguating a view and service that share a name', () => {
     const app = workbenchApp({
-      entry: './src/App.tsx',
       name: 'my-app',
       services: [{name: 'sync', src: './src/sync.ts', type: 'worker'}],
       views: [{name: 'sync', src: './src/SyncPanel.tsx', type: 'panel'}],
     })
     const ids = deriveInterfaces(app, {isApp: true})?.map((iface) => iface.id) ?? []
-    expect(ids).toEqual(['my-app-panel-sync', 'my-app-worker-sync', 'my-app-app-my-app'])
+    expect(ids).toEqual(['my-app-panel-sync', 'my-app-worker-sync'])
     expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  test('derives interfaces best-effort without validating them', () => {
+    // Validation is the caller's job (build/deploy throw, dev logs) — deriving
+    // stays pure, so an invalid combination still maps to its records.
+    const app = workbenchApp({
+      entry: './src/App.tsx',
+      views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})?.map((iface) => iface.type)).toEqual([
+      'panel',
+      'app',
+    ])
   })
 
   test('does not put the config in the interface set', () => {
@@ -146,6 +184,7 @@ describe('deriveInterfaces', () => {
         appType: 'media-library',
         fields: [{name: 'description', src: './src/description.ts', title: 'Description'}],
       },
+      isSingleton: true,
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
     })
     // only the panel — the config rides deriveConfigs, not interfaces

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
@@ -32,6 +32,7 @@ export function workbenchApp(overrides: Record<string, unknown> = {}): CliConfig
   return unstable_defineApp({
     name: 'test-app',
     organizationId: 'org-123',
+    slug: 'test-app',
     title: 'Test App',
     ...overrides,
   }) as unknown as CliConfig['app']

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevServerRegistration.test.ts
@@ -107,6 +107,29 @@ describe('startDevServerRegistration', () => {
     )
   })
 
+  test('logs an invalid config and keeps the dev server running', async () => {
+    const output = createMockOutput()
+    const handle = await register({
+      cliConfig: workbenchCliConfig({
+        app: workbenchApp({
+          views: [
+            {name: 'feed', src: './src/Feed.tsx', type: 'panel'},
+            {name: 'inbox', src: './src/Inbox.tsx', type: 'panel'},
+          ],
+        }),
+      }),
+      output,
+    })
+
+    // Registration still completed rather than throwing.
+    expect(handle.close).toBeInstanceOf(Function)
+    expect(mockRegisterDevServer).toHaveBeenCalled()
+    // All errors are reported in a single message, not one warning at a time.
+    expect(output.warn).toHaveBeenCalledTimes(1)
+    expect(output.warn).toHaveBeenCalledWith(expect.stringContaining('at most one panel view'))
+    expect(output.error).not.toHaveBeenCalled()
+  })
+
   test('omits projectId when api.projectId is not configured', async () => {
     await register()
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/startDevServerRegistration.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startDevServerRegistration.ts
@@ -2,6 +2,7 @@ import {type CliConfig, getCliConfigUncached, type Output} from '@sanity/cli-cor
 import {type ViteDevServer} from 'vite'
 
 import {resolveAppId} from '../../appId.js'
+import {formatWorkbenchAppErrors, validateWorkbenchApp} from '../../validateWorkbenchApp.js'
 import {deriveConfigs, deriveInterfaces} from './deriveInterfaces.js'
 import {trackExposesSet} from './exposesSetId.js'
 import {type DevServerManifest, registerDevServer} from './registry.js'
@@ -38,6 +39,18 @@ interface DevServerRegistrationHandle {
   close: () => Promise<void>
 }
 
+/**
+ * Log any config validation errors without aborting. Unlike build and deploy,
+ * dev stays up on an invalid config so the author sees the errors and fixes them
+ * live on the next save.
+ */
+function reportConfigErrors(app: CliConfig['app'], output: Output): void {
+  const errors = validateWorkbenchApp(app)
+  if (errors.length === 0) return
+  // `output.error` exits the process; `warn` keeps the dev server alive.
+  output.warn(formatWorkbenchAppErrors(errors))
+}
+
 /** The address the server actually bound — the live socket, which can differ from the configured port under non-strict ports. */
 function serverAddress(server: ViteDevServer) {
   const resolvedHost = server.config.server.host
@@ -59,6 +72,8 @@ export async function startDevServerRegistration(
   const {cliConfig, extractManifest, isApp, onInterfaceSetChange, output, server, workDir} = options
 
   const {host: appHost, port: appPort} = serverAddress(server)
+
+  reportConfigErrors(cliConfig.app, output)
 
   // Forwarded alongside (not inside) the manifest so the workbench renders local
   // panels/workers and reads the configs without a deploy.
@@ -86,6 +101,7 @@ export async function startDevServerRegistration(
     // so omitting would wipe the registered set.
     extract: async (params) => {
       const app = (await getCliConfigUncached(params.workDir)).app
+      reportConfigErrors(app, output)
       return {
         configs: await deriveConfigs(app),
         interfaces: deriveInterfaces(app, {isApp}),

--- a/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
@@ -22,6 +22,7 @@ function workbenchApp(): DeployableWorkbenchApp {
     app: unstable_defineApp({
       name: 'my-app',
       organizationId: 'org-1',
+      slug: 'my-app',
       title: 'My App',
       views: [{name: 'insights', src: './src/Insights.tsx', title: 'Insights', type: 'panel'}],
     }),

--- a/packages/@sanity/workbench-cli/src/defineApp.ts
+++ b/packages/@sanity/workbench-cli/src/defineApp.ts
@@ -30,9 +30,7 @@ const DockGroupSchema = z.enum(['dock.system', 'dock.applications', 'dock.user']
 export type DockGroup = z.output<typeof DockGroupSchema>
 
 /**
- * Runtime-validation schema for `unstable_defineApp`. Validates the full shape
- * including the internal `applicationType`; the user-facing `DefineAppInput`
- * type below omits that field.
+ * Runtime-validation schema for `unstable_defineApp`.
  * @internal
  */
 export const DefineAppInputSchema = z
@@ -55,7 +53,7 @@ export const DefineAppInputSchema = z
      * derives the app's navigable `app` view from it. SDK apps only — setting it
      * on a studio is rejected (studio app views are not yet implemented).
      */
-    entry: z.optional(z.string()),
+    entry: z.optional(z.string("must be a path to the app's entry file")),
     /** Dock group to render in. Defaults to `dock.applications` when omitted. */
     group: z.optional(DockGroupSchema),
     /** Optional icon override (path to an SVG). Wins over manifest/studio icon. */
@@ -73,15 +71,10 @@ export const DefineAppInputSchema = z
     ),
     /** Sort position within the group, ascending. Defaults to `100` when omitted. */
     priority: z.optional(z.number()),
-    /**
-     * Background services the app runs (e.g. a `worker` emitting dock badges).
-     * Metadata only — built into worker artifacts and persisted to the
-     * application service on deploy, not into the app manifest. Service `name`s
-     * must be unique within the app.
-     */
+    /** Background services the app runs (e.g. a `worker` emitting dock badges). */
     services: z.optional(
       z
-        .array(ServiceDeclarationSchema)
+        .array(ServiceDeclarationSchema, 'must be an array of services')
         .check(
           z.refine(
             (services) => new Set(services.map((service) => service.name)).size === services.length,
@@ -92,14 +85,10 @@ export const DefineAppInputSchema = z
     slug: z.string('App `slug` is required — the hostname the application is created at on deploy'),
     /** User-facing app title. Wins over studio.config.ts title on merge. */
     title: z.string(),
-    /**
-     * Views the app exposes (e.g. dock panels). Metadata only — built into
-     * render artifacts and persisted to the application service on deploy, not
-     * into the app manifest. View `name`s must be unique within the app.
-     */
+    /** Views the app exposes (e.g. dock panels). */
     views: z.optional(
       z
-        .array(InterfaceDeclarationSchema)
+        .array(InterfaceDeclarationSchema, 'must be an array of panels')
         .check(
           z.refine(
             (views) => new Set(views.map((view) => view.name)).size === views.length,
@@ -128,18 +117,36 @@ export const DefineAppInputSchema = z
       path: ['config'],
     }),
   )
+  .check(
+    // An app exposes one interface kind: an app view (`entry`) or panels.
+    z.refine(
+      (input) => !(input.entry !== undefined && (input.views?.length ?? 0) > 0),
+      'An app cannot expose both an app view (`entry`) and panel views. Declare one or the other.',
+    ),
+  )
+  .check(
+    z.refine(
+      (input) => (input.views?.length ?? 0) <= 1,
+      'An app can expose at most one panel view.',
+    ),
+  )
 
 /**
  * User-facing input for `unstable_defineApp`. Excludes the internal
  * `applicationType`, `isSingleton`, and `config` — validated by the
  * schema but not part of the public surface (Sanity-owned apps set them via
- * `@ts-expect-error`).
+ * `@ts-expect-error`). A union so an app declares an app `entry` or `views`,
+ * never both.
  * @public
  */
 export type DefineAppInput = Omit<
   z.output<typeof DefineAppInputSchema>,
-  'applicationType' | 'config' | 'isSingleton'
->
+  'applicationType' | 'config' | 'entry' | 'isSingleton' | 'views'
+> &
+  (
+    | {entry?: never; views?: NonNullable<z.output<typeof DefineAppInputSchema>['views']>}
+    | {entry?: string; views?: never}
+  )
 
 /**
  * Nominal brand the CLI discriminates on to enable the workbench build/deploy
@@ -154,9 +161,7 @@ const WORKBENCH_APP: unique symbol = Symbol.for('sanity.workbench.defineApp')
  * input plus the internal brand — users only ever see `DefineAppInput`.
  * @public
  */
-export interface DefineAppResult extends DefineAppInput {
-  readonly [WORKBENCH_APP]: true
-}
+export type DefineAppResult = DefineAppInput & {readonly [WORKBENCH_APP]: true}
 
 /**
  * A branded app as the CLI reads it — the full schema shape, including the

--- a/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
@@ -7,6 +7,7 @@
 import {type AppVisibility, type CliConfig} from '@sanity/cli-core'
 
 import {type DefineAppInput, isWorkbenchApp, readConfig, type WorkbenchApp} from './defineApp.js'
+import {formatWorkbenchAppErrors, validateWorkbenchApp} from './validateWorkbenchApp.js'
 
 /**
  * Bundled so adding a declaration family touches this type and the artifact
@@ -57,6 +58,9 @@ export function resolveWorkbenchApp(
 ): ResolvedWorkbenchApp | null {
   const app = cliConfig?.app
   if (!isWorkbenchApp(app)) return null
+
+  const errors = validateWorkbenchApp(app)
+  if (errors.length > 0) throw new Error(formatWorkbenchAppErrors(errors))
 
   return {
     applicationType: app.applicationType,

--- a/packages/@sanity/workbench-cli/src/validateWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/validateWorkbenchApp.ts
@@ -1,0 +1,23 @@
+import {DefineAppInputSchema} from './defineApp.js'
+
+/**
+ * Collect validation errors for a workbench app.
+ * @internal
+ */
+export function validateWorkbenchApp(app: unknown): string[] {
+  const result = DefineAppInputSchema.safeParse(app)
+  if (result.success) return []
+
+  return result.error.issues.map((issue) => {
+    const location = issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
+    return `${location}${issue.message}`
+  })
+}
+
+/**
+ * Render the errors as one message, so callers report them together.
+ * @internal
+ */
+export function formatWorkbenchAppErrors(errors: string[]): string {
+  return ['Invalid workbench app config:', ...errors.map((error) => `  - ${error}`)].join('\n')
+}


### PR DESCRIPTION
### Description

The `unstable_defineApp` result bypassed the config-load schema (`parseWorkbenchCliConfig`), so an app's config was never validated at runtime — invalid setups (an app view plus panels, more than one panel, malformed or misnamed declarations, missing required fields) only surfaced deep in a build or deploy, if at all.

Now the whole `DefineAppInputSchema` is checked at the workbench-cli entry points through a single `validateWorkbenchApp` utility that returns the errors (each prefixed with the offending field). Callers set the policy:

- Build, deploy, and preview fail fast — `resolveWorkbenchApp` throws.
- Dev logs the errors and keeps the server running, so the author can fix them on the next save.

It also tightens the interface rules from [SDK-1949](https://linear.app/sanity/issue/SDK-1949/cli-tighten-validation-for-interfaces): `entry` and `views` are mutually exclusive (a union on `unstable_defineApp`), and an app declares at most one panel.

### Testing

Unit tests cover the schema rules, the type union, the validator, the build-time throw, and the dev log-and-continue path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every workbench build, dev, and deploy path handles app config and tightens the public `unstable_defineApp` shape; invalid existing configs will now fail or warn where they previously might have proceeded.
> 
> **Overview**
> Workbench apps now run the full `DefineAppInputSchema` at CLI entry points via **`validateWorkbenchApp`**, so bad `unstable_defineApp` configs fail early with field-prefixed errors instead of surfacing deep in build or deploy.
> 
> **`resolveWorkbenchApp`** throws on validation errors (build, deploy, preview). **Dev** warns once with all issues and keeps the server running, including on config re-read from the manifest watcher. **`DefineAppInput`** is a TypeScript union: either an app **`entry`** or **`views`**, not both, and **at most one panel** view—matching new Zod refinements on the schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df1d0552f259785d554517e521ddfe1149fa4ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->