### PR TITLE
fix(cli): auto-set strictExecutionOrder when unstable_bundledDev is enabled

### DIFF
--- a/.changeset/pr-1591.md
+++ b/.changeset/pr-1591.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(cli): auto-set strictExecutionOrder when unstable_bundledDev is enabled

--- a/packages/@sanity/cli/src/server/__tests__/devServer.test.ts
+++ b/packages/@sanity/cli/src/server/__tests__/devServer.test.ts
@@ -76,6 +76,45 @@ describe('startDevServer', () => {
     )
   })
 
+  test('sets strictExecutionOrder when bundledDev is set', async () => {
+    await startDevServer(baseOptions({bundledDev: true}))
+
+    const passedConfig = mockCreateServer.mock.calls[0][0]
+    // Without this, shared chunks can evaluate before the entry chunk's
+    // react-refresh preamble and throw "@vitejs/plugin-react can't detect preamble".
+    expect(passedConfig.build.rolldownOptions.output).toEqual({strictExecutionOrder: true})
+  })
+
+  test('preserves existing rolldown output options when enabling strictExecutionOrder', async () => {
+    mockGetViteConfig.mockResolvedValue({
+      build: {rolldownOptions: {output: {exports: 'named'}}},
+      configFile: false,
+    })
+
+    await startDevServer(baseOptions({bundledDev: true}))
+
+    const passedConfig = mockCreateServer.mock.calls[0][0]
+    expect(passedConfig.build.rolldownOptions.output).toEqual({
+      exports: 'named',
+      strictExecutionOrder: true,
+    })
+  })
+
+  test('applies strictExecutionOrder to each entry when rolldown output is an array', async () => {
+    mockGetViteConfig.mockResolvedValue({
+      build: {rolldownOptions: {output: [{exports: 'named'}, {format: 'es'}]}},
+      configFile: false,
+    })
+
+    await startDevServer(baseOptions({bundledDev: true}))
+
+    const passedConfig = mockCreateServer.mock.calls[0][0]
+    expect(passedConfig.build.rolldownOptions.output).toEqual([
+      {exports: 'named', strictExecutionOrder: true},
+      {format: 'es', strictExecutionOrder: true},
+    ])
+  })
+
   test('does not touch experimental or build options when bundledDev is off', async () => {
     await startDevServer(baseOptions({bundledDev: false}))
 
@@ -105,6 +144,9 @@ describe('startDevServer', () => {
     expect(mockExtendViteConfigWithUserConfig).toHaveBeenCalledOnce()
     const configPassedToExtend = mockExtendViteConfigWithUserConfig.mock.calls[0][1]
     expect(configPassedToExtend.experimental).toEqual({bundledDev: true})
+    expect(configPassedToExtend.build.rolldownOptions.output).toEqual({
+      strictExecutionOrder: true,
+    })
 
     // ...and createServer receives the user-extended result.
     const passedConfig = mockCreateServer.mock.calls[0][0]

--- a/packages/@sanity/cli/src/server/devServer.ts
+++ b/packages/@sanity/cli/src/server/devServer.ts
@@ -128,14 +128,24 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
   // `<root>/index.html`. Sanity has no such file — it serves a virtual document
   // rewritten to `.sanity/runtime/index.html` — so point the bundler at the real
   // runtime HTML, otherwise the build fails with UNRESOLVED_ENTRY.
+  //
+  // Also force `strictExecutionOrder` so shared chunks cannot evaluate before the
+  // entry chunk's react-refresh preamble (which otherwise throws
+  // "@vitejs/plugin-react can't detect preamble").
+  // See https://github.com/vitejs/vite-plugin-react/issues/1191
   if (bundledDev) {
+    const existingRolldown = viteConfig.build?.rolldownOptions
+    const existingOutput = existingRolldown?.output
     viteConfig = {
       ...viteConfig,
       build: {
         ...viteConfig.build,
         rolldownOptions: {
-          ...viteConfig.build?.rolldownOptions,
+          ...existingRolldown,
           input: path.join(cwd, '.sanity', 'runtime', 'index.html'),
+          output: Array.isArray(existingOutput)
+            ? existingOutput.map((entry) => ({...entry, strictExecutionOrder: true}))
+            : {...existingOutput, strictExecutionOrder: true},
         },
       },
       experimental: {...viteConfig.experimental, bundledDev: true},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

When `unstable_bundledDev` is set, `sanity dev` now also enables Rolldown `build.rolldownOptions.output.strictExecutionOrder`.

Without it, shared chunks can evaluate before the entry chunk’s react-refresh preamble and throw `@vitejs/plugin-react can't detect preamble` ([vite-plugin-react#1191](https://github.com/vitejs/vite-plugin-react/issues/1191)). That option was previously wired manually in studio `sanity.cli.ts` configs (see [sanity#13573](https://github.com/sanity-io/sanity/pull/13573)); this moves it into the CLI so enabling `unstable_bundledDev` alone is enough.

User `vite` overrides in `sanity.cli.ts` still run after this and keep final say.

### What to review

- `packages/@sanity/cli/src/server/devServer.ts` — bundledDev path now sets `strictExecutionOrder` (including when existing `output` is an object or array)
- `packages/@sanity/cli/src/server/__tests__/devServer.test.ts` — coverage for the new default and merge behavior

### Testing

- Unit tests for `startDevServer` / bundledDev mode (`devServer.test.ts`) — all 8 passing
- `pnpm check:types` for `@sanity/cli`

### Notes for release

Auto-enable Rolldown `strictExecutionOrder` when `unstable_bundledDev` is set so react-refresh works without a manual Vite override

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4607a1f-53ce-40bd-8010-7415851bad5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4607a1f-53ce-40bd-8010-7415851bad5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

