### PR TITLE
feat(cli): add `sanity new` to mint unclaimed projects without logging in

### DIFF
--- a/.changeset/pr-1592.md
+++ b/.changeset/pr-1592.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+---
+
+feat(cli): add `sanity new` to mint unclaimed projects without logging in

--- a/.changeset/pr-1592.md
+++ b/.changeset/pr-1592.md
@@ -1,6 +1,7 @@
 <!-- auto-generated -->
 ---
 '@sanity/cli-core': minor
+'@sanity/cli-test': minor
 '@sanity/cli': minor
 ---
 

--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -138,6 +138,7 @@
     "tsx": "catalog:",
     "vite": "catalog:",
     "vite-node": "catalog:",
+    "wrap-ansi": "^9.0.2",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/@sanity/cli-core/package.json
+++ b/packages/@sanity/cli-core/package.json
@@ -124,6 +124,7 @@
     "@sanity/client": "catalog:",
     "boxen": "^8.0.1",
     "debug": "catalog:",
+    "dotenv": "catalog:",
     "empathic": "catalog:",
     "get-it": "^8.8.0",
     "get-tsconfig": "catalog:",

--- a/packages/@sanity/cli-core/src/_exports/config.ts
+++ b/packages/@sanity/cli-core/src/_exports/config.ts
@@ -14,6 +14,10 @@ export {
   type ConfigStore,
   type TypeGenConfig,
 } from '../config/cli/types/cliConfig.js'
+export {
+  resolveMintedProjectToken,
+  UNCLAIMED_PROJECTS_CONFIG_KEY,
+} from '../config/cli/unclaimedProjects.js'
 export {isWorkbenchApp, parseWorkbenchCliConfig} from '../config/cli/workbenchApp.js'
 export {findProjectRoot} from '../config/findProjectRoot.js'
 export {findProjectRootSync} from '../config/findProjectRootSync.js'

--- a/packages/@sanity/cli-core/src/_exports/config.ts
+++ b/packages/@sanity/cli-core/src/_exports/config.ts
@@ -17,7 +17,9 @@ export {
   type TypeGenConfig,
 } from '../config/cli/types/cliConfig.js'
 export {
+  findMintedProjectEnvBoundary,
   type MintedProjectCredential,
+  type MintedProjectEnvBoundary,
   resolveMintedProjectCredential,
   resolveMintedProjectToken,
   UNCLAIMED_PROJECTS_CONFIG_KEY,

--- a/packages/@sanity/cli-core/src/_exports/config.ts
+++ b/packages/@sanity/cli-core/src/_exports/config.ts
@@ -1,6 +1,7 @@
 // Exports related to retrieving CLI, studio, app or workbench configuration or paths.
 
 export {
+  activateCliSessionForProcess,
   clearCliTokenCache,
   getCliToken,
   getCliUserConfig,

--- a/packages/@sanity/cli-core/src/_exports/config.ts
+++ b/packages/@sanity/cli-core/src/_exports/config.ts
@@ -5,6 +5,8 @@ export {
   getCliToken,
   getCliUserConfig,
   getUserConfig,
+  resolveCliCredential,
+  type ResolvedCliCredential,
   setCliUserConfig,
 } from '../config/cli/cliUserConfig.js'
 export {getCliConfig, getCliConfigUncached} from '../config/cli/getCliConfig.js'
@@ -15,6 +17,8 @@ export {
   type TypeGenConfig,
 } from '../config/cli/types/cliConfig.js'
 export {
+  type MintedProjectCredential,
+  resolveMintedProjectCredential,
   resolveMintedProjectToken,
   UNCLAIMED_PROJECTS_CONFIG_KEY,
 } from '../config/cli/unclaimedProjects.js'

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -24,6 +24,10 @@ export {
   type ConfigStore,
 } from '../config/cli/types/cliConfig.js'
 export {type UserViteConfig} from '../config/cli/types/userViteConfig.js'
+export {
+  resolveMintedProjectToken,
+  UNCLAIMED_PROJECTS_CONFIG_KEY,
+} from '../config/cli/unclaimedProjects.js'
 export {type ApplicationType, isWorkbenchApp} from '../config/cli/workbenchApp.js'
 export {findProjectRoot} from '../config/findProjectRoot.js'
 export {findProjectRootSync} from '../config/findProjectRootSync.js'

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -24,10 +24,6 @@ export {
   type ConfigStore,
 } from '../config/cli/types/cliConfig.js'
 export {type UserViteConfig} from '../config/cli/types/userViteConfig.js'
-export {
-  resolveMintedProjectToken,
-  UNCLAIMED_PROJECTS_CONFIG_KEY,
-} from '../config/cli/unclaimedProjects.js'
 export {type ApplicationType, isWorkbenchApp} from '../config/cli/workbenchApp.js'
 export {findProjectRoot} from '../config/findProjectRoot.js'
 export {findProjectRootSync} from '../config/findProjectRootSync.js'

--- a/packages/@sanity/cli-core/src/_exports/ux.ts
+++ b/packages/@sanity/cli-core/src/_exports/ux.ts
@@ -7,6 +7,7 @@ export {
   type Spacing,
 } from '../ux/boxen.js'
 export {colorizeJson} from '../ux/colorizeJson.js'
+export {createFlow, type Flow} from '../ux/flowOutput.js'
 export {logSymbols} from '../ux/logSymbols.js'
 export {
   checkbox,

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
@@ -36,6 +36,7 @@ describe('cliUserConfig', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
   })
 
   describe('getCliToken()', () => {
@@ -273,8 +274,18 @@ describe('cliUserConfig', () => {
       )
     })
 
-    test('invalidates token cache after setting authToken', () => {
+    test('activates a newly stored authToken for the current process', () => {
       setCliUserConfig('authToken', 'new-token')
+      expect(setCachedToken).toHaveBeenCalledWith('new-token')
+      expect(clearCliTokenCache).not.toHaveBeenCalled()
+    })
+
+    test('does not outrank an explicitly exported authToken', () => {
+      vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
+
+      setCliUserConfig('authToken', 'new-token')
+
+      expect(setCachedToken).not.toHaveBeenCalled()
       expect(clearCliTokenCache).toHaveBeenCalled()
     })
 

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
@@ -20,9 +20,9 @@ vi.mock('../../../util/readJsonFileSync.js')
 vi.mock('../../../util/writeJsonFileSync.js')
 vi.mock('node:fs')
 
-const mockResolveMintedProjectToken = vi.hoisted(() => vi.fn())
+const mockResolveMintedProjectCredential = vi.hoisted(() => vi.fn())
 vi.mock('../unclaimedProjects.js', () => ({
-  resolveMintedProjectToken: mockResolveMintedProjectToken,
+  resolveMintedProjectCredential: mockResolveMintedProjectCredential,
   UNCLAIMED_PROJECTS_CONFIG_KEY: 'unclaimedProjects',
 }))
 
@@ -44,8 +44,8 @@ describe('cliUserConfig', () => {
       // clearAllMocks() does not reset implementations, so make the cache
       // state explicit for every test
       vi.mocked(getCachedToken).mockReturnValue(undefined)
-      // No minted ledger token by default, tests that want one opt in.
-      mockResolveMintedProjectToken.mockReturnValue(undefined)
+      // No minted ledger credential by default, tests that want one opt in.
+      mockResolveMintedProjectCredential.mockReturnValue(undefined)
     })
     afterEach(() => {
       vi.unstubAllEnvs()
@@ -69,7 +69,10 @@ describe('cliUserConfig', () => {
     })
 
     test('should return the ledger token when no env token is set, ahead of the login session', async () => {
-      mockResolveMintedProjectToken.mockReturnValue('ledger-token')
+      mockResolveMintedProjectCredential.mockReturnValue({
+        projectId: 'abc123',
+        token: 'ledger-token',
+      })
 
       const token = await getCliToken()
       expect(token).toBe('ledger-token')
@@ -80,11 +83,14 @@ describe('cliUserConfig', () => {
 
     test('should prefer the env token over the ledger token', async () => {
       vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
-      mockResolveMintedProjectToken.mockReturnValue('ledger-token')
+      mockResolveMintedProjectCredential.mockReturnValue({
+        projectId: 'abc123',
+        token: 'ledger-token',
+      })
 
       const token = await getCliToken()
       expect(token).toBe('env-token')
-      expect(mockResolveMintedProjectToken).not.toHaveBeenCalled()
+      expect(mockResolveMintedProjectCredential).not.toHaveBeenCalled()
     })
 
     test('should return undefined if no token is available', async () => {

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
@@ -20,6 +20,12 @@ vi.mock('../../../util/readJsonFileSync.js')
 vi.mock('../../../util/writeJsonFileSync.js')
 vi.mock('node:fs')
 
+const mockResolveMintedProjectToken = vi.hoisted(() => vi.fn())
+vi.mock('../unclaimedProjects.js', () => ({
+  resolveMintedProjectToken: mockResolveMintedProjectToken,
+  UNCLAIMED_PROJECTS_CONFIG_KEY: 'unclaimedProjects',
+}))
+
 const mockGetCliUserConfig = vi.spyOn(_internals, 'getCliUserConfig')
 
 describe('cliUserConfig', () => {
@@ -38,6 +44,8 @@ describe('cliUserConfig', () => {
       // clearAllMocks() does not reset implementations, so make the cache
       // state explicit for every test
       vi.mocked(getCachedToken).mockReturnValue(undefined)
+      // No minted ledger token by default, tests that want one opt in.
+      mockResolveMintedProjectToken.mockReturnValue(undefined)
     })
     afterEach(() => {
       vi.unstubAllEnvs()
@@ -58,6 +66,25 @@ describe('cliUserConfig', () => {
       const token = await getCliToken()
       expect(token).toBe('config-token')
       expect(mockGetCliUserConfig).toHaveBeenCalledWith('authToken')
+    })
+
+    test('should return the ledger token when no env token is set, ahead of the login session', async () => {
+      mockResolveMintedProjectToken.mockReturnValue('ledger-token')
+
+      const token = await getCliToken()
+      expect(token).toBe('ledger-token')
+      expect(vi.mocked(setCachedToken)).toHaveBeenCalledWith('ledger-token')
+      // The ledger tier short-circuits before the stored login session is consulted.
+      expect(mockGetCliUserConfig).not.toHaveBeenCalled()
+    })
+
+    test('should prefer the env token over the ledger token', async () => {
+      vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
+      mockResolveMintedProjectToken.mockReturnValue('ledger-token')
+
+      const token = await getCliToken()
+      expect(token).toBe('env-token')
+      expect(mockResolveMintedProjectToken).not.toHaveBeenCalled()
     })
 
     test('should return undefined if no token is available', async () => {
@@ -318,6 +345,13 @@ describe('cliUserConfig', () => {
       expect(clearCliTokenCache).toHaveBeenCalled()
     })
 
+    test('set invalidates token cache when key is the minted-project ledger', () => {
+      // getCliToken resolves the robot token from this key, so a write must drop the cache.
+      const store = getUserConfig()
+      store.set('unclaimedProjects', {abc123: {token: 'sk-robot'}})
+      expect(clearCliTokenCache).toHaveBeenCalled()
+    })
+
     test('set does not invalidate token cache for other keys', () => {
       const store = getUserConfig()
       store.set('telemetryConsent', 'granted')
@@ -359,6 +393,14 @@ describe('cliUserConfig', () => {
       vi.mocked(readJsonFileSync).mockReturnValueOnce({authToken: 'old-token'})
       const store = getUserConfig()
       store.delete('authToken')
+      expect(clearCliTokenCache).toHaveBeenCalled()
+    })
+
+    test('delete invalidates token cache when key is the minted-project ledger', () => {
+      // Dropping a claimed project must not leave its robot token cached for the process.
+      vi.mocked(readJsonFileSync).mockReturnValueOnce({unclaimedProjects: {abc123: {token: 'x'}}})
+      const store = getUserConfig()
+      store.delete('unclaimedProjects')
       expect(clearCliTokenCache).toHaveBeenCalled()
     })
 

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
@@ -8,6 +8,7 @@ import {writeJsonFileSync} from '../../../util/writeJsonFileSync.js'
 import {clearCliTokenCache, getCachedToken, setCachedToken} from '../cliTokenCache.js'
 import {
   _internals,
+  activateCliSessionForProcess,
   getCliToken,
   getCliUserConfig,
   getUserConfig,
@@ -274,10 +275,10 @@ describe('cliUserConfig', () => {
       )
     })
 
-    test('activates a newly stored authToken for the current process', () => {
+    test('invalidates the token cache after storing authToken', () => {
       setCliUserConfig('authToken', 'new-token')
-      expect(setCachedToken).toHaveBeenCalledWith('new-token')
-      expect(clearCliTokenCache).not.toHaveBeenCalled()
+      expect(clearCliTokenCache).toHaveBeenCalled()
+      expect(setCachedToken).not.toHaveBeenCalled()
     })
 
     test('does not outrank an explicitly exported authToken', () => {
@@ -292,6 +293,14 @@ describe('cliUserConfig', () => {
     test('invalidates token cache after clearing authToken', () => {
       setCliUserConfig('authToken', undefined)
       expect(clearCliTokenCache).toHaveBeenCalled()
+    })
+  })
+
+  describe('activateCliSessionForProcess', () => {
+    test('explicitly activates the newly stored session', () => {
+      activateCliSessionForProcess('new-token')
+
+      expect(setCachedToken).toHaveBeenCalledWith('new-token')
     })
   })
 

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/resolveCliCredential.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/resolveCliCredential.test.ts
@@ -1,0 +1,251 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {clearCliTokenCache} from '../cliTokenCache.js'
+import {getCliToken, getUserConfig, resolveCliCredential} from '../cliUserConfig.js'
+
+// The resolver is the one place CLI credential precedence lives, so these tests run the real
+// config store (via SANITY_CLI_CONFIG_PATH) and a real `.env` instead of mocking file readers.
+let dir: string
+let envPath: string
+let configPath: string
+
+function writeConfig(config: Record<string, unknown>): void {
+  fs.writeFileSync(configPath, JSON.stringify(config))
+}
+
+const ledger = {abc123: {projectId: 'abc123', token: 'sk-robot'}}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sanity-resolve-cred-'))
+  envPath = path.join(dir, '.env')
+  configPath = path.join(dir, 'config.json')
+  vi.stubEnv('SANITY_CLI_CONFIG_PATH', configPath)
+  // Isolate from the shell running the tests.
+  vi.stubEnv('SANITY_AUTH_TOKEN', '')
+  vi.stubEnv('SANITY_PROJECT_ID', '')
+  clearCliTokenCache()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+  clearCliTokenCache()
+  fs.rmSync(dir, {force: true, recursive: true})
+})
+
+describe('resolveCliCredential', () => {
+  test('environment token only', async () => {
+    vi.stubEnv('SANITY_AUTH_TOKEN', ' env-token ')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'environment',
+      token: 'env-token',
+    })
+  })
+
+  test('minted-project token only, including the project id that selected it', async () => {
+    writeConfig({unclaimedProjects: ledger})
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      projectId: 'abc123',
+      source: 'minted-project',
+      token: 'sk-robot',
+    })
+  })
+
+  test('stored session only', async () => {
+    writeConfig({authToken: 'session-token'})
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'session',
+      token: 'session-token',
+    })
+  })
+
+  test('no credential anywhere', async () => {
+    await expect(resolveCliCredential(dir)).resolves.toEqual({source: 'none'})
+  })
+
+  test('environment token outranks the minted-project token', async () => {
+    vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
+    writeConfig({unclaimedProjects: ledger})
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'environment',
+      token: 'env-token',
+    })
+  })
+
+  test('environment token outranks the stored session', async () => {
+    vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
+    writeConfig({authToken: 'session-token'})
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'environment',
+      token: 'env-token',
+    })
+  })
+
+  test('minted-project token outranks the stored session', async () => {
+    writeConfig({authToken: 'session-token', unclaimedProjects: ledger})
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      projectId: 'abc123',
+      source: 'minted-project',
+      token: 'sk-robot',
+    })
+  })
+
+  test('a blank environment token does not outrank anything', async () => {
+    vi.stubEnv('SANITY_AUTH_TOKEN', '   ')
+    writeConfig({authToken: 'session-token'})
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'session',
+      token: 'session-token',
+    })
+  })
+
+  test('a malformed ledger falls through to the stored session', async () => {
+    writeConfig({authToken: 'session-token', unclaimedProjects: 'not-an-object'})
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'session',
+      token: 'session-token',
+    })
+  })
+
+  test('a ledger record without a token falls through to the stored session', async () => {
+    writeConfig({authToken: 'session-token', unclaimedProjects: {abc123: {projectId: 'abc123'}}})
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'session',
+      token: 'session-token',
+    })
+  })
+
+  test('a ledger record with an empty token falls through to the stored session', async () => {
+    writeConfig({
+      authToken: 'session-token',
+      unclaimedProjects: {abc123: {projectId: 'abc123', token: ''}},
+    })
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'session',
+      token: 'session-token',
+    })
+  })
+
+  test('a ledger record with a whitespace-only token falls through to the stored session', async () => {
+    writeConfig({
+      authToken: 'session-token',
+      unclaimedProjects: {abc123: {projectId: 'abc123', token: '   '}},
+    })
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'session',
+      token: 'session-token',
+    })
+  })
+
+  test('the .env project id wins over a shell-exported SANITY_PROJECT_ID', async () => {
+    vi.stubEnv('SANITY_PROJECT_ID', 'otherproj')
+    writeConfig({
+      unclaimedProjects: {
+        ...ledger,
+        otherproj: {projectId: 'otherproj', token: 'sk-wrong'},
+      },
+    })
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      projectId: 'abc123',
+      source: 'minted-project',
+      token: 'sk-robot',
+    })
+  })
+
+  test('is uncached: reflects a ledger change on the very next call', async () => {
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+    writeConfig({authToken: 'session-token'})
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'session',
+      token: 'session-token',
+    })
+
+    getUserConfig().set('unclaimedProjects', ledger)
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      projectId: 'abc123',
+      source: 'minted-project',
+      token: 'sk-robot',
+    })
+  })
+})
+
+describe('getCliToken delegation', () => {
+  test('resolves through the resolver and keeps caching the token', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(dir)
+    writeConfig({authToken: 'session-token'})
+
+    await expect(getCliToken()).resolves.toBe('session-token')
+
+    // Cached: a config change without invalidation is not observed...
+    fs.writeFileSync(configPath, JSON.stringify({authToken: 'other-token'}))
+    await expect(getCliToken()).resolves.toBe('session-token')
+  })
+
+  test('a ledger write invalidates the cache so the robot token takes over', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(dir)
+    writeConfig({authToken: 'session-token'})
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(getCliToken()).resolves.toBe('session-token')
+
+    // Recording a mint writes the ledger through the config store, which drops the cache.
+    getUserConfig().set('unclaimedProjects', ledger)
+
+    await expect(getCliToken()).resolves.toBe('sk-robot')
+  })
+
+  test('a ledger delete invalidates the cache so the session takes back over', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(dir)
+    writeConfig({authToken: 'session-token', unclaimedProjects: ledger})
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(getCliToken()).resolves.toBe('sk-robot')
+
+    getUserConfig().delete('unclaimedProjects')
+
+    await expect(getCliToken()).resolves.toBe('session-token')
+  })
+
+  test('returns undefined when the resolver finds no credential', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(dir)
+
+    await expect(getCliToken()).resolves.toBeUndefined()
+  })
+
+  test('a blank ledger token never shadows the stored session', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(dir)
+    writeConfig({
+      authToken: 'session-token',
+      unclaimedProjects: {abc123: {projectId: 'abc123', token: '   '}},
+    })
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(getCliToken()).resolves.toBe('session-token')
+  })
+})

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/resolveCliCredential.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/resolveCliCredential.test.ts
@@ -5,7 +5,12 @@ import path from 'node:path'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {clearCliTokenCache} from '../cliTokenCache.js'
-import {getCliToken, getUserConfig, resolveCliCredential} from '../cliUserConfig.js'
+import {
+  getCliToken,
+  getUserConfig,
+  resolveCliCredential,
+  setCliUserConfig,
+} from '../cliUserConfig.js'
 
 // The resolver is the one place CLI credential precedence lives, so these tests run the real
 // config store (via SANITY_CLI_CONFIG_PATH) and a real `.env` instead of mocking file readers.
@@ -55,6 +60,17 @@ describe('resolveCliCredential', () => {
       projectId: 'abc123',
       source: 'minted-project',
       token: 'sk-robot',
+    })
+  })
+
+  test('root .env minted-project token recovers when the ledger write is missing', async () => {
+    writeConfig({authToken: 'session-token'})
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-env-robot"\n')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      projectId: 'abc123',
+      source: 'minted-project',
+      token: 'sk-env-robot',
     })
   })
 
@@ -196,6 +212,24 @@ describe('resolveCliCredential', () => {
 })
 
 describe('getCliToken delegation', () => {
+  test('a fresh login session displaces an invalid root .env token for this process', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(dir)
+    fs.writeFileSync(
+      envPath,
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="invalid-mint-token"\n',
+    )
+
+    await expect(getCliToken()).resolves.toBe('invalid-mint-token')
+
+    setCliUserConfig('authToken', 'fresh-session-token')
+    await expect(getCliToken()).resolves.toBe('fresh-session-token')
+
+    // The override is deliberately process-scoped. A new invocation resolves the mint token
+    // normally, preserving pre-claim access for users who also have a stored login session.
+    clearCliTokenCache()
+    await expect(getCliToken()).resolves.toBe('invalid-mint-token')
+  })
+
   test('resolves through the resolver and keeps caching the token', async () => {
     vi.spyOn(process, 'cwd').mockReturnValue(dir)
     writeConfig({authToken: 'session-token'})

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/resolveCliCredential.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/resolveCliCredential.test.ts
@@ -6,6 +6,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {clearCliTokenCache} from '../cliTokenCache.js'
 import {
+  activateCliSessionForProcess,
   getCliToken,
   getUserConfig,
   resolveCliCredential,
@@ -238,7 +239,7 @@ describe('resolveCliCredential', () => {
 })
 
 describe('getCliToken delegation', () => {
-  test('a fresh login session displaces an invalid root .env token for this process', async () => {
+  test('an embedded login explicitly displaces an invalid root .env token for this process', async () => {
     vi.spyOn(process, 'cwd').mockReturnValue(dir)
     fs.writeFileSync(
       envPath,
@@ -248,12 +249,28 @@ describe('getCliToken delegation', () => {
     await expect(getCliToken()).resolves.toBe('invalid-mint-token')
 
     setCliUserConfig('authToken', 'fresh-session-token')
+    await expect(getCliToken()).resolves.toBe('invalid-mint-token')
+
+    activateCliSessionForProcess('fresh-session-token')
     await expect(getCliToken()).resolves.toBe('fresh-session-token')
 
     // The override is deliberately process-scoped. A new invocation resolves the mint token
     // normally, preserving pre-claim access for users who also have a stored login session.
     clearCliTokenCache()
     await expect(getCliToken()).resolves.toBe('invalid-mint-token')
+  })
+
+  test('standalone login preserves an exported token until an embedded flow activates its session', async () => {
+    vi.stubEnv('SANITY_AUTH_TOKEN', 'exported-token')
+
+    setCliUserConfig('authToken', 'fresh-session-token')
+    await expect(getCliToken()).resolves.toBe('exported-token')
+
+    activateCliSessionForProcess('fresh-session-token')
+    await expect(getCliToken()).resolves.toBe('fresh-session-token')
+
+    clearCliTokenCache()
+    await expect(getCliToken()).resolves.toBe('exported-token')
   })
 
   test('resolves through the resolver and keeps caching the token', async () => {

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/resolveCliCredential.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/resolveCliCredential.test.ts
@@ -63,6 +63,19 @@ describe('resolveCliCredential', () => {
     })
   })
 
+  test('a mint-root credential outranks the stored session from a deep frontend directory', async () => {
+    const frontendDir = path.join(dir, 'web', 'src')
+    fs.mkdirSync(frontendDir, {recursive: true})
+    writeConfig({authToken: 'session-token', unclaimedProjects: ledger})
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(resolveCliCredential(frontendDir)).resolves.toEqual({
+      projectId: 'abc123',
+      source: 'minted-project',
+      token: 'sk-robot',
+    })
+  })
+
   test('root .env minted-project token recovers when the ledger write is missing', async () => {
     writeConfig({authToken: 'session-token'})
     fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-env-robot"\n')
@@ -141,6 +154,19 @@ describe('resolveCliCredential', () => {
 
   test('a ledger record without a token falls through to the stored session', async () => {
     writeConfig({authToken: 'session-token', unclaimedProjects: {abc123: {projectId: 'abc123'}}})
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+
+    await expect(resolveCliCredential(dir)).resolves.toEqual({
+      source: 'session',
+      token: 'session-token',
+    })
+  })
+
+  test('a ledger record for a different project falls through to the stored session', async () => {
+    writeConfig({
+      authToken: 'session-token',
+      unclaimedProjects: {abc123: {projectId: 'otherproj', token: 'sk-wrong'}},
+    })
     fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
 
     await expect(resolveCliCredential(dir)).resolves.toEqual({

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/unclaimedProjects.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/unclaimedProjects.test.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {resolveMintedProjectToken} from '../unclaimedProjects.js'
+
+let dir: string
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sanity-unclaimed-'))
+})
+
+afterEach(() => {
+  fs.rmSync(dir, {force: true, recursive: true})
+  vi.unstubAllEnvs()
+})
+
+describe('resolveMintedProjectToken', () => {
+  test('returns the ledger token for the project id in the directory .env', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+
+    expect(resolveMintedProjectToken({abc123: {projectId: 'abc123', token: 'sk-robot'}}, dir)).toBe(
+      'sk-robot',
+    )
+  })
+
+  test('reads the directory .env, not a shell-exported SANITY_PROJECT_ID from another project', () => {
+    // A stale shell export must not steal a different project's ledger token — the value in this
+    // directory's .env wins.
+    vi.stubEnv('SANITY_PROJECT_ID', 'otherproj')
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+
+    expect(
+      resolveMintedProjectToken(
+        {
+          abc123: {projectId: 'abc123', token: 'sk-robot'},
+          otherproj: {projectId: 'otherproj', token: 'sk-wrong'},
+        },
+        dir,
+      ),
+    ).toBe('sk-robot')
+  })
+
+  test('follows dotenv grammar: strips inline comments and takes the last value', () => {
+    // Matches readEnvValues (mint/init/logout/nudges) rather than a divergent first-match parser.
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      '# SANITY_PROJECT_ID="commented"\nSANITY_PROJECT_ID=stale\nSANITY_PROJECT_ID=abc123 # inline\n',
+    )
+
+    expect(resolveMintedProjectToken({abc123: {projectId: 'abc123', token: 'sk-robot'}}, dir)).toBe(
+      'sk-robot',
+    )
+  })
+
+  test('returns undefined when the directory has no .env project id', () => {
+    expect(
+      resolveMintedProjectToken({abc123: {projectId: 'abc123', token: 'sk-robot'}}, dir),
+    ).toBeUndefined()
+  })
+
+  test('returns undefined when the ledger has no record for that project', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="other"\n')
+
+    expect(
+      resolveMintedProjectToken({abc123: {projectId: 'abc123', token: 'sk-robot'}}, dir),
+    ).toBeUndefined()
+  })
+
+  test('returns undefined when the record carries no token', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+
+    expect(resolveMintedProjectToken({abc123: {projectId: 'abc123'}}, dir)).toBeUndefined()
+  })
+
+  test('returns undefined when the ledger is empty or absent', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+
+    expect(resolveMintedProjectToken({}, dir)).toBeUndefined()
+    expect(resolveMintedProjectToken(undefined, dir)).toBeUndefined()
+  })
+})

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/unclaimedProjects.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/unclaimedProjects.test.ts
@@ -26,6 +26,26 @@ describe('resolveMintedProjectToken', () => {
     )
   })
 
+  test('falls back to the directory .env token when the ledger write is absent', () => {
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-env-robot"\n',
+    )
+
+    expect(resolveMintedProjectToken(undefined, dir)).toBe('sk-env-robot')
+  })
+
+  test('keeps the ledger token authoritative when the directory .env token differs', () => {
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-env-robot"\n',
+    )
+
+    expect(resolveMintedProjectToken({abc123: {token: 'sk-ledger-robot'}}, dir)).toBe(
+      'sk-ledger-robot',
+    )
+  })
+
   test('reads the directory .env, not a shell-exported SANITY_PROJECT_ID from another project', () => {
     // A stale shell export must not steal a different project's ledger token — the value in this
     // directory's .env wins.
@@ -61,7 +81,7 @@ describe('resolveMintedProjectToken', () => {
     ).toBeUndefined()
   })
 
-  test('returns undefined when the ledger has no record for that project', () => {
+  test('returns undefined when neither the ledger nor .env has a token for that project', () => {
     fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="other"\n')
 
     expect(
@@ -69,7 +89,7 @@ describe('resolveMintedProjectToken', () => {
     ).toBeUndefined()
   })
 
-  test('returns undefined when the record carries no token', () => {
+  test('returns undefined when the record and .env carry no token', () => {
     fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
 
     expect(resolveMintedProjectToken({abc123: {projectId: 'abc123'}}, dir)).toBeUndefined()
@@ -86,7 +106,7 @@ describe('resolveMintedProjectToken', () => {
     ).toBeUndefined()
   })
 
-  test('returns undefined when the ledger is empty or absent', () => {
+  test('returns undefined when the ledger is empty or absent and .env carries no token', () => {
     fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
 
     expect(resolveMintedProjectToken({}, dir)).toBeUndefined()
@@ -101,6 +121,18 @@ describe('resolveMintedProjectCredential', () => {
     expect(
       resolveMintedProjectCredential({abc123: {projectId: 'abc123', token: 'sk-robot'}}, dir),
     ).toEqual({projectId: 'abc123', token: 'sk-robot'})
+  })
+
+  test('returns the root .env credential when no ledger record was persisted', () => {
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-env-robot"\n',
+    )
+
+    expect(resolveMintedProjectCredential(undefined, dir)).toEqual({
+      projectId: 'abc123',
+      token: 'sk-env-robot',
+    })
   })
 
   test('returns undefined when no valid credential can be resolved', () => {

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/unclaimedProjects.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/unclaimedProjects.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {resolveMintedProjectToken} from '../unclaimedProjects.js'
+import {resolveMintedProjectCredential, resolveMintedProjectToken} from '../unclaimedProjects.js'
 
 let dir: string
 
@@ -75,10 +75,50 @@ describe('resolveMintedProjectToken', () => {
     expect(resolveMintedProjectToken({abc123: {projectId: 'abc123'}}, dir)).toBeUndefined()
   })
 
+  test('returns undefined when the record token is empty or whitespace-only', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+
+    expect(
+      resolveMintedProjectToken({abc123: {projectId: 'abc123', token: ''}}, dir),
+    ).toBeUndefined()
+    expect(
+      resolveMintedProjectToken({abc123: {projectId: 'abc123', token: '   '}}, dir),
+    ).toBeUndefined()
+  })
+
   test('returns undefined when the ledger is empty or absent', () => {
     fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
 
     expect(resolveMintedProjectToken({}, dir)).toBeUndefined()
     expect(resolveMintedProjectToken(undefined, dir)).toBeUndefined()
+  })
+})
+
+describe('resolveMintedProjectCredential', () => {
+  test('returns the ledger token together with the project id that selected it', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+
+    expect(
+      resolveMintedProjectCredential({abc123: {projectId: 'abc123', token: 'sk-robot'}}, dir),
+    ).toEqual({projectId: 'abc123', token: 'sk-robot'})
+  })
+
+  test('returns undefined when no valid credential can be resolved', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+
+    expect(resolveMintedProjectCredential({abc123: {projectId: 'abc123'}}, dir)).toBeUndefined()
+    expect(resolveMintedProjectCredential(undefined, dir)).toBeUndefined()
+    expect(resolveMintedProjectCredential('not-a-ledger', dir)).toBeUndefined()
+  })
+
+  test('rejects an empty or whitespace-only token instead of constructing a credential', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+
+    expect(
+      resolveMintedProjectCredential({abc123: {projectId: 'abc123', token: ''}}, dir),
+    ).toBeUndefined()
+    expect(
+      resolveMintedProjectCredential({abc123: {projectId: 'abc123', token: '   '}}, dir),
+    ).toBeUndefined()
   })
 })

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/unclaimedProjects.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/unclaimedProjects.test.ts
@@ -41,9 +41,9 @@ describe('resolveMintedProjectToken', () => {
       'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-env-robot"\n',
     )
 
-    expect(resolveMintedProjectToken({abc123: {token: 'sk-ledger-robot'}}, dir)).toBe(
-      'sk-ledger-robot',
-    )
+    expect(
+      resolveMintedProjectToken({abc123: {projectId: 'abc123', token: 'sk-ledger-robot'}}, dir),
+    ).toBe('sk-ledger-robot')
   })
 
   test('reads the directory .env, not a shell-exported SANITY_PROJECT_ID from another project', () => {
@@ -123,6 +123,87 @@ describe('resolveMintedProjectCredential', () => {
     ).toEqual({projectId: 'abc123', token: 'sk-robot'})
   })
 
+  test('resolves the mint-root ledger credential from generated, renamed, and deep frontends', () => {
+    const frontendDirectories = [
+      path.join(dir, 'web'),
+      path.join(dir, 'existing-frontend'),
+      path.join(dir, 'existing-frontend', 'packages', 'site'),
+    ]
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+
+    for (const frontendDirectory of frontendDirectories) {
+      fs.mkdirSync(frontendDirectory, {recursive: true})
+      expect(
+        resolveMintedProjectCredential(
+          {abc123: {projectId: 'abc123', token: 'sk-robot'}},
+          frontendDirectory,
+        ),
+      ).toEqual({projectId: 'abc123', token: 'sk-robot'})
+    }
+  })
+
+  test('a nearer credential boundary blocks the mint root even when incomplete or malformed', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    const records = {abc123: {projectId: 'abc123', token: 'sk-robot'}}
+    const nearerBoundaries = [
+      'SANITY_AUTH_TOKEN="sk-nearer"\n',
+      'SANITY_CLAIM_URL=\n',
+      'SANITY_PROJECT_ID=\n',
+      'SANITY_PROJECT_ID\n',
+      'export SANITY_PROJECT_ID\n',
+    ]
+
+    for (const [index, contents] of nearerBoundaries.entries()) {
+      const descendant = path.join(dir, `frontend-${index}`, 'deep')
+      fs.mkdirSync(descendant, {recursive: true})
+      fs.writeFileSync(path.join(path.dirname(descendant), '.env'), contents)
+
+      expect(resolveMintedProjectCredential(records, descendant)).toBeUndefined()
+    }
+  })
+
+  test('recovers the mint-root .env token from generated and unrelated nested frontends', () => {
+    const generatedFrontend = path.join(dir, 'web')
+    const frontend = path.join(dir, 'existing-frontend')
+    const descendant = path.join(frontend, 'packages', 'site')
+    fs.mkdirSync(generatedFrontend)
+    fs.mkdirSync(descendant, {recursive: true})
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-env-robot"\n',
+    )
+    fs.writeFileSync(
+      path.join(frontend, '.env'),
+      '# SANITY_PROJECT_ID="commented"\nSANITY_AUTH_TOKEN_HINT="not-a-token"\nDATABASE_URL="postgres://localhost"\n',
+    )
+    fs.writeFileSync(
+      path.join(frontend, 'packages', '.env.local'),
+      'SANITY_PROJECT_ID="ignored-local-file"\n',
+    )
+
+    for (const cwd of [generatedFrontend, descendant]) {
+      expect(resolveMintedProjectCredential(undefined, cwd)).toEqual({
+        projectId: 'abc123',
+        token: 'sk-env-robot',
+      })
+    }
+  })
+
+  test('an unreadable nearer .env fails closed instead of inheriting the mint root', () => {
+    const frontend = path.join(dir, 'web')
+    const descendant = path.join(frontend, 'deep')
+    fs.mkdirSync(descendant, {recursive: true})
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    fs.mkdirSync(path.join(frontend, '.env'))
+
+    expect(
+      resolveMintedProjectCredential(
+        {abc123: {projectId: 'abc123', token: 'sk-robot'}},
+        descendant,
+      ),
+    ).toBeUndefined()
+  })
+
   test('returns the root .env credential when no ledger record was persisted', () => {
     fs.writeFileSync(
       path.join(dir, '.env'),
@@ -141,6 +222,34 @@ describe('resolveMintedProjectCredential', () => {
     expect(resolveMintedProjectCredential({abc123: {projectId: 'abc123'}}, dir)).toBeUndefined()
     expect(resolveMintedProjectCredential(undefined, dir)).toBeUndefined()
     expect(resolveMintedProjectCredential('not-a-ledger', dir)).toBeUndefined()
+  })
+
+  test('rejects ledger records whose own project id is missing or mismatched', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+
+    expect(
+      resolveMintedProjectCredential({abc123: {token: 'sk-missing-project'}}, dir),
+    ).toBeUndefined()
+    expect(
+      resolveMintedProjectCredential(
+        {abc123: {projectId: 'otherproj', token: 'sk-mismatched-project'}},
+        dir,
+      ),
+    ).toBeUndefined()
+  })
+
+  test('falls back to the selected .env token when its ledger record is malformed', () => {
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-env-robot"\n',
+    )
+
+    expect(
+      resolveMintedProjectCredential(
+        {abc123: {projectId: 'otherproj', token: 'sk-mismatched-project'}},
+        dir,
+      ),
+    ).toEqual({projectId: 'abc123', token: 'sk-env-robot'})
   })
 
   test('rejects an empty or whitespace-only token instead of constructing a credential', () => {

--- a/packages/@sanity/cli-core/src/config/cli/cliTokenCache.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliTokenCache.ts
@@ -1,6 +1,6 @@
 /**
  * Module-level cache for the CLI auth token, shared between
- * `getCliToken` (reads/writes) and `setCliUserConfig` (invalidates).
+ * `getCliToken` (reads/writes) and `setCliUserConfig` (updates/invalidates).
  *
  * Extracted into its own module to avoid a circular dependency
  * between `cliUserConfig.ts` and `getCliToken.ts`.
@@ -19,7 +19,8 @@ export function setCachedToken(token: string | undefined): void {
  * Clear the in-process token cache so the next `getCliToken()` call
  * re-reads from disk or the environment.
  *
- * Called automatically by `setCliUserConfig('authToken', ...)`.
+ * Called automatically when the stored session is cleared or an exported token must retain
+ * precedence over a newly stored session.
  *
  * @internal
  */

--- a/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
@@ -22,8 +22,9 @@ export const _internals = {
 
 /**
  * The active CLI credential together with where it came from, in precedence order:
- * a nonblank `SANITY_AUTH_TOKEN` in the environment, then the minted-project ledger record
- * selected by the current directory's `.env` project id, then the stored login session.
+ * a nonblank `SANITY_AUTH_TOKEN` in the environment, then the minted-project credential selected
+ * by the current directory's `.env` project id (ledger first, root `.env` as recovery), then the
+ * stored login session.
  *
  * @internal
  */
@@ -48,10 +49,9 @@ export async function resolveCliCredential(cwd?: string): Promise<ResolvedCliCre
     return {source: 'environment', token: envToken}
   }
 
-  // A minted directory carries the robot token in both `.env` (for the app runtime) and the
-  // ledger. This resolves it from the ledger, keyed by the `.env` project id, because env
-  // injection never runs before a config file exists — the gap that stops `sanity init`
-  // authenticating in a freshly minted directory.
+  // A minted directory carries the robot token in both `.env` and the ledger. Resolve the ledger
+  // copy first, with the root `.env` copy as recovery when the ledger write failed. Env injection
+  // never runs before a config file exists, which is the gap this directory-aware tier closes.
   let minted
   try {
     minted = resolveMintedProjectCredential(getUserConfig().get(UNCLAIMED_PROJECTS_CONFIG_KEY), cwd)
@@ -132,9 +132,16 @@ export function setCliUserConfig(prop: 'authToken', value: string | undefined): 
     writeJsonFileSync(configPath, {...config, [prop]: value}, {pretty: true})
   }
 
-  // Invalidate the in-process token cache so subsequent getCliToken() calls
-  // pick up the new value from disk.
-  clearCliTokenCache()
+  // A successful explicit login must take effect for the rest of this process. Otherwise an
+  // invalid project-local mint token can keep winning normal resolution after the fresh session
+  // is stored, and the command that initiated login immediately fails its next authenticated
+  // request. Preserve an explicitly exported token as the highest-precedence process credential.
+  const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
+  if (value && !envToken) {
+    setCachedToken(value)
+  } else {
+    clearCliTokenCache()
+  }
 }
 
 /**

--- a/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
@@ -98,6 +98,21 @@ export async function getCliToken(): Promise<string | undefined> {
   setCachedToken(token)
   return token
 }
+
+/**
+ * Make a freshly stored login session the active credential for the rest of this process.
+ *
+ * Embedded authentication flows use this after an invalid active credential triggered login.
+ * Standalone login deliberately does not, so environment and minted-project credentials retain
+ * their normal precedence and can be reported to the user.
+ *
+ * @param token - The newly stored login session token
+ * @internal
+ */
+export function activateCliSessionForProcess(token: string): void {
+  setCachedToken(token)
+}
+
 const cliUserConfigSchema = {
   authToken: z.optional(z.string()),
 }
@@ -133,16 +148,7 @@ export function setCliUserConfig(prop: 'authToken', value: string | undefined): 
     writeJsonFileSync(configPath, {...config, [prop]: value}, {pretty: true})
   }
 
-  // A successful explicit login must take effect for the rest of this process. Otherwise an
-  // invalid project-local mint token can keep winning normal resolution after the fresh session
-  // is stored, and the command that initiated login immediately fails its next authenticated
-  // request. Preserve an explicitly exported token as the highest-precedence process credential.
-  const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
-  if (value && !envToken) {
-    setCachedToken(value)
-  } else {
-    clearCliTokenCache()
-  }
+  clearCliTokenCache()
 }
 
 /**

--- a/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
@@ -10,7 +10,7 @@ import {readJsonFileSync} from '../../util/readJsonFileSync.js'
 import {writeJsonFileSync} from '../../util/writeJsonFileSync.js'
 import {clearCliTokenCache, getCachedToken, setCachedToken} from './cliTokenCache.js'
 import {type ConfigStore} from './types/cliConfig.js'
-import {resolveMintedProjectToken, UNCLAIMED_PROJECTS_CONFIG_KEY} from './unclaimedProjects.js'
+import {resolveMintedProjectCredential, UNCLAIMED_PROJECTS_CONFIG_KEY} from './unclaimedProjects.js'
 
 // Re-export so existing consumers don't break
 export {clearCliTokenCache} from './cliTokenCache.js'
@@ -18,6 +18,56 @@ export {clearCliTokenCache} from './cliTokenCache.js'
 // Only used for testing
 export const _internals = {
   getCliUserConfig,
+}
+
+/**
+ * The active CLI credential together with where it came from, in precedence order:
+ * a nonblank `SANITY_AUTH_TOKEN` in the environment, then the minted-project ledger record
+ * selected by the current directory's `.env` project id, then the stored login session.
+ *
+ * @internal
+ */
+export type ResolvedCliCredential =
+  | {projectId: string; source: 'minted-project'; token: string}
+  | {source: 'environment'; token: string}
+  | {source: 'none'}
+  | {source: 'session'; token: string}
+
+/**
+ * Resolve the active CLI credential and its source. Uncached: callers that explain which
+ * identity is in effect (login/logout warnings) need a fresh answer, not a source inferred
+ * from a cached string. Token-oriented callers should keep using {@link getCliToken}.
+ *
+ * @param cwd - Directory whose `.env` selects the minted-project ledger record; defaults to
+ * the process working directory
+ * @internal
+ */
+export async function resolveCliCredential(cwd?: string): Promise<ResolvedCliCredential> {
+  const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
+  if (envToken) {
+    return {source: 'environment', token: envToken}
+  }
+
+  // A minted directory carries the robot token in both `.env` (for the app runtime) and the
+  // ledger. This resolves it from the ledger, keyed by the `.env` project id, because env
+  // injection never runs before a config file exists — the gap that stops `sanity init`
+  // authenticating in a freshly minted directory.
+  let minted
+  try {
+    minted = resolveMintedProjectCredential(getUserConfig().get(UNCLAIMED_PROJECTS_CONFIG_KEY), cwd)
+  } catch {
+    // Fall through to the login session.
+  }
+  if (minted) {
+    return {projectId: minted.projectId, source: 'minted-project', token: minted.token}
+  }
+
+  const sessionToken = _internals.getCliUserConfig('authToken')
+  if (sessionToken) {
+    return {source: 'session', token: sessionToken}
+  }
+
+  return {source: 'none'}
 }
 
 /**
@@ -41,31 +91,11 @@ export async function getCliToken(): Promise<string | undefined> {
     return cached
   }
 
-  const token = process.env.SANITY_AUTH_TOKEN
-  if (token) {
-    const trimmed = token.trim()
-    setCachedToken(trimmed)
-    return trimmed
-  }
+  const credential = await resolveCliCredential()
+  const token = credential.source === 'none' ? undefined : credential.token
 
-  // A minted directory carries the robot token in both `.env` (for the app runtime) and the
-  // ledger. This resolves it from the ledger, keyed by the `.env` project id, because env
-  // injection never runs before a config file exists — the gap that stops `sanity init`
-  // authenticating in a freshly minted directory.
-  let mintedToken: string | undefined
-  try {
-    mintedToken = resolveMintedProjectToken(getUserConfig().get(UNCLAIMED_PROJECTS_CONFIG_KEY))
-  } catch {
-    // Fall through to the login session.
-  }
-  if (mintedToken) {
-    setCachedToken(mintedToken)
-    return mintedToken
-  }
-
-  const configToken = _internals.getCliUserConfig('authToken')
-  setCachedToken(configToken)
-  return configToken
+  setCachedToken(token)
+  return token
 }
 const cliUserConfigSchema = {
   authToken: z.optional(z.string()),

--- a/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
@@ -23,8 +23,8 @@ export const _internals = {
 /**
  * The active CLI credential together with where it came from, in precedence order:
  * a nonblank `SANITY_AUTH_TOKEN` in the environment, then the minted-project credential selected
- * by the current directory's `.env` project id (ledger first, root `.env` as recovery), then the
- * stored login session.
+ * by the nearest ancestor `.env` credential boundary (ledger first, that `.env` as recovery), then
+ * the stored login session.
  *
  * @internal
  */
@@ -39,8 +39,8 @@ export type ResolvedCliCredential =
  * identity is in effect (login/logout warnings) need a fresh answer, not a source inferred
  * from a cached string. Token-oriented callers should keep using {@link getCliToken}.
  *
- * @param cwd - Directory whose `.env` selects the minted-project ledger record; defaults to
- * the process working directory
+ * @param cwd - Directory where the minted-project `.env` ancestor search starts; defaults to the
+ * process working directory
  * @internal
  */
 export async function resolveCliCredential(cwd?: string): Promise<ResolvedCliCredential> {
@@ -50,8 +50,9 @@ export async function resolveCliCredential(cwd?: string): Promise<ResolvedCliCre
   }
 
   // A minted directory carries the robot token in both `.env` and the ledger. Resolve the ledger
-  // copy first, with the root `.env` copy as recovery when the ledger write failed. Env injection
-  // never runs before a config file exists, which is the gap this directory-aware tier closes.
+  // copy first, with the selected ancestor `.env` copy as recovery when the ledger write failed.
+  // Env injection remains scoped to a discovered project root, which is the gap this independent
+  // directory-aware tier closes.
   let minted
   try {
     minted = resolveMintedProjectCredential(getUserConfig().get(UNCLAIMED_PROJECTS_CONFIG_KEY), cwd)

--- a/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
@@ -48,9 +48,10 @@ export async function getCliToken(): Promise<string | undefined> {
     return trimmed
   }
 
-  // A minted directory carries only its (non-secret) project id in `.env`; the robot token lives
-  // in the ledger. This resolves it without env injection, which never runs before a config file
-  // exists — the gap that stops `sanity init` authenticating in a freshly minted directory.
+  // A minted directory carries the robot token in both `.env` (for the app runtime) and the
+  // ledger. This resolves it from the ledger, keyed by the `.env` project id, because env
+  // injection never runs before a config file exists — the gap that stops `sanity init`
+  // authenticating in a freshly minted directory.
   let mintedToken: string | undefined
   try {
     mintedToken = resolveMintedProjectToken(getUserConfig().get(UNCLAIMED_PROJECTS_CONFIG_KEY))

--- a/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
@@ -10,6 +10,7 @@ import {readJsonFileSync} from '../../util/readJsonFileSync.js'
 import {writeJsonFileSync} from '../../util/writeJsonFileSync.js'
 import {clearCliTokenCache, getCachedToken, setCachedToken} from './cliTokenCache.js'
 import {type ConfigStore} from './types/cliConfig.js'
+import {resolveMintedProjectToken, UNCLAIMED_PROJECTS_CONFIG_KEY} from './unclaimedProjects.js'
 
 // Re-export so existing consumers don't break
 export {clearCliTokenCache} from './cliTokenCache.js'
@@ -45,6 +46,20 @@ export async function getCliToken(): Promise<string | undefined> {
     const trimmed = token.trim()
     setCachedToken(trimmed)
     return trimmed
+  }
+
+  // A minted directory carries only its (non-secret) project id in `.env`; the robot token lives
+  // in the ledger. This resolves it without env injection, which never runs before a config file
+  // exists — the gap that stops `sanity init` authenticating in a freshly minted directory.
+  let mintedToken: string | undefined
+  try {
+    mintedToken = resolveMintedProjectToken(getUserConfig().get(UNCLAIMED_PROJECTS_CONFIG_KEY))
+  } catch {
+    // Fall through to the login session.
+  }
+  if (mintedToken) {
+    setCachedToken(mintedToken)
+    return mintedToken
   }
 
   const configToken = _internals.getCliUserConfig('authToken')
@@ -109,6 +124,16 @@ export function getCliUserConfig(prop: 'authToken'): string | undefined {
 }
 
 /**
+ * Keys whose writes must invalidate the in-process token cache, because `getCliToken` resolves
+ * from them: the stored login session (`authToken`) and the minted-project ledger. Without this,
+ * dropping a claimed project from the ledger leaves the robot token cached for the rest of the
+ * process, breaking the post-claim handoff to the logged-in user.
+ */
+function affectsToken(key: string): boolean {
+  return key === 'authToken' || key === UNCLAIMED_PROJECTS_CONFIG_KEY
+}
+
+/**
  * Get a key-value store backed by the CLI user configuration file
  * (`~/.config/sanity/config.json`).
  *
@@ -136,7 +161,7 @@ export function getUserConfig(): ConfigStore {
       const configPath = getCliUserConfigPath()
       mkdirSync(dirname(configPath), {recursive: true})
       writeJsonFileSync(configPath, {...config, [key]: value}, {pretty: true})
-      if (key === 'authToken') clearCliTokenCache()
+      if (affectsToken(key)) clearCliTokenCache()
     },
 
     // No mkdirSync needed: if readConfig() succeeded the directory already exists.
@@ -145,7 +170,7 @@ export function getUserConfig(): ConfigStore {
       if (!(key in config)) return
       const {[key]: _, ...rest} = config
       writeJsonFileSync(getCliUserConfigPath(), rest, {pretty: true})
-      if (key === 'authToken') clearCliTokenCache()
+      if (affectsToken(key)) clearCliTokenCache()
     },
   }
 }

--- a/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
+++ b/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {parse as parseDotenv} from 'dotenv'
+
+import {debug} from '../../_exports/debug.js'
+
+/** User config key holding minted-but-unclaimed projects, keyed by project id. */
+export const UNCLAIMED_PROJECTS_CONFIG_KEY = 'unclaimedProjects'
+
+/**
+ * Read a single key straight from the directory's `.env`, using dotenv's grammar so it matches
+ * `readEnvValues` (used by mint/init/logout/nudges) exactly. Unlike Vite's `loadEnv`, it ignores
+ * `process.env`, so a shell `export` from another project can't shadow this directory's `.env`.
+ */
+function readEnvFileValue(cwd: string, key: string): string | undefined {
+  const envPath = path.join(cwd, '.env')
+  if (!fs.existsSync(envPath)) return undefined
+  return parseDotenv(fs.readFileSync(envPath, 'utf8'))[key]?.trim() || undefined
+}
+
+/**
+ * Resolve the robot token for the minted project the current directory points at, given the
+ * ledger `records` (the `unclaimedProjects` config value). Lets the CLI authenticate in a freshly
+ * minted directory that has no config file — where env injection never runs. The token is owned
+ * by the ledger, not `.env`: `.env` only carries the non-secret project id. Never throws.
+ */
+export function resolveMintedProjectToken(
+  records: unknown,
+  cwd: string = process.cwd(),
+): string | undefined {
+  try {
+    if (!records || typeof records !== 'object') return undefined
+
+    const projectId = readEnvFileValue(cwd, 'SANITY_PROJECT_ID')
+    if (!projectId) return undefined
+
+    const record = (records as Record<string, {token?: unknown}>)[projectId]
+    return typeof record?.token === 'string' ? record.token : undefined
+  } catch (err) {
+    debug('failed to resolve minted project token: %s', err)
+    return undefined
+  }
+}

--- a/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
+++ b/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
@@ -27,27 +27,34 @@ export interface MintedProjectCredential {
 /**
  * Resolve the robot credential for the minted project the current directory points at, given the
  * ledger `records` (the `unclaimedProjects` config value). Lets the CLI authenticate in a freshly
- * minted directory that has no config file — where env injection never runs. Mint writes the same
- * token into `.env` for the app runtime (which is why `.env` must stay gitignored); the CLI
- * resolves it from the ledger instead because env injection never runs before a config file
- * exists, and `.env` is user-mutable. Never throws.
+ * minted directory that has no config file — where env injection never runs. The ledger remains
+ * authoritative when it has a usable token; the root `.env` token is the recovery path when the
+ * ledger write failed. Mint writes both values before scaffolding, and `.env` must stay gitignored.
+ * Never throws.
  */
 export function resolveMintedProjectCredential(
   records: unknown,
   cwd: string = process.cwd(),
 ): MintedProjectCredential | undefined {
   try {
-    if (!records || typeof records !== 'object') return undefined
-
     const projectId = readEnvFileValue(cwd, 'SANITY_PROJECT_ID')
     if (!projectId) return undefined
 
-    const record = (records as Record<string, {token?: unknown}>)[projectId]
-    const token = record?.token
-    // A blank token cannot authenticate anything; treat the record as invalid so resolution
-    // falls through to the stored login session instead of surfacing an unusable credential.
-    if (typeof token !== 'string' || !token.trim()) return undefined
-    return {projectId, token}
+    const record =
+      records && typeof records === 'object'
+        ? (records as Record<string, {token?: unknown}>)[projectId]
+        : undefined
+    const recordToken = record?.token
+    if (typeof recordToken === 'string' && recordToken.trim()) {
+      return {projectId, token: recordToken}
+    }
+
+    // Mint can still persist the project-local credential if its separate user-config ledger
+    // write fails. Read only this directory's `.env` (never process.env or nested Studio env)
+    // so commands at the mint root can authenticate without silently taking another project's
+    // shell export.
+    const envToken = readEnvFileValue(cwd, 'SANITY_AUTH_TOKEN')
+    return envToken ? {projectId, token: envToken} : undefined
   } catch (err) {
     debug('failed to resolve minted project credential: %s', err)
     return undefined

--- a/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
+++ b/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
@@ -19,18 +19,23 @@ function readEnvFileValue(cwd: string, key: string): string | undefined {
   return parseDotenv(fs.readFileSync(envPath, 'utf8'))[key]?.trim() || undefined
 }
 
+export interface MintedProjectCredential {
+  projectId: string
+  token: string
+}
+
 /**
- * Resolve the robot token for the minted project the current directory points at, given the
+ * Resolve the robot credential for the minted project the current directory points at, given the
  * ledger `records` (the `unclaimedProjects` config value). Lets the CLI authenticate in a freshly
  * minted directory that has no config file — where env injection never runs. Mint writes the same
  * token into `.env` for the app runtime (which is why `.env` must stay gitignored); the CLI
  * resolves it from the ledger instead because env injection never runs before a config file
  * exists, and `.env` is user-mutable. Never throws.
  */
-export function resolveMintedProjectToken(
+export function resolveMintedProjectCredential(
   records: unknown,
   cwd: string = process.cwd(),
-): string | undefined {
+): MintedProjectCredential | undefined {
   try {
     if (!records || typeof records !== 'object') return undefined
 
@@ -38,9 +43,23 @@ export function resolveMintedProjectToken(
     if (!projectId) return undefined
 
     const record = (records as Record<string, {token?: unknown}>)[projectId]
-    return typeof record?.token === 'string' ? record.token : undefined
+    const token = record?.token
+    // A blank token cannot authenticate anything; treat the record as invalid so resolution
+    // falls through to the stored login session instead of surfacing an unusable credential.
+    if (typeof token !== 'string' || !token.trim()) return undefined
+    return {projectId, token}
   } catch (err) {
-    debug('failed to resolve minted project token: %s', err)
+    debug('failed to resolve minted project credential: %s', err)
     return undefined
   }
+}
+
+/**
+ * Token-only view of {@link resolveMintedProjectCredential}, kept for existing consumers.
+ */
+export function resolveMintedProjectToken(
+  records: unknown,
+  cwd: string = process.cwd(),
+): string | undefined {
+  return resolveMintedProjectCredential(records, cwd)?.token
 }

--- a/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
+++ b/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
@@ -8,15 +8,53 @@ import {debug} from '../../_exports/debug.js'
 /** User config key holding minted-but-unclaimed projects, keyed by project id. */
 export const UNCLAIMED_PROJECTS_CONFIG_KEY = 'unclaimedProjects'
 
+const MINTED_CREDENTIAL_BOUNDARY_KEYS = [
+  'SANITY_AUTH_TOKEN',
+  'SANITY_CLAIM_URL',
+  'SANITY_PROJECT_ID',
+] as const
+
+function mentionsMintedCredentialBoundary(contents: string): boolean {
+  return contents.split(/\r?\n/u).some((line) => {
+    let statement = line.trimStart()
+    if (!statement || statement.startsWith('#')) return false
+
+    statement = statement.replace(/^export\s+/u, '')
+    return MINTED_CREDENTIAL_BOUNDARY_KEYS.some((key) => {
+      if (!statement.startsWith(key)) return false
+      const nextCharacter = statement[key.length]
+      return nextCharacter === undefined || !/[A-Z0-9_]/iu.test(nextCharacter)
+    })
+  })
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT'
+}
+
 /**
- * Read a single key straight from the directory's `.env`, using dotenv's grammar so it matches
- * `readEnvValues` (used by mint/init/logout/nudges) exactly. Unlike Vite's `loadEnv`, it ignores
- * `process.env`, so a shell `export` from another project can't shadow this directory's `.env`.
+ * Find the nearest ancestor `.env` that establishes a Sanity credential boundary. The walk stays
+ * lexical, parses only the selected file, and never consults or mutates `process.env`.
  */
-function readEnvFileValue(cwd: string, key: string): string | undefined {
-  const envPath = path.join(cwd, '.env')
-  if (!fs.existsSync(envPath)) return undefined
-  return parseDotenv(fs.readFileSync(envPath, 'utf8'))[key]?.trim() || undefined
+function readMintedProjectEnv(cwd: string): Record<string, string> | undefined {
+  let directory = path.resolve(cwd)
+
+  while (true) {
+    let contents: string | undefined
+    try {
+      contents = fs.readFileSync(path.join(directory, '.env'), 'utf8')
+    } catch (error) {
+      if (!isMissingFileError(error)) return undefined
+    }
+
+    if (contents !== undefined && mentionsMintedCredentialBoundary(contents)) {
+      return parseDotenv(contents)
+    }
+
+    const parent = path.dirname(directory)
+    if (parent === directory) return undefined
+    directory = parent
+  }
 }
 
 export interface MintedProjectCredential {
@@ -25,35 +63,39 @@ export interface MintedProjectCredential {
 }
 
 /**
- * Resolve the robot credential for the minted project the current directory points at, given the
- * ledger `records` (the `unclaimedProjects` config value). Lets the CLI authenticate in a freshly
- * minted directory that has no config file — where env injection never runs. The ledger remains
- * authoritative when it has a usable token; the root `.env` token is the recovery path when the
- * ledger write failed. Mint writes both values before scaffolding, and `.env` must stay gitignored.
- * Never throws.
+ * Resolve the robot credential selected by the nearest ancestor `.env` credential boundary, given
+ * the ledger `records` (the `unclaimedProjects` config value). Lets the CLI authenticate from a
+ * freshly minted root or its generated descendants. The ledger remains authoritative when its
+ * record matches the selected project and has a usable token; the same `.env` token is the recovery
+ * path when the ledger write failed. Mint writes both values before scaffolding, and `.env` must
+ * stay gitignored. Never throws.
  */
 export function resolveMintedProjectCredential(
   records: unknown,
   cwd: string = process.cwd(),
 ): MintedProjectCredential | undefined {
   try {
-    const projectId = readEnvFileValue(cwd, 'SANITY_PROJECT_ID')
+    const env = readMintedProjectEnv(cwd)
+    if (!env) return undefined
+
+    const projectId = env.SANITY_PROJECT_ID?.trim()
     if (!projectId) return undefined
 
-    const record =
+    const record: unknown =
       records && typeof records === 'object'
-        ? (records as Record<string, {token?: unknown}>)[projectId]
+        ? (records as Record<string, unknown>)[projectId]
         : undefined
-    const recordToken = record?.token
-    if (typeof recordToken === 'string' && recordToken.trim()) {
-      return {projectId, token: recordToken}
+    if (record && typeof record === 'object' && !Array.isArray(record)) {
+      const {projectId: recordProjectId, token: recordToken} = record as Record<string, unknown>
+      if (recordProjectId === projectId && typeof recordToken === 'string' && recordToken.trim()) {
+        return {projectId, token: recordToken}
+      }
     }
 
     // Mint can still persist the project-local credential if its separate user-config ledger
-    // write fails. Read only this directory's `.env` (never process.env or nested Studio env)
-    // so commands at the mint root can authenticate without silently taking another project's
-    // shell export.
-    const envToken = readEnvFileValue(cwd, 'SANITY_AUTH_TOKEN')
+    // write fails. Read only the selected boundary's `.env` (never process.env or another env file)
+    // so descendants can authenticate without silently taking another project's shell export.
+    const envToken = env.SANITY_AUTH_TOKEN?.trim()
     return envToken ? {projectId, token: envToken} : undefined
   } catch (err) {
     debug('failed to resolve minted project credential: %s', err)

--- a/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
+++ b/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
@@ -22,8 +22,10 @@ function readEnvFileValue(cwd: string, key: string): string | undefined {
 /**
  * Resolve the robot token for the minted project the current directory points at, given the
  * ledger `records` (the `unclaimedProjects` config value). Lets the CLI authenticate in a freshly
- * minted directory that has no config file — where env injection never runs. The token is owned
- * by the ledger, not `.env`: `.env` only carries the non-secret project id. Never throws.
+ * minted directory that has no config file — where env injection never runs. Mint writes the same
+ * token into `.env` for the app runtime (which is why `.env` must stay gitignored); the CLI
+ * resolves it from the ledger instead because env injection never runs before a config file
+ * exists, and `.env` is user-mutable. Never throws.
  */
 export function resolveMintedProjectToken(
   records: unknown,

--- a/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
+++ b/packages/@sanity/cli-core/src/config/cli/unclaimedProjects.ts
@@ -32,23 +32,32 @@ function isMissingFileError(error: unknown): boolean {
   return error instanceof Error && 'code' in error && error.code === 'ENOENT'
 }
 
+export interface MintedProjectEnvBoundary {
+  contents: string
+  envPath: string
+}
+
 /**
  * Find the nearest ancestor `.env` that establishes a Sanity credential boundary. The walk stays
- * lexical, parses only the selected file, and never consults or mutates `process.env`.
+ * lexical and never consults or mutates `process.env`. Missing files are skipped; other read
+ * errors propagate so callers can fail closed.
  */
-function readMintedProjectEnv(cwd: string): Record<string, string> | undefined {
+export function findMintedProjectEnvBoundary(
+  cwd: string = process.cwd(),
+): MintedProjectEnvBoundary | undefined {
   let directory = path.resolve(cwd)
 
   while (true) {
     let contents: string | undefined
+    const envPath = path.join(directory, '.env')
     try {
-      contents = fs.readFileSync(path.join(directory, '.env'), 'utf8')
+      contents = fs.readFileSync(envPath, 'utf8')
     } catch (error) {
-      if (!isMissingFileError(error)) return undefined
+      if (!isMissingFileError(error)) throw error
     }
 
     if (contents !== undefined && mentionsMintedCredentialBoundary(contents)) {
-      return parseDotenv(contents)
+      return {contents, envPath}
     }
 
     const parent = path.dirname(directory)
@@ -75,9 +84,10 @@ export function resolveMintedProjectCredential(
   cwd: string = process.cwd(),
 ): MintedProjectCredential | undefined {
   try {
-    const env = readMintedProjectEnv(cwd)
-    if (!env) return undefined
+    const boundary = findMintedProjectEnvBoundary(cwd)
+    if (!boundary) return undefined
 
+    const env = parseDotenv(boundary.contents)
     const projectId = env.SANITY_PROJECT_ID?.trim()
     if (!projectId) return undefined
 

--- a/packages/@sanity/cli-core/src/ux/__tests__/flowOutput.test.ts
+++ b/packages/@sanity/cli-core/src/ux/__tests__/flowOutput.test.ts
@@ -1,0 +1,70 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {createFlow} from '../flowOutput.js'
+
+const mockIsInteractive = vi.hoisted(() => vi.fn())
+const mockStart = vi.hoisted(() => vi.fn())
+const mockSpinner = vi.hoisted(() => vi.fn())
+
+vi.mock('../../util/isInteractive.js', () => ({
+  isInteractive: mockIsInteractive,
+}))
+vi.mock('../spinner.js', () => ({
+  spinner: mockSpinner,
+}))
+
+const stopAndPersist = vi.fn()
+const {columns: origColumns, isTTY: origIsTTY} = process.stderr
+
+function setStderr(isTTY: boolean, columns: number): void {
+  Object.defineProperty(process.stderr, 'isTTY', {configurable: true, value: isTTY})
+  Object.defineProperty(process.stderr, 'columns', {configurable: true, value: columns})
+}
+
+beforeEach(() => {
+  mockIsInteractive.mockReturnValue(true)
+  mockStart.mockReturnValue({stopAndPersist})
+  mockSpinner.mockReturnValue({start: mockStart})
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  setStderr(origIsTTY as boolean, origColumns as number)
+})
+
+describe('createFlow spin', () => {
+  test('animates for an interactive run on a real stderr TTY', () => {
+    setStderr(true, 80)
+
+    createFlow(() => {})
+      .spin('minting')
+      .succeed('minted')
+
+    expect(mockSpinner).toHaveBeenCalledTimes(1)
+    expect(stopAndPersist).toHaveBeenCalledTimes(1)
+  })
+
+  test('prints a plain line instead of animating when not interactive', () => {
+    setStderr(true, 80)
+    mockIsInteractive.mockReturnValue(false)
+    const lines: string[] = []
+
+    createFlow((line = '') => lines.push(line)).spin('minting')
+
+    expect(mockSpinner).not.toHaveBeenCalled()
+    expect(lines[0]).toContain('minting')
+  })
+
+  test('degrades when stderr is not a TTY, or is a zero-width pty', () => {
+    for (const [isTTY, columns] of [
+      [false, 80],
+      [true, 0],
+    ] as const) {
+      vi.clearAllMocks()
+      mockIsInteractive.mockReturnValue(true)
+      setStderr(isTTY, columns)
+      createFlow(() => {}).spin('minting')
+      expect(mockSpinner).not.toHaveBeenCalled()
+    }
+  })
+})

--- a/packages/@sanity/cli-core/src/ux/__tests__/flowOutput.test.ts
+++ b/packages/@sanity/cli-core/src/ux/__tests__/flowOutput.test.ts
@@ -59,6 +59,9 @@ describe('createFlow output', () => {
     expect(lines.map((line) => stripVTControlCharacters(line).slice(3)).join(' ')).toBe(
       'Claiming keeps everything you built and makes the dataset readable.',
     )
+    expect(lines.every((line) => line.includes('\u001B[36m') && line.endsWith('\u001B[39m'))).toBe(
+      true,
+    )
   })
 
   test('keeps a long claim URL intact on one standalone TTY line', () => {
@@ -74,6 +77,17 @@ describe('createFlow output', () => {
     expect(lines[0]).toContain('\u001B]8;;')
   })
 
+  test('wraps by terminal cell width without splitting long words', () => {
+    setStdout(true, 10)
+    const lines: string[] = []
+    const flow = createFlow((line = '') => lines.push(stripVTControlCharacters(line)))
+
+    flow.line('界界界 a')
+    flow.line('unbreakable')
+
+    expect(lines).toEqual(['│  界界界', '│  a', '│  unbreakable'])
+  })
+
   test('prints a bare claim URL without control bytes when stdout is not a TTY', () => {
     setStdout(false, 20)
     const lines: string[] = []
@@ -83,6 +97,21 @@ describe('createFlow output', () => {
 
     expect(lines).toEqual([`│  ${url}`])
     expect(lines[0]).toBe(stripVTControlCharacters(lines[0]))
+  })
+
+  test.each([
+    ['TTY', true],
+    ['non-TTY', false],
+  ])('sanitizes ESC, BEL, and C1 controls in %s link output', (_, isTTY) => {
+    setStdout(isTTY, 80)
+    const lines: string[] = []
+    const unsafeUrl = 'https://www.sanity.io/manage/claim/\u001B\u0007\u009Csecret'
+    const sanitizedUrl = 'https://www.sanity.io/manage/claim/%1B%07%C2%9Csecret'
+
+    createFlow((line = '') => lines.push(line)).link(unsafeUrl)
+
+    expect(lines[0].slice(lines[0].indexOf('  ') + 2)).toBe(sanitizedUrl)
+    expect(lines[0]).not.toContain('\u001B]8;;')
   })
 })
 

--- a/packages/@sanity/cli-core/src/ux/__tests__/flowOutput.test.ts
+++ b/packages/@sanity/cli-core/src/ux/__tests__/flowOutput.test.ts
@@ -1,3 +1,5 @@
+import {stripVTControlCharacters} from 'node:util'
+
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {createFlow} from '../flowOutput.js'
@@ -15,10 +17,16 @@ vi.mock('../spinner.js', () => ({
 
 const stopAndPersist = vi.fn()
 const {columns: origColumns, isTTY: origIsTTY} = process.stderr
+const {columns: origStdoutColumns, isTTY: origStdoutIsTTY} = process.stdout
 
 function setStderr(isTTY: boolean, columns: number): void {
   Object.defineProperty(process.stderr, 'isTTY', {configurable: true, value: isTTY})
   Object.defineProperty(process.stderr, 'columns', {configurable: true, value: columns})
+}
+
+function setStdout(isTTY: boolean, columns: number): void {
+  Object.defineProperty(process.stdout, 'isTTY', {configurable: true, value: isTTY})
+  Object.defineProperty(process.stdout, 'columns', {configurable: true, value: columns})
 }
 
 beforeEach(() => {
@@ -30,6 +38,52 @@ beforeEach(() => {
 afterEach(() => {
   vi.clearAllMocks()
   setStderr(origIsTTY as boolean, origColumns as number)
+  setStdout(origStdoutIsTTY as boolean, origStdoutColumns as number)
+})
+
+describe('createFlow output', () => {
+  test('wraps styled prose to the terminal width with a rail on every physical line', () => {
+    setStdout(true, 20)
+    const lines: string[] = []
+
+    createFlow((line = '') => lines.push(line)).highlight(
+      '\u001B[36mClaiming keeps everything you built and makes the dataset readable.\u001B[39m',
+    )
+
+    expect(lines.length).toBeGreaterThan(1)
+    expect(stripVTControlCharacters(lines[0])).toMatch(/^◆ {2}/)
+    expect(lines.slice(1).map((line) => stripVTControlCharacters(line))).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^│ {2}/)]),
+    )
+    expect(lines.every((line) => stripVTControlCharacters(line).length <= 20)).toBe(true)
+    expect(lines.map((line) => stripVTControlCharacters(line).slice(3)).join(' ')).toBe(
+      'Claiming keeps everything you built and makes the dataset readable.',
+    )
+  })
+
+  test('keeps a long claim URL intact on one standalone TTY line', () => {
+    setStdout(true, 20)
+    const lines: string[] = []
+    const url = `https://www.sanity.io/manage/claim/${'secret'.repeat(12)}`
+
+    createFlow((line = '') => lines.push(line)).link(url)
+
+    expect(lines).toHaveLength(1)
+    expect(stripVTControlCharacters(lines[0])).toBe(`│  ${url}`)
+    expect(lines[0]).not.toContain('\n')
+    expect(lines[0]).toContain('\u001B]8;;')
+  })
+
+  test('prints a bare claim URL without control bytes when stdout is not a TTY', () => {
+    setStdout(false, 20)
+    const lines: string[] = []
+    const url = 'https://www.sanity.io/manage/claim/secret'
+
+    createFlow((line = '') => lines.push(line)).link(url)
+
+    expect(lines).toEqual([`│  ${url}`])
+    expect(lines[0]).toBe(stripVTControlCharacters(lines[0]))
+  })
 })
 
 describe('createFlow spin', () => {

--- a/packages/@sanity/cli-core/src/ux/flowOutput.ts
+++ b/packages/@sanity/cli-core/src/ux/flowOutput.ts
@@ -1,0 +1,84 @@
+import {styleText} from 'node:util'
+
+import {isInteractive} from '../util/isInteractive.js'
+import {spinner, type SpinnerInstance} from './spinner.js'
+
+type LogFn = (message?: string) => void
+
+const SPINNER_FRAMES = ['◐ ', '◓ ', '◑ ', '◒ ']
+
+function rail(glyph: string): string {
+  return styleText('gray', glyph)
+}
+
+export interface Flow {
+  /** `│` — a blank rail line separating steps. */
+  gap(): void
+  /** `◆` — an outcome the user should act on or remember. */
+  highlight(text: string): void
+  /** `┌` — opening line of the story. */
+  intro(text: string): void
+  /** `│  <text>` — a continuation line belonging to the previous step. */
+  line(text: string): void
+  /** `●` — a step happening behind the scenes, or a tip. */
+  note(text: string): void
+  /** `└` — closing line of the story. */
+  outro(text: string): void
+  /** `◇` — a completed step or produced value. */
+  result(text: string): void
+  /**
+   * An in-flight step. Resolve it with `succeed(text)` (persists as a `◇` line) or `fail(text)`;
+   * renders on stderr so machine-readable stdout is never corrupted.
+   */
+  spin(text: string): {fail(text: string): void; succeed(text: string): void}
+}
+
+/** Create a {@link Flow} that writes rail lines through `log`. */
+export function createFlow(log: LogFn): Flow {
+  return {
+    gap() {
+      log(rail('│'))
+    },
+    highlight(text: string) {
+      log(`${styleText('green', '◆')}  ${text}`)
+    },
+    intro(text: string) {
+      log(`${rail('┌')}  ${text}`)
+    },
+    line(text: string) {
+      log(`${rail('│')}  ${text}`)
+    },
+    note(text: string) {
+      log(`${rail('●')}  ${text}`)
+    },
+    outro(text: string) {
+      log(`${rail('└')}  ${text}`)
+    },
+    result(text: string) {
+      log(`${rail('◇')}  ${text}`)
+    },
+    spin(text: string) {
+      // No human, or stderr can't render cleanly (piped, or a zero-width pty that sends ora into
+      // a re-render hot loop): print a plain line instead of animating.
+      if (!isInteractive() || !process.stderr.isTTY || !process.stderr.columns) {
+        this.note(text)
+        return {
+          fail: (failText: string) => log(`${styleText('red', '✖')}  ${failText}`),
+          succeed: (successText: string) => log(`${rail('◇')}  ${successText}`),
+        }
+      }
+      const spin: SpinnerInstance = spinner({
+        spinner: {frames: SPINNER_FRAMES, interval: 120},
+        text,
+      }).start()
+      return {
+        fail(failText: string) {
+          spin.stopAndPersist({symbol: `${styleText('red', '✖')} `, text: failText})
+        },
+        succeed(successText: string) {
+          spin.stopAndPersist({symbol: `${rail('◇')} `, text: successText})
+        },
+      }
+    },
+  }
+}

--- a/packages/@sanity/cli-core/src/ux/flowOutput.ts
+++ b/packages/@sanity/cli-core/src/ux/flowOutput.ts
@@ -1,4 +1,4 @@
-import {styleText} from 'node:util'
+import {stripVTControlCharacters, styleText} from 'node:util'
 
 import {isInteractive} from '../util/isInteractive.js'
 import {spinner, type SpinnerInstance} from './spinner.js'
@@ -11,6 +11,80 @@ function rail(glyph: string): string {
   return styleText('gray', glyph)
 }
 
+const RAIL_PREFIX_WIDTH = 3
+function visibleWidth(text: string): number {
+  return [...stripVTControlCharacters(text)].length
+}
+
+function wrapLine(text: string, width: number): string[] {
+  if (visibleWidth(text) <= width) return [text]
+
+  const chunks = text.match(/\S+|\s+/g)
+  if (!chunks) return ['']
+
+  const lines: string[] = []
+  let current = ''
+  let whitespace = ''
+
+  for (const chunk of chunks) {
+    if (/^\s+$/.test(chunk)) {
+      whitespace += chunk
+      continue
+    }
+
+    const candidate = current ? `${current}${whitespace}${chunk}` : chunk
+    if (current && visibleWidth(candidate) > width) {
+      lines.push(current.trimEnd())
+      current = chunk
+    } else {
+      current = candidate
+    }
+    whitespace = ''
+  }
+
+  lines.push(current.trimEnd())
+  return lines
+}
+
+function wrapText(text: string): string[] {
+  if (
+    !process.stdout.isTTY ||
+    !Number.isFinite(process.stdout.columns) ||
+    process.stdout.columns <= 0
+  ) {
+    return text.split(/\r?\n/)
+  }
+  const columns = process.stdout.columns
+  const width = Math.max(columns - RAIL_PREFIX_WIDTH, 1)
+  return text.split(/\r?\n/).flatMap((line) => wrapLine(line, width))
+}
+
+function writeRailed(log: LogFn, glyph: string, text: string): void {
+  for (const [index, line] of wrapText(text).entries()) {
+    const marker =
+      index === 0 && glyph === '◆' ? styleText('green', glyph) : rail(index === 0 ? glyph : '│')
+    log(`${marker}  ${line}`)
+  }
+}
+
+function isSafeTerminalLink(url: string): boolean {
+  for (const character of url) {
+    const codePoint = character.codePointAt(0)
+    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) return false
+  }
+  try {
+    const protocol = new URL(url).protocol
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function terminalLink(url: string): string {
+  if (!process.stdout.isTTY || !isSafeTerminalLink(url)) return url
+  return `\u001B]8;;${url}\u0007${styleText(['cyan', 'underline'], url)}\u001B]8;;\u0007`
+}
+
 export interface Flow {
   /** `│` — a blank rail line separating steps. */
   gap(): void
@@ -20,6 +94,8 @@ export interface Flow {
   intro(text: string): void
   /** `│  <text>` — a continuation line belonging to the previous step. */
   line(text: string): void
+  /** A copy-safe URL. Long URLs are never hard-wrapped. */
+  link(url: string, options?: {label?: string; outro?: boolean}): void
   /** `●` — a step happening behind the scenes, or a tip. */
   note(text: string): void
   /** `└` — closing line of the story. */
@@ -40,22 +116,26 @@ export function createFlow(log: LogFn): Flow {
       log(rail('│'))
     },
     highlight(text: string) {
-      log(`${styleText('green', '◆')}  ${text}`)
+      writeRailed(log, '◆', text)
     },
     intro(text: string) {
-      log(`${rail('┌')}  ${text}`)
+      writeRailed(log, '┌', text)
     },
     line(text: string) {
-      log(`${rail('│')}  ${text}`)
+      writeRailed(log, '│', text)
+    },
+    link(url: string, options = {}) {
+      const label = options.label ? `${options.label} ` : ''
+      log(`${rail(options.outro ? '└' : '│')}  ${label}${terminalLink(url)}`)
     },
     note(text: string) {
-      log(`${rail('●')}  ${text}`)
+      writeRailed(log, '●', text)
     },
     outro(text: string) {
-      log(`${rail('└')}  ${text}`)
+      writeRailed(log, '└', text)
     },
     result(text: string) {
-      log(`${rail('◇')}  ${text}`)
+      writeRailed(log, '◇', text)
     },
     spin(text: string) {
       // No human, or stderr can't render cleanly (piped, or a zero-width pty that sends ora into

--- a/packages/@sanity/cli-core/src/ux/flowOutput.ts
+++ b/packages/@sanity/cli-core/src/ux/flowOutput.ts
@@ -1,4 +1,6 @@
-import {stripVTControlCharacters, styleText} from 'node:util'
+import {styleText} from 'node:util'
+
+import wrapAnsi from 'wrap-ansi'
 
 import {isInteractive} from '../util/isInteractive.js'
 import {spinner, type SpinnerInstance} from './spinner.js'
@@ -12,40 +14,6 @@ function rail(glyph: string): string {
 }
 
 const RAIL_PREFIX_WIDTH = 3
-function visibleWidth(text: string): number {
-  return [...stripVTControlCharacters(text)].length
-}
-
-function wrapLine(text: string, width: number): string[] {
-  if (visibleWidth(text) <= width) return [text]
-
-  const chunks = text.match(/\S+|\s+/g)
-  if (!chunks) return ['']
-
-  const lines: string[] = []
-  let current = ''
-  let whitespace = ''
-
-  for (const chunk of chunks) {
-    if (/^\s+$/.test(chunk)) {
-      whitespace += chunk
-      continue
-    }
-
-    const candidate = current ? `${current}${whitespace}${chunk}` : chunk
-    if (current && visibleWidth(candidate) > width) {
-      lines.push(current.trimEnd())
-      current = chunk
-    } else {
-      current = candidate
-    }
-    whitespace = ''
-  }
-
-  lines.push(current.trimEnd())
-  return lines
-}
-
 function wrapText(text: string): string[] {
   if (
     !process.stdout.isTTY ||
@@ -56,7 +24,7 @@ function wrapText(text: string): string[] {
   }
   const columns = process.stdout.columns
   const width = Math.max(columns - RAIL_PREFIX_WIDTH, 1)
-  return text.split(/\r?\n/).flatMap((line) => wrapLine(line, width))
+  return wrapAnsi(text, width, {hard: false, wordWrap: true}).split('\n')
 }
 
 function writeRailed(log: LogFn, glyph: string, text: string): void {
@@ -67,11 +35,13 @@ function writeRailed(log: LogFn, glyph: string, text: string): void {
   }
 }
 
+function isTerminalControl(character: string): boolean {
+  const codePoint = character.codePointAt(0)
+  return codePoint !== undefined && (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f))
+}
+
 function isSafeTerminalLink(url: string): boolean {
-  for (const character of url) {
-    const codePoint = character.codePointAt(0)
-    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) return false
-  }
+  if ([...url].some((character) => isTerminalControl(character))) return false
   try {
     const protocol = new URL(url).protocol
     return protocol === 'http:' || protocol === 'https:'
@@ -80,8 +50,17 @@ function isSafeTerminalLink(url: string): boolean {
   }
 }
 
+function encodeTerminalControls(value: string): string {
+  return [...value]
+    .map((character) => (isTerminalControl(character) ? encodeURIComponent(character) : character))
+    .join('')
+}
+
 function terminalLink(url: string): string {
-  if (!process.stdout.isTTY || !isSafeTerminalLink(url)) return url
+  const sanitizedUrl = encodeTerminalControls(url)
+  if (!process.stdout.isTTY || sanitizedUrl !== url || !isSafeTerminalLink(url)) {
+    return sanitizedUrl
+  }
   return `\u001B]8;;${url}\u0007${styleText(['cyan', 'underline'], url)}\u001B]8;;\u0007`
 }
 

--- a/packages/@sanity/cli-test/src/mocks/cli-core/config.ts
+++ b/packages/@sanity/cli-test/src/mocks/cli-core/config.ts
@@ -8,6 +8,8 @@ export const getCliConfigUncached: Mock = vi.fn()
 /** @internal */
 export const getCliConfigSync: Mock = vi.fn()
 /** @internal */
+export const findMintedProjectEnvBoundary: Mock = vi.fn()
+/** @internal */
 export const isWorkbenchApp: Mock = vi.fn()
 /** @internal */
 export const parseWorkbenchCliConfig: Mock = vi.fn()

--- a/packages/@sanity/cli/oclif.config.js
+++ b/packages/@sanity/cli/oclif.config.js
@@ -10,6 +10,7 @@ export default {
       './dist/hooks/prerun/injectEnvVariables.js',
       './dist/hooks/prerun/setupTelemetry.js',
       './dist/hooks/prerun/warnings.js',
+      './dist/hooks/prerun/claimReminders.js',
     ],
   },
   // Note: do not add '@sanity/migrate' here. The `migrations` commands now ship

--- a/packages/@sanity/cli/src/actions/auth/__tests__/ensureAuthenticated.test.ts
+++ b/packages/@sanity/cli/src/actions/auth/__tests__/ensureAuthenticated.test.ts
@@ -153,13 +153,17 @@ describe('ensureAuthenticated', () => {
 
     const user = await ensureAuthenticated({output: mockOutput, telemetry: mockTelemetry})
 
-    expect(mockLogin).toHaveBeenCalledWith({output: mockOutput, telemetry: mockTelemetry})
+    expect(mockLogin).toHaveBeenCalledWith({
+      activateSessionForProcess: true,
+      output: mockOutput,
+      telemetry: mockTelemetry,
+    })
     expect(mockOutput.warn).toHaveBeenCalledWith(LOGIN_REQUIRED_MESSAGE)
     expect(user).toEqual(expect.objectContaining({email: 'new@example.com'}))
   })
 
-  test('triggers login when token is expired', async () => {
-    mockGetCliToken.mockResolvedValue('expired-token')
+  test('activates the fresh session when an injected token fails validation', async () => {
+    mockGetCliToken.mockResolvedValue('injected-env-token')
     mockGetById.mockRejectedValueOnce(createHttpError(401, 'Unauthorized')).mockResolvedValue({
       email: 'reauthed@example.com',
       id: 'user-789',
@@ -170,7 +174,11 @@ describe('ensureAuthenticated', () => {
 
     const user = await ensureAuthenticated({output: mockOutput, telemetry: mockTelemetry})
 
-    expect(mockLogin).toHaveBeenCalled()
+    expect(mockLogin).toHaveBeenCalledWith({
+      activateSessionForProcess: true,
+      output: mockOutput,
+      telemetry: mockTelemetry,
+    })
     expect(user).toEqual(expect.objectContaining({email: 'reauthed@example.com'}))
   })
 

--- a/packages/@sanity/cli/src/actions/auth/ensureAuthenticated.ts
+++ b/packages/@sanity/cli/src/actions/auth/ensureAuthenticated.ts
@@ -31,7 +31,11 @@ export async function ensureAuthenticated(options: {
   options.output.warn(LOGIN_REQUIRED_MESSAGE)
 
   try {
-    await login({output: options.output, telemetry: options.telemetry})
+    await login({
+      activateSessionForProcess: true,
+      output: options.output,
+      telemetry: options.telemetry,
+    })
   } catch (cause) {
     throw new LoginError(getErrorMessage(cause), {cause})
   }

--- a/packages/@sanity/cli/src/actions/auth/login/__tests__/login.vercel.test.ts
+++ b/packages/@sanity/cli/src/actions/auth/login/__tests__/login.vercel.test.ts
@@ -1,4 +1,5 @@
 import {getCliToken, getCliUserConfig, setCliUserConfig} from '@sanity/cli-core'
+import {activateCliSessionForProcess} from '@sanity/cli-core/config'
 import open from 'open'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -25,6 +26,11 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
   }
 })
 
+vi.mock('@sanity/cli-core/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core/config')>()),
+  activateCliSessionForProcess: vi.fn(),
+}))
+
 vi.mock('@sanity/cli-core/ux', () => ({
   spinner: vi.fn(() => ({
     start: vi.fn(() => ({
@@ -50,6 +56,7 @@ vi.mock('../../../../util/canLaunchBrowser.js', () => ({
 
 const mockedGetCliToken = vi.mocked(getCliToken)
 const mockedSetCliUserConfig = vi.mocked(setCliUserConfig)
+const mockedActivateCliSessionForProcess = vi.mocked(activateCliSessionForProcess)
 const mockedStartServerForTokenCallback = vi.mocked(startServerForTokenCallback)
 const mockedGetProvider = vi.mocked(getProvider)
 const mockedValidateToken = vi.mocked(validateToken)
@@ -125,6 +132,12 @@ describe('#login vercel provider', () => {
 
     expect(vi.isMockFunction(getCliUserConfig)).toBe(true)
     expect(vi.mocked(getCliUserConfig)).toHaveBeenCalledWith('authToken')
+  })
+
+  test('activates the fresh session when an embedded authentication flow opts in', async () => {
+    await login({activateSessionForProcess: true, open: false, output, telemetry})
+
+    expect(mockedActivateCliSessionForProcess).toHaveBeenCalledWith('test-token')
   })
 
   test('records telemetry errors for token validation failures', async () => {

--- a/packages/@sanity/cli/src/actions/auth/login/__tests__/login.vercel.test.ts
+++ b/packages/@sanity/cli/src/actions/auth/login/__tests__/login.vercel.test.ts
@@ -1,4 +1,4 @@
-import {getCliToken, setCliUserConfig} from '@sanity/cli-core'
+import {getCliToken, getCliUserConfig, setCliUserConfig} from '@sanity/cli-core'
 import open from 'open'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -12,6 +12,9 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
   return {
     ...actual,
     getCliToken: vi.fn(),
+    // `getCliUserConfig` reads the config file directly rather than through `getUserConfig`, so
+    // without this it returns the developer's real session and `login` revokes it over the network.
+    getCliUserConfig: vi.fn(),
     getUserConfig: vi.fn().mockReturnValue({
       delete: vi.fn(),
       get: vi.fn(),
@@ -115,6 +118,13 @@ describe('#login vercel provider', () => {
     )
     expect(mockedOpen).not.toHaveBeenCalled()
     expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'test-token')
+  })
+
+  test('reads the previous session from the mocked config, never the real one', async () => {
+    await login({experimental: true, output, telemetry} as never)
+
+    expect(vi.isMockFunction(getCliUserConfig)).toBe(true)
+    expect(vi.mocked(getCliUserConfig)).toHaveBeenCalledWith('authToken')
   })
 
   test('records telemetry errors for token validation failures', async () => {

--- a/packages/@sanity/cli/src/actions/auth/login/login.ts
+++ b/packages/@sanity/cli/src/actions/auth/login/login.ts
@@ -1,6 +1,6 @@
 import {
   type CLITelemetryStore,
-  getCliToken,
+  getCliUserConfig,
   getUserConfig,
   type Output,
   setCliUserConfig,
@@ -45,7 +45,8 @@ interface LoginOptions {
  */
 export async function login(options: LoginOptions) {
   const {output, telemetry} = options
-  const previousToken = await getCliToken()
+  // Not `getCliToken()`: it prefers env and ledger robot tokens, which never revoke the session.
+  const previousToken = getCliUserConfig('authToken')
 
   const trace = telemetry.trace(LoginTrace)
   trace.start()

--- a/packages/@sanity/cli/src/actions/auth/login/login.ts
+++ b/packages/@sanity/cli/src/actions/auth/login/login.ts
@@ -6,6 +6,7 @@ import {
   setCliUserConfig,
   subdebug,
 } from '@sanity/cli-core'
+import {activateCliSessionForProcess} from '@sanity/cli-core/config'
 import {spinner} from '@sanity/cli-core/ux'
 import {isHttpError} from '@sanity/client'
 import open from 'open'
@@ -24,6 +25,7 @@ interface LoginOptions {
 
   telemetry: CLITelemetryStore
 
+  activateSessionForProcess?: boolean
   experimental?: boolean
   open?: boolean
   provider?: string
@@ -54,7 +56,7 @@ export async function login(options: LoginOptions) {
   if (typeof options.token === 'string') {
     try {
       const authToken = await validateToken(options.token)
-      await storeAuthToken(authToken, previousToken, output)
+      await storeAuthToken(authToken, previousToken, output, options.activateSessionForProcess)
       trace.complete()
     } catch (err: unknown) {
       trace.error(err as Error)
@@ -111,7 +113,7 @@ export async function login(options: LoginOptions) {
     })
   }
 
-  await storeAuthToken(authToken, previousToken, output)
+  await storeAuthToken(authToken, previousToken, output, options.activateSessionForProcess)
 
   trace.complete()
 }
@@ -120,8 +122,10 @@ async function storeAuthToken(
   authToken: string,
   previousToken: string | undefined,
   output: Output,
+  activateSessionForProcess = false,
 ) {
   setCliUserConfig('authToken', authToken)
+  if (activateSessionForProcess) activateCliSessionForProcess(authToken)
   getUserConfig().delete('telemetryConsent')
 
   // If we had a session previously, attempt to clear it

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -212,7 +212,8 @@ describe('initAction (direct)', () => {
     expect(caughtError).toBeInstanceOf(InitError)
     const initError = caughtError as InitError
     expect(initError.message).toContain('Not logged in. Run `sanity login` to authenticate')
-    expect(initError.message).toContain('run `sanity new` to create a project without logging in')
+    expect(initError.message).toContain('To create a project without logging in, run `sanity new`')
+    expect(initError.message).toContain('https://sanity.new')
     expect(initError.exitCode).toBe(1)
   })
 

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -74,6 +74,7 @@ vi.mock('../../auth/login/login.js', () => ({
 vi.mock('../../../util/envFile.js', () => ({
   GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
   readEnvValues: mockReadEnvValues,
+  TOKEN_ENV_FILES: './.env, or sanity/.env.local in a scaffolded project',
 }))
 
 vi.mock('../../../util/claimNudges.js', () => ({

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -16,6 +16,7 @@ import {type InitContext, type InitOptions} from '../types.js'
 // ---------------------------------------------------------------------------
 
 const mockGetById = vi.hoisted(() => vi.fn())
+const mockGetCliToken = vi.hoisted(() => vi.fn())
 const mockValidateSession = vi.hoisted(() => vi.fn())
 const mockLogin = vi.hoisted(() => vi.fn())
 const mockInspectEnvKeys = vi.hoisted(() =>
@@ -45,6 +46,7 @@ vi.mock('@sanity/cli-core', async (importOriginal) => {
 
   return {
     ...actual,
+    getCliToken: mockGetCliToken,
     getGlobalCliClient: vi.fn().mockResolvedValue({
       projects: {
         list: vi
@@ -164,6 +166,7 @@ async function useMintedDescendant(options: {unreadable?: boolean} = {}): Promis
 describe('initAction (direct)', () => {
   afterEach(() => {
     vi.clearAllMocks()
+    mockGetCliToken.mockReset()
     const pending = nock.pendingMocks()
     nock.cleanAll()
     expect(pending, 'pending mocks').toEqual([])
@@ -319,6 +322,43 @@ describe('initAction (direct)', () => {
     const initError = caughtError as InitError
     expect(initError.message).toContain('unclaimed Sanity project (abc123)')
     expect(initError.message).toContain('Set SANITY_AUTH_TOKEN')
+    expect(initError.message).not.toContain('run `sanity new`')
+  })
+
+  test('unattended reports an available but rejected minted credential as invalid', async () => {
+    mockValidateSession.mockResolvedValue(null)
+    mockGetCliToken.mockResolvedValue('expired-or-revoked-token')
+    mockInspectEnvKeys.mockReturnValue({
+      blankKeys: [],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {SANITY_PROJECT_ID: 'abc123'},
+    })
+    mockGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
+
+    const context = createTestContext()
+    let caughtError: unknown
+    try {
+      await initAction(
+        {
+          ...defaultOptions,
+          dataset: 'production',
+          outputPath: '/tmp/test-output',
+          project: 'test-project',
+          unattended: true,
+        },
+        context,
+      )
+    } catch (error) {
+      caughtError = error
+    }
+
+    expect(caughtError).toBeInstanceOf(InitError)
+    const initError = caughtError as InitError
+    expect(initError.message).toContain(
+      'available auth token is invalid, expired, or lacks the required access',
+    )
+    expect(initError.message).toContain('Set SANITY_AUTH_TOKEN to a valid token')
+    expect(initError.message).not.toContain("token isn't available here")
     expect(initError.message).not.toContain('run `sanity new`')
   })
 

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -3,7 +3,6 @@ import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
-import {LOGIN_REQUIRED_MESSAGE} from '../../auth/login/loginInstructions.js'
 import {initAction} from '../initAction.js'
 import {InitError} from '../initError.js'
 import {type InitContext, type InitOptions} from '../types.js'
@@ -15,6 +14,8 @@ import {type InitContext, type InitOptions} from '../types.js'
 const mockGetById = vi.hoisted(() => vi.fn())
 const mockValidateSession = vi.hoisted(() => vi.fn())
 const mockLogin = vi.hoisted(() => vi.fn())
+const mockReadEnvValues = vi.hoisted(() => vi.fn(() => ({}) as Record<string, string>))
+const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn())
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -68,6 +69,15 @@ vi.mock('../../auth/ensureAuthenticated.js', () => ({
 
 vi.mock('../../auth/login/login.js', () => ({
   login: mockLogin,
+}))
+
+vi.mock('../../../util/envFile.js', () => ({
+  GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
+  readEnvValues: mockReadEnvValues,
+}))
+
+vi.mock('../../../util/claimNudges.js', () => ({
+  getMintedProjectRecord: mockGetMintedProjectRecord,
 }))
 
 // ---------------------------------------------------------------------------
@@ -201,7 +211,161 @@ describe('initAction (direct)', () => {
 
     expect(caughtError).toBeInstanceOf(InitError)
     const initError = caughtError as InitError
-    expect(initError.message).toBe(LOGIN_REQUIRED_MESSAGE)
+    expect(initError.message).toContain('Not logged in. Run `sanity login` to authenticate')
+    expect(initError.message).toContain('run `sanity new` to create a project without logging in')
     expect(initError.exitCode).toBe(1)
+  })
+
+  test('unattended not-logged-in in a minted directory points at its token, not `sanity new`', async () => {
+    mockValidateSession.mockResolvedValue(null)
+    mockReadEnvValues.mockReturnValue({SANITY_PROJECT_ID: 'abc123'})
+    // A ledger record is what marks this as a known unclaimed mint.
+    mockGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
+
+    const context = createTestContext()
+    const options: InitOptions = {
+      ...defaultOptions,
+      dataset: 'production',
+      outputPath: '/tmp/test-output',
+      project: 'test-project',
+      unattended: true,
+    }
+
+    let caughtError: unknown
+    try {
+      await initAction(options, context)
+    } catch (error) {
+      caughtError = error
+    }
+
+    const initError = caughtError as InitError
+    expect(initError.message).toContain('unclaimed Sanity project (abc123)')
+    expect(initError.message).toContain('Set SANITY_AUTH_TOKEN')
+    expect(initError.message).not.toContain('run `sanity new`')
+  })
+
+  test('unattended not-logged-in with guarded .env keys but no ledger record: no mislabel, no sanity new', async () => {
+    // `sanity init --env` also writes SANITY_PROJECT_ID and it survives a claim, so a bare id with
+    // no ledger record must not be mislabeled an unclaimed mint — and since `sanity new` is still
+    // refused here (guarded key present), it must not be suggested either.
+    mockValidateSession.mockResolvedValue(null)
+    mockReadEnvValues.mockReturnValue({SANITY_PROJECT_ID: 'claimedproj'})
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+
+    const context = createTestContext()
+    const options: InitOptions = {
+      ...defaultOptions,
+      dataset: 'production',
+      outputPath: '/tmp/test-output',
+      project: 'test-project',
+      unattended: true,
+    }
+
+    let caughtError: unknown
+    try {
+      await initAction(options, context)
+    } catch (error) {
+      caughtError = error
+    }
+
+    const initError = caughtError as InitError
+    expect(initError.message).toContain('already has Sanity credentials in .env')
+    expect(initError.message).not.toContain('unclaimed Sanity project (claimedproj)')
+    expect(initError.message).not.toContain('sanity new')
+  })
+
+  test('never greets a robot-token session as "logged in as null"', async () => {
+    // A minted project's robot token authenticates but has no email to display.
+    mockValidateSession.mockResolvedValue({
+      email: '',
+      id: 'robot',
+      name: '',
+      provider: 'sanity-token',
+    })
+
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      uri: '/features',
+    }).reply(200, ['privateDataset'])
+
+    const context = createTestContext()
+    const options: InitOptions = {
+      ...defaultOptions,
+      bare: true,
+      dataset: 'production',
+      project: 'test-project',
+    }
+
+    await initAction(options, context)
+
+    const combined = vi
+      .mocked(context.output.log)
+      .mock.calls.map((call) => call[0])
+      .join('\n')
+    expect(combined).toContain('You are logged in as robot using an API token')
+    expect(combined).not.toContain('null')
+  })
+
+  test('suppresses the "two ways to start" banner in a minted directory', async () => {
+    // `sanity new` is refused by the remint guard in a minted directory, so its banner would
+    // steer the user toward a dead end — mirror the unattended path, which already special-cases it.
+    mockValidateSession.mockResolvedValue(null)
+    mockReadEnvValues.mockReturnValue({SANITY_PROJECT_ID: 'abc123'})
+    mockGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
+    // The banner renders before login(); reject there to stop before the networked getCliUser.
+    mockLogin.mockRejectedValueOnce(new Error('stop'))
+
+    const context = createTestContext()
+    await initAction(
+      {...defaultOptions, dataset: 'production', project: 'test-project'},
+      context,
+    ).catch(() => {})
+
+    const combined = vi
+      .mocked(context.output.log)
+      .mock.calls.map((call) => call[0])
+      .join('\n')
+    expect(combined).not.toContain('Two ways to start')
+  })
+
+  test('suppresses the banner when .env has guarded keys but no ledger record (still remint-blocked)', async () => {
+    // A copied minted directory or an `init --env` leftover: no ledger record, but `sanity new` is
+    // still refused because guarded keys are present — so the banner must stay suppressed.
+    mockValidateSession.mockResolvedValue(null)
+    mockReadEnvValues.mockReturnValue({SANITY_PROJECT_ID: 'copied-or-claimed'})
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+    mockLogin.mockRejectedValueOnce(new Error('stop'))
+
+    const context = createTestContext()
+    await initAction(
+      {...defaultOptions, dataset: 'production', project: 'test-project'},
+      context,
+    ).catch(() => {})
+
+    const combined = vi
+      .mocked(context.output.log)
+      .mock.calls.map((call) => call[0])
+      .join('\n')
+    expect(combined).not.toContain('Two ways to start')
+  })
+
+  test('shows the "two ways to start" banner when the directory has no minted project', async () => {
+    mockValidateSession.mockResolvedValue(null)
+    mockReadEnvValues.mockReturnValue({})
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+    mockLogin.mockRejectedValueOnce(new Error('stop'))
+
+    const context = createTestContext()
+    await initAction(
+      {...defaultOptions, dataset: 'production', project: 'test-project'},
+      context,
+    ).catch(() => {})
+
+    const combined = vi
+      .mocked(context.output.log)
+      .mock.calls.map((call) => call[0])
+      .join('\n')
+    expect(combined).toContain('Two ways to start')
   })
 })

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
 import {createTestClient, mockApi} from '@sanity/cli-test'
 import nock from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -15,13 +19,16 @@ const mockGetById = vi.hoisted(() => vi.fn())
 const mockValidateSession = vi.hoisted(() => vi.fn())
 const mockLogin = vi.hoisted(() => vi.fn())
 const mockInspectEnvKeys = vi.hoisted(() =>
-  vi.fn(
-    (): {
+  vi.fn<
+    (
+      _envPath: string,
+      _keys: readonly string[],
+    ) => {
       blankKeys: string[]
       presentKeys: string[]
-      values: Record<string, string>
-    } => ({blankKeys: [], presentKeys: [], values: {}}),
-  ),
+      values: Partial<Record<string, string>>
+    }
+  >(() => ({blankKeys: [], presentKeys: [], values: {}})),
 )
 const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn())
 
@@ -122,6 +129,31 @@ function createTestContext(): InitContext {
       }),
     } as unknown as InitContext['telemetry'],
     workDir: '/tmp/test-work-dir',
+  }
+}
+
+async function useMintedDescendant(options: {unreadable?: boolean} = {}): Promise<() => void> {
+  const mintRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sanity-init-minted-root-'))
+  const descendant = path.join(mintRoot, 'web')
+  fs.mkdirSync(descendant)
+  const envPath = path.join(mintRoot, '.env')
+  if (options.unreadable) {
+    fs.mkdirSync(envPath)
+  } else {
+    fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\n')
+  }
+  const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(descendant)
+  if (!options.unreadable) {
+    const {inspectEnvKeys} = await vi.importActual<typeof import('../../../util/envFile.js')>(
+      '../../../util/envFile.js',
+    )
+    mockInspectEnvKeys.mockImplementation(inspectEnvKeys)
+  }
+
+  return () => {
+    mockInspectEnvKeys.mockImplementation(() => ({blankKeys: [], presentKeys: [], values: {}}))
+    cwdSpy.mockRestore()
+    fs.rmSync(mintRoot, {force: true, recursive: true})
   }
 }
 
@@ -257,6 +289,94 @@ describe('initAction (direct)', () => {
     expect(initError.message).not.toContain('run `sanity new`')
   })
 
+  test('unattended not-logged-in in a minted descendant keeps the mint-root guidance', async () => {
+    const cleanup = await useMintedDescendant()
+    mockValidateSession.mockResolvedValue(null)
+    mockGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
+
+    const context = createTestContext()
+    const options: InitOptions = {
+      ...defaultOptions,
+      dataset: 'production',
+      outputPath: '/tmp/test-output',
+      project: 'test-project',
+      unattended: true,
+    }
+
+    let caughtError: unknown
+    try {
+      await initAction(options, context)
+    } catch (error) {
+      caughtError = error
+    } finally {
+      cleanup()
+    }
+
+    const initError = caughtError as InitError
+    expect(initError.message).toContain('unclaimed Sanity project (abc123)')
+    expect(initError.message).toContain('Set SANITY_AUTH_TOKEN')
+    expect(initError.message).not.toContain('run `sanity new`')
+  })
+
+  test('unattended reports an unreadable ancestor credential boundary without suggesting a remint', async () => {
+    const cleanup = await useMintedDescendant({unreadable: true})
+    mockValidateSession.mockResolvedValue(null)
+
+    const context = createTestContext()
+    let caughtError: unknown
+    try {
+      await initAction(
+        {
+          ...defaultOptions,
+          dataset: 'production',
+          outputPath: '/tmp/test-output',
+          project: 'test-project',
+          unattended: true,
+        },
+        context,
+      )
+    } catch (error) {
+      caughtError = error
+    } finally {
+      cleanup()
+    }
+
+    expect(caughtError).toBeInstanceOf(InitError)
+    const initError = caughtError as InitError
+    expect(initError.message).toContain('Could not inspect the Sanity credential boundary')
+    expect(initError.message).toContain('Ensure ancestor .env files are readable regular files')
+    expect(initError.message).not.toContain('sanity new')
+    expect(initError.exitCode).toBe(1)
+  })
+
+  test('interactive warns on an unreadable ancestor boundary, suppresses the remint banner, and logs in', async () => {
+    const cleanup = await useMintedDescendant({unreadable: true})
+    mockValidateSession.mockResolvedValue(null)
+    mockLogin.mockRejectedValueOnce(new Error('stop'))
+
+    const context = createTestContext()
+    try {
+      await expect(
+        initAction({...defaultOptions, dataset: 'production', project: 'test-project'}, context),
+      ).rejects.toThrow('Login failed: stop')
+    } finally {
+      cleanup()
+    }
+
+    const warnings = vi
+      .mocked(context.output.warn)
+      .mock.calls.map((call) => call[0])
+      .join('\n')
+    const logged = vi
+      .mocked(context.output.log)
+      .mock.calls.map((call) => call[0])
+      .join('\n')
+    expect(warnings).toContain('Could not inspect the Sanity credential boundary')
+    expect(warnings).toContain('Ensure ancestor .env files are readable regular files')
+    expect(logged).not.toContain('Two ways to start')
+    expect(mockLogin).toHaveBeenCalledOnce()
+  })
+
   test('unattended not-logged-in with guarded .env keys but no ledger record: no mislabel, no sanity new', async () => {
     // `sanity init --env` also writes SANITY_PROJECT_ID and it survives a claim, so a bare id with
     // no ledger record must not be mislabeled an unclaimed mint — and since `sanity new` is still
@@ -355,24 +475,24 @@ describe('initAction (direct)', () => {
     expect(combined).not.toContain('null')
   })
 
-  test('suppresses the "two ways to start" banner in a minted directory', async () => {
+  test('suppresses the "two ways to start" banner in a minted descendant', async () => {
     // `sanity new` is refused by the remint guard in a minted directory, so its banner would
     // steer the user toward a dead end — mirror the unattended path, which already special-cases it.
+    const cleanup = await useMintedDescendant()
     mockValidateSession.mockResolvedValue(null)
-    mockInspectEnvKeys.mockReturnValue({
-      blankKeys: [],
-      presentKeys: ['SANITY_PROJECT_ID'],
-      values: {SANITY_PROJECT_ID: 'abc123'},
-    })
     mockGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
     // The banner renders before login(); reject there to stop before the networked getCliUser.
     mockLogin.mockRejectedValueOnce(new Error('stop'))
 
     const context = createTestContext()
-    await initAction(
-      {...defaultOptions, dataset: 'production', project: 'test-project'},
-      context,
-    ).catch(() => {})
+    try {
+      await initAction(
+        {...defaultOptions, dataset: 'production', project: 'test-project'},
+        context,
+      ).catch(() => {})
+    } finally {
+      cleanup()
+    }
 
     const combined = vi
       .mocked(context.output.log)

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -14,7 +14,15 @@ import {type InitContext, type InitOptions} from '../types.js'
 const mockGetById = vi.hoisted(() => vi.fn())
 const mockValidateSession = vi.hoisted(() => vi.fn())
 const mockLogin = vi.hoisted(() => vi.fn())
-const mockReadEnvValues = vi.hoisted(() => vi.fn(() => ({}) as Record<string, string>))
+const mockInspectEnvKeys = vi.hoisted(() =>
+  vi.fn(
+    (): {
+      blankKeys: string[]
+      presentKeys: string[]
+      values: Record<string, string>
+    } => ({blankKeys: [], presentKeys: [], values: {}}),
+  ),
+)
 const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn())
 
 // ---------------------------------------------------------------------------
@@ -73,7 +81,7 @@ vi.mock('../../auth/login/login.js', () => ({
 
 vi.mock('../../../util/envFile.js', () => ({
   GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
-  readEnvValues: mockReadEnvValues,
+  inspectEnvKeys: mockInspectEnvKeys,
   TOKEN_ENV_FILES: './.env, or sanity/.env.local in a scaffolded project',
 }))
 
@@ -220,7 +228,11 @@ describe('initAction (direct)', () => {
 
   test('unattended not-logged-in in a minted directory points at its token, not `sanity new`', async () => {
     mockValidateSession.mockResolvedValue(null)
-    mockReadEnvValues.mockReturnValue({SANITY_PROJECT_ID: 'abc123'})
+    mockInspectEnvKeys.mockReturnValue({
+      blankKeys: [],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {SANITY_PROJECT_ID: 'abc123'},
+    })
     // A ledger record is what marks this as a known unclaimed mint.
     mockGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
 
@@ -251,7 +263,11 @@ describe('initAction (direct)', () => {
     // no ledger record must not be mislabeled an unclaimed mint — and since `sanity new` is still
     // refused here (guarded key present), it must not be suggested either.
     mockValidateSession.mockResolvedValue(null)
-    mockReadEnvValues.mockReturnValue({SANITY_PROJECT_ID: 'claimedproj'})
+    mockInspectEnvKeys.mockReturnValue({
+      blankKeys: [],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {SANITY_PROJECT_ID: 'claimedproj'},
+    })
     mockGetMintedProjectRecord.mockReturnValue(undefined)
 
     const context = createTestContext()
@@ -273,6 +289,37 @@ describe('initAction (direct)', () => {
     const initError = caughtError as InitError
     expect(initError.message).toContain('already has Sanity credentials in .env')
     expect(initError.message).not.toContain('unclaimed Sanity project (claimedproj)')
+    expect(initError.message).not.toContain('sanity new')
+  })
+
+  test('unattended not-logged-in with blank guarded placeholders explains how to unblock', async () => {
+    mockValidateSession.mockResolvedValue(null)
+    mockInspectEnvKeys.mockReturnValue({
+      blankKeys: ['SANITY_PROJECT_ID', 'SANITY_AUTH_TOKEN'],
+      presentKeys: ['SANITY_PROJECT_ID', 'SANITY_AUTH_TOKEN'],
+      values: {},
+    })
+
+    const context = createTestContext()
+    const options: InitOptions = {
+      ...defaultOptions,
+      dataset: 'production',
+      outputPath: '/tmp/test-output',
+      project: 'test-project',
+      unattended: true,
+    }
+
+    let caughtError: unknown
+    try {
+      await initAction(options, context)
+    } catch (error) {
+      caughtError = error
+    }
+
+    const initError = caughtError as InitError
+    expect(initError.message).toContain(
+      'blank Sanity credential placeholders in .env: SANITY_PROJECT_ID, SANITY_AUTH_TOKEN',
+    )
     expect(initError.message).not.toContain('sanity new')
   })
 
@@ -313,7 +360,11 @@ describe('initAction (direct)', () => {
     // `sanity new` is refused by the remint guard in a minted directory, so its banner would
     // steer the user toward a dead end — mirror the unattended path, which already special-cases it.
     mockValidateSession.mockResolvedValue(null)
-    mockReadEnvValues.mockReturnValue({SANITY_PROJECT_ID: 'abc123'})
+    mockInspectEnvKeys.mockReturnValue({
+      blankKeys: [],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {SANITY_PROJECT_ID: 'abc123'},
+    })
     mockGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
     // The banner renders before login(); reject there to stop before the networked getCliUser.
     mockLogin.mockRejectedValueOnce(new Error('stop'))
@@ -335,8 +386,34 @@ describe('initAction (direct)', () => {
     // A copied minted directory or an `init --env` leftover: no ledger record, but `sanity new` is
     // still refused because guarded keys are present — so the banner must stay suppressed.
     mockValidateSession.mockResolvedValue(null)
-    mockReadEnvValues.mockReturnValue({SANITY_PROJECT_ID: 'copied-or-claimed'})
+    mockInspectEnvKeys.mockReturnValue({
+      blankKeys: [],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {SANITY_PROJECT_ID: 'copied-or-claimed'},
+    })
     mockGetMintedProjectRecord.mockReturnValue(undefined)
+    mockLogin.mockRejectedValueOnce(new Error('stop'))
+
+    const context = createTestContext()
+    await initAction(
+      {...defaultOptions, dataset: 'production', project: 'test-project'},
+      context,
+    ).catch(() => {})
+
+    const combined = vi
+      .mocked(context.output.log)
+      .mock.calls.map((call) => call[0])
+      .join('\n')
+    expect(combined).not.toContain('Two ways to start')
+  })
+
+  test('suppresses the banner when .env has blank guarded placeholders', async () => {
+    mockValidateSession.mockResolvedValue(null)
+    mockInspectEnvKeys.mockReturnValue({
+      blankKeys: ['SANITY_PROJECT_ID'],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {},
+    })
     mockLogin.mockRejectedValueOnce(new Error('stop'))
 
     const context = createTestContext()
@@ -354,7 +431,7 @@ describe('initAction (direct)', () => {
 
   test('shows the "two ways to start" banner when the directory has no minted project', async () => {
     mockValidateSession.mockResolvedValue(null)
-    mockReadEnvValues.mockReturnValue({})
+    mockInspectEnvKeys.mockReturnValue({blankKeys: [], presentKeys: [], values: {}})
     mockGetMintedProjectRecord.mockReturnValue(undefined)
     mockLogin.mockRejectedValueOnce(new Error('stop'))
 

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -230,6 +230,39 @@ describe('initAction (direct)', () => {
     expect(combined).toContain('production')
   })
 
+  test('embedded login activates its fresh session before init continues', async () => {
+    mockValidateSession.mockResolvedValue(null)
+    mockLogin.mockResolvedValue(undefined)
+    mockGetById.mockResolvedValue({
+      email: 'fresh@example.com',
+      id: 'user-456',
+      name: 'Fresh User',
+      provider: 'github',
+    })
+
+    mockApi({
+      apiVersion: PROJECT_FEATURES_API_VERSION,
+      method: 'get',
+      uri: '/features',
+    }).reply(200, ['privateDataset'])
+
+    const context = createTestContext()
+    await initAction(
+      {
+        ...defaultOptions,
+        bare: true,
+        dataset: 'production',
+        project: 'test-project',
+      },
+      context,
+    )
+
+    expect(mockLogin).toHaveBeenCalledWith(
+      expect.objectContaining({activateSessionForProcess: true}),
+    )
+    expect(mockGetById).toHaveBeenCalledWith('me')
+  })
+
   test('throws InitError when not authenticated in unattended mode', async () => {
     mockValidateSession.mockResolvedValue(null)
 

--- a/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initAction.test.ts
@@ -79,10 +79,9 @@ vi.mock('../../auth/login/login.js', () => ({
   login: mockLogin,
 }))
 
-vi.mock('../../../util/envFile.js', () => ({
-  GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
+vi.mock('../../../util/envFile.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../util/envFile.js')>()),
   inspectEnvKeys: mockInspectEnvKeys,
-  TOKEN_ENV_FILES: './.env, or sanity/.env.local in a scaffolded project',
 }))
 
 vi.mock('../../../util/claimNudges.js', () => ({

--- a/packages/@sanity/cli/src/actions/init/__tests__/initStudio.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/initStudio.test.ts
@@ -1,0 +1,69 @@
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {initStudio} from '../initStudio.js'
+
+const mockUpdateProjectInitializedAt = vi.hoisted(() => vi.fn())
+const mockScaffoldAndInstall = vi.hoisted(() => vi.fn())
+const mockSelectTemplate = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../services/projects.js', () => ({
+  updateProjectInitializedAt: mockUpdateProjectInitializedAt,
+}))
+vi.mock('../scaffoldTemplate.js', () => ({
+  scaffoldAndInstall: mockScaffoldAndInstall,
+  selectTemplate: mockSelectTemplate,
+}))
+
+const mockOutputLog = vi.fn()
+const output = {log: mockOutputLog} as never
+
+const trace = {
+  error: vi.fn(),
+  log: vi.fn(),
+} as never
+
+const args = {
+  datasetName: 'production',
+  defaults: {projectName: 'My Project'},
+  displayName: 'My Project',
+  isFirstProject: false,
+  mcpConfigured: [],
+  options: {unattended: true},
+  organizationId: undefined,
+  output,
+  outputPath: '/tmp/my-project/sanity',
+  projectId: 'abc123',
+  remoteTemplateInfo: undefined,
+  sluggedName: 'sanity-studio',
+  trace,
+  workbench: false,
+  workDir: '/tmp/my-project',
+} as const
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUpdateProjectInitializedAt.mockResolvedValue(undefined)
+  mockSelectTemplate.mockResolvedValue({
+    template: {},
+    templateName: 'clean',
+    useTypeScript: true,
+  })
+  mockScaffoldAndInstall.mockResolvedValue({pkgManager: 'npm'})
+})
+
+describe('initStudio', () => {
+  test('suppresses its standalone outro when the pre-claim caller owns the narration', async () => {
+    await initStudio({...args, preclaim: true} as never)
+
+    expect(mockScaffoldAndInstall).toHaveBeenCalled()
+    expect(mockOutputLog).not.toHaveBeenCalled()
+  })
+
+  test('keeps the standalone Studio outro for regular init calls', async () => {
+    await initStudio({...args, preclaim: false} as never)
+
+    const lines = mockOutputLog.mock.calls.flat().join('\n')
+    expect(lines).toContain('Success! Your Studio has been created')
+    expect(lines).toContain('Get started by running npm run dev')
+  })
+})

--- a/packages/@sanity/cli/src/actions/init/__tests__/newCommandBanner.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/newCommandBanner.test.ts
@@ -1,0 +1,42 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {renderNewCommandBanner} from '../newCommandBanner.js'
+
+function render(): string {
+  const log = vi.fn()
+  renderNewCommandBanner({error: vi.fn() as never, log, warn: vi.fn()})
+  return (
+    log.mock.calls
+      .map(([line]) => String(line ?? ''))
+      .join('\n')
+      // eslint-disable-next-line no-control-regex -- strip ANSI styling
+      .replaceAll(/\u001B\[[0-9;]*m/g, '')
+      // eslint-disable-next-line no-control-regex -- strip OSC 8 hyperlink wrappers
+      .replaceAll(/\u001B\]8;;[^\u0007]*\u0007/g, '')
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('#renderNewCommandBanner', () => {
+  test('renders the two-ways-to-start signpost box, blank-line padded', () => {
+    const banner = render()
+
+    expect(banner).toContain('Two ways to start')
+    expect(banner).toContain('sanity init')
+    expect(banner).toContain('sanity new')
+    expect(banner).toContain('claim it within 72 hours')
+    expect(banner).toContain('https://sanity.new')
+    expect(banner).toContain('╭') // boxed — the one-time signpost keeps its box
+    expect(banner.startsWith('\n')).toBe(true)
+    expect(banner.endsWith('\n')).toBe(true)
+  })
+
+  test('ignores the retired SANITY_NEW_BANNER switch', () => {
+    vi.stubEnv('SANITY_NEW_BANNER', '3')
+
+    expect(render()).toContain('Two ways to start')
+  })
+})

--- a/packages/@sanity/cli/src/actions/init/__tests__/newCommandBanner.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/newCommandBanner.test.ts
@@ -28,8 +28,15 @@ describe('#renderNewCommandBanner', () => {
     expect(banner).toContain('sanity init')
     expect(banner).toContain('sanity new')
     expect(banner).toContain('claim it within 72 hours')
-    expect(banner).toContain('https://sanity.new')
     expect(banner).toContain('╭') // boxed — the one-time signpost keeps its box
+    // The agent lines sit below the box, unboxed, in the shared "If an agent is running this"
+    // voice.
+    const boxEnd = banner.indexOf('╰')
+    expect(banner.indexOf('If an agent is running this, use `sanity new --json`')).toBeGreaterThan(
+      boxEnd,
+    )
+    expect(banner.indexOf('https://sanity.new')).toBeGreaterThan(boxEnd)
+    expect(banner).toContain('Fetch https://sanity.new to learn more.')
     expect(banner.startsWith('\n')).toBe(true)
     expect(banner.endsWith('\n')).toBe(true)
   })

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -7,6 +7,7 @@ import {
   subdebug,
   type TelemetryUserProperties,
 } from '@sanity/cli-core'
+import {findMintedProjectEnvBoundary} from '@sanity/cli-core/config'
 import {logSymbols, spinner} from '@sanity/cli-core/ux'
 import {type TelemetryTrace} from '@sanity/telemetry'
 import {type Framework, frameworks} from '@vercel/frameworks'
@@ -403,11 +404,29 @@ async function ensureAuthenticated(
     return {user}
   }
 
-  // `sanity new`'s remint guard refuses whenever any guarded `.env` key is present, so wherever
-  // that's the case we must not steer the user toward `sanity new` — it would dead-end. A ledger
-  // record narrows that further to a *known* unclaimed mint (a bare SANITY_PROJECT_ID is also
-  // written by `sanity init --env` and survives a claim), which earns more specific guidance.
-  const guardedInspection = inspectEnvKeys(path.join(process.cwd(), '.env'), GUARDED_ENV_KEYS)
+  // `sanity new`'s remint guard refuses whenever the nearest ancestor credential boundary has a
+  // guarded `.env` key, so in that scope we must not steer the user toward `sanity new` — it would
+  // dead-end. A ledger record narrows that further to a *known* unclaimed mint (a bare
+  // SANITY_PROJECT_ID is also written by `sanity init --env` and survives a claim), which earns
+  // more specific guidance.
+  const cwd = process.cwd()
+  let guardedInspection: ReturnType<typeof inspectEnvKeys>
+  let credentialBoundaryInspectionFailed = false
+  try {
+    const guardedEnvPath = findMintedProjectEnvBoundary(cwd)?.envPath ?? path.join(cwd, '.env')
+    guardedInspection = inspectEnvKeys(guardedEnvPath, GUARDED_ENV_KEYS)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    const message =
+      `Could not inspect the Sanity credential boundary: ${detail}. ` +
+      'Ensure ancestor .env files are readable regular files, then re-run.'
+    if (options.unattended) {
+      throw new InitError(message, exitCodes.RUNTIME_ERROR)
+    }
+    output.warn(message)
+    credentialBoundaryInspectionFailed = true
+    guardedInspection = {blankKeys: [], presentKeys: [], values: {}}
+  }
   const guardedEnv = guardedInspection.values
   const hasGuardedKeys = guardedInspection.presentKeys.length > 0
   const mintedRecord = guardedEnv.SANITY_PROJECT_ID
@@ -442,7 +461,7 @@ async function ensureAuthenticated(
   output.warn(LOGIN_REQUIRED_MESSAGE)
 
   // Suppressed wherever `sanity new` would be refused (any guarded `.env` key present).
-  if (!hasGuardedKeys) renderNewCommandBanner(output)
+  if (!hasGuardedKeys && !credentialBoundaryInspectionFailed) renderNewCommandBanner(output)
 
   try {
     await login({

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -465,6 +465,7 @@ async function ensureAuthenticated(
 
   try {
     await login({
+      activateSessionForProcess: true,
       output,
       telemetry: trace.newContext('login'),
     })

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -20,6 +20,7 @@ import {detectFrameworkRecord} from '../../util/detectFramework.js'
 import {GUARDED_ENV_KEYS, inspectEnvKeys} from '../../util/envFile.js'
 import {formatCliErrorMessages} from '../../util/formatCliErrorMessages.js'
 import {getProjectDefaults} from '../../util/getProjectDefaults.js'
+import {CLAIM_WINDOW_HOURS, SANITY_NEW_URL} from '../../util/mintProjectConstants.js'
 import {validateSession} from '../auth/ensureAuthenticated.js'
 import {getProviderName, getUserDisplayName} from '../auth/getProviderName.js'
 import {login} from '../auth/login/login.js'
@@ -431,8 +432,8 @@ async function ensureAuthenticated(
       message =
         'Not logged in. Run `sanity login` to authenticate, then re-run this command. ' +
         'To create a project without logging in, run `sanity new` (use --json for ' +
-        'machine-readable output) and claim it with a Sanity account within 72 hours to keep it. ' +
-        'Fetch https://sanity.new to learn more.'
+        `machine-readable output) and claim it with a Sanity account within ${CLAIM_WINDOW_HOURS} hours to keep it. ` +
+        `Fetch ${SANITY_NEW_URL} to learn more.`
     }
     throw new InitError(message, exitCodes.RUNTIME_ERROR)
   }

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -425,8 +425,9 @@ async function ensureAuthenticated(
     } else {
       message =
         'Not logged in. Run `sanity login` to authenticate, then re-run this command. ' +
-        'Alternatively, run `sanity new` to create a project without logging in — ' +
-        'you can claim it with a Sanity account later. See `sanity new --help`.'
+        'To create a project without logging in, run `sanity new` (use --json for ' +
+        'machine-readable output) and claim it with a Sanity account within 72 hours to keep it. ' +
+        'Fetch https://sanity.new to learn more.'
     }
     throw new InitError(message, exitCodes.RUNTIME_ERROR)
   }

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import {styleText} from 'node:util'
 
 import {
@@ -14,7 +15,9 @@ import deburr from 'lodash-es/deburr.js'
 import {promptForConfigFiles} from '../../prompts/init/nextjs.js'
 import {getCliUser} from '../../services/user.js'
 import {CLIInitStepCompleted, type InitStepResult} from '../../telemetry/init.telemetry.js'
+import {getMintedProjectRecord} from '../../util/claimNudges.js'
 import {detectFrameworkRecord} from '../../util/detectFramework.js'
+import {GUARDED_ENV_KEYS, readEnvValues} from '../../util/envFile.js'
 import {formatCliErrorMessages} from '../../util/formatCliErrorMessages.js'
 import {getProjectDefaults} from '../../util/getProjectDefaults.js'
 import {validateSession} from '../auth/ensureAuthenticated.js'
@@ -32,6 +35,7 @@ import {InitError} from './initError.js'
 import {flagOrDefault, shouldPrompt, writeStagingEnvIfNeeded} from './initHelpers.js'
 import {initNextJs} from './initNextJs.js'
 import {initStudio} from './initStudio.js'
+import {renderNewCommandBanner} from './newCommandBanner.js'
 import {getPlan} from './plan/getPlan.js'
 import {createProjectFromName} from './project/createProjectFromName.js'
 import {getProjectDetails} from './project/getProjectDetails.js'
@@ -381,6 +385,8 @@ function checkFlagsInUnattendedMode(
   }
 }
 
+// A robot token from `sanity new` has no display name — greeting it as "logged in as null"
+// reads as a bug. Name the identity for what it is instead.
 async function ensureAuthenticated(
   options: InitOptions,
   output: InitContext['output'],
@@ -396,12 +402,40 @@ async function ensureAuthenticated(
     return {user}
   }
 
+  // `sanity new`'s remint guard refuses whenever any guarded `.env` key is present, so wherever
+  // that's the case we must not steer the user toward `sanity new` — it would dead-end. A ledger
+  // record narrows that further to a *known* unclaimed mint (a bare SANITY_PROJECT_ID is also
+  // written by `sanity init --env` and survives a claim), which earns more specific guidance.
+  const guardedEnv = readEnvValues(path.join(process.cwd(), '.env'), [...GUARDED_ENV_KEYS])
+  const hasGuardedKeys = GUARDED_ENV_KEYS.some((key) => guardedEnv[key] !== undefined)
+  const mintedRecord = guardedEnv.SANITY_PROJECT_ID
+    ? getMintedProjectRecord(guardedEnv.SANITY_PROJECT_ID)
+    : undefined
+
   if (options.unattended) {
-    throw new InitError(LOGIN_REQUIRED_MESSAGE, exitCodes.RUNTIME_ERROR)
+    let message: string
+    if (mintedRecord) {
+      message =
+        `This directory has an unclaimed Sanity project (${guardedEnv.SANITY_PROJECT_ID}) but its ` +
+        "token isn't available here. Set SANITY_AUTH_TOKEN from its .env, or claim the project, then re-run."
+    } else if (hasGuardedKeys) {
+      message =
+        'Not logged in, and this directory already has Sanity credentials in .env. Set ' +
+        'SANITY_AUTH_TOKEN, or run in a different directory, then re-run.'
+    } else {
+      message =
+        'Not logged in. Run `sanity login` to authenticate, then re-run this command. ' +
+        'Alternatively, run `sanity new` to create a project without logging in — ' +
+        'you can claim it with a Sanity account later. See `sanity new --help`.'
+    }
+    throw new InitError(message, exitCodes.RUNTIME_ERROR)
   }
 
   trace.log({step: 'login'})
   output.warn(LOGIN_REQUIRED_MESSAGE)
+
+  // Suppressed wherever `sanity new` would be refused (any guarded `.env` key present).
+  if (!hasGuardedKeys) renderNewCommandBanner(output)
 
   try {
     await login({

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -17,7 +17,7 @@ import {getCliUser} from '../../services/user.js'
 import {CLIInitStepCompleted, type InitStepResult} from '../../telemetry/init.telemetry.js'
 import {getMintedProjectRecord} from '../../util/claimNudges.js'
 import {detectFrameworkRecord} from '../../util/detectFramework.js'
-import {GUARDED_ENV_KEYS, readEnvValues} from '../../util/envFile.js'
+import {GUARDED_ENV_KEYS, inspectEnvKeys} from '../../util/envFile.js'
 import {formatCliErrorMessages} from '../../util/formatCliErrorMessages.js'
 import {getProjectDefaults} from '../../util/getProjectDefaults.js'
 import {validateSession} from '../auth/ensureAuthenticated.js'
@@ -406,8 +406,9 @@ async function ensureAuthenticated(
   // that's the case we must not steer the user toward `sanity new` — it would dead-end. A ledger
   // record narrows that further to a *known* unclaimed mint (a bare SANITY_PROJECT_ID is also
   // written by `sanity init --env` and survives a claim), which earns more specific guidance.
-  const guardedEnv = readEnvValues(path.join(process.cwd(), '.env'), [...GUARDED_ENV_KEYS])
-  const hasGuardedKeys = GUARDED_ENV_KEYS.some((key) => guardedEnv[key] !== undefined)
+  const guardedInspection = inspectEnvKeys(path.join(process.cwd(), '.env'), GUARDED_ENV_KEYS)
+  const guardedEnv = guardedInspection.values
+  const hasGuardedKeys = guardedInspection.presentKeys.length > 0
   const mintedRecord = guardedEnv.SANITY_PROJECT_ID
     ? getMintedProjectRecord(guardedEnv.SANITY_PROJECT_ID)
     : undefined
@@ -418,6 +419,10 @@ async function ensureAuthenticated(
       message =
         `This directory has an unclaimed Sanity project (${guardedEnv.SANITY_PROJECT_ID}) but its ` +
         "token isn't available here. Set SANITY_AUTH_TOKEN from its .env, or claim the project, then re-run."
+    } else if (guardedInspection.blankKeys.length > 0) {
+      message =
+        'Not logged in, and this directory has blank Sanity credential placeholders in .env: ' +
+        `${guardedInspection.blankKeys.join(', ')}. Remove or populate them, then re-run.`
     } else if (hasGuardedKeys) {
       message =
         'Not logged in, and this directory already has Sanity credentials in .env. Set ' +

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -3,6 +3,7 @@ import {styleText} from 'node:util'
 
 import {
   exitCodes,
+  getCliToken,
   type SanityOrgUser,
   subdebug,
   type TelemetryUserProperties,
@@ -436,9 +437,13 @@ async function ensureAuthenticated(
   if (options.unattended) {
     let message: string
     if (mintedRecord) {
-      message =
-        `This directory has an unclaimed Sanity project (${guardedEnv.SANITY_PROJECT_ID}) but its ` +
-        "token isn't available here. Set SANITY_AUTH_TOKEN from its .env, or claim the project, then re-run."
+      const activeToken = await getCliToken()
+      message = activeToken
+        ? `This directory has an unclaimed Sanity project (${guardedEnv.SANITY_PROJECT_ID}), but ` +
+          'the available auth token is invalid, expired, or lacks the required access. Set ' +
+          'SANITY_AUTH_TOKEN to a valid token, or claim the project, then re-run.'
+        : `This directory has an unclaimed Sanity project (${guardedEnv.SANITY_PROJECT_ID}) but its ` +
+          "token isn't available here. Set SANITY_AUTH_TOKEN from its .env, or claim the project, then re-run."
     } else if (guardedInspection.blankKeys.length > 0) {
       message =
         'Not logged in, and this directory has blank Sanity credential placeholders in .env: ' +

--- a/packages/@sanity/cli/src/actions/init/initStudio.ts
+++ b/packages/@sanity/cli/src/actions/init/initStudio.ts
@@ -33,6 +33,7 @@ export async function initStudio({
   organizationId,
   output,
   outputPath,
+  preclaim = false,
   projectId,
   remoteTemplateInfo,
   sluggedName,
@@ -49,6 +50,7 @@ export async function initStudio({
   organizationId: string | undefined
   output: Output
   outputPath: string
+  preclaim?: boolean
   projectId: string
   remoteTemplateInfo: RepoInfo | undefined
   sluggedName: string
@@ -167,7 +169,10 @@ export async function initStudio({
   output.log('\n')
   output.log(`Other helpful commands:`)
   output.log(`npx sanity docs browse     to open the documentation in a browser`)
-  output.log(`npx sanity manage          to open the project settings in a browser`)
+  // The robot token on an unclaimed project cannot manage settings, so Manage is a dead end.
+  if (!preclaim) {
+    output.log(`npx sanity manage          to open the project settings in a browser`)
+  }
   output.log(`npx sanity help            to explore the CLI manual`)
 
   if (isFirstProject) {

--- a/packages/@sanity/cli/src/actions/init/initStudio.ts
+++ b/packages/@sanity/cli/src/actions/init/initStudio.ts
@@ -140,6 +140,9 @@ export async function initStudio({
     output.log(`  ${styleText('cyan', `npx sanity dataset create <name>`)}\n`)
   }
 
+  // `sanity new` owns the combined Studio/frontend outro and the pre-claim token URL.
+  if (preclaim) return
+
   const devCommandMap: Record<PackageManager, string> = {
     bun: 'bun dev',
     manual: 'npm run dev',
@@ -169,10 +172,7 @@ export async function initStudio({
   output.log('\n')
   output.log(`Other helpful commands:`)
   output.log(`npx sanity docs browse     to open the documentation in a browser`)
-  // The robot token on an unclaimed project cannot manage settings, so Manage is a dead end.
-  if (!preclaim) {
-    output.log(`npx sanity manage          to open the project settings in a browser`)
-  }
+  output.log(`npx sanity manage          to open the project settings in a browser`)
   output.log(`npx sanity help            to explore the CLI manual`)
 
   if (isFirstProject) {

--- a/packages/@sanity/cli/src/actions/init/newCommandBanner.ts
+++ b/packages/@sanity/cli/src/actions/init/newCommandBanner.ts
@@ -1,0 +1,28 @@
+import {styleText} from 'node:util'
+
+import {boxen} from '@sanity/cli-core/ux'
+
+import {hyperlink as link} from '../../util/terminalLink.js'
+import {type InitContext} from './types.js'
+
+const SANITY_NEW_URL = 'https://sanity.new'
+
+export function renderNewCommandBanner(output: InitContext['output']): void {
+  output.log('')
+  output.log(
+    boxen(
+      `${styleText('bold', 'Two ways to start')}
+
+${styleText('cyan', 'sanity init')}  Log in and set up a Studio ${styleText('dim', "(you're here)")}
+${styleText('cyan', 'sanity new')}   No login — mint a project now, claim it within 72 hours
+
+Learn how it works: ${link(SANITY_NEW_URL, SANITY_NEW_URL)}`,
+      {
+        borderColor: 'cyan',
+        borderStyle: 'round',
+        padding: 1,
+      },
+    ),
+  )
+  output.log('')
+}

--- a/packages/@sanity/cli/src/actions/init/newCommandBanner.ts
+++ b/packages/@sanity/cli/src/actions/init/newCommandBanner.ts
@@ -2,10 +2,9 @@ import {styleText} from 'node:util'
 
 import {boxen} from '@sanity/cli-core/ux'
 
+import {CLAIM_WINDOW_HOURS, SANITY_NEW_URL} from '../../util/mintProjectConstants.js'
 import {hyperlink as link} from '../../util/terminalLink.js'
 import {type InitContext} from './types.js'
-
-const SANITY_NEW_URL = 'https://sanity.new'
 
 export function renderNewCommandBanner(output: InitContext['output']): void {
   output.log('')
@@ -15,7 +14,7 @@ export function renderNewCommandBanner(output: InitContext['output']): void {
 
 ${styleText('cyan', 'sanity init')}  Log in or sign up and make a new project ${styleText('dim', "(you're here)")}
 ${styleText('cyan', 'sanity new')}   Create a project without an account.
-             Sign up and claim it within 72 hours to keep it.`,
+             Sign up and claim it within ${CLAIM_WINDOW_HOURS} hours to keep it.`,
       {
         borderColor: 'cyan',
         borderStyle: 'round',

--- a/packages/@sanity/cli/src/actions/init/newCommandBanner.ts
+++ b/packages/@sanity/cli/src/actions/init/newCommandBanner.ts
@@ -13,10 +13,9 @@ export function renderNewCommandBanner(output: InitContext['output']): void {
     boxen(
       `${styleText('bold', 'Two ways to start')}
 
-${styleText('cyan', 'sanity init')}  Log in and set up a Studio ${styleText('dim', "(you're here)")}
-${styleText('cyan', 'sanity new')}   No login — mint a project now, claim it within 72 hours
-
-Learn how it works: ${link(SANITY_NEW_URL, SANITY_NEW_URL)}`,
+${styleText('cyan', 'sanity init')}  Log in or sign up and make a new project ${styleText('dim', "(you're here)")}
+${styleText('cyan', 'sanity new')}   Create a project without an account.
+             Sign up and claim it within 72 hours to keep it.`,
       {
         borderColor: 'cyan',
         borderStyle: 'round',
@@ -24,5 +23,13 @@ Learn how it works: ${link(SANITY_NEW_URL, SANITY_NEW_URL)}`,
       },
     ),
   )
+  output.log('')
+  output.log(
+    styleText(
+      'dim',
+      'If an agent is running this, use `sanity new --json` to create a project programmatically.',
+    ),
+  )
+  output.log(styleText('dim', `Fetch ${link(SANITY_NEW_URL, SANITY_NEW_URL)} to learn more.`))
   output.log('')
 }

--- a/packages/@sanity/cli/src/actions/scaffold/__tests__/createFrontend.test.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/__tests__/createFrontend.test.ts
@@ -13,12 +13,11 @@ const mockExeca = vi.hoisted(() => vi.fn())
 const mockInstallNewPackages = vi.hoisted(() => vi.fn())
 const mockProgressFail = vi.hoisted(() => vi.fn())
 const mockProgressSucceed = vi.hoisted(() => vi.fn())
+const mockSpinner = vi.hoisted(() => vi.fn())
 
 vi.mock('execa', () => ({execa: mockExeca}))
 vi.mock('@sanity/cli-core/ux', () => ({
-  spinner: () => ({
-    start: () => ({fail: mockProgressFail, succeed: mockProgressSucceed}),
-  }),
+  spinner: mockSpinner,
 }))
 vi.mock('../../../util/packageManager/installPackages.js', () => ({
   installNewPackages: mockInstallNewPackages,
@@ -33,6 +32,9 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockExeca.mockResolvedValue({exitCode: 0})
   mockInstallNewPackages.mockResolvedValue(undefined)
+  mockSpinner.mockReturnValue({
+    start: () => ({fail: mockProgressFail, succeed: mockProgressSucceed}),
+  })
 })
 
 describe('createFrontend', () => {
@@ -100,6 +102,21 @@ describe('createFrontend', () => {
 
     const options = mockExeca.mock.calls[0][2]
     expect(options).toMatchObject({stdio: ['ignore', 'pipe', 'pipe']})
+    expect(mockSpinner).toHaveBeenCalledWith({
+      discardStdin: true,
+      text: 'Creating your Next.js app\n',
+    })
+  })
+
+  test('keeps terminal SIGINT enabled while cancellation is active', async () => {
+    const controller = new AbortController()
+
+    await createFrontend({...args, cancelSignal: controller.signal})
+
+    expect(mockSpinner).toHaveBeenCalledWith({
+      discardStdin: false,
+      text: 'Creating your Next.js app\n',
+    })
   })
 
   test('wraps a scaffolder failure so the caller can keep the minted project', async () => {

--- a/packages/@sanity/cli/src/actions/scaffold/__tests__/createFrontend.test.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/__tests__/createFrontend.test.ts
@@ -1,0 +1,157 @@
+import path from 'node:path'
+
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {
+  createFrontend,
+  frontendScaffoldCommand,
+  FrontendScaffoldError,
+  installFrontendDeps,
+} from '../createFrontend.js'
+
+const mockExeca = vi.hoisted(() => vi.fn())
+const mockInstallNewPackages = vi.hoisted(() => vi.fn())
+
+vi.mock('execa', () => ({execa: mockExeca}))
+vi.mock('../../../util/packageManager/installPackages.js', () => ({
+  installNewPackages: mockInstallNewPackages,
+}))
+
+const outputLog = vi.fn()
+const output = {log: outputLog, warn: vi.fn()} as never
+
+const args = {dirName: 'web', output, packageManager: 'npm' as const, workDir: '/tmp/my-project'}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockExeca.mockResolvedValue({exitCode: 0})
+  mockInstallNewPackages.mockResolvedValue(undefined)
+})
+
+describe('createFrontend', () => {
+  test('scaffolds without prompting and without a nested git repository', () => {
+    return createFrontend(args).then(() => {
+      const [command, execArgs, options] = mockExeca.mock.calls[0]
+      expect(command).toBe('npx')
+      expect(execArgs).toContain('create-next-app@^16')
+      expect(execArgs).toContain('web')
+      expect(execArgs).toContain('--disable-git')
+      expect(execArgs).toContain('--yes')
+      expect(options).toMatchObject({cwd: '/tmp/my-project'})
+    })
+  })
+
+  test('answers npx as well as create-next-app, so nothing in the chain can prompt', async () => {
+    await createFrontend(args)
+
+    const [, execArgs, options] = mockExeca.mock.calls[0]
+    const spec = (execArgs as string[]).indexOf('create-next-app@^16')
+    expect((execArgs as string[]).slice(0, spec)).toContain('--yes')
+    expect((execArgs as string[]).slice(spec)).toContain('--yes')
+    expect(options).toMatchObject({env: expect.objectContaining({npm_config_yes: 'true'})})
+  })
+
+  test('constrains the scaffolder to a major, never @latest', async () => {
+    await createFrontend(args)
+
+    const execArgs = mockExeca.mock.calls[0][1] as string[]
+    const spec = execArgs.find((arg) => arg.startsWith('create-next-app'))
+    expect(spec).toMatch(/^create-next-app@\^\d+$/)
+    expect(spec).not.toContain('latest')
+  })
+
+  test('prints the same command it runs, package-manager flag aside', async () => {
+    await createFrontend(args)
+
+    const execArgs = mockExeca.mock.calls[0][1] as string[]
+    expect(`npx ${execArgs.filter((arg) => !arg.startsWith('--use-')).join(' ')}`).toBe(
+      frontendScaffoldCommand('web'),
+    )
+  })
+
+  test('tells create-next-app which package manager to use', async () => {
+    await createFrontend({...args, packageManager: 'pnpm'})
+
+    expect(mockExeca.mock.calls[0][1]).toContain('--use-pnpm')
+  })
+
+  test('omits the package-manager flag when there is no equivalent', async () => {
+    await createFrontend({...args, packageManager: 'manual'})
+
+    const execArgs = mockExeca.mock.calls[0][1] as string[]
+    expect(execArgs.some((arg) => arg.startsWith('--use-'))).toBe(false)
+  })
+
+  test('does not install dependencies: that is a separate, separately-failing step', async () => {
+    await createFrontend(args)
+
+    expect(mockInstallNewPackages).not.toHaveBeenCalled()
+  })
+
+  test('closes stdin, so a prompt we missed fails instead of hanging', async () => {
+    await createFrontend(args)
+
+    const options = mockExeca.mock.calls[0][2]
+    expect(options).toMatchObject({stdio: ['ignore', 'pipe', 'pipe']})
+  })
+
+  test('wraps a scaffolder failure so the caller can keep the minted project', async () => {
+    mockExeca.mockRejectedValue(new Error('ENOENT'))
+
+    await expect(createFrontend(args)).rejects.toThrow(FrontendScaffoldError)
+    await expect(createFrontend(args)).rejects.toThrow('create-next-app failed: ENOENT')
+    expect(mockInstallNewPackages).not.toHaveBeenCalled()
+  })
+
+  test('surfaces the scaffolder output on a non-zero exit, which stdout alone would hide', async () => {
+    mockExeca.mockResolvedValue({exitCode: 1, stderr: 'EACCES: permission denied', stdout: ''})
+
+    await expect(createFrontend(args)).rejects.toThrow('create-next-app failed with exit code 1')
+    expect(outputLog).toHaveBeenCalledWith('EACCES: permission denied')
+  })
+
+  test('reports a failure that produced no output at all', async () => {
+    mockExeca.mockResolvedValue({exitCode: 1, stderr: '', stdout: ''})
+
+    await expect(createFrontend(args)).rejects.toThrow('create-next-app failed with exit code 1')
+    expect(outputLog).not.toHaveBeenCalled()
+  })
+
+  test('survives a thrown value that is not an Error', async () => {
+    mockExeca.mockRejectedValue('killed')
+
+    await expect(createFrontend(args)).rejects.toThrow('create-next-app failed: killed')
+  })
+
+  test('treats a spawn failure with no exit code as a failure too', async () => {
+    mockExeca.mockResolvedValue({failed: true, stderr: 'spawn npx ENOENT'})
+
+    await expect(createFrontend(args)).rejects.toThrow(FrontendScaffoldError)
+  })
+})
+
+describe('installFrontendDeps', () => {
+  test('installs next-sanity into the frontend, not the parent directory', async () => {
+    await installFrontendDeps(args)
+
+    expect(mockInstallNewPackages).toHaveBeenCalledWith(
+      {packageManager: 'npm', packages: ['next-sanity@13']},
+      expect.objectContaining({workDir: path.join('/tmp/my-project', 'web')}),
+    )
+  })
+
+  test('normalises the CLIError that installNewPackages throws into our own type', async () => {
+    mockInstallNewPackages.mockRejectedValue(new Error('registry down'))
+
+    await expect(installFrontendDeps(args)).rejects.toThrow(FrontendScaffoldError)
+    await expect(installFrontendDeps(args)).rejects.toThrow(
+      'Installing next-sanity failed: registry down',
+    )
+  })
+
+  test('normalises a thrown value that is not an Error', async () => {
+    mockInstallNewPackages.mockRejectedValue('ENOSPC')
+
+    await expect(installFrontendDeps(args)).rejects.toThrow('Installing next-sanity failed: ENOSPC')
+  })
+})

--- a/packages/@sanity/cli/src/actions/scaffold/__tests__/createFrontend.test.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/__tests__/createFrontend.test.ts
@@ -46,7 +46,7 @@ describe('createFrontend', () => {
       expect(execArgs).toContain('web')
       expect(execArgs).toContain('--disable-git')
       expect(execArgs).toContain('--yes')
-      expect(options).toMatchObject({cwd: '/tmp/my-project'})
+      expect(options).toMatchObject({cwd: '/tmp/my-project', timeout: expect.any(Number)})
     })
   })
 
@@ -177,8 +177,11 @@ describe('installFrontendDeps', () => {
     await installFrontendDeps(args)
 
     expect(mockInstallNewPackages).toHaveBeenCalledWith(
-      {packageManager: 'npm', packages: ['next-sanity@13']},
-      expect.objectContaining({workDir: path.join('/tmp/my-project', 'web')}),
+      {packageManager: 'npm', packages: ['next-sanity']},
+      expect.objectContaining({
+        timeout: expect.any(Number),
+        workDir: path.join('/tmp/my-project', 'web'),
+      }),
     )
   })
 

--- a/packages/@sanity/cli/src/actions/scaffold/__tests__/createFrontend.test.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/__tests__/createFrontend.test.ts
@@ -11,8 +11,15 @@ import {
 
 const mockExeca = vi.hoisted(() => vi.fn())
 const mockInstallNewPackages = vi.hoisted(() => vi.fn())
+const mockProgressFail = vi.hoisted(() => vi.fn())
+const mockProgressSucceed = vi.hoisted(() => vi.fn())
 
 vi.mock('execa', () => ({execa: mockExeca}))
+vi.mock('@sanity/cli-core/ux', () => ({
+  spinner: () => ({
+    start: () => ({fail: mockProgressFail, succeed: mockProgressSucceed}),
+  }),
+}))
 vi.mock('../../../util/packageManager/installPackages.js', () => ({
   installNewPackages: mockInstallNewPackages,
 }))
@@ -128,6 +135,24 @@ describe('createFrontend', () => {
 
     await expect(createFrontend(args)).rejects.toThrow(FrontendScaffoldError)
   })
+
+  test('propagates cancellation when create-next-app exits successfully on SIGINT', async () => {
+    const controller = new AbortController()
+    mockExeca.mockImplementation(async () => {
+      controller.abort(new Error('SIGINT'))
+      return {exitCode: 0}
+    })
+
+    const error = await createFrontend({...args, cancelSignal: controller.signal}).catch(
+      (err: unknown) => err,
+    )
+
+    expect(error).toEqual(new Error('SIGINT'))
+    expect(error).not.toBeInstanceOf(FrontendScaffoldError)
+    expect(mockExeca.mock.calls[0][2]).toMatchObject({cancelSignal: controller.signal})
+    expect(mockProgressFail).toHaveBeenCalledOnce()
+    expect(mockProgressSucceed).not.toHaveBeenCalled()
+  })
 })
 
 describe('installFrontendDeps', () => {
@@ -153,5 +178,24 @@ describe('installFrontendDeps', () => {
     mockInstallNewPackages.mockRejectedValue('ENOSPC')
 
     await expect(installFrontendDeps(args)).rejects.toThrow('Installing next-sanity failed: ENOSPC')
+  })
+
+  test('propagates cancellation while installing next-sanity', async () => {
+    const controller = new AbortController()
+    mockInstallNewPackages.mockImplementation(async () => {
+      controller.abort(new Error('SIGINT'))
+      controller.signal.throwIfAborted()
+    })
+
+    const error = await installFrontendDeps({...args, cancelSignal: controller.signal}).catch(
+      (err: unknown) => err,
+    )
+
+    expect(error).toEqual(new Error('SIGINT'))
+    expect(error).not.toBeInstanceOf(FrontendScaffoldError)
+    expect(mockInstallNewPackages).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({cancelSignal: controller.signal}),
+    )
   })
 })

--- a/packages/@sanity/cli/src/actions/scaffold/__tests__/scaffoldProject.test.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/__tests__/scaffoldProject.test.ts
@@ -84,6 +84,7 @@ describe('scaffoldProject', () => {
 
     expect(result.studioPath).toBe(path.join(workDir, STUDIO_DIR))
     expect(result.frontendPath).toBe(path.join(workDir, FRONTEND_DIR))
+    expect(result.frontendPackageManager).toBe('npm')
     expect(result.detectedFramework).toBeUndefined()
     expect(result.warnings).toEqual([])
     expect(mockCreateFrontend).toHaveBeenCalledWith(

--- a/packages/@sanity/cli/src/actions/scaffold/__tests__/scaffoldProject.test.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/__tests__/scaffoldProject.test.ts
@@ -202,6 +202,21 @@ describe('scaffoldProject', () => {
     await expect(scaffoldProject(args)).rejects.toThrow('disk full')
   })
 
+  test('propagates frontend cancellation without writing frontend configuration', async () => {
+    const controller = new AbortController()
+    mockCreateFrontend.mockImplementation(async () => {
+      controller.abort(new Error('SIGINT'))
+      controller.signal.throwIfAborted()
+    })
+
+    await expect(scaffoldProject({...args, cancelSignal: controller.signal})).rejects.toThrow(
+      'SIGINT',
+    )
+
+    expect(envWriteFor(path.join(workDir, FRONTEND_DIR, '.env.local'))).toBeUndefined()
+    expect(mockInstallFrontendDeps).not.toHaveBeenCalled()
+  })
+
   test('writes the frontend env before installing, so a failed install keeps it configured', async () => {
     const {FrontendScaffoldError} = await import('../createFrontend.js')
     mockInstallFrontendDeps.mockRejectedValue(
@@ -219,6 +234,18 @@ describe('scaffoldProject', () => {
     mockInstallFrontendDeps.mockRejectedValue(new Error('segfault'))
 
     await expect(scaffoldProject(args)).rejects.toThrow('segfault')
+  })
+
+  test('propagates dependency installation cancellation', async () => {
+    const controller = new AbortController()
+    mockInstallFrontendDeps.mockImplementation(async () => {
+      controller.abort(new Error('SIGINT'))
+      controller.signal.throwIfAborted()
+    })
+
+    await expect(scaffoldProject({...args, cancelSignal: controller.signal})).rejects.toThrow(
+      'SIGINT',
+    )
   })
 
   test('a failed Studio env write degrades to a warning instead of unwinding the mint', async () => {

--- a/packages/@sanity/cli/src/actions/scaffold/__tests__/scaffoldProject.test.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/__tests__/scaffoldProject.test.ts
@@ -1,0 +1,327 @@
+import {mkdirSync, mkdtempSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import path from 'node:path'
+
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {
+  existingScaffoldEnvFiles,
+  FRONTEND_DIR,
+  FRONTEND_ENV_FILE,
+  scaffoldProject,
+  STUDIO_DIR,
+  STUDIO_ENV_FILE,
+} from '../scaffoldProject.js'
+
+const mockInitStudio = vi.hoisted(() => vi.fn())
+const mockCreateFrontend = vi.hoisted(() => vi.fn())
+const mockInstallFrontendDeps = vi.hoisted(() => vi.fn())
+const mockDetectFrameworkRecord = vi.hoisted(() => vi.fn())
+const mockAppendEnvValues = vi.hoisted(() => vi.fn())
+const mockResolvePackageManager = vi.hoisted(() => vi.fn())
+const mockGetProjectDefaults = vi.hoisted(() => vi.fn())
+
+vi.mock('../../init/initStudio.js', () => ({initStudio: mockInitStudio}))
+vi.mock('../createFrontend.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../createFrontend.js')>()),
+  createFrontend: mockCreateFrontend,
+  installFrontendDeps: mockInstallFrontendDeps,
+}))
+vi.mock('../../../util/detectFramework.js', () => ({
+  detectFrameworkRecord: mockDetectFrameworkRecord,
+}))
+vi.mock('../../../util/envFile.js', () => ({appendEnvValues: mockAppendEnvValues}))
+vi.mock('../../init/resolvePackageManager.js', () => ({
+  resolvePackageManager: mockResolvePackageManager,
+}))
+vi.mock('../../../util/getProjectDefaults.js', () => ({
+  getProjectDefaults: mockGetProjectDefaults,
+}))
+
+const trace = {complete: vi.fn(), error: vi.fn(), log: vi.fn(), newContext: vi.fn(), start: vi.fn()}
+
+const output = {
+  error: vi.fn(),
+  log: vi.fn(),
+  print: vi.fn(),
+  spinner: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+} as never
+
+const telemetry = {trace: () => trace} as never
+
+const workDir = '/tmp/my-project'
+
+const args = {
+  dataset: 'production',
+  displayName: 'My Project',
+  output,
+  projectId: 'abc123',
+  telemetry,
+  token: 'sk-robot-token',
+  workDir,
+}
+
+function envWriteFor(file: string) {
+  return mockAppendEnvValues.mock.calls.find(([envPath]) => envPath === file)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockDetectFrameworkRecord.mockResolvedValue(null)
+  mockResolvePackageManager.mockResolvedValue('npm')
+  mockGetProjectDefaults.mockResolvedValue({projectName: 'My Project'})
+  mockInitStudio.mockResolvedValue(undefined)
+  mockCreateFrontend.mockResolvedValue(undefined)
+  mockInstallFrontendDeps.mockResolvedValue(undefined)
+  mockAppendEnvValues.mockReturnValue({created: true, skippedKeys: [], wroteKeys: []})
+})
+
+describe('scaffoldProject', () => {
+  test('scaffolds a Studio and a frontend as siblings of the minted directory', async () => {
+    const result = await scaffoldProject(args)
+
+    expect(result.studioPath).toBe(path.join(workDir, STUDIO_DIR))
+    expect(result.frontendPath).toBe(path.join(workDir, FRONTEND_DIR))
+    expect(result.detectedFramework).toBeUndefined()
+    expect(result.warnings).toEqual([])
+    expect(mockCreateFrontend).toHaveBeenCalledWith(
+      expect.objectContaining({dirName: FRONTEND_DIR, workDir}),
+    )
+  })
+
+  test('drives the Studio scaffold with the minted project and no account lookups', async () => {
+    await scaffoldProject(args)
+
+    const [call] = mockInitStudio.mock.calls
+    expect(call[0]).toMatchObject({
+      datasetName: 'production',
+      outputPath: path.join(workDir, STUDIO_DIR),
+      preclaim: true,
+      projectId: 'abc123',
+    })
+    expect(call[0].options).toMatchObject({
+      git: false,
+      mcpMode: 'skip',
+      project: 'abc123',
+      skillsMode: 'skip',
+      template: 'clean',
+      unattended: true,
+    })
+  })
+
+  test('puts the token in the Studio .env.local only, and never in .env', async () => {
+    await scaffoldProject(args)
+
+    const studioEnv = envWriteFor(path.join(workDir, STUDIO_DIR, '.env.local'))
+    const frontendEnv = envWriteFor(path.join(workDir, FRONTEND_DIR, '.env.local'))
+
+    expect(studioEnv?.[1]).toEqual({SANITY_AUTH_TOKEN: 'sk-robot-token'})
+    expect(frontendEnv?.[1]).toEqual({
+      NEXT_PUBLIC_SANITY_DATASET: 'production',
+      NEXT_PUBLIC_SANITY_PROJECT_ID: 'abc123',
+    })
+    const wroteToPlainEnv = mockAppendEnvValues.mock.calls.some(([envPath]) =>
+      String(envPath).endsWith(`${path.sep}.env`),
+    )
+    expect(wroteToPlainEnv).toBe(false)
+  })
+
+  test('writes the token to exactly one file, and never under a browser-exposed prefix', async () => {
+    await scaffoldProject(args)
+
+    const filesWithToken = mockAppendEnvValues.mock.calls
+      .filter(([, values]) =>
+        Object.values(values as Record<string, string>).includes('sk-robot-token'),
+      )
+      .map(([envPath]) => String(envPath))
+    expect(filesWithToken).toEqual([path.join(workDir, STUDIO_DIR, '.env.local')])
+
+    const exposed = mockAppendEnvValues.mock.calls.flatMap(([, values]) =>
+      Object.entries(values as Record<string, string>).filter(
+        ([key, value]) =>
+          value === 'sk-robot-token' &&
+          (key.startsWith('NEXT_PUBLIC_') ||
+            key.startsWith('SANITY_STUDIO_') ||
+            key.startsWith('PUBLIC_') ||
+            key.startsWith('VITE_')),
+      ),
+    )
+
+    expect(exposed).toEqual([])
+  })
+
+  test('leaves an existing app alone but still scaffolds the Studio beside it', async () => {
+    mockDetectFrameworkRecord.mockResolvedValue({name: 'Next.js', slug: 'nextjs'})
+
+    const result = await scaffoldProject(args)
+
+    expect(mockCreateFrontend).not.toHaveBeenCalled()
+    expect(mockInitStudio).toHaveBeenCalled()
+    expect(result.detectedFramework).toBe('Next.js')
+    expect(result.frontendPath).toBeUndefined()
+    expect(result.frontendEnv).toEqual({
+      NEXT_PUBLIC_SANITY_DATASET: 'production',
+      NEXT_PUBLIC_SANITY_PROJECT_ID: 'abc123',
+    })
+    expect(envWriteFor(path.join(workDir, FRONTEND_DIR, '.env.local'))).toBeUndefined()
+  })
+
+  test('a framework that is not Next.js also keeps the frontend untouched', async () => {
+    mockDetectFrameworkRecord.mockResolvedValue({name: 'Astro', slug: 'astro'})
+
+    const result = await scaffoldProject(args)
+
+    expect(mockCreateFrontend).not.toHaveBeenCalled()
+    expect(result.detectedFramework).toBe('Astro')
+  })
+
+  test('keeps the Studio when the frontend scaffold fails, and reports it', async () => {
+    const {FrontendScaffoldError} = await import('../createFrontend.js')
+    mockCreateFrontend.mockRejectedValue(new FrontendScaffoldError('create-next-app failed: boom'))
+
+    const result = await scaffoldProject(args)
+
+    expect(result.studioPath).toBe(path.join(workDir, STUDIO_DIR))
+    expect(result.frontendPath).toBeUndefined()
+    expect(result.warnings).toEqual([expect.stringContaining('create-next-app failed: boom')])
+    expect(envWriteFor(path.join(workDir, STUDIO_DIR, '.env.local'))).toBeDefined()
+  })
+
+  test('records a non-Error Studio failure as an Error on the trace, and rethrows', async () => {
+    mockInitStudio.mockRejectedValue('worker died')
+
+    await expect(scaffoldProject(args)).rejects.toBe('worker died')
+    expect(trace.error).toHaveBeenCalledWith(expect.any(Error))
+  })
+
+  test('propagates an unexpected frontend error rather than swallowing it', async () => {
+    mockCreateFrontend.mockRejectedValue(new Error('disk full'))
+
+    await expect(scaffoldProject(args)).rejects.toThrow('disk full')
+  })
+
+  test('writes the frontend env before installing, so a failed install keeps it configured', async () => {
+    const {FrontendScaffoldError} = await import('../createFrontend.js')
+    mockInstallFrontendDeps.mockRejectedValue(
+      new FrontendScaffoldError('Installing next-sanity failed: registry down'),
+    )
+
+    const result = await scaffoldProject(args)
+
+    expect(result.frontendPath).toBe(path.join(workDir, FRONTEND_DIR))
+    expect(envWriteFor(path.join(workDir, FRONTEND_DIR, '.env.local'))).toBeDefined()
+    expect(result.warnings).toEqual([expect.stringContaining('Installing next-sanity failed')])
+  })
+
+  test('the non-FrontendScaffoldError guard rethrows (defensive: installFrontendDeps wraps all)', async () => {
+    mockInstallFrontendDeps.mockRejectedValue(new Error('segfault'))
+
+    await expect(scaffoldProject(args)).rejects.toThrow('segfault')
+  })
+
+  test('a failed Studio env write degrades to a warning instead of unwinding the mint', async () => {
+    mockAppendEnvValues.mockImplementation((envPath: string) => {
+      if (String(envPath).includes(STUDIO_DIR)) throw new Error('EACCES')
+      return {created: true, skippedKeys: [], wroteKeys: []}
+    })
+
+    const result = await scaffoldProject(args)
+
+    expect(result.studioPath).toBe(path.join(workDir, STUDIO_DIR))
+    expect(result.warnings).toEqual([
+      expect.stringContaining(`Couldn't write ${STUDIO_DIR}/.env.local`),
+    ])
+  })
+
+  test('a pre-existing blank key counts as not written, not as success', async () => {
+    mockAppendEnvValues.mockImplementation((envPath: string) => ({
+      created: false,
+      skippedKeys: String(envPath).includes(FRONTEND_DIR) ? ['NEXT_PUBLIC_SANITY_PROJECT_ID'] : [],
+      wroteKeys: [],
+    }))
+
+    const result = await scaffoldProject(args)
+
+    expect(result.frontendEnvWritten).toBe(false)
+    expect(result.warnings).toEqual([
+      expect.stringContaining(`Couldn't write ${FRONTEND_DIR}/.env.local`),
+    ])
+  })
+
+  test('a failed frontend env write is reported, not thrown', async () => {
+    mockAppendEnvValues.mockImplementation((envPath: string) => {
+      if (String(envPath).includes(FRONTEND_DIR)) throw new Error('EACCES')
+      return {created: true, skippedKeys: [], wroteKeys: []}
+    })
+
+    const result = await scaffoldProject(args)
+
+    expect(result.warnings).toEqual([
+      expect.stringContaining(`Couldn't write ${FRONTEND_DIR}/.env.local`),
+    ])
+  })
+
+  test('records a failed Studio scaffold on the telemetry trace and rethrows', async () => {
+    mockInitStudio.mockRejectedValue(new Error('template missing'))
+
+    await expect(scaffoldProject(args)).rejects.toThrow('template missing')
+
+    expect(trace.error).toHaveBeenCalledWith(expect.any(Error))
+    expect(trace.complete).not.toHaveBeenCalled()
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+    expect(mockCreateFrontend).not.toHaveBeenCalled()
+  })
+
+  test('passes a detected package manager through to both scaffolders', async () => {
+    mockResolvePackageManager.mockResolvedValue('pnpm')
+
+    await scaffoldProject(args)
+
+    expect(mockInitStudio.mock.calls[0][0].options).toMatchObject({packageManager: 'pnpm'})
+    expect(mockCreateFrontend).toHaveBeenCalledWith(
+      expect.objectContaining({packageManager: 'pnpm'}),
+    )
+  })
+
+  test('leaves the Studio package manager unset for managers init cannot drive', async () => {
+    mockResolvePackageManager.mockResolvedValue('bun')
+
+    await scaffoldProject(args)
+
+    expect(mockInitStudio.mock.calls[0][0].options.packageManager).toBeUndefined()
+    expect(mockCreateFrontend).toHaveBeenCalledWith(
+      expect.objectContaining({packageManager: 'bun'}),
+    )
+  })
+})
+
+function scaffoldEnvTree(dirs: string[]): string {
+  const root = mkdtempSync(path.join(tmpdir(), 'scaffold-env-'))
+  for (const dir of dirs) {
+    mkdirSync(path.join(root, dir), {recursive: true})
+    writeFileSync(path.join(root, dir, '.env.local'), 'SANITY_AUTH_TOKEN="old"\n')
+  }
+  return root
+}
+
+describe('existingScaffoldEnvFiles', () => {
+  test('reports only the scaffolded env files that exist', () => {
+    expect(existingScaffoldEnvFiles(scaffoldEnvTree([STUDIO_DIR, FRONTEND_DIR]))).toEqual([
+      STUDIO_ENV_FILE,
+      FRONTEND_ENV_FILE,
+    ])
+    expect(existingScaffoldEnvFiles(scaffoldEnvTree([FRONTEND_DIR]))).toEqual([FRONTEND_ENV_FILE])
+    expect(existingScaffoldEnvFiles(scaffoldEnvTree([]))).toEqual([])
+  })
+
+  test('names them with forward slashes, which callers key guidance off', () => {
+    // A `path.join` here yields backslashes on Windows, and every caller that looks these paths up
+    // by name silently finds nothing.
+    expect([STUDIO_ENV_FILE, FRONTEND_ENV_FILE]).toEqual(['sanity/.env.local', 'web/.env.local'])
+    expect(existingScaffoldEnvFiles(scaffoldEnvTree([STUDIO_DIR]))).toEqual([
+      expect.not.stringContaining('\\'),
+    ])
+  })
+})

--- a/packages/@sanity/cli/src/actions/scaffold/__tests__/scaffoldProject.test.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/__tests__/scaffoldProject.test.ts
@@ -2,12 +2,14 @@ import {mkdirSync, mkdtempSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import path from 'node:path'
 
+import {frameworks} from '@vercel/frameworks'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {
   existingScaffoldEnvFiles,
   FRONTEND_DIR,
   FRONTEND_ENV_FILE,
+  FRONTEND_ENV_PREFIX_OVERRIDES,
   scaffoldProject,
   STUDIO_DIR,
   STUDIO_ENV_FILE,
@@ -85,6 +87,7 @@ describe('scaffoldProject', () => {
     expect(result.studioPath).toBe(path.join(workDir, STUDIO_DIR))
     expect(result.frontendPath).toBe(path.join(workDir, FRONTEND_DIR))
     expect(result.frontendPackageManager).toBe('npm')
+    expect(result.frontendEnvPrefix).toBe('NEXT_PUBLIC_')
     expect(result.detectedFramework).toBeUndefined()
     expect(result.warnings).toEqual([])
     expect(mockCreateFrontend).toHaveBeenCalledWith(
@@ -154,13 +157,18 @@ describe('scaffoldProject', () => {
   })
 
   test('leaves an existing app alone but still scaffolds the Studio beside it', async () => {
-    mockDetectFrameworkRecord.mockResolvedValue({name: 'Next.js', slug: 'nextjs'})
+    mockDetectFrameworkRecord.mockResolvedValue({
+      envPrefix: 'NEXT_PUBLIC_',
+      name: 'Next.js',
+      slug: 'nextjs',
+    })
 
     const result = await scaffoldProject(args)
 
     expect(mockCreateFrontend).not.toHaveBeenCalled()
     expect(mockInitStudio).toHaveBeenCalled()
     expect(result.detectedFramework).toBe('Next.js')
+    expect(result.frontendEnvPrefix).toBe('NEXT_PUBLIC_')
     expect(result.frontendPath).toBeUndefined()
     expect(result.frontendEnv).toEqual({
       NEXT_PUBLIC_SANITY_DATASET: 'production',
@@ -170,12 +178,59 @@ describe('scaffoldProject', () => {
   })
 
   test('a framework that is not Next.js also keeps the frontend untouched', async () => {
-    mockDetectFrameworkRecord.mockResolvedValue({name: 'Astro', slug: 'astro'})
+    mockDetectFrameworkRecord.mockResolvedValue({
+      envPrefix: 'PUBLIC_',
+      name: 'Astro',
+      slug: 'astro',
+    })
 
     const result = await scaffoldProject(args)
 
     expect(mockCreateFrontend).not.toHaveBeenCalled()
     expect(result.detectedFramework).toBe('Astro')
+  })
+
+  test.each([
+    ['Astro', 'astro', 'PUBLIC_', 'PUBLIC_'],
+    ['Vite', 'vite', 'VITE_', 'VITE_'],
+    ['Nuxt', 'nuxtjs', 'NUXT_ENV_', 'NUXT_PUBLIC_'],
+    ['SvelteKit', 'sveltekit-1', undefined, 'PUBLIC_'],
+    ['Next.js', 'nextjs', 'NEXT_PUBLIC_', 'NEXT_PUBLIC_'],
+  ] as const)(
+    'uses the resolved public prefix for detected %s apps',
+    async (name, slug, envPrefix, expectedPrefix) => {
+      mockDetectFrameworkRecord.mockResolvedValue({envPrefix, name, slug})
+
+      const result = await scaffoldProject(args)
+
+      expect(result.frontendEnvPrefix).toBe(expectedPrefix)
+      expect(result.frontendEnv).toEqual({
+        [`${expectedPrefix}SANITY_DATASET`]: 'production',
+        [`${expectedPrefix}SANITY_PROJECT_ID`]: 'abc123',
+      })
+    },
+  )
+
+  test('uses an explicit Next.js fallback payload when the detected prefix is unknown', async () => {
+    mockDetectFrameworkRecord.mockResolvedValue({name: 'Mystery', slug: 'mystery'})
+
+    const result = await scaffoldProject(args)
+
+    expect(result.frontendEnvPrefix).toBeUndefined()
+    expect(result.frontendEnv).toEqual({
+      NEXT_PUBLIC_SANITY_DATASET: 'production',
+      NEXT_PUBLIC_SANITY_PROJECT_ID: 'abc123',
+    })
+  })
+
+  test('keeps prefix override keys aligned with installed framework slugs', () => {
+    const dependencySlugs: ReadonlySet<string> = new Set(
+      frameworks.flatMap((framework) => (framework.slug ? [framework.slug] : [])),
+    )
+
+    expect(
+      Object.keys(FRONTEND_ENV_PREFIX_OVERRIDES).every((slug) => dependencySlugs.has(slug)),
+    ).toBe(true)
   })
 
   test('keeps the Studio when the frontend scaffold fails, and reports it', async () => {

--- a/packages/@sanity/cli/src/actions/scaffold/createFrontend.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/createFrontend.ts
@@ -55,11 +55,13 @@ export class FrontendScaffoldError extends Error {
 
 // Closed stdin is what guarantees no prompt can wait for a human, rather than trusting the flags.
 export async function createFrontend({
+  cancelSignal,
   dirName,
   output,
   packageManager,
   workDir,
 }: {
+  cancelSignal?: AbortSignal
   dirName: string
   output: Output
   packageManager: PackageManager
@@ -73,6 +75,7 @@ export async function createFrontend({
   let result
   try {
     result = await execa('npx', args, {
+      cancelSignal,
       cwd: workDir,
       encoding: 'utf8',
       env: {
@@ -82,8 +85,10 @@ export async function createFrontend({
       reject: false,
       stdio: ['ignore', 'pipe', 'pipe'],
     })
+    cancelSignal?.throwIfAborted()
   } catch (err) {
     progress.fail()
+    cancelSignal?.throwIfAborted()
     throw new FrontendScaffoldError(
       `create-next-app failed: ${err instanceof Error ? err.message : String(err)}`,
     )
@@ -104,11 +109,13 @@ export async function createFrontend({
 }
 
 export async function installFrontendDeps({
+  cancelSignal,
   dirName,
   output,
   packageManager,
   workDir,
 }: {
+  cancelSignal?: AbortSignal
   dirName: string
   output: Output
   packageManager: PackageManager
@@ -117,9 +124,11 @@ export async function installFrontendDeps({
   try {
     await installNewPackages(
       {packageManager, packages: [NEXT_SANITY_SPEC]},
-      {output, workDir: path.join(workDir, dirName)},
+      {cancelSignal, output, workDir: path.join(workDir, dirName)},
     )
+    cancelSignal?.throwIfAborted()
   } catch (err) {
+    cancelSignal?.throwIfAborted()
     throw new FrontendScaffoldError(
       `Installing next-sanity failed: ${err instanceof Error ? err.message : String(err)}`,
     )

--- a/packages/@sanity/cli/src/actions/scaffold/createFrontend.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/createFrontend.ts
@@ -14,7 +14,9 @@ const debug = subdebug('scaffold')
 
 const CREATE_NEXT_APP_SPEC = 'create-next-app@^16'
 
-const NEXT_SANITY_SPEC = 'next-sanity@13'
+const NEXT_SANITY_SPEC = 'next-sanity'
+
+const SCAFFOLD_TIMEOUT_MS = 10 * 60_000
 
 const packageManagerFlag: Record<PackageManager, string | undefined> = {
   bun: '--use-bun',
@@ -87,6 +89,7 @@ export async function createFrontend({
       },
       reject: false,
       stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: SCAFFOLD_TIMEOUT_MS,
     })
     cancelSignal?.throwIfAborted()
   } catch (err) {
@@ -127,7 +130,12 @@ export async function installFrontendDeps({
   try {
     await installNewPackages(
       {packageManager, packages: [NEXT_SANITY_SPEC]},
-      {cancelSignal, output, workDir: path.join(workDir, dirName)},
+      {
+        cancelSignal,
+        output,
+        timeout: SCAFFOLD_TIMEOUT_MS,
+        workDir: path.join(workDir, dirName),
+      },
     )
     cancelSignal?.throwIfAborted()
   } catch (err) {

--- a/packages/@sanity/cli/src/actions/scaffold/createFrontend.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/createFrontend.ts
@@ -1,0 +1,127 @@
+import path from 'node:path'
+
+import {type Output, subdebug} from '@sanity/cli-core'
+import {spinner} from '@sanity/cli-core/ux'
+import {execa} from 'execa'
+
+import {installNewPackages} from '../../util/packageManager/installPackages.js'
+import {
+  getPartialEnvWithNpmPath,
+  type PackageManager,
+} from '../../util/packageManager/packageManagerChoice.js'
+
+const debug = subdebug('scaffold')
+
+const CREATE_NEXT_APP_SPEC = 'create-next-app@^16'
+
+const NEXT_SANITY_SPEC = 'next-sanity@13'
+
+const packageManagerFlag: Record<PackageManager, string | undefined> = {
+  bun: '--use-bun',
+  manual: undefined,
+  npm: '--use-npm',
+  pnpm: '--use-pnpm',
+  yarn: '--use-yarn',
+}
+
+// Explicit rather than left to `--yes`, which replays whatever preferences `create-next-app` saved
+// from an earlier run on this machine.
+const scaffolderFlags = [
+  '--typescript',
+  '--app',
+  '--eslint',
+  '--tailwind',
+  '--no-src-dir',
+  '--disable-git',
+  '--yes',
+]
+
+// The leading `--yes` is npx's own confirmation; one placed after the spec goes to create-next-app.
+function scaffolderArgs(dirName: string, packageManager?: PackageManager): string[] {
+  const pmFlag = packageManager ? packageManagerFlag[packageManager] : undefined
+  return ['--yes', CREATE_NEXT_APP_SPEC, dirName, ...scaffolderFlags, ...(pmFlag ? [pmFlag] : [])]
+}
+
+export function frontendScaffoldCommand(dirName: string): string {
+  return `npx ${scaffolderArgs(dirName).join(' ')}`
+}
+
+export class FrontendScaffoldError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'FrontendScaffoldError'
+  }
+}
+
+// Closed stdin is what guarantees no prompt can wait for a human, rather than trusting the flags.
+export async function createFrontend({
+  dirName,
+  output,
+  packageManager,
+  workDir,
+}: {
+  dirName: string
+  output: Output
+  packageManager: PackageManager
+  workDir: string
+}): Promise<void> {
+  const args = scaffolderArgs(dirName, packageManager)
+
+  debug('Scaffolding frontend: npx %s', args.join(' '))
+
+  const progress = spinner('Creating your Next.js app\n').start()
+  let result
+  try {
+    result = await execa('npx', args, {
+      cwd: workDir,
+      encoding: 'utf8',
+      env: {
+        ...getPartialEnvWithNpmPath(workDir),
+        npm_config_yes: 'true',
+      },
+      reject: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (err) {
+    progress.fail()
+    throw new FrontendScaffoldError(
+      `create-next-app failed: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+
+  if (result.failed || result.exitCode) {
+    progress.fail()
+    const commandOutput = [result.stdout, result.stderr]
+      .filter((chunk): chunk is string => typeof chunk === 'string' && chunk.length > 0)
+      .join('\n')
+    if (commandOutput) output.log(commandOutput)
+    throw new FrontendScaffoldError(
+      `create-next-app failed${result.exitCode ? ` with exit code ${result.exitCode}` : ''}`,
+    )
+  }
+
+  progress.succeed()
+}
+
+export async function installFrontendDeps({
+  dirName,
+  output,
+  packageManager,
+  workDir,
+}: {
+  dirName: string
+  output: Output
+  packageManager: PackageManager
+  workDir: string
+}): Promise<void> {
+  try {
+    await installNewPackages(
+      {packageManager, packages: [NEXT_SANITY_SPEC]},
+      {output, workDir: path.join(workDir, dirName)},
+    )
+  } catch (err) {
+    throw new FrontendScaffoldError(
+      `Installing next-sanity failed: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+}

--- a/packages/@sanity/cli/src/actions/scaffold/createFrontend.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/createFrontend.ts
@@ -71,7 +71,10 @@ export async function createFrontend({
 
   debug('Scaffolding frontend: npx %s', args.join(' '))
 
-  const progress = spinner('Creating your Next.js app\n').start()
+  const progress = spinner({
+    discardStdin: !cancelSignal,
+    text: 'Creating your Next.js app\n',
+  }).start()
   let result
   try {
     result = await execa('npx', args, {

--- a/packages/@sanity/cli/src/actions/scaffold/scaffoldProject.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/scaffoldProject.ts
@@ -53,6 +53,7 @@ export interface ScaffoldResult {
   warnings: string[]
 
   detectedFramework?: string
+  frontendPackageManager?: PackageManager
   frontendPath?: string
 }
 
@@ -213,7 +214,14 @@ export async function scaffoldProject({
     warnings.push(`${err.message}. Run the install yourself in ./${FRONTEND_DIR}.`)
   }
 
-  return {frontendEnv, frontendEnvWritten, frontendPath, studioPath, warnings}
+  return {
+    frontendEnv,
+    frontendEnvWritten,
+    frontendPackageManager: resolvedPackageManager,
+    frontendPath,
+    studioPath,
+    warnings,
+  }
 }
 
 function writeScaffoldEnv(

--- a/packages/@sanity/cli/src/actions/scaffold/scaffoldProject.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/scaffoldProject.ts
@@ -24,6 +24,13 @@ const debug = subdebug('scaffold')
 export const STUDIO_DIR = 'sanity'
 export const FRONTEND_DIR = 'web'
 
+const NEXTJS_ENV_PREFIX = 'NEXT_PUBLIC_'
+
+export const FRONTEND_ENV_PREFIX_OVERRIDES = {
+  nuxtjs: 'NUXT_PUBLIC_',
+  'sveltekit-1': 'PUBLIC_',
+} as const satisfies Record<string, string>
+
 const STUDIO_PACKAGE_NAME = 'sanity-studio'
 
 const STUDIO_PACKAGE_MANAGERS = new Set<PackageManager>(['npm', 'pnpm', 'yarn'])
@@ -53,8 +60,27 @@ export interface ScaffoldResult {
   warnings: string[]
 
   detectedFramework?: string
+
+  frontendEnvPrefix?: string
   frontendPackageManager?: PackageManager
   frontendPath?: string
+}
+
+function resolveFrontendEnvPrefix(detected: Framework): string | undefined {
+  const override =
+    FRONTEND_ENV_PREFIX_OVERRIDES[detected.slug as keyof typeof FRONTEND_ENV_PREFIX_OVERRIDES]
+  return (override ?? detected.envPrefix?.trim()) || undefined
+}
+
+function createFrontendEnv(
+  dataset: string,
+  projectId: string,
+  prefix: string,
+): Record<string, string> {
+  return {
+    [`${prefix}SANITY_DATASET`]: dataset,
+    [`${prefix}SANITY_PROJECT_ID`]: projectId,
+  }
 }
 
 // The token goes to `.env.local`, never `.env`: the scaffolded `.gitignore` covers `*.local` only.
@@ -153,16 +179,15 @@ export async function scaffoldProject({
     )
   }
 
-  const frontendEnv = {
-    NEXT_PUBLIC_SANITY_DATASET: dataset,
-    NEXT_PUBLIC_SANITY_PROJECT_ID: projectId,
-  }
+  const frontendEnvPrefix = detected ? resolveFrontendEnvPrefix(detected) : NEXTJS_ENV_PREFIX
+  const frontendEnv = createFrontendEnv(dataset, projectId, frontendEnvPrefix ?? NEXTJS_ENV_PREFIX)
 
   if (detected) {
     debug('Detected %s in %s, leaving the frontend alone', detected.name, workDir)
     return {
       detectedFramework: detected.name,
       frontendEnv,
+      frontendEnvPrefix,
       frontendEnvWritten: false,
       studioPath,
       warnings,
@@ -184,7 +209,13 @@ export async function scaffoldProject({
         `${err.message}. Scaffold it with \`${frontendScaffoldCommand(FRONTEND_DIR)}\`, ` +
           'then add the env values below.',
       )
-      return {frontendEnv, frontendEnvWritten: false, studioPath, warnings}
+      return {
+        frontendEnv,
+        frontendEnvPrefix,
+        frontendEnvWritten: false,
+        studioPath,
+        warnings,
+      }
     }
     throw err
   }
@@ -216,6 +247,7 @@ export async function scaffoldProject({
 
   return {
     frontendEnv,
+    frontendEnvPrefix,
     frontendEnvWritten,
     frontendPackageManager: resolvedPackageManager,
     frontendPath,

--- a/packages/@sanity/cli/src/actions/scaffold/scaffoldProject.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/scaffoldProject.ts
@@ -1,0 +1,227 @@
+import {existsSync} from 'node:fs'
+import path from 'node:path'
+
+import {type CLITelemetryStore, type Output, subdebug} from '@sanity/cli-core'
+import {type Framework, frameworks} from '@vercel/frameworks'
+
+import {CLIInitStepCompleted} from '../../telemetry/init.telemetry.js'
+import {detectFrameworkRecord} from '../../util/detectFramework.js'
+import {appendEnvValues} from '../../util/envFile.js'
+import {getProjectDefaults} from '../../util/getProjectDefaults.js'
+import {type PackageManager} from '../../util/packageManager/packageManagerChoice.js'
+import {initStudio} from '../init/initStudio.js'
+import {resolvePackageManager} from '../init/resolvePackageManager.js'
+import {type InitOptions} from '../init/types.js'
+import {
+  createFrontend,
+  frontendScaffoldCommand,
+  FrontendScaffoldError,
+  installFrontendDeps,
+} from './createFrontend.js'
+
+const debug = subdebug('scaffold')
+
+export const STUDIO_DIR = 'sanity'
+export const FRONTEND_DIR = 'web'
+
+const STUDIO_PACKAGE_NAME = 'sanity-studio'
+
+const STUDIO_PACKAGE_MANAGERS = new Set<PackageManager>(['npm', 'pnpm', 'yarn'])
+
+export function manualScaffoldCommands(options: {dataset: string; projectId: string}): string[] {
+  const {dataset, projectId} = options
+  return [
+    `npx sanity init --project ${projectId} --dataset ${dataset} --output-path ${STUDIO_DIR} --no-mcp --no-skills --no-git -y`,
+    frontendScaffoldCommand(FRONTEND_DIR),
+  ]
+}
+
+/** Display paths, so guidance reads the same on every platform and callers can key off them. */
+export const STUDIO_ENV_FILE = `${STUDIO_DIR}/.env.local`
+export const FRONTEND_ENV_FILE = `${FRONTEND_DIR}/.env.local`
+
+export function existingScaffoldEnvFiles(workDir: string): string[] {
+  return [STUDIO_ENV_FILE, FRONTEND_ENV_FILE].filter((relative) =>
+    existsSync(path.join(workDir, relative)),
+  )
+}
+
+export interface ScaffoldResult {
+  frontendEnv: Record<string, string>
+  frontendEnvWritten: boolean
+  studioPath: string
+  warnings: string[]
+
+  detectedFramework?: string
+  frontendPath?: string
+}
+
+// The token goes to `.env.local`, never `.env`: the scaffolded `.gitignore` covers `*.local` only.
+export async function scaffoldProject({
+  dataset,
+  displayName,
+  output,
+  packageManager,
+  projectId,
+  telemetry,
+  token,
+  workDir,
+}: {
+  dataset: string
+  displayName: string
+  output: Output
+  packageManager?: PackageManager
+  projectId: string
+  telemetry: CLITelemetryStore
+  token: string
+  workDir: string
+}): Promise<ScaffoldResult> {
+  const detected = await detectFrameworkRecord({
+    frameworkList: frameworks as readonly Framework[],
+    rootPath: workDir,
+  })
+  const studioPath = path.join(workDir, STUDIO_DIR)
+  const warnings: string[] = []
+
+  const resolvedPackageManager = await resolvePackageManager({
+    interactive: false,
+    output,
+    packageManager: packageManager as PackageManager,
+    targetDir: workDir,
+  })
+
+  const options: InitOptions = {
+    autoUpdates: true,
+    bare: false,
+    dataset,
+    datasetDefault: true,
+    fromCreate: false,
+    // A nested repository would not inherit the root `.gitignore` that keeps the token out of git.
+    git: false,
+    mcpMode: 'skip',
+    outputPath: studioPath,
+    packageManager: STUDIO_PACKAGE_MANAGERS.has(resolvedPackageManager)
+      ? (resolvedPackageManager as InitOptions['packageManager'])
+      : undefined,
+    project: projectId,
+    skillsMode: 'skip',
+    template: 'clean',
+    typescript: true,
+    unattended: true,
+  }
+
+  const trace = telemetry.trace(CLIInitStepCompleted)
+  trace.start()
+  try {
+    await initStudio({
+      datasetName: dataset,
+      defaults: await getProjectDefaults({isPlugin: false, workDir}),
+      displayName,
+      isFirstProject: false,
+      mcpConfigured: [],
+      options,
+      organizationId: undefined,
+      output,
+      outputPath: studioPath,
+      preclaim: true,
+      projectId,
+      remoteTemplateInfo: undefined,
+      sluggedName: STUDIO_PACKAGE_NAME,
+      trace,
+      workbench: false,
+      workDir,
+    })
+    trace.complete()
+  } catch (err) {
+    trace.error(err instanceof Error ? err : new Error(String(err)))
+    throw err
+  }
+
+  const studioEnvWritten = writeScaffoldEnv(
+    path.join(studioPath, '.env.local'),
+    {SANITY_AUTH_TOKEN: token},
+    'Added by `sanity new`. Keep this file out of git: it holds a live project token.',
+  )
+  if (!studioEnvWritten) {
+    warnings.push(
+      `Couldn't write ${STUDIO_DIR}/.env.local. Add SANITY_AUTH_TOKEN to it yourself, from ./.env.`,
+    )
+  }
+
+  const frontendEnv = {
+    NEXT_PUBLIC_SANITY_DATASET: dataset,
+    NEXT_PUBLIC_SANITY_PROJECT_ID: projectId,
+  }
+
+  if (detected) {
+    debug('Detected %s in %s, leaving the frontend alone', detected.name, workDir)
+    return {
+      detectedFramework: detected.name,
+      frontendEnv,
+      frontendEnvWritten: false,
+      studioPath,
+      warnings,
+    }
+  }
+
+  try {
+    await createFrontend({
+      dirName: FRONTEND_DIR,
+      output,
+      packageManager: resolvedPackageManager,
+      workDir,
+    })
+  } catch (err) {
+    if (err instanceof FrontendScaffoldError) {
+      warnings.push(
+        `${err.message}. Scaffold it with \`${frontendScaffoldCommand(FRONTEND_DIR)}\`, ` +
+          'then add the env values below.',
+      )
+      return {frontendEnv, frontendEnvWritten: false, studioPath, warnings}
+    }
+    throw err
+  }
+
+  const frontendPath = path.join(workDir, FRONTEND_DIR)
+
+  const frontendEnvWritten = writeScaffoldEnv(
+    path.join(frontendPath, '.env.local'),
+    frontendEnv,
+    'Added by `sanity new`.',
+  )
+  if (!frontendEnvWritten) {
+    warnings.push(`Couldn't write ${FRONTEND_DIR}/.env.local.`)
+  }
+
+  try {
+    await installFrontendDeps({
+      dirName: FRONTEND_DIR,
+      output,
+      packageManager: resolvedPackageManager,
+      workDir,
+    })
+  } catch (err) {
+    if (!(err instanceof FrontendScaffoldError)) throw err
+    warnings.push(`${err.message}. Run the install yourself in ./${FRONTEND_DIR}.`)
+  }
+
+  return {frontendEnv, frontendEnvWritten, frontendPath, studioPath, warnings}
+}
+
+function writeScaffoldEnv(
+  envPath: string,
+  values: Record<string, string>,
+  banner: string,
+): boolean {
+  try {
+    const written = appendEnvValues(envPath, values, {banner: [banner]})
+    if (written.skippedKeys.length > 0) {
+      debug('%s already had %s; values not written', envPath, written.skippedKeys.join(', '))
+      return false
+    }
+    return true
+  } catch (err) {
+    debug('Failed writing %s: %O', envPath, err)
+    return false
+  }
+}

--- a/packages/@sanity/cli/src/actions/scaffold/scaffoldProject.ts
+++ b/packages/@sanity/cli/src/actions/scaffold/scaffoldProject.ts
@@ -58,6 +58,7 @@ export interface ScaffoldResult {
 
 // The token goes to `.env.local`, never `.env`: the scaffolded `.gitignore` covers `*.local` only.
 export async function scaffoldProject({
+  cancelSignal,
   dataset,
   displayName,
   output,
@@ -67,6 +68,7 @@ export async function scaffoldProject({
   token,
   workDir,
 }: {
+  cancelSignal?: AbortSignal
   dataset: string
   displayName: string
   output: Output
@@ -76,6 +78,7 @@ export async function scaffoldProject({
   token: string
   workDir: string
 }): Promise<ScaffoldResult> {
+  cancelSignal?.throwIfAborted()
   const detected = await detectFrameworkRecord({
     frameworkList: frameworks as readonly Framework[],
     rootPath: workDir,
@@ -137,6 +140,7 @@ export async function scaffoldProject({
     throw err
   }
 
+  cancelSignal?.throwIfAborted()
   const studioEnvWritten = writeScaffoldEnv(
     path.join(studioPath, '.env.local'),
     {SANITY_AUTH_TOKEN: token},
@@ -166,11 +170,13 @@ export async function scaffoldProject({
 
   try {
     await createFrontend({
+      cancelSignal,
       dirName: FRONTEND_DIR,
       output,
       packageManager: resolvedPackageManager,
       workDir,
     })
+    cancelSignal?.throwIfAborted()
   } catch (err) {
     if (err instanceof FrontendScaffoldError) {
       warnings.push(
@@ -195,11 +201,13 @@ export async function scaffoldProject({
 
   try {
     await installFrontendDeps({
+      cancelSignal,
       dirName: FRONTEND_DIR,
       output,
       packageManager: resolvedPackageManager,
       workDir,
     })
+    cancelSignal?.throwIfAborted()
   } catch (err) {
     if (!(err instanceof FrontendScaffoldError)) throw err
     warnings.push(`${err.message}. Run the install yourself in ./${FRONTEND_DIR}.`)

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -2,7 +2,6 @@ import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {LOGIN_REQUIRED_MESSAGE} from '../../../actions/auth/login/loginInstructions.js'
 import {PROJECT_FEATURES_API_VERSION} from '../../../services/getProjectFeatures.js'
 import {PROJECTS_API_VERSION} from '../../../services/projects.js'
 import {InitCommand} from '../../init.js'
@@ -54,6 +53,13 @@ vi.mock('../../../util/detectFramework.js', () => ({
     name: 'Next.js',
     slug: 'nextjs',
   }),
+}))
+
+// Isolate from any ambient .env in the working directory: init only reads it to tailor the
+// not-logged-in hint, and a developer's local .env must not steer these auth assertions.
+vi.mock('../../../util/envFile.js', () => ({
+  GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
+  readEnvValues: vi.fn(() => ({})),
 }))
 
 vi.mock('../../../actions/auth/login/login.js', () => ({
@@ -205,7 +211,8 @@ describe('#init: authentication', () => {
       },
     })
 
-    expect(error?.message).toContain(LOGIN_REQUIRED_MESSAGE)
+    expect(error?.message).toContain('Not logged in. Run `sanity login` to authenticate')
+    expect(error?.message).toContain('run `sanity new` to create a project without logging in')
     expect(error?.oclif?.exit).toBe(1)
   })
 
@@ -213,7 +220,7 @@ describe('#init: authentication', () => {
     mockGetById.mockRejectedValueOnce(createHttpError(401, 'Unauthorized'))
 
     setupInitSuccessMocks()
-    const {error} = await testCommand(
+    const {error, stdout} = await testCommand(
       InitCommand,
       [
         '--dataset=test',
@@ -235,6 +242,8 @@ describe('#init: authentication', () => {
     )
 
     if (error) throw error
+    expect(stdout).toContain('Two ways to start')
+    expect(stdout).toContain('claim it within 72 hours')
     expect(mockLogin).toHaveBeenCalled()
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -57,11 +57,10 @@ vi.mock('../../../util/detectFramework.js', () => ({
 
 // Isolate from any ambient .env in the working directory: init only reads it to tailor the
 // not-logged-in hint, and a developer's local .env must not steer these auth assertions.
-vi.mock('../../../util/envFile.js', () => ({
-  GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
+vi.mock('../../../util/envFile.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../util/envFile.js')>()),
   inspectEnvKeys: vi.fn(() => ({blankKeys: [], presentKeys: [], values: {}})),
   readEnvValues: vi.fn(() => ({})),
-  TOKEN_ENV_FILES: './.env, or sanity/.env.local in a scaffolded project',
 }))
 
 vi.mock('../../../actions/auth/login/login.js', () => ({

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -59,6 +59,7 @@ vi.mock('../../../util/detectFramework.js', () => ({
 // not-logged-in hint, and a developer's local .env must not steer these auth assertions.
 vi.mock('../../../util/envFile.js', () => ({
   GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
+  inspectEnvKeys: vi.fn(() => ({blankKeys: [], presentKeys: [], values: {}})),
   readEnvValues: vi.fn(() => ({})),
   TOKEN_ENV_FILES: './.env, or sanity/.env.local in a scaffolded project',
 }))

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -212,7 +212,7 @@ describe('#init: authentication', () => {
     })
 
     expect(error?.message).toContain('Not logged in. Run `sanity login` to authenticate')
-    expect(error?.message).toContain('run `sanity new` to create a project without logging in')
+    expect(error?.message).toContain('To create a project without logging in, run `sanity new`')
     expect(error?.oclif?.exit).toBe(1)
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/init/init.authentication.test.ts
@@ -60,6 +60,7 @@ vi.mock('../../../util/detectFramework.js', () => ({
 vi.mock('../../../util/envFile.js', () => ({
   GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
   readEnvValues: vi.fn(() => ({})),
+  TOKEN_ENV_FILES: './.env, or sanity/.env.local in a scaffolded project',
 }))
 
 vi.mock('../../../actions/auth/login/login.js', () => ({

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -4,7 +4,7 @@ import {Readable} from 'node:stream'
 import {createTestClient, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import open from 'open'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {startServerForTokenCallback} from '../../actions/auth/authServer.js'
 import {LOGIN_PROVIDER_IDS} from '../../actions/auth/login/loginInstructions.js'
@@ -34,19 +34,14 @@ vi.mock('@sanity/cli-core/ux', async () => {
 // Mock browser launching
 vi.mock('open')
 
-// The outranked-session warnings read the cwd `.env` and the unclaimed-projects ledger. Both
-// are real machine state, so pin them to be inert unless a test opts in.
-const mockReadEnvValues = vi.hoisted(() => vi.fn().mockReturnValue({}))
-const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn().mockReturnValue(undefined))
+// The outranked-session warnings resolve the active credential source. The real resolver reads
+// machine state (env, cwd `.env`, the ledger, the stored session), so pin it to be inert unless
+// a test opts in.
+const mockedResolveCliCredential = vi.hoisted(() => vi.fn())
 
-vi.mock('../../util/envFile.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../util/envFile.js')>()),
-  readEnvValues: mockReadEnvValues,
-}))
-
-vi.mock('../../util/claimNudges.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../util/claimNudges.js')>()),
-  getMintedProjectRecord: mockGetMintedProjectRecord,
+vi.mock('@sanity/cli-core/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core/config')>()),
+  resolveCliCredential: mockedResolveCliCredential,
 }))
 
 // Mock platform detection
@@ -232,6 +227,10 @@ function mockValidTokenLogin(token: string) {
 }
 
 describe('#login', {timeout: 10_000}, () => {
+  beforeEach(() => {
+    mockedResolveCliCredential.mockResolvedValue({source: 'none'})
+  })
+
   afterEach(() => {
     if (originalStdinDescriptor) {
       Object.defineProperty(process, 'stdin', originalStdinDescriptor)
@@ -537,8 +536,8 @@ describe('#login', {timeout: 10_000}, () => {
   })
 
   describe('Outranked Session Warnings', () => {
-    test('warns when SANITY_AUTH_TOKEN outranks the fresh session', async () => {
-      vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
+    test('warns when the resolver reports an environment credential', async () => {
+      mockedResolveCliCredential.mockResolvedValue({source: 'environment', token: 'env-token'})
       mockValidTokenLogin('valid-token')
 
       const {error, stderr, stdout} = await testTokenLogin('valid-token')
@@ -549,15 +548,11 @@ describe('#login', {timeout: 10_000}, () => {
       expect(stderr).toContain('It outranks this login session')
     })
 
-    test('warns when the directory acts as an unclaimed minted project', async () => {
-      vi.stubEnv('SANITY_AUTH_TOKEN', '')
-      mockReadEnvValues.mockReturnValueOnce({SANITY_PROJECT_ID: 'abc123'})
-      mockGetMintedProjectRecord.mockReturnValueOnce({
-        claimToken: 'claim-token',
-        claimUrl: 'https://www.sanity.io/claim/some-token',
-        expiresAt: '2099-01-01T00:00:00.000Z',
-        mintedAt: '2026-07-24T00:00:00.000Z',
+    test('warns when the resolver reports a minted-project credential', async () => {
+      mockedResolveCliCredential.mockResolvedValue({
         projectId: 'abc123',
+        source: 'minted-project',
+        token: 'sk-robot',
       })
       mockValidTokenLogin('valid-token')
 
@@ -568,8 +563,19 @@ describe('#login', {timeout: 10_000}, () => {
       expect(stderr).toContain('outranks this login session')
     })
 
-    test('stays quiet when nothing outranks the session', async () => {
-      vi.stubEnv('SANITY_AUTH_TOKEN', '')
+    test('stays quiet when the resolver reports the fresh session as active', async () => {
+      // The resolver runs after the new session is stored, so 'session' means the login won.
+      mockedResolveCliCredential.mockResolvedValue({source: 'session', token: 'valid-token'})
+      mockValidTokenLogin('valid-token')
+
+      const {error, stderr} = await testTokenLogin('valid-token')
+
+      if (error) throw error
+      expect(stderr).not.toContain('outranks this login session')
+    })
+
+    test('stays quiet when the resolver reports no credential', async () => {
+      mockedResolveCliCredential.mockResolvedValue({source: 'none'})
       mockValidTokenLogin('valid-token')
 
       const {error, stderr} = await testTokenLogin('valid-token')

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -17,6 +17,7 @@ import {LoginCommand} from '../login.js'
 const mockInput = vi.hoisted(() => vi.fn())
 const mockSelect = vi.hoisted(() => vi.fn())
 const mockedGetCliToken = vi.hoisted(() => vi.fn())
+const mockedGetCliUserConfig = vi.hoisted(() => vi.fn())
 const mockedSetCliUserConfig = vi.hoisted(() => vi.fn())
 const mockedIsInteractive = vi.hoisted(() => vi.fn().mockReturnValue(true))
 
@@ -72,6 +73,7 @@ vi.mock('@sanity/cli-core', async () => {
   return {
     ...actual,
     getCliToken: mockedGetCliToken,
+    getCliUserConfig: mockedGetCliUserConfig,
     getGlobalCliClient: vi
       .fn()
       .mockImplementation((options: {apiVersion: string; token?: string}) => {
@@ -400,7 +402,7 @@ describe('#login', {timeout: 10_000}, () => {
     })
 
     test('invalidates an existing session after token login', async () => {
-      mockedGetCliToken.mockResolvedValue('old-auth-token')
+      mockedGetCliUserConfig.mockReturnValue('old-auth-token')
 
       mockApi({
         apiVersion: USERS_API_VERSION,
@@ -442,8 +444,41 @@ describe('#login', {timeout: 10_000}, () => {
       expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'new-auth-token')
     })
 
+    test('revokes the stored session even when a robot token outranks it', async () => {
+      mockedGetCliToken.mockResolvedValue('sk-robot-token-outranking-the-session')
+      mockedGetCliUserConfig.mockReturnValue('old-auth-token')
+
+      mockApi({apiVersion: USERS_API_VERSION, method: 'get', uri: '/users/me'})
+        .matchHeader('authorization', 'Bearer new-auth-token')
+        .reply(200, {
+          email: 'test@example.com',
+          id: 'user-123',
+          name: 'Test User',
+          provider: 'github',
+        })
+
+      mockApi({apiVersion: USERS_API_VERSION, method: 'get', uri: '/users/me'})
+        .matchHeader('authorization', 'Bearer old-auth-token')
+        .reply(200, {
+          email: 'old@example.com',
+          id: 'old-user-123',
+          name: 'Old User',
+          provider: 'github',
+        })
+
+      const revoke = mockApi({apiVersion: AUTH_API_VERSION, method: 'post', uri: '/auth/logout'})
+        .matchHeader('authorization', 'Bearer old-auth-token')
+        .reply(200)
+
+      const {error} = await testTokenLogin('new-auth-token')
+
+      if (error) throw error
+      expect(revoke.isDone()).toBe(true)
+      expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'new-auth-token')
+    })
+
     test('does not invalidate an existing Sanity API token after token login', async () => {
-      mockedGetCliToken.mockResolvedValue('old-api-token')
+      mockedGetCliUserConfig.mockReturnValue('old-api-token')
 
       mockApi({
         apiVersion: USERS_API_VERSION,
@@ -478,7 +513,7 @@ describe('#login', {timeout: 10_000}, () => {
     })
 
     test('does not invalidate an unchanged token after token login', async () => {
-      mockedGetCliToken.mockResolvedValue('same-token')
+      mockedGetCliUserConfig.mockReturnValue('same-token')
 
       mockApi({
         apiVersion: USERS_API_VERSION,
@@ -1167,7 +1202,7 @@ describe('#login', {timeout: 10_000}, () => {
 
   describe('Session Management', () => {
     test('invalidates existing session on new login', async () => {
-      mockedGetCliToken.mockResolvedValue('old-auth-token')
+      mockedGetCliUserConfig.mockReturnValue('old-auth-token')
       mockSingleProviderLogin()
 
       mockApi({
@@ -1200,7 +1235,7 @@ describe('#login', {timeout: 10_000}, () => {
     })
 
     test('clears an expired previous token without invalidating it', async () => {
-      mockedGetCliToken.mockResolvedValue('expired-token')
+      mockedGetCliUserConfig.mockReturnValue('expired-token')
       mockSingleProviderLogin('session-401')
 
       mockApi({
@@ -1220,7 +1255,7 @@ describe('#login', {timeout: 10_000}, () => {
 
     test('warns on non-401 error when invalidating session', async () => {
       // 500 should produce a warning
-      mockedGetCliToken.mockResolvedValue('old-token')
+      mockedGetCliUserConfig.mockReturnValue('old-token')
       mockSingleProviderLogin()
 
       mockApi({
@@ -1254,7 +1289,7 @@ describe('#login', {timeout: 10_000}, () => {
     })
 
     test('does not invalidate a previous Sanity API token on new login', async () => {
-      mockedGetCliToken.mockResolvedValue('old-api-token')
+      mockedGetCliUserConfig.mockReturnValue('old-api-token')
       mockSingleProviderLogin()
 
       mockApi({
@@ -1279,7 +1314,7 @@ describe('#login', {timeout: 10_000}, () => {
     })
 
     test('attempts logout when previous token type check fails', async () => {
-      mockedGetCliToken.mockResolvedValue('old-token')
+      mockedGetCliUserConfig.mockReturnValue('old-token')
       mockSingleProviderLogin()
 
       mockApi({

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -33,6 +33,21 @@ vi.mock('@sanity/cli-core/ux', async () => {
 // Mock browser launching
 vi.mock('open')
 
+// The outranked-session warnings read the cwd `.env` and the unclaimed-projects ledger. Both
+// are real machine state, so pin them to be inert unless a test opts in.
+const mockReadEnvValues = vi.hoisted(() => vi.fn().mockReturnValue({}))
+const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn().mockReturnValue(undefined))
+
+vi.mock('../../util/envFile.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../util/envFile.js')>()),
+  readEnvValues: mockReadEnvValues,
+}))
+
+vi.mock('../../util/claimNudges.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../util/claimNudges.js')>()),
+  getMintedProjectRecord: mockGetMintedProjectRecord,
+}))
+
 // Mock platform detection
 vi.mock('../../util/canLaunchBrowser.js', () => ({
   canLaunchBrowser: vi.fn().mockReturnValue(true),
@@ -196,6 +211,22 @@ function mockSingleProviderLogin(sessionId = 'test-session-id') {
 function testTokenLogin(token: string) {
   mockStdin(token)
   return testCommand(LoginCommand, ['--with-token'])
+}
+
+function mockValidTokenLogin(token: string) {
+  mockedGetCliToken.mockResolvedValue('')
+  mockApi({
+    apiVersion: USERS_API_VERSION,
+    method: 'get',
+    uri: '/users/me',
+  })
+    .matchHeader('authorization', `Bearer ${token}`)
+    .reply(200, {
+      email: 'test@example.com',
+      id: 'user-123',
+      name: 'Test User',
+      provider: 'github',
+    })
 }
 
 describe('#login', {timeout: 10_000}, () => {
@@ -467,6 +498,49 @@ describe('#login', {timeout: 10_000}, () => {
       if (error) throw error
       expect(stderr).not.toContain('Failed to invalidate previous session')
       expect(mockedSetCliUserConfig).toHaveBeenCalledWith('authToken', 'same-token')
+    })
+  })
+
+  describe('Outranked Session Warnings', () => {
+    test('warns when SANITY_AUTH_TOKEN outranks the fresh session', async () => {
+      vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
+      mockValidTokenLogin('valid-token')
+
+      const {error, stderr, stdout} = await testTokenLogin('valid-token')
+
+      if (error) throw error
+      expect(stdout).toContain('Login successful')
+      expect(stderr).toContain('SANITY_AUTH_TOKEN is set in the environment')
+      expect(stderr).toContain('It outranks this login session')
+    })
+
+    test('warns when the directory acts as an unclaimed minted project', async () => {
+      vi.stubEnv('SANITY_AUTH_TOKEN', '')
+      mockReadEnvValues.mockReturnValueOnce({SANITY_PROJECT_ID: 'abc123'})
+      mockGetMintedProjectRecord.mockReturnValueOnce({
+        claimToken: 'claim-token',
+        claimUrl: 'https://www.sanity.io/claim/some-token',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        mintedAt: '2026-07-24T00:00:00.000Z',
+        projectId: 'abc123',
+      })
+      mockValidTokenLogin('valid-token')
+
+      const {error, stderr} = await testTokenLogin('valid-token')
+
+      if (error) throw error
+      expect(stderr).toContain('unclaimed Sanity project abc123')
+      expect(stderr).toContain('outranks this login session')
+    })
+
+    test('stays quiet when nothing outranks the session', async () => {
+      vi.stubEnv('SANITY_AUTH_TOKEN', '')
+      mockValidTokenLogin('valid-token')
+
+      const {error, stderr} = await testTokenLogin('valid-token')
+
+      if (error) throw error
+      expect(stderr).not.toContain('outranks this login session')
     })
   })
 

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -583,7 +583,7 @@ describe('#login', {timeout: 10_000}, () => {
       const {error, stderr} = await testTokenLogin('valid-token')
 
       if (error) throw error
-      expect(stderr).toContain('SANITY_AUTH_TOKEN from ./.env')
+      expect(stderr).toContain("SANITY_AUTH_TOKEN from this project's .env")
       expect(stderr).toContain('outranks this login session')
       expect(stderr).not.toContain('unclaimed Sanity project')
       expect(stderr).not.toContain('Claim the project')

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -11,6 +11,7 @@ import {LOGIN_PROVIDER_IDS} from '../../actions/auth/login/loginInstructions.js'
 import {AUTH_API_VERSION} from '../../services/auth.js'
 import {USERS_API_VERSION} from '../../services/user.js'
 import {canLaunchBrowser} from '../../util/canLaunchBrowser.js'
+import {TOKEN_ENV_FILES} from '../../util/envFile.js'
 import {LoginCommand} from '../login.js'
 
 // Hoisted mocks for user prompts
@@ -552,6 +553,7 @@ describe('#login', {timeout: 10_000}, () => {
       expect(stdout).toContain('Login successful')
       expect(stderr).toContain('SANITY_AUTH_TOKEN is set in the environment')
       expect(stderr).toContain('It outranks this login session')
+      expect(stderr.replaceAll(/\s*›\s*/g, ' ').replaceAll(/\s+/g, ' ')).toContain(TOKEN_ENV_FILES)
     })
 
     test('warns when the resolver reports a known unclaimed minted-project credential', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -40,9 +40,11 @@ vi.mock('open')
 // a test opts in.
 const mockedResolveCliCredential = vi.hoisted(() => vi.fn())
 const mockedGetMintedProjectRecord = vi.hoisted(() => vi.fn())
+const mockedActivateCliSessionForProcess = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/cli-core/config', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@sanity/cli-core/config')>()),
+  activateCliSessionForProcess: mockedActivateCliSessionForProcess,
   resolveCliCredential: mockedResolveCliCredential,
 }))
 
@@ -553,7 +555,10 @@ describe('#login', {timeout: 10_000}, () => {
       expect(stdout).toContain('Login successful')
       expect(stderr).toContain('SANITY_AUTH_TOKEN is set in the environment')
       expect(stderr).toContain('It outranks this login session')
-      expect(stderr.replaceAll(/\s*›\s*/g, ' ').replaceAll(/\s+/g, ' ')).toContain(TOKEN_ENV_FILES)
+      expect(stderr.replaceAll(/\s*[›»]\s*/g, ' ').replaceAll(/\s+/g, ' ')).toContain(
+        TOKEN_ENV_FILES,
+      )
+      expect(mockedActivateCliSessionForProcess).not.toHaveBeenCalled()
     })
 
     test('warns when the resolver reports a known unclaimed minted-project credential', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/login.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/login.test.ts
@@ -38,10 +38,15 @@ vi.mock('open')
 // machine state (env, cwd `.env`, the ledger, the stored session), so pin it to be inert unless
 // a test opts in.
 const mockedResolveCliCredential = vi.hoisted(() => vi.fn())
+const mockedGetMintedProjectRecord = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/cli-core/config', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@sanity/cli-core/config')>()),
   resolveCliCredential: mockedResolveCliCredential,
+}))
+
+vi.mock('../../util/claimNudges.js', () => ({
+  getMintedProjectRecord: mockedGetMintedProjectRecord,
 }))
 
 // Mock platform detection
@@ -229,6 +234,7 @@ function mockValidTokenLogin(token: string) {
 describe('#login', {timeout: 10_000}, () => {
   beforeEach(() => {
     mockedResolveCliCredential.mockResolvedValue({source: 'none'})
+    mockedGetMintedProjectRecord.mockReturnValue(undefined)
   })
 
   afterEach(() => {
@@ -548,9 +554,25 @@ describe('#login', {timeout: 10_000}, () => {
       expect(stderr).toContain('It outranks this login session')
     })
 
-    test('warns when the resolver reports a minted-project credential', async () => {
+    test('warns when the resolver reports a known unclaimed minted-project credential', async () => {
       mockedResolveCliCredential.mockResolvedValue({
         projectId: 'abc123',
+        source: 'minted-project',
+        token: 'sk-robot',
+      })
+      mockedGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
+      mockValidTokenLogin('valid-token')
+
+      const {error, stderr} = await testTokenLogin('valid-token')
+
+      if (error) throw error
+      expect(stderr).toContain('unclaimed Sanity project abc123')
+      expect(stderr).toContain('outranks this login session')
+    })
+
+    test('does not label a project-local .env credential as unclaimed', async () => {
+      mockedResolveCliCredential.mockResolvedValue({
+        projectId: 'claimed123',
         source: 'minted-project',
         token: 'sk-robot',
       })
@@ -559,8 +581,10 @@ describe('#login', {timeout: 10_000}, () => {
       const {error, stderr} = await testTokenLogin('valid-token')
 
       if (error) throw error
-      expect(stderr).toContain('unclaimed Sanity project abc123')
+      expect(stderr).toContain('SANITY_AUTH_TOKEN from ./.env')
       expect(stderr).toContain('outranks this login session')
+      expect(stderr).not.toContain('unclaimed Sanity project')
+      expect(stderr).not.toContain('Claim the project')
     })
 
     test('stays quiet when the resolver reports the fresh session as active', async () => {

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -1,29 +1,45 @@
-import {getCliToken, setCliUserConfig} from '@sanity/cli-core'
+import {getCliUserConfig, setCliUserConfig} from '@sanity/cli-core'
 import {mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {AUTH_API_VERSION} from '../../services/auth.js'
 import {LogoutCommand} from '../logout.js'
 
 const mockConfigStoreDelete = vi.hoisted(() => vi.fn())
+const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn())
+const mockReadEnvValues = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/cli-core', async () => {
   const actual = await vi.importActual<typeof import('@sanity/cli-core')>('@sanity/cli-core')
   return {
     ...actual,
-    getCliToken: vi.fn(),
+    getCliUserConfig: vi.fn(),
     getUserConfig: vi.fn().mockReturnValue({
       delete: mockConfigStoreDelete,
     }),
     setCliUserConfig: vi.fn(),
   }
 })
+vi.mock('../../util/claimNudges.js', () => ({
+  getMintedProjectRecord: mockGetMintedProjectRecord,
+}))
+vi.mock('../../util/envFile.js', () => ({
+  readEnvValues: mockReadEnvValues,
+}))
 
-const mockedGetCliToken = vi.mocked(getCliToken)
+const mockedGetCliUserConfig = vi.mocked(getCliUserConfig)
 const mockedSetConfig = vi.mocked(setCliUserConfig)
 
+beforeEach(() => {
+  // Baselines no-token cases, otherwise auth token might be populated by test env shell.
+  vi.stubEnv('SANITY_AUTH_TOKEN', '')
+  mockReadEnvValues.mockReturnValue({})
+  mockGetMintedProjectRecord.mockReturnValue(undefined)
+})
+
 afterEach(() => {
+  vi.unstubAllEnvs()
   vi.clearAllMocks()
   const pending = pendingMocks()
   cleanAll()
@@ -31,8 +47,8 @@ afterEach(() => {
 })
 
 describe('#logout', () => {
-  test('logs out successfully if a token exists', async () => {
-    mockedGetCliToken.mockResolvedValueOnce('test-token')
+  test('logs out successfully if a stored session exists', async () => {
+    mockedGetCliUserConfig.mockReturnValueOnce('test-token')
 
     mockApi({
       apiVersion: AUTH_API_VERSION,
@@ -48,7 +64,7 @@ describe('#logout', () => {
   })
 
   test('logs out successfully when session is expired (401)', async () => {
-    mockedGetCliToken.mockResolvedValueOnce('test-token')
+    mockedGetCliUserConfig.mockReturnValueOnce('test-token')
 
     mockApi({
       apiVersion: AUTH_API_VERSION,
@@ -66,8 +82,8 @@ describe('#logout', () => {
     expect(mockConfigStoreDelete).toHaveBeenCalledWith('telemetryConsent')
   })
 
-  test('shows an error if no token exists', async () => {
-    mockedGetCliToken.mockResolvedValueOnce('')
+  test('shows an error if no credentials exist', async () => {
+    mockedGetCliUserConfig.mockReturnValueOnce(undefined)
 
     const {stdout} = await testCommand(LogoutCommand)
 
@@ -76,19 +92,66 @@ describe('#logout', () => {
     expect(mockConfigStoreDelete).not.toHaveBeenCalled()
   })
 
-  test('throws error on API failure (non-401)', async () => {
-    mockedGetCliToken.mockResolvedValueOnce('test-token')
+  test('env token only: explains it cannot be logged out, calls no API', async () => {
+    vi.stubEnv('SANITY_AUTH_TOKEN', 'sk-robot-token')
+    mockedGetCliUserConfig.mockReturnValueOnce(undefined)
+
+    const {error, stderr, stdout} = await testCommand(LogoutCommand)
+
+    expect(error).toBeUndefined()
+    expect(stderr).toContain('SANITY_AUTH_TOKEN is set in the environment')
+    // oclif wraps warnings, so assert a fragment that fits on one wrapped line.
+    expect(stderr).toContain('Remove that variable')
+    expect(stdout).not.toContain('No login credentials found')
+    expect(mockedSetConfig).not.toHaveBeenCalled()
+    expect(mockConfigStoreDelete).not.toHaveBeenCalled()
+  })
+
+  test('minted directory: warns the ledger robot identity survives logout', async () => {
+    mockedGetCliUserConfig.mockReturnValueOnce(undefined)
+    mockReadEnvValues.mockReturnValue({SANITY_PROJECT_ID: 'abc123'})
+    mockGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
+
+    const {error, stderr, stdout} = await testCommand(LogoutCommand)
+
+    expect(error).toBeUndefined()
+    expect(stderr).toContain('acts as unclaimed Sanity project abc123')
+    // The ledger identity counts as credentials — don't claim there are none.
+    expect(stdout).not.toContain('No login credentials found')
+    expect(mockGetMintedProjectRecord).toHaveBeenCalledWith('abc123')
+  })
+
+  test('env token plus stored session: warns about the env token and ends the session', async () => {
+    vi.stubEnv('SANITY_AUTH_TOKEN', 'sk-robot-token')
+    mockedGetCliUserConfig.mockReturnValueOnce('session-token')
 
     mockApi({
       apiVersion: AUTH_API_VERSION,
       method: 'post',
       uri: '/auth/logout',
-    }).reply(500, {message: 'Internal Server Error'})
+    }).reply(200)
+
+    const {stderr, stdout} = await testCommand(LogoutCommand)
+
+    expect(stderr).toContain('SANITY_AUTH_TOKEN is set in the environment')
+    expect(stdout).toContain('Logged out successfully')
+    expect(mockedSetConfig).toHaveBeenCalledWith('authToken', undefined)
+  })
+
+  test('surfaces only the status on API failure, never the response body', async () => {
+    mockedGetCliUserConfig.mockReturnValueOnce('test-token')
+
+    mockApi({
+      apiVersion: AUTH_API_VERSION,
+      method: 'post',
+      uri: '/auth/logout',
+    }).reply(500, {message: 'Populus error: something internal'})
 
     const {error} = await testCommand(LogoutCommand)
 
     expect(error).toBeDefined()
-    expect(error?.message).toContain('Failed to logout')
+    expect(error?.message).toContain('Failed to logout (HTTP 500)')
+    expect(error?.message).not.toContain('Populus')
     expect(mockedSetConfig).not.toHaveBeenCalled()
     expect(mockConfigStoreDelete).not.toHaveBeenCalled()
   })

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -125,11 +125,15 @@ describe('#logout', () => {
     vi.stubEnv('SANITY_AUTH_TOKEN', 'sk-robot-token')
     mockedGetCliUserConfig.mockReturnValueOnce('session-token')
 
+    // Matching the Authorization header proves the session token hit /auth/logout; sending the
+    // env token there is the exact leak the command guards against.
     mockApi({
       apiVersion: AUTH_API_VERSION,
       method: 'post',
       uri: '/auth/logout',
-    }).reply(200)
+    })
+      .matchHeader('authorization', 'Bearer session-token')
+      .reply(200)
 
     const {stderr, stdout} = await testCommand(LogoutCommand)
 

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -7,8 +7,7 @@ import {AUTH_API_VERSION} from '../../services/auth.js'
 import {LogoutCommand} from '../logout.js'
 
 const mockConfigStoreDelete = vi.hoisted(() => vi.fn())
-const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn())
-const mockReadEnvValues = vi.hoisted(() => vi.fn())
+const mockedResolveCliCredential = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/cli-core', async () => {
   const actual = await vi.importActual<typeof import('@sanity/cli-core')>('@sanity/cli-core')
@@ -21,22 +20,18 @@ vi.mock('@sanity/cli-core', async () => {
     setCliUserConfig: vi.fn(),
   }
 })
-vi.mock('../../util/claimNudges.js', () => ({
-  getMintedProjectRecord: mockGetMintedProjectRecord,
-}))
-vi.mock('../../util/envFile.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../util/envFile.js')>()),
-  readEnvValues: mockReadEnvValues,
+// The active-identity warnings come from the credential resolver; pin it so the tests never read
+// real machine state (env, cwd `.env`, the ledger).
+vi.mock('@sanity/cli-core/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core/config')>()),
+  resolveCliCredential: mockedResolveCliCredential,
 }))
 
 const mockedGetCliUserConfig = vi.mocked(getCliUserConfig)
 const mockedSetConfig = vi.mocked(setCliUserConfig)
 
 beforeEach(() => {
-  // Baselines no-token cases, otherwise auth token might be populated by test env shell.
-  vi.stubEnv('SANITY_AUTH_TOKEN', '')
-  mockReadEnvValues.mockReturnValue({})
-  mockGetMintedProjectRecord.mockReturnValue(undefined)
+  mockedResolveCliCredential.mockResolvedValue({source: 'none'})
 })
 
 afterEach(() => {
@@ -49,6 +44,7 @@ afterEach(() => {
 
 describe('#logout', () => {
   test('logs out successfully if a stored session exists', async () => {
+    mockedResolveCliCredential.mockResolvedValue({source: 'session', token: 'test-token'})
     mockedGetCliUserConfig.mockReturnValueOnce('test-token')
 
     mockApi({
@@ -94,7 +90,7 @@ describe('#logout', () => {
   })
 
   test('env token only: explains it cannot be logged out, calls no API', async () => {
-    vi.stubEnv('SANITY_AUTH_TOKEN', 'sk-robot-token')
+    mockedResolveCliCredential.mockResolvedValue({source: 'environment', token: 'sk-robot-token'})
     mockedGetCliUserConfig.mockReturnValueOnce(undefined)
 
     const {error, stderr, stdout} = await testCommand(LogoutCommand)
@@ -109,9 +105,12 @@ describe('#logout', () => {
   })
 
   test('minted directory: warns the ledger robot identity survives logout', async () => {
+    mockedResolveCliCredential.mockResolvedValue({
+      projectId: 'abc123',
+      source: 'minted-project',
+      token: 'sk-robot',
+    })
     mockedGetCliUserConfig.mockReturnValueOnce(undefined)
-    mockReadEnvValues.mockReturnValue({SANITY_PROJECT_ID: 'abc123'})
-    mockGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
 
     const {error, stderr, stdout} = await testCommand(LogoutCommand)
 
@@ -119,15 +118,14 @@ describe('#logout', () => {
     expect(stderr).toContain('acts as unclaimed Sanity project abc123')
     // The ledger identity counts as credentials — don't claim there are none.
     expect(stdout).not.toContain('No login credentials found')
-    expect(mockGetMintedProjectRecord).toHaveBeenCalledWith('abc123')
   })
 
   test('env token plus stored session: warns about the env token and ends the session', async () => {
-    vi.stubEnv('SANITY_AUTH_TOKEN', 'sk-robot-token')
+    mockedResolveCliCredential.mockResolvedValue({source: 'environment', token: 'sk-robot-token'})
     mockedGetCliUserConfig.mockReturnValueOnce('session-token')
 
     // Matching the Authorization header proves the session token hit /auth/logout; sending the
-    // env token there is the exact leak the command guards against.
+    // active env token there is the exact leak the command guards against.
     mockApi({
       apiVersion: AUTH_API_VERSION,
       method: 'post',
@@ -139,6 +137,31 @@ describe('#logout', () => {
     const {stderr, stdout} = await testCommand(LogoutCommand)
 
     expect(stderr).toContain('SANITY_AUTH_TOKEN is set in the environment')
+    expect(stdout).toContain('Logged out successfully')
+    expect(mockedSetConfig).toHaveBeenCalledWith('authToken', undefined)
+  })
+
+  test('minted robot plus stored session: warns, and still revokes only the session token', async () => {
+    // The robot outranks the session for auth, but logout must still end the stored session,
+    // and must never send the robot token to the session logout endpoint.
+    mockedResolveCliCredential.mockResolvedValue({
+      projectId: 'abc123',
+      source: 'minted-project',
+      token: 'sk-robot',
+    })
+    mockedGetCliUserConfig.mockReturnValueOnce('session-token')
+
+    mockApi({
+      apiVersion: AUTH_API_VERSION,
+      method: 'post',
+      uri: '/auth/logout',
+    })
+      .matchHeader('authorization', 'Bearer session-token')
+      .reply(200)
+
+    const {stderr, stdout} = await testCommand(LogoutCommand)
+
+    expect(stderr).toContain('acts as unclaimed Sanity project abc123')
     expect(stdout).toContain('Logged out successfully')
     expect(mockedSetConfig).toHaveBeenCalledWith('authToken', undefined)
   })

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -24,7 +24,8 @@ vi.mock('@sanity/cli-core', async () => {
 vi.mock('../../util/claimNudges.js', () => ({
   getMintedProjectRecord: mockGetMintedProjectRecord,
 }))
-vi.mock('../../util/envFile.js', () => ({
+vi.mock('../../util/envFile.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../util/envFile.js')>()),
   readEnvValues: mockReadEnvValues,
 }))
 

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -140,7 +140,7 @@ describe('#logout', () => {
     const {error, stderr, stdout} = await testCommand(LogoutCommand)
 
     expect(error).toBeUndefined()
-    expect(stderr).toContain('SANITY_AUTH_TOKEN from ./.env')
+    expect(stderr).toContain("SANITY_AUTH_TOKEN from this project's .env")
     expect(stderr).not.toContain('unclaimed Sanity project')
     expect(stderr).not.toContain('Claim the project')
     expect(stdout).not.toContain('No login credentials found')

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -8,6 +8,7 @@ import {LogoutCommand} from '../logout.js'
 
 const mockConfigStoreDelete = vi.hoisted(() => vi.fn())
 const mockedResolveCliCredential = vi.hoisted(() => vi.fn())
+const mockedGetMintedProjectRecord = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/cli-core', async () => {
   const actual = await vi.importActual<typeof import('@sanity/cli-core')>('@sanity/cli-core')
@@ -27,11 +28,16 @@ vi.mock('@sanity/cli-core/config', async (importOriginal) => ({
   resolveCliCredential: mockedResolveCliCredential,
 }))
 
+vi.mock('../../util/claimNudges.js', () => ({
+  getMintedProjectRecord: mockedGetMintedProjectRecord,
+}))
+
 const mockedGetCliUserConfig = vi.mocked(getCliUserConfig)
 const mockedSetConfig = vi.mocked(setCliUserConfig)
 
 beforeEach(() => {
   mockedResolveCliCredential.mockResolvedValue({source: 'none'})
+  mockedGetMintedProjectRecord.mockReturnValue(undefined)
 })
 
 afterEach(() => {
@@ -110,6 +116,7 @@ describe('#logout', () => {
       source: 'minted-project',
       token: 'sk-robot',
     })
+    mockedGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
     mockedGetCliUserConfig.mockReturnValueOnce(undefined)
 
     const {error, stderr, stdout} = await testCommand(LogoutCommand)
@@ -117,6 +124,23 @@ describe('#logout', () => {
     expect(error).toBeUndefined()
     expect(stderr).toContain('acts as unclaimed Sanity project abc123')
     // The ledger identity counts as credentials — don't claim there are none.
+    expect(stdout).not.toContain('No login credentials found')
+  })
+
+  test('project-local .env credential: does not claim the project is unclaimed', async () => {
+    mockedResolveCliCredential.mockResolvedValue({
+      projectId: 'claimed123',
+      source: 'minted-project',
+      token: 'sk-robot',
+    })
+    mockedGetCliUserConfig.mockReturnValueOnce(undefined)
+
+    const {error, stderr, stdout} = await testCommand(LogoutCommand)
+
+    expect(error).toBeUndefined()
+    expect(stderr).toContain('SANITY_AUTH_TOKEN from ./.env')
+    expect(stderr).not.toContain('unclaimed Sanity project')
+    expect(stderr).not.toContain('Claim the project')
     expect(stdout).not.toContain('No login credentials found')
   })
 
@@ -149,6 +173,7 @@ describe('#logout', () => {
       source: 'minted-project',
       token: 'sk-robot',
     })
+    mockedGetMintedProjectRecord.mockReturnValue({projectId: 'abc123'})
     mockedGetCliUserConfig.mockReturnValueOnce('session-token')
 
     mockApi({

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -104,7 +104,7 @@ describe('#logout', () => {
 
     expect(error).toBeUndefined()
     expect(stderr).toContain('SANITY_AUTH_TOKEN is set in the environment')
-    expect(stderr.replaceAll(/\s*›\s*/g, ' ').replaceAll(/\s+/g, ' ')).toContain(TOKEN_ENV_FILES)
+    expect(stderr.replaceAll(/\s*[›»]\s*/g, ' ').replaceAll(/\s+/g, ' ')).toContain(TOKEN_ENV_FILES)
     // oclif wraps warnings, so assert a fragment that fits on one wrapped line.
     expect(stderr).toContain('Remove that variable')
     expect(stdout).not.toContain('No login credentials found')

--- a/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/logout.test.ts
@@ -4,6 +4,7 @@ import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {AUTH_API_VERSION} from '../../services/auth.js'
+import {TOKEN_ENV_FILES} from '../../util/envFile.js'
 import {LogoutCommand} from '../logout.js'
 
 const mockConfigStoreDelete = vi.hoisted(() => vi.fn())
@@ -103,6 +104,7 @@ describe('#logout', () => {
 
     expect(error).toBeUndefined()
     expect(stderr).toContain('SANITY_AUTH_TOKEN is set in the environment')
+    expect(stderr.replaceAll(/\s*›\s*/g, ' ').replaceAll(/\s+/g, ' ')).toContain(TOKEN_ENV_FILES)
     // oclif wraps warnings, so assert a fragment that fits on one wrapped line.
     expect(stderr).toContain('Remove that variable')
     expect(stdout).not.toContain('No login credentials found')

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -1,14 +1,13 @@
-import path from 'node:path'
 import {text} from 'node:stream/consumers'
 
 import {Command, Flags} from '@oclif/core'
 import {type FlagInput} from '@oclif/core/interfaces'
 import {exitCodes, SanityCommand} from '@sanity/cli-core'
+import {resolveCliCredential} from '@sanity/cli-core/config'
 
 import {login} from '../actions/auth/login/login.js'
 import {LOGIN_PROVIDER_IDS} from '../actions/auth/login/loginInstructions.js'
-import {getMintedProjectRecord} from '../util/claimNudges.js'
-import {readEnvValues, TOKEN_ENV_FILES} from '../util/envFile.js'
+import {TOKEN_ENV_FILES} from '../util/envFile.js'
 
 export class LoginCommand extends SanityCommand<typeof LoginCommand> {
   static override description = 'Log in to your Sanity account'
@@ -81,29 +80,24 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
         token,
       })
       this.log('Login successful')
-      this.warnWhenSessionIsOutranked()
+      await this.warnWhenSessionIsOutranked()
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       this.error(`Login failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 
-  private warnWhenSessionIsOutranked() {
-    const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
-    if (envToken) {
+  // The new session is already stored, so a 'session' source means the login is active and
+  // nothing outranks it.
+  private async warnWhenSessionIsOutranked() {
+    const credential = await resolveCliCredential()
+    if (credential.source === 'environment') {
       this.warn(
         `SANITY_AUTH_TOKEN is set in the environment (often via ${TOKEN_ENV_FILES}). It outranks this login session. Remove that variable to act as the account you just logged in with.`,
       )
-      return
-    }
-
-    const {SANITY_PROJECT_ID} = readEnvValues(path.join(process.cwd(), '.env'), [
-      'SANITY_PROJECT_ID',
-    ])
-    const mintedRecord = SANITY_PROJECT_ID ? getMintedProjectRecord(SANITY_PROJECT_ID) : undefined
-    if (mintedRecord) {
+    } else if (credential.source === 'minted-project') {
       this.warn(
-        `This directory acts as unclaimed Sanity project ${SANITY_PROJECT_ID} via its robot token, which outranks this login session here. Claim the project to act as yourself.`,
+        `This directory acts as unclaimed Sanity project ${credential.projectId} via its robot token, which outranks this login session here. Claim the project to act as yourself.`,
       )
     }
   }

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -103,7 +103,7 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
         )
       } else {
         this.warn(
-          `This directory uses SANITY_AUTH_TOKEN from ./.env for Sanity project ${credential.projectId}, which outranks this login session here. Remove SANITY_AUTH_TOKEN from ./.env to act as the account you just logged in with.`,
+          `This directory uses SANITY_AUTH_TOKEN from this project's .env for Sanity project ${credential.projectId}, which outranks this login session here. Remove SANITY_AUTH_TOKEN from that .env to act as the account you just logged in with.`,
         )
       }
     }

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -8,7 +8,7 @@ import {exitCodes, SanityCommand} from '@sanity/cli-core'
 import {login} from '../actions/auth/login/login.js'
 import {LOGIN_PROVIDER_IDS} from '../actions/auth/login/loginInstructions.js'
 import {getMintedProjectRecord} from '../util/claimNudges.js'
-import {readEnvValues} from '../util/envFile.js'
+import {readEnvValues, TOKEN_ENV_FILES} from '../util/envFile.js'
 
 export class LoginCommand extends SanityCommand<typeof LoginCommand> {
   static override description = 'Log in to your Sanity account'
@@ -92,7 +92,7 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
     const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
     if (envToken) {
       this.warn(
-        'SANITY_AUTH_TOKEN is set in the environment (often via ./.env). It outranks this login session. Remove that variable to act as the account you just logged in with.',
+        `SANITY_AUTH_TOKEN is set in the environment (often via ${TOKEN_ENV_FILES}). It outranks this login session. Remove that variable to act as the account you just logged in with.`,
       )
       return
     }

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import {text} from 'node:stream/consumers'
 
 import {Command, Flags} from '@oclif/core'
@@ -6,6 +7,8 @@ import {exitCodes, SanityCommand} from '@sanity/cli-core'
 
 import {login} from '../actions/auth/login/login.js'
 import {LOGIN_PROVIDER_IDS} from '../actions/auth/login/loginInstructions.js'
+import {getMintedProjectRecord} from '../util/claimNudges.js'
+import {readEnvValues} from '../util/envFile.js'
 
 export class LoginCommand extends SanityCommand<typeof LoginCommand> {
   static override description = 'Log in to your Sanity account'
@@ -78,9 +81,30 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
         token,
       })
       this.log('Login successful')
+      this.warnWhenSessionIsOutranked()
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       this.error(`Login failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
+    }
+  }
+
+  private warnWhenSessionIsOutranked() {
+    const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
+    if (envToken) {
+      this.warn(
+        'SANITY_AUTH_TOKEN is set in the environment (often via ./.env). It outranks this login session. Remove that variable to act as the account you just logged in with.',
+      )
+      return
+    }
+
+    const {SANITY_PROJECT_ID} = readEnvValues(path.join(process.cwd(), '.env'), [
+      'SANITY_PROJECT_ID',
+    ])
+    const mintedRecord = SANITY_PROJECT_ID ? getMintedProjectRecord(SANITY_PROJECT_ID) : undefined
+    if (mintedRecord) {
+      this.warn(
+        `This directory acts as unclaimed Sanity project ${SANITY_PROJECT_ID} via its robot token, which outranks this login session here. Claim the project to act as yourself.`,
+      )
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -7,6 +7,7 @@ import {resolveCliCredential} from '@sanity/cli-core/config'
 
 import {login} from '../actions/auth/login/login.js'
 import {LOGIN_PROVIDER_IDS} from '../actions/auth/login/loginInstructions.js'
+import {getMintedProjectRecord} from '../util/claimNudges.js'
 import {TOKEN_ENV_FILES} from '../util/envFile.js'
 
 export class LoginCommand extends SanityCommand<typeof LoginCommand> {
@@ -96,9 +97,15 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
         `SANITY_AUTH_TOKEN is set in the environment (often via ${TOKEN_ENV_FILES}). It outranks this login session. Remove that variable to act as the account you just logged in with.`,
       )
     } else if (credential.source === 'minted-project') {
-      this.warn(
-        `This directory acts as unclaimed Sanity project ${credential.projectId} via its robot token, which outranks this login session here. Claim the project to act as yourself.`,
-      )
+      if (getMintedProjectRecord(credential.projectId)) {
+        this.warn(
+          `This directory acts as unclaimed Sanity project ${credential.projectId} via its robot token, which outranks this login session here. Claim the project to act as yourself.`,
+        )
+      } else {
+        this.warn(
+          `This directory uses SANITY_AUTH_TOKEN from ./.env for Sanity project ${credential.projectId}, which outranks this login session here. Remove SANITY_AUTH_TOKEN from ./.env to act as the account you just logged in with.`,
+        )
+      }
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/logout.ts
+++ b/packages/@sanity/cli/src/commands/logout.ts
@@ -1,6 +1,8 @@
+import path from 'node:path'
+
 import {
   exitCodes,
-  getCliToken,
+  getCliUserConfig,
   getUserConfig,
   SanityCommand,
   setCliUserConfig,
@@ -8,6 +10,8 @@ import {
 import {isHttpError} from '@sanity/client'
 
 import {logout} from '../services/auth.js'
+import {getMintedProjectRecord} from '../util/claimNudges.js'
+import {readEnvValues} from '../util/envFile.js'
 
 export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
   static override description = 'Log out of the current session'
@@ -15,14 +19,36 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
   public async run(): Promise<void> {
     await this.parse(LogoutCommand)
 
-    const previousToken = await getCliToken()
-    if (!previousToken) {
-      this.log('No login credentials found')
+    // Prevents SANITY_AUTH_TOKEN from causing errors when passed to session lookup endpoints.
+    const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
+    if (envToken) {
+      this.warn(
+        'SANITY_AUTH_TOKEN is set in the environment (often via ./.env) — logging out cannot end it. Remove that variable to stop acting as its identity.',
+      )
+    }
+
+    // getCliToken also authenticates from the unclaimed-projects ledger, ahead of the login
+    // session, so in a minted directory the CLI keeps acting as the project robot after logout.
+    // Surface that rather than reporting no credentials.
+    const {SANITY_PROJECT_ID} = readEnvValues(path.join(process.cwd(), '.env'), [
+      'SANITY_PROJECT_ID',
+    ])
+    const mintedRecord = SANITY_PROJECT_ID ? getMintedProjectRecord(SANITY_PROJECT_ID) : undefined
+    if (mintedRecord) {
+      this.warn(
+        `This directory acts as unclaimed Sanity project ${SANITY_PROJECT_ID} via a stored robot token — logout cannot end that. Claim the project, or run sanity elsewhere, to stop acting as it.`,
+      )
+    }
+
+    // Target the stored login session directly to avoid sending env token to session endpoint.
+    const sessionToken = getCliUserConfig('authToken')
+    if (!sessionToken) {
+      if (!envToken && !mintedRecord) this.log('No login credentials found')
       return
     }
 
     try {
-      await logout()
+      await logout(sessionToken)
 
       this.clearConfig()
     } catch (error) {
@@ -32,6 +58,14 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
       if (isHttpError(error) && error.response.statusCode === 401) {
         this.clearConfig()
         return
+      }
+      // API failure bodies can name internal services — surface only the status, keep the
+      // local credentials so a retry is possible.
+      if (isHttpError(error)) {
+        this.error(
+          `Failed to logout (HTTP ${error.response.statusCode}). Your local session was kept — try again shortly.`,
+          {exit: exitCodes.RUNTIME_ERROR},
+        )
       }
       const err = error instanceof Error ? error : new Error(`${error}`)
       this.error(`Failed to logout: ${err.message}`, {exit: exitCodes.RUNTIME_ERROR})

--- a/packages/@sanity/cli/src/commands/logout.ts
+++ b/packages/@sanity/cli/src/commands/logout.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 import {
   exitCodes,
   getCliUserConfig,
@@ -7,11 +5,11 @@ import {
   SanityCommand,
   setCliUserConfig,
 } from '@sanity/cli-core'
+import {resolveCliCredential} from '@sanity/cli-core/config'
 import {isHttpError} from '@sanity/client'
 
 import {logout} from '../services/auth.js'
-import {getMintedProjectRecord} from '../util/claimNudges.js'
-import {readEnvValues, TOKEN_ENV_FILES} from '../util/envFile.js'
+import {TOKEN_ENV_FILES} from '../util/envFile.js'
 
 export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
   static override description = 'Log out of the current session'
@@ -19,31 +17,25 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
   public async run(): Promise<void> {
     await this.parse(LogoutCommand)
 
-    // Prevents SANITY_AUTH_TOKEN from causing errors when passed to session lookup endpoints.
-    const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
-    if (envToken) {
+    // The active credential may be an environment or minted-project robot token, which logout
+    // cannot end. Surface that instead of reporting no credentials. Only the stored login
+    // session is ever revoked, so those tokens are never sent to the session logout endpoint.
+    const credential = await resolveCliCredential()
+    if (credential.source === 'environment') {
       this.warn(
         `SANITY_AUTH_TOKEN is set in the environment (often via ${TOKEN_ENV_FILES}). Logging out cannot end it. Remove that variable to stop acting as its identity.`,
       )
-    }
-
-    // getCliToken also authenticates from the unclaimed-projects ledger, ahead of the login
-    // session, so in a minted directory the CLI keeps acting as the project robot after logout.
-    // Surface that rather than reporting no credentials.
-    const {SANITY_PROJECT_ID} = readEnvValues(path.join(process.cwd(), '.env'), [
-      'SANITY_PROJECT_ID',
-    ])
-    const mintedRecord = SANITY_PROJECT_ID ? getMintedProjectRecord(SANITY_PROJECT_ID) : undefined
-    if (mintedRecord) {
+    } else if (credential.source === 'minted-project') {
       this.warn(
-        `This directory acts as unclaimed Sanity project ${SANITY_PROJECT_ID} via a stored robot token. Logout cannot end that. Claim the project, or run sanity elsewhere, to stop acting as it.`,
+        `This directory acts as unclaimed Sanity project ${credential.projectId} via a stored robot token. Logout cannot end that. Claim the project, or run sanity elsewhere, to stop acting as it.`,
       )
     }
 
-    // Target the stored login session directly to avoid sending env token to session endpoint.
+    // Target the stored login session directly to avoid sending the active token to the session
+    // endpoint: an outranking credential must not prevent revoking a separately stored session.
     const sessionToken = getCliUserConfig('authToken')
     if (!sessionToken) {
-      if (!envToken && !mintedRecord) this.log('No login credentials found')
+      if (credential.source === 'none') this.log('No login credentials found')
       return
     }
 

--- a/packages/@sanity/cli/src/commands/logout.ts
+++ b/packages/@sanity/cli/src/commands/logout.ts
@@ -11,7 +11,7 @@ import {isHttpError} from '@sanity/client'
 
 import {logout} from '../services/auth.js'
 import {getMintedProjectRecord} from '../util/claimNudges.js'
-import {readEnvValues} from '../util/envFile.js'
+import {readEnvValues, TOKEN_ENV_FILES} from '../util/envFile.js'
 
 export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
   static override description = 'Log out of the current session'
@@ -23,7 +23,7 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
     const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
     if (envToken) {
       this.warn(
-        'SANITY_AUTH_TOKEN is set in the environment (often via ./.env). Logging out cannot end it. Remove that variable to stop acting as its identity.',
+        `SANITY_AUTH_TOKEN is set in the environment (often via ${TOKEN_ENV_FILES}). Logging out cannot end it. Remove that variable to stop acting as its identity.`,
       )
     }
 

--- a/packages/@sanity/cli/src/commands/logout.ts
+++ b/packages/@sanity/cli/src/commands/logout.ts
@@ -9,6 +9,7 @@ import {resolveCliCredential} from '@sanity/cli-core/config'
 import {isHttpError} from '@sanity/client'
 
 import {logout} from '../services/auth.js'
+import {getMintedProjectRecord} from '../util/claimNudges.js'
 import {TOKEN_ENV_FILES} from '../util/envFile.js'
 
 export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
@@ -26,9 +27,15 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
         `SANITY_AUTH_TOKEN is set in the environment (often via ${TOKEN_ENV_FILES}). Logging out cannot end it. Remove that variable to stop acting as its identity.`,
       )
     } else if (credential.source === 'minted-project') {
-      this.warn(
-        `This directory acts as unclaimed Sanity project ${credential.projectId} via a stored robot token. Logout cannot end that. Claim the project, or run sanity elsewhere, to stop acting as it.`,
-      )
+      if (getMintedProjectRecord(credential.projectId)) {
+        this.warn(
+          `This directory acts as unclaimed Sanity project ${credential.projectId} via a stored robot token. Logout cannot end that. Claim the project, or run sanity elsewhere, to stop acting as it.`,
+        )
+      } else {
+        this.warn(
+          `This directory uses SANITY_AUTH_TOKEN from ./.env for Sanity project ${credential.projectId}. Logout cannot end that. Remove SANITY_AUTH_TOKEN from ./.env to stop acting as it.`,
+        )
+      }
     }
 
     // Target the stored login session directly to avoid sending the active token to the session

--- a/packages/@sanity/cli/src/commands/logout.ts
+++ b/packages/@sanity/cli/src/commands/logout.ts
@@ -33,7 +33,7 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
         )
       } else {
         this.warn(
-          `This directory uses SANITY_AUTH_TOKEN from ./.env for Sanity project ${credential.projectId}. Logout cannot end that. Remove SANITY_AUTH_TOKEN from ./.env to stop acting as it.`,
+          `This directory uses SANITY_AUTH_TOKEN from this project's .env for Sanity project ${credential.projectId}. Logout cannot end that. Remove SANITY_AUTH_TOKEN from that .env to stop acting as it.`,
         )
       }
     }

--- a/packages/@sanity/cli/src/commands/logout.ts
+++ b/packages/@sanity/cli/src/commands/logout.ts
@@ -23,7 +23,7 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
     const envToken = process.env.SANITY_AUTH_TOKEN?.trim()
     if (envToken) {
       this.warn(
-        'SANITY_AUTH_TOKEN is set in the environment (often via ./.env) — logging out cannot end it. Remove that variable to stop acting as its identity.',
+        'SANITY_AUTH_TOKEN is set in the environment (often via ./.env). Logging out cannot end it. Remove that variable to stop acting as its identity.',
       )
     }
 
@@ -36,7 +36,7 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
     const mintedRecord = SANITY_PROJECT_ID ? getMintedProjectRecord(SANITY_PROJECT_ID) : undefined
     if (mintedRecord) {
       this.warn(
-        `This directory acts as unclaimed Sanity project ${SANITY_PROJECT_ID} via a stored robot token — logout cannot end that. Claim the project, or run sanity elsewhere, to stop acting as it.`,
+        `This directory acts as unclaimed Sanity project ${SANITY_PROJECT_ID} via a stored robot token. Logout cannot end that. Claim the project, or run sanity elsewhere, to stop acting as it.`,
       )
     }
 
@@ -63,7 +63,7 @@ export class LogoutCommand extends SanityCommand<typeof LogoutCommand> {
       // local credentials so a retry is possible.
       if (isHttpError(error)) {
         this.error(
-          `Failed to logout (HTTP ${error.response.statusCode}). Your local session was kept — try again shortly.`,
+          `Failed to logout (HTTP ${error.response.statusCode}). Your local session was kept; try again shortly.`,
           {exit: exitCodes.RUNTIME_ERROR},
         )
       }

--- a/packages/@sanity/cli/src/commands/new.ts
+++ b/packages/@sanity/cli/src/commands/new.ts
@@ -1,0 +1,10 @@
+import {MintProjectCommand} from './projects/mint.js'
+
+/**
+ * Top-level alias for `sanity projects mint`.
+ * Subclassed to share implementation and give `sanity new` its own entry in help output.
+ */
+export class NewCommand extends MintProjectCommand {
+  // Don't inherit the parent's `project:mint` alias — it must resolve to a single command.
+  static override hiddenAliases: string[] = []
+}

--- a/packages/@sanity/cli/src/commands/new.ts
+++ b/packages/@sanity/cli/src/commands/new.ts
@@ -1,3 +1,6 @@
+import {Args, Flags} from '@oclif/core'
+
+import {CLAIM_WINDOW_HOURS, SANITY_NEW_URL} from '../util/mintProjectConstants.js'
 import {MintProjectCommand} from './projects/mint.js'
 
 /**
@@ -5,6 +8,73 @@ import {MintProjectCommand} from './projects/mint.js'
  * Subclassed to share implementation and give `sanity new` its own entry in help output.
  */
 export class NewCommand extends MintProjectCommand {
+  static override args = {
+    projectName: Args.string({
+      description: 'Display name for the project',
+      required: false,
+    }),
+  }
+
+  static override description =
+    'Create a Sanity project without an account to get started.\n' +
+    '\n' +
+    'By default, this creates two folders: ./sanity, a Studio where you write and edit content, ' +
+    'and ./web, a connected Next.js website. Use --no-scaffold to create only the project.\n' +
+    '\n' +
+    `Claim the project with a Sanity account within ${CLAIM_WINDOW_HOURS} hours. Claiming is free, ` +
+    'takes about a minute, and keeps everything you built working. If it is not claimed by the ' +
+    'deadline, the project and all its content are permanently deleted.\n' +
+    '\n' +
+    'The claim link and access token are secrets. Credentials are saved in a gitignored .env ' +
+    'file. The token can read and change all content, so never copy it into browser code. ' +
+    'After claiming, remove the token when you are ready to use your own account.\n' +
+    '\n' +
+    `Setup details for people and agents: ${SANITY_NEW_URL}. If you are an agent: give the claim ` +
+    'link to the person you are working for so they can open it themselves before the deadline.'
+
+  static override examples = [
+    {
+      command: '<%= config.bin %> <%= command.id %>',
+      description: 'Interactively create a project and starter apps',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> "My New Project"',
+      description: 'Create a project named "My New Project"',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --yes',
+      description: 'Create a project non-interactively with defaults',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --no-scaffold',
+      description: 'Create only the project without starter apps',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --json',
+      description: 'Create a project and return its credentials as JSON without writing files',
+    },
+  ]
+
+  static override flags = {
+    ...MintProjectCommand.flags,
+    force: Flags.boolean({
+      default: false,
+      description:
+        'Create a fresh project even when .env already has Sanity credentials (the file is left untouched; replacement values are printed)',
+    }),
+    scaffold: Flags.boolean({
+      allowNo: true,
+      default: true,
+      description:
+        'Create ./sanity (a Studio for editing content) and ./web (a connected Next.js website); use --no-scaffold for the project only',
+    }),
+    yes: Flags.boolean({
+      char: 'y',
+      default: false,
+      description: 'Skip prompts and use the default project name',
+    }),
+  }
+
   // Don't inherit the parent's `project:mint` alias — it must resolve to a single command.
   static override hiddenAliases: string[] = []
 }

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.blankEnv.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.blankEnv.test.ts
@@ -56,6 +56,14 @@ function listDir(): string[] {
   return fs.readdirSync(dir).toSorted()
 }
 
+function enterMintedDescendant(): {descendant: string; envReference: string} {
+  const descendant = path.join(dir, 'web')
+  fs.mkdirSync(descendant)
+  cwdSpy.mockReturnValue(descendant)
+  fs.writeFileSync(envPath, 'SANITY_PROJECT_ID="abc123"\nSANITY_AUTH_TOKEN="sk-root-robot"\n')
+  return {descendant, envReference: path.relative(descendant, envPath)}
+}
+
 async function runAndCatch(
   argv: string[],
 ): Promise<Error & {code?: string; suggestions?: string[]}> {
@@ -96,6 +104,70 @@ afterEach(() => {
 
 describe('#projects:mint blank .env placeholders (real env helpers)', () => {
   const blankEnv = 'SANITY_PROJECT_ID=\nSANITY_AUTH_TOKEN=\n'
+
+  test('refuses a second mint from a generated descendant of the mint root', async () => {
+    const {descendant, envReference} = enterMintedDescendant()
+
+    const err = await runAndCatch(['My New Project'])
+
+    expect(err.code).toBe('UNVERIFIED_SANITY_CREDENTIALS')
+    expect(err.message).toContain(`The ancestor ${envReference} already has`)
+    expect(err.message).not.toContain("This directory's .env")
+    expect(err.suggestions?.join('\n')).toContain(
+      `outside the project scope established by ${envReference}`,
+    )
+    expect(err.suggestions?.join('\n')).not.toContain('in a different directory')
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(fs.existsSync(path.join(descendant, '.env'))).toBe(false)
+  })
+
+  test('claimed-project cleanup names the ancestor token files from a descendant', async () => {
+    const {descendant, envReference} = enterMintedDescendant()
+    const studioEnvReference = path.relative(descendant, path.join(dir, 'sanity', '.env.local'))
+    mockGetMintedProjectRecord.mockReturnValue({
+      claimToken: 'old-claim-token',
+      projectId: 'abc123',
+    })
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'claimed'})
+
+    const err = await runAndCatch(['My New Project'])
+    const suggestions = err.suggestions?.join('\n')
+
+    expect(err.code).toBe('CLAIMED_PROJECT_IN_ENV')
+    expect(suggestions).toContain(
+      `remove SANITY_AUTH_TOKEN from ${envReference} or ${studioEnvReference}`,
+    )
+    expect(suggestions).not.toContain('./.env or sanity/.env.local')
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('--force replacement discovers and names stale files in the ancestor scope', async () => {
+    const {descendant, envReference} = enterMintedDescendant()
+    const studioDir = path.join(dir, 'sanity')
+    fs.mkdirSync(studioDir)
+    fs.writeFileSync(path.join(studioDir, '.env.local'), 'SANITY_AUTH_TOKEN="sk-root-robot"\n')
+    fs.writeFileSync(
+      path.join(descendant, '.env.local'),
+      'NEXT_PUBLIC_SANITY_PROJECT_ID="abc123"\n',
+    )
+    const studioEnvReference = path.relative(descendant, path.join(studioDir, '.env.local'))
+    const frontendEnvReference = path.relative(descendant, path.join(descendant, '.env.local'))
+
+    await MintProjectCommand.run(['My New Project', '--force'])
+
+    const lines = vi.mocked(mocks.SanityCmdOutput.log).mock.calls.flat().join('\n')
+    expect(lines).toContain(
+      `--force: minting a new project. ${envReference} is left untouched; new values follow.`,
+    )
+    expect(lines).toContain(`Update ${envReference} yourself`)
+    expect(lines).toContain(
+      `${studioEnvReference} and ${frontendEnvReference} still hold superseded values`,
+    )
+    expect(lines).toContain(`because ${envReference} still points at the previous project`)
+    expect(lines).not.toContain('Update ./.env yourself')
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mockScaffoldProject).not.toHaveBeenCalled()
+  })
 
   test('refuses before provisioning and leaves the directory untouched', async () => {
     fs.writeFileSync(envPath, blankEnv)

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.blankEnv.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.blankEnv.test.ts
@@ -1,0 +1,184 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {MintProjectCommand} from '../mint.js'
+
+// The blank-placeholder refusal exists because line presence (the writer's definition of
+// "exists") and effective dotenv value (the guard's) can disagree. Proving it with mocked env
+// helpers would just restate the mocks, so this suite runs the real envFile implementation
+// against a real temporary `.env` and only mocks the external boundaries.
+const mockMintUnclaimedProject = vi.hoisted(() => vi.fn())
+const mockLookupClaimState = vi.hoisted(() => vi.fn())
+const mockRecordMintedProject = vi.hoisted(() => vi.fn())
+const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn())
+const mockForgetMintedProject = vi.hoisted(() => vi.fn())
+const mockScaffoldProject = vi.hoisted(() => vi.fn())
+
+vi.mock(
+  '@sanity/cli-core/SanityCommand',
+  () => import('@sanity/cli-test/mocks/cli-core/SanityCommand'),
+)
+vi.mock('../../../services/mintProject.js', () => ({
+  lookupClaimState: mockLookupClaimState,
+  mintUnclaimedProject: mockMintUnclaimedProject,
+}))
+vi.mock('../../../util/claimNudges.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../util/claimNudges.js')>()),
+  forgetMintedProject: mockForgetMintedProject,
+  getMintedProjectRecord: mockGetMintedProjectRecord,
+  recordMintedProject: mockRecordMintedProject,
+}))
+vi.mock('../../../actions/scaffold/scaffoldProject.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../actions/scaffold/scaffoldProject.js')>()),
+  scaffoldProject: mockScaffoldProject,
+}))
+
+const mockMinted = {
+  apiHost: 'https://abc123.api.sanity.io',
+  claimApiUrl: 'https://api.sanity.io/v1/provision/claim',
+  claimToken: 'claim-token',
+  claimUrl: 'https://www.sanity.io/claim/some-token',
+  datasetName: 'production',
+  expiresAt: '2026-07-18T00:00:00.000Z',
+  resourceId: 'abc123',
+  token: 'sk-robot-token',
+}
+
+let dir: string
+let envPath: string
+let cwdSpy: ReturnType<typeof vi.spyOn>
+
+function listDir(): string[] {
+  return fs.readdirSync(dir).toSorted()
+}
+
+async function runAndCatch(
+  argv: string[],
+): Promise<Error & {code?: string; suggestions?: string[]}> {
+  const err = await MintProjectCommand.run(argv).then(
+    () => undefined,
+    (thrown: unknown) => thrown,
+  )
+  expect(err).toBeInstanceOf(Error)
+  return err as Error & {code?: string; suggestions?: string[]}
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sanity-mint-blankenv-'))
+  envPath = path.join(dir, '.env')
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(dir)
+
+  mockMintUnclaimedProject.mockResolvedValue(mockMinted)
+  mockLookupClaimState.mockResolvedValue(undefined)
+  mockGetMintedProjectRecord.mockReturnValue(undefined)
+  mockRecordMintedProject.mockReturnValue(true)
+  mockForgetMintedProject.mockReturnValue(true)
+  mockScaffoldProject.mockResolvedValue({
+    frontendEnv: {},
+    frontendEnvWritten: true,
+    frontendPath: path.join(dir, 'web'),
+    studioPath: path.join(dir, 'sanity'),
+    warnings: [],
+  })
+  mocks.SanityCmdIsUnattended.mockReturnValue(true)
+})
+
+afterEach(() => {
+  cwdSpy.mockRestore()
+  vi.clearAllMocks()
+  fs.rmSync(dir, {force: true, recursive: true})
+  process.exitCode = undefined
+})
+
+describe('#projects:mint blank .env placeholders (real env helpers)', () => {
+  const blankEnv = 'SANITY_PROJECT_ID=\nSANITY_AUTH_TOKEN=\n'
+
+  test('refuses before provisioning and leaves the directory untouched', async () => {
+    fs.writeFileSync(envPath, blankEnv)
+
+    const err = await runAndCatch(['My New Project'])
+
+    expect(err.message).toContain(
+      'blank Sanity credential placeholders: SANITY_AUTH_TOKEN, SANITY_PROJECT_ID',
+    )
+    expect(err.message).toContain('No project was minted')
+    expect(err.code).toBe('BLANK_SANITY_ENV_VALUES')
+    expect(err.suggestions?.join('\n')).toContain('Remove those blank lines')
+    // --force cannot fix this (the writer never edits existing lines), so never suggest it.
+    expect(err.message).not.toContain('--force')
+    expect(err.suggestions?.join('\n')).not.toContain('--force')
+
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(mockRecordMintedProject).not.toHaveBeenCalled()
+    expect(mockScaffoldProject).not.toHaveBeenCalled()
+    // No filesystem side effects: .env is byte-identical and nothing else was created.
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(blankEnv)
+    expect(listDir()).toEqual(['.env'])
+  })
+
+  test('--force does not bypass the refusal', async () => {
+    fs.writeFileSync(envPath, blankEnv)
+
+    const err = await runAndCatch(['My New Project', '--force'])
+
+    expect(err.code).toBe('BLANK_SANITY_ENV_VALUES')
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(blankEnv)
+  })
+
+  test('a second run against the unchanged file still refuses without provisioning', async () => {
+    fs.writeFileSync(envPath, blankEnv)
+
+    const first = await runAndCatch(['My New Project'])
+    const second = await runAndCatch(['My New Project'])
+
+    expect(first.code).toBe('BLANK_SANITY_ENV_VALUES')
+    expect(second.code).toBe('BLANK_SANITY_ENV_VALUES')
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(blankEnv)
+  })
+
+  test('reports only the keys that are actually blank', async () => {
+    // A whitespace-only quoted value and an export-prefixed blank line both count as blank;
+    // the nonblank claim URL must not be named.
+    fs.writeFileSync(
+      envPath,
+      'export SANITY_AUTH_TOKEN=\nSANITY_PROJECT_ID="   "\nSANITY_CLAIM_URL=https://www.sanity.io/claim/tok\n',
+    )
+
+    const err = await runAndCatch(['My New Project'])
+
+    expect(err.code).toBe('BLANK_SANITY_ENV_VALUES')
+    expect(err.message).toContain('SANITY_AUTH_TOKEN, SANITY_PROJECT_ID')
+    expect(err.message).not.toContain('SANITY_CLAIM_URL')
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('a blank unguarded key (SANITY_DATASET=) does not trigger the refusal', async () => {
+    fs.writeFileSync(envPath, 'SANITY_DATASET=\n')
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    // The real writer appends the guarded keys but skips the blank SANITY_DATASET line.
+    const contents = fs.readFileSync(envPath, 'utf8')
+    expect(contents).toContain('SANITY_DATASET=\n')
+    expect(contents).toContain(`SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+    expect(contents).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(contents).not.toContain(`SANITY_DATASET="${mockMinted.datasetName}"`)
+  })
+
+  test('a directory with no .env mints and persists credentials with the real helpers', async () => {
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'My New Project'})
+    const contents = fs.readFileSync(envPath, 'utf8')
+    expect(contents).toContain(`SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+    expect(contents).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf8')).toContain('.env*')
+  })
+})

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.blankEnv.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.blankEnv.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
+import {NewCommand} from '../../new.js'
 import {MintProjectCommand} from '../mint.js'
 
 // The blank-placeholder refusal exists because line presence (the writer's definition of
@@ -119,6 +120,25 @@ describe('#projects:mint blank .env placeholders (real env helpers)', () => {
     expect(err.suggestions?.join('\n')).not.toContain('in a different directory')
     expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
     expect(fs.existsSync(path.join(descendant, '.env'))).toBe(false)
+  })
+
+  test('sanity new reports an actionable error when an ancestor credential boundary is unreadable', async () => {
+    const descendant = path.join(dir, 'web')
+    fs.mkdirSync(descendant)
+    fs.mkdirSync(envPath)
+    cwdSpy.mockReturnValue(descendant)
+
+    const err = await NewCommand.run(['My New Project']).then(
+      () => undefined,
+      (thrown: unknown) => thrown,
+    )
+
+    expect(err).toBeInstanceOf(Error)
+    const cliError = err as Error & {code?: string}
+    expect(cliError.code).toBe('CREDENTIAL_BOUNDARY_INSPECTION_FAILED')
+    expect(cliError.message).toContain('Could not inspect the Sanity credential boundary')
+    expect(cliError.message).toContain('Ensure ancestor .env files are readable regular files')
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
   })
 
   test('claimed-project cleanup names the ancestor token files from a descendant', async () => {

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
@@ -1,0 +1,608 @@
+import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {NewCommand} from '../../new.js'
+import {MintProjectCommand} from '../mint.js'
+
+const mockMintUnclaimedProject = vi.hoisted(() => vi.fn())
+const mockLookupClaimState = vi.hoisted(() => vi.fn())
+const mockRecordMintedProject = vi.hoisted(() => vi.fn())
+const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn())
+const mockForgetMintedProject = vi.hoisted(() => vi.fn())
+const mockReadEnvValues = vi.hoisted(() => vi.fn())
+const mockAppendEnvValues = vi.hoisted(() => vi.fn())
+const mockEnsureEnvGitignored = vi.hoisted(() => vi.fn(() => ({added: false, ignored: true})))
+const mockIsEnvTracked = vi.hoisted(() => vi.fn(() => false))
+const mockInput = vi.hoisted(() => vi.fn())
+
+vi.mock(
+  '@sanity/cli-core/SanityCommand',
+  () => import('@sanity/cli-test/mocks/cli-core/SanityCommand'),
+)
+vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sanity/cli-core/ux')>()
+  return {
+    ...original,
+    input: mockInput,
+    // Silence the flow spinner — its lifecycle is exercised via the command outcome.
+    spinner: () => ({
+      start: () => ({fail: vi.fn(), stopAndPersist: vi.fn()}),
+    }),
+  }
+})
+vi.mock('../../../services/mintProject.js', () => ({
+  lookupClaimState: mockLookupClaimState,
+  mintUnclaimedProject: mockMintUnclaimedProject,
+}))
+vi.mock('../../../util/claimNudges.js', () => ({
+  forgetMintedProject: mockForgetMintedProject,
+  getMintedProjectRecord: mockGetMintedProjectRecord,
+  recordMintedProject: mockRecordMintedProject,
+}))
+vi.mock('../../../util/envFile.js', () => ({
+  appendEnvValues: mockAppendEnvValues,
+  ensureEnvGitignored: mockEnsureEnvGitignored,
+  GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
+  isEnvTracked: mockIsEnvTracked,
+  readEnvValues: mockReadEnvValues,
+}))
+
+const mockMinted = {
+  apiHost: 'https://abc123.api.sanity.io',
+  claimApiUrl: 'https://api.sanity.io/v1/provision/claim',
+  claimToken: 'claim-token',
+  claimUrl: 'https://www.sanity.io/claim/some-token',
+  datasetName: 'production',
+  expiresAt: '2026-07-18T00:00:00.000Z',
+  resourceId: 'abc123',
+  token: 'sk-robot-token',
+}
+
+const expectedResult = {
+  apiHost: mockMinted.apiHost,
+  claimApiUrl: mockMinted.claimApiUrl,
+  claimToken: mockMinted.claimToken,
+  claimUrl: mockMinted.claimUrl,
+  dataset: mockMinted.datasetName,
+  expiresAt: mockMinted.expiresAt,
+  projectId: mockMinted.resourceId,
+  token: mockMinted.token,
+}
+
+/** `.env` contents of a directory that already went through a mint. */
+const existingEnv = {
+  SANITY_AUTH_TOKEN: 'sk-old-token',
+  SANITY_DATASET: 'production',
+  SANITY_PROJECT_ID: 'oldproj',
+}
+
+const existingRecord = {
+  claimToken: 'old-claim-token',
+  claimUrl: 'https://www.sanity.io/claim/old-claim-token',
+  expiresAt: '2099-01-01T00:00:00.000Z',
+  mintedAt: '2026-07-01T00:00:00.000Z',
+  projectId: 'oldproj',
+}
+
+function loggedLines(): string {
+  return vi.mocked(mocks.SanityCmdOutput.log).mock.calls.flat().join('\n')
+}
+
+beforeEach(() => {
+  mockMintUnclaimedProject.mockResolvedValue(mockMinted)
+  mockLookupClaimState.mockResolvedValue(undefined)
+  mockGetMintedProjectRecord.mockReturnValue(undefined)
+  mockRecordMintedProject.mockReturnValue(true)
+  mockForgetMintedProject.mockReturnValue(true)
+  mockReadEnvValues.mockReturnValue({})
+  mockEnsureEnvGitignored.mockReturnValue({added: false, ignored: true})
+  mockIsEnvTracked.mockReturnValue(false)
+  mockAppendEnvValues.mockReturnValue({
+    created: true,
+    skippedKeys: [],
+    wroteKeys: ['SANITY_AUTH_TOKEN', 'SANITY_DATASET', 'SANITY_PROJECT_ID'],
+  })
+  // Default to unattended so tests without a name argument never hang on the prompt.
+  mocks.SanityCmdIsUnattended.mockReturnValue(true)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  // oclif's catch sets process.exitCode when a command throws (in JSON mode it swallows the
+  // error after printing the structured payload) — reset so tests never leak a failing code.
+  process.exitCode = undefined
+})
+
+describe('#projects:mint', () => {
+  test('mints a project with the provided name and narrates the flow', async () => {
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'My New Project'})
+    expect(mockRecordMintedProject).toHaveBeenCalledWith(mockMinted)
+    expect(mockForgetMintedProject).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
+
+    const lines = loggedLines()
+    // The splash renders first: squiggle art plus full link URLs.
+    expect(lines).toContain('@@@@')
+    expect(lines).toContain('https://sanity.new')
+    expect(lines).toContain('https://sanity.io/learn')
+    expect(lines).toContain("Let's get you set up with a Sanity project.")
+    // The --yes hint is redundant when the run is already non-interactive.
+    expect(lines).not.toContain('--yes')
+    expect(lines).toContain(mockMinted.resourceId)
+    expect(lines).toContain(mockMinted.datasetName)
+    expect(lines).toContain(mockMinted.claimUrl)
+    expect(lines).toContain(mockMinted.expiresAt)
+    // Without a TTY the spinner degrades to plain rail lines through the same log sink.
+    expect(lines).toContain('Minting your project...')
+    expect(lines).toContain('Project minted')
+    expect(lines).toContain('Happy coding')
+  })
+
+  test('appends credentials and claim context to .env in a fresh directory', async () => {
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockAppendEnvValues).toHaveBeenCalledWith(
+      expect.stringMatching(/\.env$/),
+      {
+        SANITY_AUTH_TOKEN: mockMinted.token,
+        SANITY_DATASET: mockMinted.datasetName,
+        SANITY_PROJECT_ID: mockMinted.resourceId,
+      },
+      expect.objectContaining({
+        banner: expect.arrayContaining([expect.stringContaining(mockMinted.claimUrl)]),
+      }),
+    )
+    expect(loggedLines()).toContain(
+      'Saved credentials to ./.env as SANITY_AUTH_TOKEN, SANITY_DATASET, SANITY_PROJECT_ID',
+    )
+  })
+
+  test('gitignores .env after writing it, and says so when it adds the entry', async () => {
+    mockEnsureEnvGitignored.mockReturnValue({added: true, ignored: true})
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockEnsureEnvGitignored).toHaveBeenCalledWith(expect.any(String))
+    expect(loggedLines()).toContain('Added .env to .gitignore so the token stays out of git.')
+  })
+
+  test('stays quiet about gitignore when .env is already ignored', async () => {
+    mockEnsureEnvGitignored.mockReturnValue({added: false, ignored: true})
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(loggedLines()).not.toContain('Added .env to .gitignore')
+  })
+
+  test('warns when the ledger write fails, since bare-directory auth depends on it', async () => {
+    mockRecordMintedProject.mockReturnValue(false)
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const warnings = vi.mocked(mocks.SanityCmdOutput.warn).mock.calls.flat().join('\n')
+    expect(warnings).toContain("Couldn't save this project to the local registry")
+  })
+
+  test('warns to untrack an already git-tracked .env, since gitignore cannot protect it', async () => {
+    mockIsEnvTracked.mockReturnValue(true)
+    mockEnsureEnvGitignored.mockReturnValue({added: true, ignored: true})
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const warnings = vi.mocked(mocks.SanityCmdOutput.warn).mock.calls.flat().join('\n')
+    expect(warnings).toContain('.env is already tracked by git')
+    expect(warnings).toContain('git rm --cached .env')
+    // The reassuring gitignore line must not appear when it wouldn't actually protect the token.
+    expect(loggedLines()).not.toContain('Added .env to .gitignore so the token stays out of git.')
+  })
+
+  test('warns when .env cannot be gitignored, so the token is never silently committable', async () => {
+    // {added: false, ignored: false} is the write-failure signal — distinct from "already
+    // ignored" ({added: false, ignored: true}), which stays quiet.
+    mockEnsureEnvGitignored.mockReturnValue({added: false, ignored: false})
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const warnings = vi.mocked(mocks.SanityCmdOutput.warn).mock.calls.flat().join('\n')
+    expect(warnings).toContain("Couldn't add .env to .gitignore")
+  })
+
+  test('hands over the values for keys the writer skipped', async () => {
+    // A template's lone SANITY_DATASET line: the writer never overwrites it, and the flow
+    // prints what the key must read instead of pretending the old value is fine.
+    mockReadEnvValues.mockReturnValue({SANITY_DATASET: 'production'})
+    mockAppendEnvValues.mockReturnValue({
+      created: false,
+      skippedKeys: ['SANITY_DATASET'],
+      wroteKeys: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('Saved credentials to ./.env as SANITY_AUTH_TOKEN, SANITY_PROJECT_ID')
+    expect(lines).toContain('./.env already has SANITY_DATASET')
+    expect(lines).toContain(`SANITY_DATASET="${mockMinted.datasetName}"`)
+  })
+
+  test('blank template leftovers never swallow the token (guard-absent, writer-present)', async () => {
+    // `SANITY_PROJECT_ID=` and `SANITY_AUTH_TOKEN=` lines: blank values are "absent" to the
+    // guard's dotenv read (mint proceeds down the fresh lane) but "present" to the writer's
+    // line check (append skips them). The skipped token's only copy must reach the terminal.
+    mockReadEnvValues.mockReturnValue({})
+    mockAppendEnvValues.mockReturnValue({
+      created: false,
+      skippedKeys: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'],
+      wroteKeys: ['SANITY_DATASET'],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('./.env already has SANITY_AUTH_TOKEN, SANITY_PROJECT_ID')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines).toContain(`SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+  })
+
+  test('gitignores .env even when every key was already present', async () => {
+    // All keys skipped means wroteKeys is empty, but .env still carries the token — the gitignore
+    // step must not be gated on having written keys this run.
+    mockAppendEnvValues.mockReturnValue({
+      created: false,
+      skippedKeys: ['SANITY_AUTH_TOKEN', 'SANITY_DATASET', 'SANITY_PROJECT_ID'],
+      wroteKeys: [],
+    })
+    mockEnsureEnvGitignored.mockReturnValue({added: true, ignored: true})
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockEnsureEnvGitignored).toHaveBeenCalledWith(expect.any(String))
+    expect(loggedLines()).toContain('Added .env to .gitignore so the token stays out of git.')
+  })
+
+  test('defaults the display name when unattended and no project name is provided', async () => {
+    await MintProjectCommand.run([])
+
+    expect(mockInput).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'My Sanity project'})
+  })
+
+  test('accepts --yes without a name argument', async () => {
+    await MintProjectCommand.run(['--yes'])
+
+    expect(mockInput).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'My Sanity project'})
+  })
+
+  test('prompts for the project name when attended', async () => {
+    mocks.SanityCmdIsUnattended.mockReturnValue(false)
+    mockInput.mockResolvedValue('Prompted Project')
+
+    await MintProjectCommand.run([])
+
+    expect(mockInput).toHaveBeenCalledWith({
+      default: 'My Sanity project',
+      message: 'Project name',
+    })
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'Prompted Project'})
+    expect(loggedLines()).toContain('--yes')
+  })
+
+  test('returns the structured result for --json output without writing .env', async () => {
+    await expect(MintProjectCommand.run(['My New Project', '--json'])).resolves.toEqual(
+      expectedResult,
+    )
+
+    // The guardrail reads .env even in JSON mode — but JSON mode never writes.
+    expect(mockReadEnvValues).toHaveBeenCalled()
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+    expect(mockInput).not.toHaveBeenCalled()
+    // "No files written" includes the user-config ledger — the caller owns the returned token.
+    expect(mockRecordMintedProject).not.toHaveBeenCalled()
+  })
+
+  test('propagates mint failures', async () => {
+    mockMintUnclaimedProject.mockRejectedValue(new Error('Mint failed (HTTP 429): rate limited'))
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      'Mint failed (HTTP 429): rate limited',
+    )
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+})
+
+describe('#projects:mint re-mint guardrail', () => {
+  test('aborts before minting when .env holds a live unclaimed project', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      state: 'claimable',
+    })
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has an unclaimed Sanity project \(oldproj\)/,
+    )
+    expect(mockLookupClaimState).toHaveBeenCalledWith('old-claim-token', expect.anything())
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+
+  test('live refusal omits the expiry clause when the server returns none', async () => {
+    // Server-confirmed claimable with a null expiry: the stale local date must not surface.
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue({
+      ...existingRecord,
+      expiresAt: '2020-01-01T00:00:00.000Z',
+    })
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'claimable'})
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has an unclaimed Sanity project \(oldproj\)\./,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('aborts before minting when the existing project was already claimed', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'claimed'})
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(/already been claimed/)
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('mints past a verified-expired project without --force, printing the new values', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mockRecordMintedProject).toHaveBeenCalledWith(mockMinted)
+    // The dead project's record is dropped once its replacement exists — a re-run must refuse
+    // instead of minting again against the rate cap.
+    expect(mockForgetMintedProject).toHaveBeenCalledWith('oldproj')
+    // .env is never modified: the new values are printed for the user to apply.
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+    const lines = loggedLines()
+    expect(lines).toContain('Found an expired unclaimed project (oldproj)')
+    expect(lines).toContain('Update ./.env yourself')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines).toContain(`SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+  })
+
+  test('a failed ledger drop in the expired lane warns instead of staying silent', async () => {
+    // Unwritable user config (sudo-owned file, sandboxed $HOME): the surviving record would
+    // re-authorize the auto-proceed on every re-run, so the flow must say so — the warning is
+    // what stops a blind agent retry loop from draining the mint budget. Still fail-open.
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
+    mockForgetMintedProject.mockReturnValue(false)
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.warn).toHaveBeenCalledWith(
+      expect.stringContaining('expired project oldproj is still recorded'),
+    )
+  })
+
+  test('--json surfaces a failed ledger drop through the warnings payload', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
+    mockForgetMintedProject.mockReturnValue(false)
+
+    await expect(MintProjectCommand.run(['My New Project', '--json'])).resolves.toEqual({
+      ...expectedResult,
+      warnings: [
+        expect.stringContaining('was not modified'),
+        expect.stringContaining('is still recorded'),
+      ],
+    })
+  })
+
+  test('lookup failure never authorizes the expired auto-proceed, even past local expiry', async () => {
+    // The project may have been claimed since the record was written — a dead lookup plus a
+    // stale local clock is not evidence enough to declare it dead and spend a mint.
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue({
+      ...existingRecord,
+      expiresAt: '2020-01-01T00:00:00.000Z',
+    })
+    mockLookupClaimState.mockResolvedValue(undefined)
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has an unclaimed Sanity project \(oldproj\)\./,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(mockForgetMintedProject).not.toHaveBeenCalled()
+  })
+
+  test('falls back to local expiry when the claim lookup fails: live aborts', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue(undefined)
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has an unclaimed Sanity project/,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('a lone SANITY_DATASET (template leftover) never blocks minting', async () => {
+    // An .env.example copied with a blank project id leaves only the dataset key — it carries
+    // no identity or credential, so the guardrail must let the mint through without --force.
+    mockReadEnvValues.mockReturnValue({SANITY_DATASET: 'production'})
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockLookupClaimState).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mockAppendEnvValues).toHaveBeenCalled()
+  })
+
+  test('aborts when existing credentials cannot be traced to a mint', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has Sanity credentials \(SANITY_AUTH_TOKEN, SANITY_PROJECT_ID\)/,
+    )
+    expect(mockLookupClaimState).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('unbound claimed verdicts fall back to the conservative refusal', async () => {
+    // A stale SANITY_CLAIM_URL whose project was claimed proves nothing about this directory's
+    // credentials — no claimed attribution, no remove-your-token advice, just the generic
+    // refusal with the --force escape.
+    mockReadEnvValues.mockReturnValue({
+      ...existingEnv,
+      SANITY_CLAIM_URL: 'https://www.sanity.io/claim/url-token',
+    })
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'claimed'})
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has Sanity credentials/,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('unbound claim-URL evidence can refuse but never authorizes the auto-proceed', async () => {
+    // A stale/unrelated SANITY_CLAIM_URL beside live credentials: its "expired" verdict is not
+    // proof about SANITY_PROJECT_ID, so minting must not proceed without --force.
+    mockReadEnvValues.mockReturnValue({
+      ...existingEnv,
+      SANITY_CLAIM_URL: 'https://www.sanity.io/claim/unrelated-token',
+    })
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has Sanity credentials/,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(mockForgetMintedProject).not.toHaveBeenCalled()
+  })
+
+  test('surfaces the credentials when the .env write fails after a successful mint', async () => {
+    mockAppendEnvValues.mockImplementation(() => {
+      throw new Error('EACCES: permission denied')
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('Add these to ./.env yourself, and keep .env out of git')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines).toContain(`SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+  })
+
+  test('recovers the claim token from SANITY_CLAIM_URL when the ledger has no record', async () => {
+    mockReadEnvValues.mockReturnValue({
+      ...existingEnv,
+      SANITY_CLAIM_URL: 'https://www.sanity.io/claim/url-token',
+    })
+    mockGetMintedProjectRecord.mockReturnValue(undefined)
+    mockLookupClaimState.mockResolvedValue({
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      state: 'claimable',
+    })
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
+      /already has an unclaimed Sanity project/,
+    )
+    expect(mockLookupClaimState).toHaveBeenCalledWith('url-token', expect.anything())
+  })
+
+  test('--json refuses a live unclaimed project with a structured error, before minting', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      state: 'claimable',
+    })
+
+    // In JSON mode oclif's catch prints `{"error": …}` and swallows — run resolves undefined.
+    await expect(MintProjectCommand.run(['My New Project', '--json'])).resolves.toBeUndefined()
+
+    expect(process.exitCode).toBe(1)
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+
+  test('--json still mints on verified-expired, warns about the stale .env, writes nothing', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+    mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
+
+    await expect(MintProjectCommand.run(['My New Project', '--json'])).resolves.toEqual({
+      ...expectedResult,
+      warnings: [expect.stringContaining('was not modified')],
+    })
+
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+    expect(mockForgetMintedProject).toHaveBeenCalledWith('oldproj')
+  })
+
+  test('--json --force mints without verification, leaves .env alone, and warns', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+
+    await expect(MintProjectCommand.run(['My New Project', '--json', '--force'])).resolves.toEqual({
+      ...expectedResult,
+      warnings: [expect.stringContaining('was not modified')],
+    })
+
+    expect(mockLookupClaimState).not.toHaveBeenCalled()
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+
+  test('--json --force in a bare directory appends nothing and warns about nothing', async () => {
+    mockReadEnvValues.mockReturnValue({})
+
+    await expect(MintProjectCommand.run(['My New Project', '--json', '--force'])).resolves.toEqual(
+      expectedResult,
+    )
+
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+  })
+
+  test('--force mints without prompting, leaves .env untouched, prints the new values', async () => {
+    mocks.SanityCmdIsUnattended.mockReturnValue(false)
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockGetMintedProjectRecord.mockReturnValue(existingRecord)
+
+    await MintProjectCommand.run(['My New Project', '--force'])
+
+    expect(mockLookupClaimState).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    // The old project may hold real content — its nudges keep running until claimed/expired.
+    expect(mockForgetMintedProject).not.toHaveBeenCalled()
+    expect(mockAppendEnvValues).not.toHaveBeenCalled()
+    const lines = loggedLines()
+    expect(lines).toContain('--force: minting a new project')
+    expect(lines).toContain('Update ./.env yourself')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+  })
+})
+
+describe('#new', () => {
+  test('runs the same mint flow as projects:mint', async () => {
+    await expect(NewCommand.run(['My New Project', '--json'])).resolves.toEqual(expectedResult)
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'My New Project'})
+  })
+
+  test('does not inherit the parent hidden aliases', () => {
+    expect(MintProjectCommand.hiddenAliases).toEqual(['project:mint'])
+    expect(NewCommand.hiddenAliases).toEqual([])
+  })
+})

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
@@ -9,7 +9,7 @@ const mockLookupClaimState = vi.hoisted(() => vi.fn())
 const mockRecordMintedProject = vi.hoisted(() => vi.fn())
 const mockGetMintedProjectRecord = vi.hoisted(() => vi.fn())
 const mockForgetMintedProject = vi.hoisted(() => vi.fn())
-const mockReadEnvValues = vi.hoisted(() => vi.fn())
+const mockInspectEnvKeys = vi.hoisted(() => vi.fn())
 const mockAppendEnvValues = vi.hoisted(() => vi.fn())
 const mockEnsureEnvGitignored = vi.hoisted(() => vi.fn(() => ({added: false, ignored: true})))
 const mockIsEnvTracked = vi.hoisted(() => vi.fn(() => false))
@@ -46,8 +46,8 @@ vi.mock('../../../util/envFile.js', () => ({
   appendEnvValues: mockAppendEnvValues,
   ensureEnvGitignored: mockEnsureEnvGitignored,
   GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
+  inspectEnvKeys: mockInspectEnvKeys,
   isEnvTracked: mockIsEnvTracked,
-  readEnvValues: mockReadEnvValues,
   TOKEN_ENV_FILES: './.env, or sanity/.env.local in a scaffolded project',
 }))
 vi.mock('../../../actions/scaffold/scaffoldProject.js', async (importOriginal) => ({
@@ -85,6 +85,13 @@ const existingEnv = {
   SANITY_PROJECT_ID: 'oldproj',
 }
 
+/** The guard's inspection of a `.env` holding these effective (nonblank) values. */
+const asInspection = (values: Record<string, string>) => ({
+  blankKeys: [],
+  presentKeys: Object.keys(values),
+  values,
+})
+
 const existingRecord = {
   claimToken: 'old-claim-token',
   claimUrl: 'https://www.sanity.io/claim/old-claim-token',
@@ -103,7 +110,7 @@ beforeEach(() => {
   mockGetMintedProjectRecord.mockReturnValue(undefined)
   mockRecordMintedProject.mockReturnValue(true)
   mockForgetMintedProject.mockReturnValue(true)
-  mockReadEnvValues.mockReturnValue({})
+  mockInspectEnvKeys.mockReturnValue(asInspection({}))
   mockEnsureEnvGitignored.mockReturnValue({added: false, ignored: true})
   mockIsEnvTracked.mockReturnValue(false)
   mockExistingScaffoldEnvFiles.mockReturnValue([])
@@ -239,7 +246,7 @@ describe('#projects:mint', () => {
   test('hands over the values for keys the writer skipped', async () => {
     // A template's lone SANITY_DATASET line: the writer never overwrites it, and the flow
     // prints what the key must read instead of pretending the old value is fine.
-    mockReadEnvValues.mockReturnValue({SANITY_DATASET: 'production'})
+    mockInspectEnvKeys.mockReturnValue(asInspection({SANITY_DATASET: 'production'}))
     mockAppendEnvValues.mockReturnValue({
       created: false,
       skippedKeys: ['SANITY_DATASET'],
@@ -255,10 +262,10 @@ describe('#projects:mint', () => {
   })
 
   test('blank template leftovers never swallow the token (guard-absent, writer-present)', async () => {
-    // `SANITY_PROJECT_ID=` and `SANITY_AUTH_TOKEN=` lines: blank values are "absent" to the
-    // guard's dotenv read (mint proceeds down the fresh lane) but "present" to the writer's
-    // line check (append skips them). The skipped token's only copy must reach the terminal.
-    mockReadEnvValues.mockReturnValue({})
+    // Blank guarded placeholders now refuse up front (see mint.blankEnv.test.ts), so with the
+    // real helpers this state needs an unguarded shadowed key or a race. If the writer ever
+    // skips keys the guard let through, the skipped token's only copy must reach the terminal.
+    mockInspectEnvKeys.mockReturnValue(asInspection({}))
     mockAppendEnvValues.mockReturnValue({
       created: false,
       skippedKeys: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'],
@@ -323,7 +330,7 @@ describe('#projects:mint', () => {
     )
 
     // The guardrail reads .env even in JSON mode — but JSON mode never writes.
-    expect(mockReadEnvValues).toHaveBeenCalled()
+    expect(mockInspectEnvKeys).toHaveBeenCalled()
     expect(mockAppendEnvValues).not.toHaveBeenCalled()
     expect(mockInput).not.toHaveBeenCalled()
     // "No files written" includes the user-config ledger — the caller owns the returned token.
@@ -342,7 +349,7 @@ describe('#projects:mint', () => {
 
 describe('#projects:mint re-mint guardrail', () => {
   test('aborts before minting when .env holds a live unclaimed project', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
     mockLookupClaimState.mockResolvedValue({
       expiresAt: '2099-01-01T00:00:00.000Z',
@@ -359,7 +366,7 @@ describe('#projects:mint re-mint guardrail', () => {
 
   test('live refusal omits the expiry clause when the server returns none', async () => {
     // Server-confirmed claimable with a null expiry: the stale local date must not surface.
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue({
       ...existingRecord,
       expiresAt: '2020-01-01T00:00:00.000Z',
@@ -373,7 +380,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('aborts before minting when the existing project was already claimed', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
     mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'claimed'})
 
@@ -382,7 +389,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('mints past a verified-expired project without --force, printing the new values', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
     mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
 
@@ -406,7 +413,7 @@ describe('#projects:mint re-mint guardrail', () => {
     // Unwritable user config (sudo-owned file, sandboxed $HOME): the surviving record would
     // re-authorize the auto-proceed on every re-run, so the flow must say so — the warning is
     // what stops a blind agent retry loop from draining the mint budget. Still fail-open.
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
     mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
     mockForgetMintedProject.mockReturnValue(false)
@@ -420,7 +427,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('--json surfaces a failed ledger drop through the warnings payload', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
     mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
     mockForgetMintedProject.mockReturnValue(false)
@@ -437,7 +444,7 @@ describe('#projects:mint re-mint guardrail', () => {
   test('lookup failure never authorizes the expired auto-proceed, even past local expiry', async () => {
     // The project may have been claimed since the record was written — a dead lookup plus a
     // stale local clock is not evidence enough to declare it dead and spend a mint.
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue({
       ...existingRecord,
       expiresAt: '2020-01-01T00:00:00.000Z',
@@ -452,7 +459,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('falls back to local expiry when the claim lookup fails: live aborts', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
     mockLookupClaimState.mockResolvedValue(undefined)
 
@@ -465,7 +472,7 @@ describe('#projects:mint re-mint guardrail', () => {
   test('a lone SANITY_DATASET (template leftover) never blocks minting', async () => {
     // An .env.example copied with a blank project id leaves only the dataset key — it carries
     // no identity or credential, so the guardrail must let the mint through without --force.
-    mockReadEnvValues.mockReturnValue({SANITY_DATASET: 'production'})
+    mockInspectEnvKeys.mockReturnValue(asInspection({SANITY_DATASET: 'production'}))
 
     await MintProjectCommand.run(['My New Project'])
 
@@ -475,7 +482,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('aborts when existing credentials cannot be traced to a mint', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(undefined)
 
     await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(
@@ -489,10 +496,9 @@ describe('#projects:mint re-mint guardrail', () => {
     // A stale SANITY_CLAIM_URL whose project was claimed proves nothing about this directory's
     // credentials — no claimed attribution, no remove-your-token advice, just the generic
     // refusal with the --force escape.
-    mockReadEnvValues.mockReturnValue({
-      ...existingEnv,
-      SANITY_CLAIM_URL: 'https://www.sanity.io/claim/url-token',
-    })
+    mockInspectEnvKeys.mockReturnValue(
+      asInspection({...existingEnv, SANITY_CLAIM_URL: 'https://www.sanity.io/claim/url-token'}),
+    )
     mockGetMintedProjectRecord.mockReturnValue(undefined)
     mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'claimed'})
 
@@ -505,10 +511,12 @@ describe('#projects:mint re-mint guardrail', () => {
   test('unbound claim-URL evidence can refuse but never authorizes the auto-proceed', async () => {
     // A stale/unrelated SANITY_CLAIM_URL beside live credentials: its "expired" verdict is not
     // proof about SANITY_PROJECT_ID, so minting must not proceed without --force.
-    mockReadEnvValues.mockReturnValue({
-      ...existingEnv,
-      SANITY_CLAIM_URL: 'https://www.sanity.io/claim/unrelated-token',
-    })
+    mockInspectEnvKeys.mockReturnValue(
+      asInspection({
+        ...existingEnv,
+        SANITY_CLAIM_URL: 'https://www.sanity.io/claim/unrelated-token',
+      }),
+    )
     mockGetMintedProjectRecord.mockReturnValue(undefined)
     mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
 
@@ -533,10 +541,9 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('recovers the claim token from SANITY_CLAIM_URL when the ledger has no record', async () => {
-    mockReadEnvValues.mockReturnValue({
-      ...existingEnv,
-      SANITY_CLAIM_URL: 'https://www.sanity.io/claim/url-token',
-    })
+    mockInspectEnvKeys.mockReturnValue(
+      asInspection({...existingEnv, SANITY_CLAIM_URL: 'https://www.sanity.io/claim/url-token'}),
+    )
     mockGetMintedProjectRecord.mockReturnValue(undefined)
     mockLookupClaimState.mockResolvedValue({
       expiresAt: '2099-01-01T00:00:00.000Z',
@@ -550,7 +557,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('--json refuses a live unclaimed project with a structured error, before minting', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
     mockLookupClaimState.mockResolvedValue({
       expiresAt: '2099-01-01T00:00:00.000Z',
@@ -566,7 +573,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('--json still mints on verified-expired, warns about the stale .env, writes nothing', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
     mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'expired'})
 
@@ -580,7 +587,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('--json --force mints without verification, leaves .env alone, and warns', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
 
     await expect(MintProjectCommand.run(['My New Project', '--json', '--force'])).resolves.toEqual({
@@ -593,7 +600,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('--json --force in a bare directory appends nothing and warns about nothing', async () => {
-    mockReadEnvValues.mockReturnValue({})
+    mockInspectEnvKeys.mockReturnValue(asInspection({}))
 
     await expect(MintProjectCommand.run(['My New Project', '--json', '--force'])).resolves.toEqual(
       expectedResult,
@@ -604,7 +611,7 @@ describe('#projects:mint re-mint guardrail', () => {
 
   test('--force mints without prompting, leaves .env untouched, prints the new values', async () => {
     mocks.SanityCmdIsUnattended.mockReturnValue(false)
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
 
     await MintProjectCommand.run(['My New Project', '--force'])
@@ -686,7 +693,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('a remint names the scaffolded env files that still hold dead values', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockExistingScaffoldEnvFiles.mockReturnValue(['sanity/.env.local', 'web/.env.local'])
 
     await MintProjectCommand.run(['My New Project', '--force'])
@@ -701,7 +708,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('a remint names keys only for the scaffolded env files that exist', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockExistingScaffoldEnvFiles.mockReturnValue(['web/.env.local'])
 
     await MintProjectCommand.run(['My New Project', '--force'])
@@ -712,7 +719,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('a remint stays quiet about scaffolded env files when there are none', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockExistingScaffoldEnvFiles.mockReturnValue([])
 
     await MintProjectCommand.run(['My New Project', '--force'])
@@ -721,7 +728,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('--json surfaces the stale scaffolded env files as a warning', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
     mockExistingScaffoldEnvFiles.mockReturnValue(['sanity/.env.local', 'web/.env.local'])
 
     const result = await MintProjectCommand.run(['My New Project', '--force', '--json'])
@@ -809,7 +816,7 @@ describe('#projects:mint re-mint guardrail', () => {
   })
 
   test('does not scaffold over a directory that already had credentials', async () => {
-    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockInspectEnvKeys.mockReturnValue(asInspection(existingEnv))
 
     await MintProjectCommand.run(['My New Project', '--force'])
 

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
@@ -34,7 +34,8 @@ vi.mock('../../../services/mintProject.js', () => ({
   lookupClaimState: mockLookupClaimState,
   mintUnclaimedProject: mockMintUnclaimedProject,
 }))
-vi.mock('../../../util/claimNudges.js', () => ({
+vi.mock('../../../util/claimNudges.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../util/claimNudges.js')>()),
   forgetMintedProject: mockForgetMintedProject,
   getMintedProjectRecord: mockGetMintedProjectRecord,
   recordMintedProject: mockRecordMintedProject,
@@ -123,10 +124,9 @@ describe('#projects:mint', () => {
     expect(mocks.SanityCmdOutput.error).not.toHaveBeenCalled()
 
     const lines = loggedLines()
-    // The splash renders first: squiggle art plus full link URLs.
+    // The splash renders first: squiggle art alone, no links.
     expect(lines).toContain('@@@@')
-    expect(lines).toContain('https://sanity.new')
-    expect(lines).toContain('https://sanity.io/learn')
+    expect(lines).not.toContain('https://sanity.io/learn')
     expect(lines).toContain("Let's get you set up with a Sanity project.")
     // The --yes hint is redundant when the run is already non-interactive.
     expect(lines).not.toContain('--yes')
@@ -137,7 +137,15 @@ describe('#projects:mint', () => {
     // Without a TTY the spinner degrades to plain rail lines through the same log sink.
     expect(lines).toContain('Minting your project...')
     expect(lines).toContain('Project minted')
-    expect(lines).toContain('Happy coding')
+    // Direct claim messaging: exact deadline, deletion consequence, and the agent handoff.
+    expect(lines).toContain('You must claim this project within 72 hours')
+    expect(lines).toContain('or your project will be deleted')
+    expect(lines).toContain("Project credentials keep working after you've claimed")
+    expect(lines).toContain('If an agent is running this, surface the full claim URL to the user.')
+    expect(lines).toContain('They need to click this link to claim the project before it expires.')
+    expect(lines).toContain(
+      'Tell your agent to fetch https://sanity.new for instructions on what to do next.',
+    )
   })
 
   test('appends credentials and claim context to .env in a fresh directory', async () => {

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
@@ -957,6 +957,41 @@ describe('#projects:mint re-mint guardrail', () => {
     )
     expect(loggedLines()).toContain(mockMinted.claimUrl)
   })
+
+  test('a scaffold SIGINT aborts instead of degrading to a warning', async () => {
+    mockScaffoldProject.mockRejectedValue(new Error('SIGINT'))
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow('SIGINT')
+
+    expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("Couldn't scaffold the project"),
+    )
+  })
+
+  test('aborts an active scaffold when the command receives SIGINT', async () => {
+    const existingListeners = process.rawListeners('SIGINT')
+    mockScaffoldProject.mockImplementation(async ({cancelSignal}) => {
+      const sigintHandler = process
+        .rawListeners('SIGINT')
+        .find((listener) => !existingListeners.includes(listener))
+      expect(sigintHandler).toBeDefined()
+      sigintHandler?.()
+      expect(cancelSignal.aborted).toBe(true)
+      return {
+        frontendEnv: {},
+        frontendEnvWritten: false,
+        studioPath: '/tmp/project/sanity',
+        warnings: [],
+      }
+    })
+
+    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow('SIGINT')
+
+    expect(mocks.SanityCmdOutput.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("Couldn't scaffold the project"),
+    )
+    expect(process.rawListeners('SIGINT')).toEqual(existingListeners)
+  })
 })
 
 describe('#new', () => {

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
@@ -1,6 +1,10 @@
+import {stripVTControlCharacters} from 'node:util'
+
 import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
+import {CLAIM_WINDOW_HOURS} from '../../../services/mintProject.js'
+import {TOKEN_ENV_FILES} from '../../../util/envFile.js'
 import {NewCommand} from '../../new.js'
 import {MintProjectCommand} from '../mint.js'
 
@@ -32,7 +36,8 @@ vi.mock('@sanity/cli-core/ux', async (importOriginal) => {
     }),
   }
 })
-vi.mock('../../../services/mintProject.js', () => ({
+vi.mock('../../../services/mintProject.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../services/mintProject.js')>()),
   lookupClaimState: mockLookupClaimState,
   mintUnclaimedProject: mockMintUnclaimedProject,
 }))
@@ -103,6 +108,17 @@ function loggedLines(): string {
   return vi.mocked(mocks.SanityCmdOutput.log).mock.calls.flat().join('\n')
 }
 
+function loggedCalls(): string[] {
+  return vi.mocked(mocks.SanityCmdOutput.log).mock.calls.map((call) => call.join(' '))
+}
+
+const {columns: originalStdoutColumns, isTTY: originalStdoutIsTTY} = process.stdout
+
+function setStdout(isTTY: boolean, columns: number): void {
+  Object.defineProperty(process.stdout, 'isTTY', {configurable: true, value: isTTY})
+  Object.defineProperty(process.stdout, 'columns', {configurable: true, value: columns})
+}
+
 beforeEach(() => {
   mockMintUnclaimedProject.mockResolvedValue(mockMinted)
   mockLookupClaimState.mockResolvedValue(undefined)
@@ -134,6 +150,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks()
+  setStdout(originalStdoutIsTTY as boolean, originalStdoutColumns as number)
   // oclif's catch sets process.exitCode when a command throws (in JSON mode it swallows the
   // error after printing the structured payload) — reset so tests never leak a failing code.
   process.exitCode = undefined
@@ -152,25 +169,95 @@ describe('#projects:mint', () => {
     // The splash renders first: squiggle art alone, no links.
     expect(lines).toContain('@@@@')
     expect(lines).not.toContain('https://sanity.io/learn')
-    expect(lines).toContain("Let's get you set up with a Sanity project.")
+    expect(lines).toContain('Setting up your Sanity project.')
     // The --yes hint is redundant when the run is already non-interactive.
     expect(lines).not.toContain('--yes')
     expect(lines).toContain(mockMinted.resourceId)
     expect(lines).toContain(mockMinted.datasetName)
     expect(lines).toContain(mockMinted.claimUrl)
-    expect(lines).toContain(mockMinted.expiresAt)
     // Without a TTY the spinner degrades to plain rail lines through the same log sink.
     expect(lines).toContain('Minting your project...')
-    expect(lines).toContain('Project minted')
+    expect(lines).toContain('Created "My New Project"')
     // Direct claim messaging: exact deadline, deletion consequence, and the agent handoff.
-    expect(lines).toContain('You must claim this project within 72 hours')
-    expect(lines).toContain('or your project will be deleted')
-    expect(lines).toContain("Project credentials keep working after you've claimed")
-    expect(lines).toContain('If an agent is running this, surface the full claim URL to the user.')
-    expect(lines).toContain('They need to click this link to claim the project before it expires.')
+    expect(lines).toContain('Claim your project by 18 July 2026, 00:00 UTC')
+    expect(lines).toContain('project and everything in it is permanently deleted at that deadline')
+    expect(lines).toContain('nothing you have built changes')
     expect(lines).toContain(
-      'Tell your agent to fetch https://sanity.new for instructions on what to do next.',
+      'If you are an agent: give this claim URL to the person you are working for.',
     )
+    expect(lines).toContain('They have to open it themselves before the deadline.')
+    expect(lines).toContain('Framework setup and what to do after claiming: https://sanity.new')
+  })
+
+  test('tells one ordered story and repeats the exact claim URL in the outro', async () => {
+    await MintProjectCommand.run(['My New Project'])
+
+    const plain = loggedCalls().map((line) => stripVTControlCharacters(line))
+    const indexOf = (part: string) => plain.findIndex((line) => line.includes(part))
+
+    expect(indexOf('Created "My New Project"')).toBeLessThan(indexOf('Project ID: abc123'))
+    expect(indexOf('Project ID: abc123')).toBeLessThan(
+      indexOf('Dataset: production (where your content lives)'),
+    )
+    expect(indexOf('Dataset: production (where your content lives)')).toBeLessThan(
+      indexOf('Claim your project by 18 July 2026, 00:00 UTC'),
+    )
+    expect(indexOf('Claim your project by 18 July 2026, 00:00 UTC')).toBeLessThan(
+      indexOf(mockMinted.claimUrl),
+    )
+    expect(indexOf(mockMinted.claimUrl)).toBeLessThan(indexOf('Created two folders'))
+    expect(indexOf('Created two folders')).toBeLessThan(indexOf('Your access token is in'))
+    expect(indexOf('Your access token is in')).toBeLessThan(indexOf('https://sanity.new'))
+
+    const claimLines = plain.filter((line) => line.includes(mockMinted.claimUrl))
+    expect(claimLines).toHaveLength(2)
+    expect(claimLines.at(-1)).toContain('Claim your project:')
+
+    const projectIdCall = loggedCalls().findIndex((line) => line.includes('Project ID: abc123'))
+    expect(mockRecordMintedProject.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(mocks.SanityCmdOutput.log).mock.invocationCallOrder[projectIdCall],
+    )
+    const firstClaimCall = loggedCalls().findIndex((line) => line.includes(mockMinted.claimUrl))
+    const firstClaimOrder = vi.mocked(mocks.SanityCmdOutput.log).mock.invocationCallOrder[
+      firstClaimCall
+    ]
+    expect(firstClaimOrder).toBeLessThan(mockAppendEnvValues.mock.invocationCallOrder[0])
+    expect(firstClaimOrder).toBeLessThan(mockScaffoldProject.mock.invocationCallOrder[0])
+  })
+
+  test.each([80, 32])(
+    'wraps prose with rails at %i columns without breaking the claim credential',
+    async (columns) => {
+      setStdout(true, columns)
+      const claimUrl = `https://www.sanity.io/manage/claim/${'copy-safe-secret'.repeat(8)}`
+      mockMintUnclaimedProject.mockResolvedValue({...mockMinted, claimUrl})
+
+      await MintProjectCommand.run(['My New Project', '--no-scaffold'])
+
+      const physicalLines = loggedCalls()
+        .flatMap((line) => line.split('\n'))
+        .map((line) => stripVTControlCharacters(line))
+      const claimLines = physicalLines.filter((line) => line.includes(claimUrl))
+      expect(claimLines).toHaveLength(2)
+      expect(claimLines.every((line) => line.includes(claimUrl))).toBe(true)
+      expect(claimLines.every((line) => !line.includes('\n'))).toBe(true)
+
+      const railedProse = physicalLines.filter(
+        (line) => /^[┌│◇◆●└] {2}/.test(line) && !line.includes(claimUrl),
+      )
+      expect(railedProse.length).toBeGreaterThan(0)
+      expect(railedProse.every((line) => line.length <= columns)).toBe(true)
+    },
+  )
+
+  test('prints claim credentials without OSC 8 bytes when stdout is not a TTY', async () => {
+    setStdout(false, 80)
+
+    await MintProjectCommand.run(['My New Project', '--no-scaffold'])
+
+    const claimLines = loggedCalls().filter((line) => line.includes(mockMinted.claimUrl))
+    expect(claimLines).toHaveLength(2)
+    expect(claimLines.every((line) => !line.includes('\u001B]8;;'))).toBe(true)
   })
 
   test('appends credentials and claim context to .env in a fresh directory', async () => {
@@ -187,9 +274,7 @@ describe('#projects:mint', () => {
         banner: expect.arrayContaining([expect.stringContaining(mockMinted.claimUrl)]),
       }),
     )
-    expect(loggedLines()).toContain(
-      'Saved credentials to ./.env as SANITY_AUTH_TOKEN, SANITY_DATASET, SANITY_PROJECT_ID',
-    )
+    expect(loggedLines()).toContain('Your access token is in ./.env and ./sanity/.env.local')
   })
 
   test('gitignores .env after writing it, and says so when it adds the entry', async () => {
@@ -257,9 +342,9 @@ describe('#projects:mint', () => {
     await MintProjectCommand.run(['My New Project'])
 
     const lines = loggedLines()
-    expect(lines).toContain('Saved credentials to ./.env as SANITY_AUTH_TOKEN, SANITY_PROJECT_ID')
     expect(lines).toContain('./.env already has SANITY_DATASET')
     expect(lines).toContain(`SANITY_DATASET="${mockMinted.datasetName}"`)
+    expect(lines).toContain('Your access token is in ./.env and ./sanity/.env.local')
   })
 
   test('blank template leftovers never swallow the token (guard-absent, writer-present)', async () => {
@@ -336,6 +421,10 @@ describe('#projects:mint', () => {
     expect(mockInput).not.toHaveBeenCalled()
     // "No files written" includes the user-config ledger — the caller owns the returned token.
     expect(mockRecordMintedProject).not.toHaveBeenCalled()
+    expect(mockEnsureEnvGitignored).not.toHaveBeenCalled()
+    expect(mockIsEnvTracked).not.toHaveBeenCalled()
+    expect(mockScaffoldProject).not.toHaveBeenCalled()
+    expect(mocks.SanityCmdOutput.log).not.toHaveBeenCalled()
   })
 
   test('propagates mint failures', async () => {
@@ -385,7 +474,16 @@ describe('#projects:mint re-mint guardrail', () => {
     mockGetMintedProjectRecord.mockReturnValue(existingRecord)
     mockLookupClaimState.mockResolvedValue({expiresAt: null, state: 'claimed'})
 
-    await expect(MintProjectCommand.run(['My New Project'])).rejects.toThrow(/already been claimed/)
+    const error = await MintProjectCommand.run(['My New Project']).catch(
+      (caught: unknown) => caught,
+    )
+
+    expect(error).toMatchObject({
+      code: 'CLAIMED_PROJECT_IN_ENV',
+      suggestions: expect.arrayContaining([
+        expect.stringContaining(`remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES}`),
+      ]),
+    })
     expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
   })
 
@@ -626,6 +724,7 @@ describe('#projects:mint re-mint guardrail', () => {
     expect(lines).toContain('--force: minting a new project')
     expect(lines).toContain('Update ./.env yourself')
     expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines.match(/--force: minting a new project/g)).toHaveLength(1)
   })
 
   test('a shadowed token alone does not block the scaffold', async () => {
@@ -644,6 +743,9 @@ describe('#projects:mint re-mint guardrail', () => {
     expect(lines).not.toContain('Skipping the sanity/ and web/ scaffold')
     expect(lines).toContain('./.env already has SANITY_AUTH_TOKEN')
     expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines).toContain('Your access token is in ./sanity/.env.local')
+    expect(lines).toContain('./.env kept its existing token')
+    expect(lines).not.toContain('Your access token is in ./.env and')
   })
 
   test('blank template lines shadow the write, so the scaffold is skipped too', async () => {
@@ -795,12 +897,15 @@ describe('#projects:mint re-mint guardrail', () => {
       }),
     )
     const lines = loggedLines()
-    expect(lines).toContain('Created ./sanity (Studio) and ./web (frontend).')
+    expect(lines).toContain('Created two folders')
+    expect(lines).toContain('./sanity — your Studio, where you write and edit content')
+    expect(lines).toContain('./web — your website, a Next.js app that reads it')
     expect(lines).toContain('cd sanity && npx sanity dev')
     expect(lines).toContain(`http://localhost:3333/#token=${mockMinted.token}`)
-    expect(lines).toContain('to enter the Studio before claiming')
+    expect(lines).toContain('the token in that link signs you in — there is no account yet')
     expect(lines).toContain('cd web && npm run dev')
-    expect(lines).toContain('Your dataset is private until you claim it')
+    expect(lines).toContain('then open http://localhost:3000/')
+    expect(lines).toContain('Your content is private until you claim')
   })
 
   test.each([
@@ -846,6 +951,12 @@ describe('#projects:mint re-mint guardrail', () => {
 
     expect(mockMintUnclaimedProject).toHaveBeenCalled()
     expect(mockScaffoldProject).not.toHaveBeenCalled()
+    const lines = loggedLines()
+    expect(lines).toContain('Project created without scaffolding')
+    expect(lines).toContain('No folders were created')
+    expect(lines).not.toContain('Created two folders')
+    expect(lines).toContain('Your access token is in ./.env')
+    expect(lines).toContain('https://sanity.new')
   })
 
   test('does not scaffold in JSON mode', async () => {
@@ -884,7 +995,8 @@ describe('#projects:mint re-mint guardrail', () => {
     await MintProjectCommand.run(['My New Project'])
 
     const lines = loggedLines()
-    expect(lines).toContain('Found Next.js here, so only ./sanity was created.')
+    expect(lines).toContain('Created ./sanity for your existing Next.js app')
+    expect(lines).toContain('Your existing Next.js frontend was left unchanged.')
     expect(lines).toContain(`http://localhost:3333/#token=${mockMinted.token}`)
     expect(lines).toContain(`NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
     expect(lines).not.toContain('cd web && npm run dev')
@@ -916,7 +1028,7 @@ describe('#projects:mint re-mint guardrail', () => {
     await MintProjectCommand.run(['My New Project'])
 
     const lines = loggedLines()
-    expect(lines).toContain('Created ./sanity (Studio). The frontend was not created.')
+    expect(lines).toContain('Created ./sanity; the frontend was not created')
     expect(lines).toContain('cd sanity && npx sanity dev')
     expect(lines).toContain(`http://localhost:3333/#token=${mockMinted.token}`)
     expect(lines).toContain(`NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
@@ -935,7 +1047,7 @@ describe('#projects:mint re-mint guardrail', () => {
     await MintProjectCommand.run(['My New Project'])
 
     const lines = loggedLines()
-    expect(lines).toContain('Created ./sanity (Studio) and ./web (frontend).')
+    expect(lines).toContain('Created two folders')
     expect(lines).toContain("./web/.env.local wasn't written.")
     expect(lines).toContain(`NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
   })
@@ -961,13 +1073,48 @@ describe('#projects:mint re-mint guardrail', () => {
 
     const lines = loggedLines()
     expect(lines).not.toContain('SANITY_API_READ_TOKEN')
-    expect(lines).toContain('Copy SANITY_AUTH_TOKEN from ./.env')
+    expect(lines).toContain('Your access token is in ./.env and ./sanity/.env.local')
+    expect(lines).toContain(
+      'The token can read and change everything in this project. Never copy it into code that runs in a browser.',
+    )
   })
 
-  test('names the right public prefix convention for a non-Next framework', async () => {
+  test.each([
+    ['Astro', 'PUBLIC_'],
+    ['Vite', 'VITE_'],
+    ['Nuxt', 'NUXT_PUBLIC_'],
+    ['SvelteKit', 'PUBLIC_'],
+    ['Next.js', 'NEXT_PUBLIC_'],
+  ] as const)(
+    'prints framework-correct environment values for detected %s apps',
+    async (detectedFramework, frontendEnvPrefix) => {
+      mockScaffoldProject.mockResolvedValue({
+        detectedFramework,
+        frontendEnv: {
+          [`${frontendEnvPrefix}SANITY_DATASET`]: mockMinted.datasetName,
+          [`${frontendEnvPrefix}SANITY_PROJECT_ID`]: mockMinted.resourceId,
+        },
+        frontendEnvPrefix,
+        frontendEnvWritten: false,
+        studioPath: '/tmp/project/sanity',
+        warnings: [],
+      })
+
+      await MintProjectCommand.run(['My New Project'])
+
+      const lines = loggedLines()
+      expect(lines).toContain(`Created ./sanity for your existing ${detectedFramework} app`)
+      expect(lines).toContain(`${frontendEnvPrefix}SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+      expect(lines).not.toContain('fallback values')
+      expect(lines).not.toContain('Next.js convention')
+    },
+  )
+
+  test('labels Next.js-shaped values as a fallback when the public prefix is unknown', async () => {
     mockScaffoldProject.mockResolvedValue({
-      detectedFramework: 'Astro',
+      detectedFramework: 'Mystery',
       frontendEnv: {NEXT_PUBLIC_SANITY_PROJECT_ID: mockMinted.resourceId},
+      frontendEnvPrefix: undefined,
       frontendEnvWritten: false,
       studioPath: '/tmp/project/sanity',
       warnings: [],
@@ -976,22 +1123,9 @@ describe('#projects:mint re-mint guardrail', () => {
     await MintProjectCommand.run(['My New Project'])
 
     const lines = loggedLines()
-    expect(lines).toContain('Found Astro here, so only ./sanity was created.')
-    expect(lines).toContain('Those names follow the Next.js convention.')
-  })
-
-  test('does not add the prefix caveat when the detected framework is Next.js', async () => {
-    mockScaffoldProject.mockResolvedValue({
-      detectedFramework: 'Next.js',
-      frontendEnv: {NEXT_PUBLIC_SANITY_PROJECT_ID: mockMinted.resourceId},
-      frontendEnvWritten: false,
-      studioPath: '/tmp/project/sanity',
-      warnings: [],
-    })
-
-    await MintProjectCommand.run(['My New Project'])
-
-    expect(loggedLines()).not.toContain('follow the Next.js convention')
+    expect(lines).toContain(`NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+    expect(lines).toContain('These fallback values use NEXT_PUBLIC_')
+    expect(lines).toContain('Translate that public prefix for Mystery')
   })
 
   test('a scaffold failure never reads as a mint failure', async () => {
@@ -1051,5 +1185,65 @@ describe('#new', () => {
   test('does not inherit the parent hidden aliases', () => {
     expect(MintProjectCommand.hiddenAliases).toEqual(['project:mint'])
     expect(NewCommand.hiddenAliases).toEqual([])
+  })
+
+  test('has newcomer help that describes creation without inheriting mint terminology', () => {
+    const help = [
+      NewCommand.description,
+      ...NewCommand.examples.map((example) =>
+        typeof example === 'string' ? example : `${example.command}\n${example.description}`,
+      ),
+      NewCommand.flags.scaffold.description,
+    ].join('\n')
+
+    expect(help).toContain('Create a Sanity project without an account')
+    expect(help).toContain('./sanity')
+    expect(help).toContain('Studio')
+    expect(help).toContain('edit content')
+    expect(help).toContain('./web')
+    expect(help).toContain('Next.js')
+    expect(help).toContain('--no-scaffold')
+    expect(help).toContain(`${CLAIM_WINDOW_HOURS} hours`)
+    expect(help).toContain('free')
+    expect(help).toContain('permanently deleted')
+    expect(help).toContain('claim link')
+    expect(help).toContain('access token')
+    expect(help).toContain('.env')
+    expect(help).toContain('gitignored')
+    expect(help).toContain('browser code')
+    expect(help).toContain('https://sanity.new')
+    expect(help).not.toMatch(/\bmint(?:ed|ing)?\b/i)
+  })
+})
+
+describe('#projects:mint help', () => {
+  test('documents the technical scaffold, credential, claim, and JSON contracts', () => {
+    const help = [
+      MintProjectCommand.description,
+      MintProjectCommand.flags.scaffold.description,
+    ].join('\n')
+
+    expect(help).toContain('./sanity')
+    expect(help).toContain('./web')
+    expect(help).toContain('Studio')
+    expect(help).toContain('Next.js')
+    expect(help).toContain('--no-scaffold')
+    expect(help).toContain('./.env')
+    expect(help).toContain('local ledger')
+    expect(help).toContain('--project-id')
+    expect(help).toContain('--json')
+    expect(help).toContain('writes no files')
+    expect(help).toContain('permanently deleted')
+    expect(help).toContain('single-use')
+    expect(help).toContain('If you are an agent')
+    expect(help).toContain('full content access')
+    expect(help).toContain('server-side')
+    expect(help).toContain('public')
+    expect(help).toContain('sanity login')
+    expect(help).toContain('remove SANITY_AUTH_TOKEN')
+    expect(help).toContain(TOKEN_ENV_FILES)
+    expect(help).toContain('https://sanity.new')
+    expect(help).not.toContain('NEXT_PUBLIC_')
+    expect(help).not.toContain('SANITY_STUDIO_')
   })
 })

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
@@ -14,6 +14,8 @@ const mockAppendEnvValues = vi.hoisted(() => vi.fn())
 const mockEnsureEnvGitignored = vi.hoisted(() => vi.fn(() => ({added: false, ignored: true})))
 const mockIsEnvTracked = vi.hoisted(() => vi.fn(() => false))
 const mockInput = vi.hoisted(() => vi.fn())
+const mockScaffoldProject = vi.hoisted(() => vi.fn())
+const mockExistingScaffoldEnvFiles = vi.hoisted(() => vi.fn(() => [] as string[]))
 
 vi.mock(
   '@sanity/cli-core/SanityCommand',
@@ -46,6 +48,12 @@ vi.mock('../../../util/envFile.js', () => ({
   GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
   isEnvTracked: mockIsEnvTracked,
   readEnvValues: mockReadEnvValues,
+  TOKEN_ENV_FILES: './.env, or sanity/.env.local in a scaffolded project',
+}))
+vi.mock('../../../actions/scaffold/scaffoldProject.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../actions/scaffold/scaffoldProject.js')>()),
+  existingScaffoldEnvFiles: mockExistingScaffoldEnvFiles,
+  scaffoldProject: mockScaffoldProject,
 }))
 
 const mockMinted = {
@@ -98,10 +106,21 @@ beforeEach(() => {
   mockReadEnvValues.mockReturnValue({})
   mockEnsureEnvGitignored.mockReturnValue({added: false, ignored: true})
   mockIsEnvTracked.mockReturnValue(false)
+  mockExistingScaffoldEnvFiles.mockReturnValue([])
   mockAppendEnvValues.mockReturnValue({
     created: true,
     skippedKeys: [],
     wroteKeys: ['SANITY_AUTH_TOKEN', 'SANITY_DATASET', 'SANITY_PROJECT_ID'],
+  })
+  mockScaffoldProject.mockResolvedValue({
+    frontendEnv: {
+      NEXT_PUBLIC_SANITY_DATASET: mockMinted.datasetName,
+      NEXT_PUBLIC_SANITY_PROJECT_ID: mockMinted.resourceId,
+    },
+    frontendEnvWritten: true,
+    frontendPath: '/tmp/project/web',
+    studioPath: '/tmp/project/sanity',
+    warnings: [],
   })
   // Default to unattended so tests without a name argument never hang on the prompt.
   mocks.SanityCmdIsUnattended.mockReturnValue(true)
@@ -172,8 +191,8 @@ describe('#projects:mint', () => {
 
     await MintProjectCommand.run(['My New Project'])
 
-    expect(mockEnsureEnvGitignored).toHaveBeenCalledWith(expect.any(String))
-    expect(loggedLines()).toContain('Added .env to .gitignore so the token stays out of git.')
+    expect(mockEnsureEnvGitignored).toHaveBeenCalledWith(expect.any(String), '.env*')
+    expect(loggedLines()).toContain('Added .env* to .gitignore so the token stays out of git.')
   })
 
   test('stays quiet about gitignore when .env is already ignored', async () => {
@@ -203,7 +222,7 @@ describe('#projects:mint', () => {
     expect(warnings).toContain('.env is already tracked by git')
     expect(warnings).toContain('git rm --cached .env')
     // The reassuring gitignore line must not appear when it wouldn't actually protect the token.
-    expect(loggedLines()).not.toContain('Added .env to .gitignore so the token stays out of git.')
+    expect(loggedLines()).not.toContain('Added .env* to .gitignore so the token stays out of git.')
   })
 
   test('warns when .env cannot be gitignored, so the token is never silently committable', async () => {
@@ -214,7 +233,7 @@ describe('#projects:mint', () => {
     await MintProjectCommand.run(['My New Project'])
 
     const warnings = vi.mocked(mocks.SanityCmdOutput.warn).mock.calls.flat().join('\n')
-    expect(warnings).toContain("Couldn't add .env to .gitignore")
+    expect(warnings).toContain("Couldn't add .env* to .gitignore")
   })
 
   test('hands over the values for keys the writer skipped', async () => {
@@ -266,8 +285,8 @@ describe('#projects:mint', () => {
 
     await MintProjectCommand.run(['My New Project'])
 
-    expect(mockEnsureEnvGitignored).toHaveBeenCalledWith(expect.any(String))
-    expect(loggedLines()).toContain('Added .env to .gitignore so the token stays out of git.')
+    expect(mockEnsureEnvGitignored).toHaveBeenCalledWith(expect.any(String), '.env*')
+    expect(loggedLines()).toContain('Added .env* to .gitignore so the token stays out of git.')
   })
 
   test('defaults the display name when unattended and no project name is provided', async () => {
@@ -599,6 +618,337 @@ describe('#projects:mint re-mint guardrail', () => {
     expect(lines).toContain('--force: minting a new project')
     expect(lines).toContain('Update ./.env yourself')
     expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+  })
+
+  test('a shadowed token alone does not block the scaffold', async () => {
+    mockAppendEnvValues.mockReturnValue({
+      created: false,
+      skippedKeys: ['SANITY_AUTH_TOKEN'],
+      wroteKeys: ['SANITY_PROJECT_ID', 'SANITY_DATASET'],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    // The scaffold writes the token into sanity/.env.local from the mint payload, and ledger auth
+    // keys off the project id, so only a missing project id can stop it.
+    expect(mockScaffoldProject).toHaveBeenCalled()
+    const lines = loggedLines()
+    expect(lines).not.toContain('Skipping the sanity/ and web/ scaffold')
+    expect(lines).toContain('./.env already has SANITY_AUTH_TOKEN')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+  })
+
+  test('blank template lines shadow the write, so the scaffold is skipped too', async () => {
+    mockAppendEnvValues.mockReturnValue({
+      created: false,
+      skippedKeys: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'],
+      wroteKeys: ['SANITY_DATASET'],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mockScaffoldProject).not.toHaveBeenCalled()
+    const lines = loggedLines()
+    expect(lines).toContain('Skipping the sanity/ and web/ scaffold')
+    expect(lines).toContain('shadowed the values')
+    expect(lines).toContain(`SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines).toContain(`SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+  })
+
+  test('a skipped dataset exemplar alone still scaffolds', async () => {
+    mockAppendEnvValues.mockReturnValue({
+      created: false,
+      skippedKeys: ['SANITY_DATASET'],
+      wroteKeys: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockScaffoldProject).toHaveBeenCalled()
+    expect(loggedLines()).not.toContain('Skipping the sanity/ and web/ scaffold')
+  })
+
+  test('a failed .env write skips the scaffold instead of building on a broken directory', async () => {
+    mockAppendEnvValues.mockImplementation(() => {
+      throw new Error('EACCES')
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mockScaffoldProject).not.toHaveBeenCalled()
+    const lines = loggedLines()
+    expect(lines).toContain('Add these to ./.env yourself')
+    expect(lines).toContain('Skipping the sanity/ and web/ scaffold')
+    expect(lines).not.toContain('./.env is written')
+    expect(loggedLines()).toContain(mockMinted.claimUrl)
+  })
+
+  test('a remint names the scaffolded env files that still hold dead values', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockExistingScaffoldEnvFiles.mockReturnValue(['sanity/.env.local', 'web/.env.local'])
+
+    await MintProjectCommand.run(['My New Project', '--force'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('still hold superseded values')
+    expect(lines).toContain(`sanity/.env.local: SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines).toContain(
+      `web/.env.local: NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`,
+    )
+    expect(lines).not.toContain(`web/.env.local: SANITY_API_READ_TOKEN`)
+  })
+
+  test('a remint names keys only for the scaffolded env files that exist', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockExistingScaffoldEnvFiles.mockReturnValue(['web/.env.local'])
+
+    await MintProjectCommand.run(['My New Project', '--force'])
+
+    const lines = loggedLines()
+    expect(lines).toContain(`web/.env.local: NEXT_PUBLIC_SANITY_PROJECT_ID`)
+    expect(lines).not.toContain('sanity/.env.local:')
+  })
+
+  test('a remint stays quiet about scaffolded env files when there are none', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockExistingScaffoldEnvFiles.mockReturnValue([])
+
+    await MintProjectCommand.run(['My New Project', '--force'])
+
+    expect(loggedLines()).not.toContain('still hold superseded values')
+  })
+
+  test('--json surfaces the stale scaffolded env files as a warning', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+    mockExistingScaffoldEnvFiles.mockReturnValue(['sanity/.env.local', 'web/.env.local'])
+
+    const result = await MintProjectCommand.run(['My New Project', '--force', '--json'])
+
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('still hold superseded values')]),
+    )
+    const stale = result.warnings?.find((w) => w.includes('still hold superseded values')) ?? ''
+    expect(stale).toContain('sanity/.env.local (SANITY_AUTH_TOKEN)')
+    expect(stale).toContain(
+      'web/.env.local (NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET)',
+    )
+    expect(stale).toContain('keep the token out of web/.env.local')
+    // Empty parens mean a named file resolved to no keys, which is how a separator mismatch shows up.
+    expect(stale).not.toContain('()')
+  })
+
+  test('recovery advice gives the real scaffold commands, never --force', async () => {
+    mockAppendEnvValues.mockReturnValue({
+      created: false,
+      skippedKeys: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'],
+      wroteKeys: [],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain(
+      `npx sanity init --project ${mockMinted.resourceId} --dataset ${mockMinted.datasetName} --output-path sanity`,
+    )
+    expect(lines).toContain('npx --yes create-next-app@^16 web')
+    expect(lines).toContain(`sanity/.env.local: SANITY_AUTH_TOKEN="${mockMinted.token}"`)
+    expect(lines).toContain(
+      `web/.env.local: NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`,
+    )
+    expect(lines).not.toMatch(/web\/\.env\.local: SANITY_AUTH_TOKEN/)
+    expect(lines).not.toMatch(/Set them to the values shown, then run/)
+    expect(lines).not.toMatch(/scaffold it yourself with `sanity init`/)
+  })
+
+  test('a scaffold throw also points at the real commands, and says no re-mint is needed', async () => {
+    mockScaffoldProject.mockRejectedValue(new Error('disk full'))
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mocks.SanityCmdOutput.warn).toHaveBeenCalledWith(
+      expect.stringContaining('nothing needs re-minting'),
+    )
+    const lines = loggedLines()
+    expect(lines).toContain('Scaffold it yourself with:')
+    expect(lines).toContain('npx --yes create-next-app@^16 web')
+  })
+
+  test('scaffolds both folders and points at each dev server', async () => {
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mockScaffoldProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataset: mockMinted.datasetName,
+        displayName: 'My New Project',
+        projectId: mockMinted.resourceId,
+        token: mockMinted.token,
+      }),
+    )
+    const lines = loggedLines()
+    expect(lines).toContain('Created ./sanity (Studio) and ./web (frontend).')
+    expect(lines).toContain('cd sanity && npx sanity dev')
+    expect(lines).toContain('cd web && npm run dev')
+    expect(lines).toContain('Your dataset is private until you claim it')
+  })
+
+  test('--no-scaffold mints without touching the filesystem beyond .env', async () => {
+    await MintProjectCommand.run(['My New Project', '--no-scaffold'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mockScaffoldProject).not.toHaveBeenCalled()
+  })
+
+  test('does not scaffold in JSON mode', async () => {
+    await expect(MintProjectCommand.run(['My New Project', '--json'])).resolves.toEqual(
+      expectedResult,
+    )
+
+    expect(mockScaffoldProject).not.toHaveBeenCalled()
+  })
+
+  test('does not scaffold over a directory that already had credentials', async () => {
+    mockReadEnvValues.mockReturnValue(existingEnv)
+
+    await MintProjectCommand.run(['My New Project', '--force'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalled()
+    expect(mockScaffoldProject).not.toHaveBeenCalled()
+  })
+
+  test('prints the frontend env values when an app is already present', async () => {
+    mockScaffoldProject.mockResolvedValue({
+      detectedFramework: 'Next.js',
+      frontendEnv: {
+        NEXT_PUBLIC_SANITY_DATASET: mockMinted.datasetName,
+        NEXT_PUBLIC_SANITY_PROJECT_ID: mockMinted.resourceId,
+      },
+      frontendEnvWritten: false,
+      studioPath: '/tmp/project/sanity',
+      warnings: [],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('Found Next.js here, so only ./sanity was created.')
+    expect(lines).toContain(`NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+    expect(lines).not.toContain('cd web && npm run dev')
+  })
+
+  test('surfaces scaffold warnings without failing the mint', async () => {
+    mockScaffoldProject.mockResolvedValue({
+      frontendEnv: {},
+      frontendEnvWritten: false,
+      studioPath: '/tmp/project/sanity',
+      warnings: ['create-next-app failed: boom. Scaffold the frontend yourself.'],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(mocks.SanityCmdOutput.warn).toHaveBeenCalledWith(
+      expect.stringContaining('create-next-app failed: boom'),
+    )
+  })
+
+  test('when the frontend was not created, says what exists and hands over its env values', async () => {
+    mockScaffoldProject.mockResolvedValue({
+      frontendEnv: {NEXT_PUBLIC_SANITY_PROJECT_ID: mockMinted.resourceId},
+      frontendEnvWritten: false,
+      studioPath: '/tmp/project/sanity',
+      warnings: ['create-next-app failed: boom. Scaffold the frontend yourself.'],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('Created ./sanity (Studio). The frontend was not created.')
+    expect(lines).toContain('cd sanity && npx sanity dev')
+    expect(lines).toContain(`NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+    expect(lines).not.toContain('cd web && npm run dev')
+  })
+
+  test('prints the frontend values when the frontend exists but its env write failed', async () => {
+    mockScaffoldProject.mockResolvedValue({
+      frontendEnv: {NEXT_PUBLIC_SANITY_PROJECT_ID: mockMinted.resourceId},
+      frontendEnvWritten: false,
+      frontendPath: '/tmp/project/web',
+      studioPath: '/tmp/project/sanity',
+      warnings: ["Couldn't write web/.env.local."],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('Created ./sanity (Studio) and ./web (frontend).')
+    expect(lines).toContain("./web/.env.local wasn't written.")
+    expect(lines).toContain(`NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+  })
+
+  test('stays quiet about env values when the frontend env write succeeded', async () => {
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).not.toContain("wasn't written")
+    expect(lines).not.toContain(`NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
+  })
+
+  test('never prints the token as a frontend env value', async () => {
+    mockScaffoldProject.mockResolvedValue({
+      detectedFramework: 'Next.js',
+      frontendEnv: {NEXT_PUBLIC_SANITY_PROJECT_ID: mockMinted.resourceId},
+      frontendEnvWritten: false,
+      studioPath: '/tmp/project/sanity',
+      warnings: [],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).not.toContain('SANITY_API_READ_TOKEN')
+    expect(lines).toContain('Copy SANITY_AUTH_TOKEN from ./.env')
+  })
+
+  test('names the right public prefix convention for a non-Next framework', async () => {
+    mockScaffoldProject.mockResolvedValue({
+      detectedFramework: 'Astro',
+      frontendEnv: {NEXT_PUBLIC_SANITY_PROJECT_ID: mockMinted.resourceId},
+      frontendEnvWritten: false,
+      studioPath: '/tmp/project/sanity',
+      warnings: [],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    const lines = loggedLines()
+    expect(lines).toContain('Found Astro here, so only ./sanity was created.')
+    expect(lines).toContain('Those names follow the Next.js convention.')
+  })
+
+  test('does not add the prefix caveat when the detected framework is Next.js', async () => {
+    mockScaffoldProject.mockResolvedValue({
+      detectedFramework: 'Next.js',
+      frontendEnv: {NEXT_PUBLIC_SANITY_PROJECT_ID: mockMinted.resourceId},
+      frontendEnvWritten: false,
+      studioPath: '/tmp/project/sanity',
+      warnings: [],
+    })
+
+    await MintProjectCommand.run(['My New Project'])
+
+    expect(loggedLines()).not.toContain('follow the Next.js convention')
+  })
+
+  test('a scaffold failure never reads as a mint failure', async () => {
+    mockScaffoldProject.mockRejectedValue(new Error('disk full'))
+
+    await expect(MintProjectCommand.run(['My New Project'])).resolves.toEqual(expectedResult)
+
+    expect(mocks.SanityCmdOutput.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Couldn't scaffold the project (disk full)"),
+    )
+    expect(loggedLines()).toContain(mockMinted.claimUrl)
   })
 })
 

--- a/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/mint.test.ts
@@ -42,13 +42,12 @@ vi.mock('../../../util/claimNudges.js', async (importOriginal) => ({
   getMintedProjectRecord: mockGetMintedProjectRecord,
   recordMintedProject: mockRecordMintedProject,
 }))
-vi.mock('../../../util/envFile.js', () => ({
+vi.mock('../../../util/envFile.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../util/envFile.js')>()),
   appendEnvValues: mockAppendEnvValues,
   ensureEnvGitignored: mockEnsureEnvGitignored,
-  GUARDED_ENV_KEYS: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID', 'SANITY_CLAIM_URL'],
   inspectEnvKeys: mockInspectEnvKeys,
   isEnvTracked: mockIsEnvTracked,
-  TOKEN_ENV_FILES: './.env, or sanity/.env.local in a scaffolded project',
 }))
 vi.mock('../../../actions/scaffold/scaffoldProject.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../actions/scaffold/scaffoldProject.js')>()),
@@ -210,13 +209,15 @@ describe('#projects:mint', () => {
     expect(loggedLines()).not.toContain('Added .env to .gitignore')
   })
 
-  test('warns when the ledger write fails, since bare-directory auth depends on it', async () => {
+  test('warns when the ledger write fails without claiming root auth is broken', async () => {
     mockRecordMintedProject.mockReturnValue(false)
 
     await MintProjectCommand.run(['My New Project'])
 
     const warnings = vi.mocked(mocks.SanityCmdOutput.warn).mock.calls.flat().join('\n')
     expect(warnings).toContain("Couldn't save this project to the local registry")
+    expect(warnings).toContain('Commands in this directory can still authenticate from ./.env')
+    expect(warnings).not.toContain('may not authenticate')
   })
 
   test('warns to untrack an already git-tracked .env, since gitignore cannot protect it', async () => {
@@ -796,8 +797,48 @@ describe('#projects:mint re-mint guardrail', () => {
     const lines = loggedLines()
     expect(lines).toContain('Created ./sanity (Studio) and ./web (frontend).')
     expect(lines).toContain('cd sanity && npx sanity dev')
+    expect(lines).toContain(`http://localhost:3333/#token=${mockMinted.token}`)
+    expect(lines).toContain('to enter the Studio before claiming')
     expect(lines).toContain('cd web && npm run dev')
     expect(lines).toContain('Your dataset is private until you claim it')
+  })
+
+  test.each([
+    ['pnpm', 'pnpm dev'],
+    ['yarn', 'yarn dev'],
+  ] as const)(
+    'prints the matching %s frontend dev command',
+    async (frontendPackageManager, devCommand) => {
+      mockScaffoldProject.mockResolvedValue({
+        frontendEnv: {},
+        frontendEnvWritten: true,
+        frontendPackageManager,
+        frontendPath: '/tmp/project/web',
+        studioPath: '/tmp/project/sanity',
+        warnings: [],
+      })
+
+      await MintProjectCommand.run(['My New Project'])
+
+      const lines = loggedLines()
+      expect(lines).toContain(`cd web && ${devCommand}`)
+      expect(lines).not.toContain('cd web && npm run dev')
+    },
+  )
+
+  test('prints the claim URL before starting the scaffold', async () => {
+    await MintProjectCommand.run(['My New Project'])
+
+    const claimLogIndex = vi
+      .mocked(mocks.SanityCmdOutput.log)
+      .mock.calls.findIndex((call) => call.join(' ').includes(mockMinted.claimUrl))
+    const claimLogOrder = vi.mocked(mocks.SanityCmdOutput.log).mock.invocationCallOrder[
+      claimLogIndex
+    ]
+    const scaffoldOrder = mockScaffoldProject.mock.invocationCallOrder[0]
+
+    expect(claimLogIndex).toBeGreaterThanOrEqual(0)
+    expect(claimLogOrder).toBeLessThan(scaffoldOrder)
   })
 
   test('--no-scaffold mints without touching the filesystem beyond .env', async () => {
@@ -822,6 +863,10 @@ describe('#projects:mint re-mint guardrail', () => {
 
     expect(mockMintUnclaimedProject).toHaveBeenCalled()
     expect(mockScaffoldProject).not.toHaveBeenCalled()
+    const lines = loggedLines()
+    expect(lines).toContain('Skipping the automatic scaffold')
+    expect(lines).toContain('After replacing those values, scaffold with:')
+    expect(lines).toContain('npx sanity init')
   })
 
   test('prints the frontend env values when an app is already present', async () => {
@@ -840,6 +885,7 @@ describe('#projects:mint re-mint guardrail', () => {
 
     const lines = loggedLines()
     expect(lines).toContain('Found Next.js here, so only ./sanity was created.')
+    expect(lines).toContain(`http://localhost:3333/#token=${mockMinted.token}`)
     expect(lines).toContain(`NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
     expect(lines).not.toContain('cd web && npm run dev')
   })
@@ -872,6 +918,7 @@ describe('#projects:mint re-mint guardrail', () => {
     const lines = loggedLines()
     expect(lines).toContain('Created ./sanity (Studio). The frontend was not created.')
     expect(lines).toContain('cd sanity && npx sanity dev')
+    expect(lines).toContain(`http://localhost:3333/#token=${mockMinted.token}`)
     expect(lines).toContain(`NEXT_PUBLIC_SANITY_PROJECT_ID="${mockMinted.resourceId}"`)
     expect(lines).not.toContain('cd web && npm run dev')
   })

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -1,0 +1,376 @@
+import path from 'node:path'
+import {styleText} from 'node:util'
+
+import {Args, Flags} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
+import {exitCodes} from '@sanity/cli-core'
+import {SanityCommand} from '@sanity/cli-core/SanityCommand'
+import {createFlow, input} from '@sanity/cli-core/ux'
+
+import {lookupClaimState, mintUnclaimedProject} from '../../services/mintProject.js'
+import {
+  forgetMintedProject,
+  getMintedProjectRecord,
+  recordMintedProject,
+} from '../../util/claimNudges.js'
+import {
+  appendEnvValues,
+  ensureEnvGitignored,
+  GUARDED_ENV_KEYS,
+  isEnvTracked,
+  readEnvValues,
+} from '../../util/envFile.js'
+import {renderNewCommandSplash} from '../../util/newCommandSplash.js'
+import {hyperlink} from '../../util/terminalLink.js'
+
+const DEFAULT_PROJECT_NAME = 'My Sanity project'
+
+function hoursUntil(iso: string): number | undefined {
+  const ms = new Date(iso).getTime() - Date.now()
+  return Number.isFinite(ms) && ms > 0 ? Math.round(ms / 3_600_000) : undefined
+}
+
+function describeExpiry(expiresAt: string | undefined): string {
+  if (!expiresAt) return ''
+  const hrs = hoursUntil(expiresAt)
+  // A past or imminent date gets no clause: stale local records must not decorate a refusal.
+  return hrs ? `, expiring in ~${hrs} hours (${expiresAt})` : ''
+}
+
+function claimTokenFromClaimUrl(claimUrl: string | undefined): string | undefined {
+  if (!claimUrl) return undefined
+  try {
+    return new URL(claimUrl).pathname.split('/').findLast(Boolean)
+  } catch {
+    return undefined
+  }
+}
+
+interface GuardResult {
+  /** Whether `.env` already held managed keys — when true, new credentials are printed, not written. */
+  hasExistingKeys: boolean
+
+  /** Verified-expired project id the new mint supersedes (drop its ledger record). */
+  expiredProjectId?: string
+}
+
+export interface MintProjectResult {
+  apiHost: string
+  claimApiUrl: string
+  claimToken: string
+  claimUrl: string
+  dataset: string
+  expiresAt: string
+  projectId: string
+  /** Robot token scoped to the freshly minted, unclaimed project. */
+  token: string
+
+  warnings?: string[]
+}
+
+export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand> {
+  static override args = {
+    projectName: Args.string({
+      description: 'Display name for the minted project',
+      required: false,
+    }),
+  }
+
+  static override description =
+    'Mint an unclaimed Sanity project without logging in.\n' +
+    'Writes the project id, dataset, and a robot token to .env, so `sanity` commands in this ' +
+    'directory run as the project. Claim it with a Sanity account within 72 hours to keep it — ' +
+    'everything keeps working after you claim, including the token. Use --json for a ' +
+    'machine-readable payload with no files written.'
+
+  static override enableJsonFlag = true
+
+  static override examples = [
+    {
+      command: '<%= config.bin %> <%= command.id %>',
+      description: 'Interactively mint an unclaimed project',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> "My New Project"',
+      description: 'Mint an unclaimed project named "My New Project"',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --yes',
+      description: 'Mint a project non-interactively with defaults',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --force',
+      description: 'Mint a fresh project even if this directory already has one',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --json',
+      description: 'Mint a project and output the token and claim details as JSON',
+    },
+  ]
+
+  static override flags = {
+    force: Flags.boolean({
+      default: false,
+      description:
+        'Mint a new project even when .env already has Sanity credentials (the file is left untouched — the new values are printed for you to apply)',
+    }),
+    yes: Flags.boolean({
+      char: 'y',
+      default: false,
+      description: `Skip prompts and use defaults (project: "${DEFAULT_PROJECT_NAME}")`,
+    }),
+  }
+
+  static override hiddenAliases: string[] = ['project:mint']
+
+  public async run(): Promise<MintProjectResult> {
+    // Under `--json` oclif suppresses `this.log` and prints the returned result instead, so the
+    // narrated flow only appears in human runs and JSON mode never writes to the filesystem.
+    const {output} = this
+    const json = this.jsonEnabled()
+    const flow = createFlow(output.log)
+    // How this command was invoked (`sanity new` vs `sanity projects mint`).
+    const invoked = [this.config.bin, ...(this.id?.split(':') ?? [])].join(' ')
+
+    const envPath = path.join(process.cwd(), '.env')
+    const guard: GuardResult = await this.guardExistingProject(envPath, invoked)
+
+    renderNewCommandSplash(output.log)
+
+    flow.intro("Let's get you set up with a Sanity project.")
+    flow.gap()
+
+    if (!this.isUnattended()) {
+      flow.note(
+        `${styleText('cyan', `${invoked} --yes`)} for a non-interactive flow with defaults.`,
+      )
+      flow.gap()
+    }
+
+    let displayName = this.args.projectName?.trim()
+    if (displayName) {
+      flow.result(`Project name: ${styleText('cyan', displayName)}`)
+      flow.gap()
+    } else if (this.isUnattended()) {
+      displayName = DEFAULT_PROJECT_NAME
+      flow.result(
+        `Project name: ${styleText('cyan', displayName)} ${styleText('dim', '(default)')}`,
+      )
+      flow.gap()
+    } else {
+      displayName =
+        (await input({default: DEFAULT_PROJECT_NAME, message: 'Project name'})).trim() ||
+        DEFAULT_PROJECT_NAME
+    }
+
+    if (!json) {
+      if (guard.expiredProjectId) {
+        flow.note(
+          `Found an expired unclaimed project (${guard.expiredProjectId}) in .env — minting a replacement. Your .env is left untouched; new values follow.`,
+        )
+      } else if (guard.hasExistingKeys) {
+        flow.note('--force: minting a new project. Your .env is left untouched; new values follow.')
+      } else {
+        flow.note('No Sanity credentials in .env yet, adding them.')
+      }
+      flow.gap()
+    }
+
+    const spin = json ? undefined : flow.spin('Minting your project...')
+    let minted
+    try {
+      minted = await mintUnclaimedProject({displayName})
+    } catch (err) {
+      spin?.fail('Minting your project failed.')
+      throw err
+    }
+    spin?.succeed('Project minted')
+
+    // `--json` writes nothing (no `.env` either), so it must not touch the ledger — the caller owns
+    // the returned token. Only the interactive path records, and so keeps showing unclaimed nudges
+    // until claim or expiry (e.g. for a `--force`-superseded live project that may hold content).
+    const recorded = json ? undefined : recordMintedProject(minted)
+
+    flow.gap()
+    flow.result(`Project ID: ${styleText('cyan', minted.resourceId)}`)
+    flow.result(`Dataset:    ${styleText('cyan', minted.datasetName)}`)
+    flow.gap()
+
+    const envValues = {
+      SANITY_AUTH_TOKEN: minted.token,
+      SANITY_DATASET: minted.datasetName,
+      SANITY_PROJECT_ID: minted.resourceId,
+    }
+    const printEnvValues = () => {
+      flow.line(`SANITY_PROJECT_ID="${minted.resourceId}"`)
+      flow.line(`SANITY_DATASET="${minted.datasetName}"`)
+      flow.line(`SANITY_AUTH_TOKEN="${minted.token}"`)
+    }
+    let warnings: MintProjectResult['warnings']
+
+    if (guard.hasExistingKeys) {
+      if (json) {
+        warnings = [
+          '.env still holds the previous Sanity values and was not modified (this command ' +
+            'never edits existing lines) — update it from this payload.',
+        ]
+      } else {
+        flow.highlight('Update ./.env yourself — replace the old Sanity values with these:')
+        printEnvValues()
+        flow.gap()
+      }
+
+      if (guard.expiredProjectId && !forgetMintedProject(guard.expiredProjectId)) {
+        const notDropped =
+          `Couldn't update the local project registry — expired project ${guard.expiredProjectId} ` +
+          'is still recorded, so re-running this command will mint another project against the rate limit.'
+        if (json) {
+          warnings = [...(warnings ?? []), notDropped]
+        } else {
+          this.output.warn(notDropped)
+        }
+      }
+    } else if (!json) {
+      try {
+        const written = appendEnvValues(envPath, envValues, {
+          banner: [
+            `Added by \`${invoked}\` — unclaimed Sanity project, expires ${minted.expiresAt}`,
+            `Claim it to keep it: ${minted.claimUrl}`,
+          ],
+        })
+        // `.env` carries the robot token whether we wrote it now or it was already present
+        // (skipped) — gitignore it either way, not just when keys were written this run.
+        const gitignore = ensureEnvGitignored(process.cwd())
+        // Gitignore does nothing for an already-tracked file, so a tracked `.env` can still be
+        // committed — check before claiming the token is protected.
+        const envTracked = isEnvTracked(process.cwd())
+        if (written.wroteKeys.length > 0) {
+          flow.highlight(`Saved credentials to ./.env as ${written.wroteKeys.join(', ')}`)
+        }
+        if (written.skippedKeys.length > 0) {
+          flow.note(`./.env already has ${written.skippedKeys.join(', ')} — make sure they read:`)
+          for (const key of written.skippedKeys) {
+            flow.line(`${key}="${envValues[key as keyof typeof envValues]}"`)
+          }
+        }
+        if (envTracked) {
+          this.output.warn(
+            '.env is already tracked by git — adding it to .gitignore does not untrack it, so the ' +
+              'token can still be committed. Run `git rm --cached .env` to stop tracking it.',
+          )
+        } else if (gitignore.added) {
+          flow.line(styleText('dim', 'Added .env to .gitignore so the token stays out of git.'))
+        } else if (!gitignore.ignored) {
+          // The write failed — .env now holds a token but may not be ignored. Never silent.
+          this.output.warn(
+            "Couldn't add .env to .gitignore — add it yourself so the robot token in .env is never committed.",
+          )
+        }
+      } catch (err) {
+        this.warn(`Couldn't write ./.env (${err instanceof Error ? err.message : err})`)
+        // The token and claim details are still recoverable from the local project registry;
+        // don't claim otherwise. Add them to .env yourself, and keep .env out of git.
+        flow.highlight('Add these to ./.env yourself, and keep .env out of git:')
+        printEnvValues()
+      }
+      flow.gap()
+    }
+
+    if (recorded === false) {
+      // The ledger is how `sanity` commands here authenticate before a config file exists; a failed
+      // write must never hide behind mint's success.
+      const msg =
+        "Couldn't save this project to the local registry — sanity commands in this directory may " +
+        'not authenticate until you set SANITY_AUTH_TOKEN from .env, add a Sanity config, or claim the project.'
+      if (json) warnings = [...(warnings ?? []), msg]
+      else this.output.warn(msg)
+    }
+
+    const hrs = hoursUntil(minted.expiresAt)
+    flow.note(
+      hrs
+        ? `Claim your project within ${styleText('yellow', `~${hrs} hours`)} (by ${minted.expiresAt}) to keep it:`
+        : `Claim your project before ${styleText('yellow', minted.expiresAt)} to keep it:`,
+    )
+    flow.line(hyperlink(styleText('cyan', minted.claimUrl), minted.claimUrl))
+    flow.gap()
+    flow.note('Everything keeps working after you claim, including the token in .env.')
+    flow.gap()
+    flow.outro('Happy coding')
+
+    return {
+      apiHost: minted.apiHost,
+      claimApiUrl: minted.claimApiUrl,
+      claimToken: minted.claimToken,
+      claimUrl: minted.claimUrl,
+      dataset: minted.datasetName,
+      expiresAt: minted.expiresAt,
+      projectId: minted.resourceId,
+      token: minted.token,
+      ...(warnings ? {warnings} : {}),
+    }
+  }
+
+  private async guardExistingProject(envPath: string, invoked: string): Promise<GuardResult> {
+    const existing = readEnvValues(envPath, [...GUARDED_ENV_KEYS])
+    const foundKeys = GUARDED_ENV_KEYS.filter((key) => existing[key] !== undefined)
+    if (foundKeys.length === 0) return {hasExistingKeys: false}
+    if (this.flags.force) {
+      return {hasExistingKeys: true}
+    }
+
+    const projectId = existing.SANITY_PROJECT_ID
+    const record = projectId ? getMintedProjectRecord(projectId) : undefined
+    const boundToken = record?.claimToken
+    const claimToken = boundToken ?? claimTokenFromClaimUrl(existing.SANITY_CLAIM_URL)
+    const lookup = claimToken ? await lookupClaimState(claimToken, {timeoutMs: 3000}) : undefined
+
+    if (lookup?.state === 'expired' && boundToken) {
+      return {expiredProjectId: projectId, hasExistingKeys: true}
+    }
+
+    if (lookup?.state === 'claimed' && boundToken) {
+      throw new CLIError(
+        `This directory's .env points at ${projectId ? `Sanity project ${projectId}` : 'a Sanity project'}, which has already been claimed.`,
+        {
+          code: 'CLAIMED_PROJECT_IN_ENV',
+          exit: exitCodes.RUNTIME_ERROR,
+          suggestions: [
+            'If it is yours: run `sanity login`, then remove SANITY_AUTH_TOKEN from .env to act as yourself',
+            `Mint a fresh project here anyway: \`${invoked} --force\` (.env is left untouched)`,
+          ],
+        },
+      )
+    }
+
+    const claimUrl = record?.claimUrl ?? existing.SANITY_CLAIM_URL
+    if (lookup?.state === 'claimable' || record) {
+      // Only continue when project expiry verified server-side.
+      const expiresAt = lookup ? (lookup.expiresAt ?? undefined) : record?.expiresAt
+      throw new CLIError(
+        `This directory already has an unclaimed Sanity project${projectId ? ` (${projectId})` : ''}${describeExpiry(expiresAt ?? undefined)}.`,
+        {
+          code: 'UNCLAIMED_PROJECT_IN_ENV',
+          exit: exitCodes.RUNTIME_ERROR,
+          suggestions: [
+            ...(claimUrl ? [`Claim it to keep it: ${claimUrl}`] : []),
+            `Mint a replacement anyway: \`${invoked} --force\` (the unclaimed project lives on until it expires)`,
+          ],
+        },
+      )
+    }
+
+    // Managed keys present, but nothing verifies what they belong to.
+    throw new CLIError(
+      `This directory's .env already has Sanity credentials (${foundKeys.join(', ')}).`,
+      {
+        code: 'UNVERIFIED_SANITY_CREDENTIALS',
+        exit: exitCodes.RUNTIME_ERROR,
+        suggestions: [
+          `Mint a fresh project anyway: \`${invoked} --force\` (.env is left untouched)`,
+          'Or run this command in a different directory',
+        ],
+      },
+    )
+  }
+}

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -7,6 +7,16 @@ import {exitCodes} from '@sanity/cli-core'
 import {SanityCommand} from '@sanity/cli-core/SanityCommand'
 import {createFlow, input} from '@sanity/cli-core/ux'
 
+import {
+  existingScaffoldEnvFiles,
+  FRONTEND_DIR,
+  FRONTEND_ENV_FILE,
+  manualScaffoldCommands,
+  scaffoldProject,
+  type ScaffoldResult,
+  STUDIO_DIR,
+  STUDIO_ENV_FILE,
+} from '../../actions/scaffold/scaffoldProject.js'
 import {lookupClaimState, mintUnclaimedProject} from '../../services/mintProject.js'
 import {
   forgetMintedProject,
@@ -20,11 +30,14 @@ import {
   GUARDED_ENV_KEYS,
   isEnvTracked,
   readEnvValues,
+  TOKEN_ENV_FILES,
 } from '../../util/envFile.js'
 import {renderNewCommandSplash} from '../../util/newCommandSplash.js'
 import {hyperlink} from '../../util/terminalLink.js'
 
 const DEFAULT_PROJECT_NAME = 'My Sanity project'
+
+const SCAFFOLD_REQUIRED_ENV_KEYS = ['SANITY_PROJECT_ID'] as const
 
 function describeExpiry(expiresAt: string | undefined): string {
   if (!expiresAt) return ''
@@ -76,9 +89,11 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     'Mint an unclaimed Sanity project without logging in.\n' +
     '\n' +
     'Credentials are written to ./.env (SANITY_PROJECT_ID, SANITY_DATASET, and ' +
-    'SANITY_AUTH_TOKEN, a robot token) and .env is gitignored, so `sanity` commands in this ' +
-    'directory run as the project with no account. Use --json for a machine-readable payload ' +
-    'instead: JSON mode writes no files and the caller owns the credentials.\n' +
+    'SANITY_AUTH_TOKEN, a robot token) and .env is gitignored, so `sanity` commands here ' +
+    'authenticate as the project with no account. Commands that need a project id still take it ' +
+    'from a Sanity config file or --project-id, so run them inside the scaffolded Studio folder. ' +
+    'Use --json for a machine-readable payload instead: JSON mode writes no files and the caller ' +
+    'owns the credentials.\n' +
     '\n' +
     'Claiming: the project must be claimed with a Sanity account within 72 hours (expiresAt) or ' +
     'it is permanently deleted, content included. The claim URL is single-use and whoever opens ' +
@@ -90,8 +105,9 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     'is private pre-claim: frontend reads must run server-side, and the token must never sit ' +
     'under a client-exposed prefix like NEXT_PUBLIC_* or SANITY_STUDIO_*.\n' +
     '\n' +
-    'After the claim, run `sanity login` and remove SANITY_AUTH_TOKEN from .env to act as your ' +
-    'own account; until then, CLI commands in this directory keep authenticating as the robot.\n' +
+    `After the claim, run \`sanity login\` and remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES} ` +
+    'to act as your own account; until then, CLI commands in this directory keep ' +
+    'authenticating as the robot.\n' +
     '\n' +
     'Minting is rate-limited per machine. Fetch https://sanity.new for agent instructions.'
 
@@ -125,6 +141,11 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       default: false,
       description:
         'Mint a new project even when .env already has Sanity credentials (the file is left untouched; the new values are printed for you to apply)',
+    }),
+    scaffold: Flags.boolean({
+      allowNo: true,
+      default: true,
+      description: `Scaffold a Studio into ./${STUDIO_DIR} and a Next.js frontend into ./${FRONTEND_DIR} after minting`,
     }),
     yes: Flags.boolean({
       char: 'y',
@@ -218,18 +239,62 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       flow.line(`SANITY_DATASET="${minted.datasetName}"`)
       flow.line(`SANITY_AUTH_TOKEN="${minted.token}"`)
     }
+    const scaffoldEnvKeys: Record<string, [key: string, value: string][]> = {
+      [FRONTEND_ENV_FILE]: [
+        ['NEXT_PUBLIC_SANITY_PROJECT_ID', minted.resourceId],
+        ['NEXT_PUBLIC_SANITY_DATASET', minted.datasetName],
+      ],
+      [STUDIO_ENV_FILE]: [['SANITY_AUTH_TOKEN', minted.token]],
+    }
+    const printScaffoldEnvLines = (files: string[]) => {
+      for (const file of files) {
+        for (const [key, value] of scaffoldEnvKeys[file] ?? []) {
+          flow.line(`${file}: ${key}="${value}"`)
+        }
+      }
+    }
+    const describeScaffoldEnvKeys = (files: string[]) =>
+      files
+        .map((file) => `${file} (${(scaffoldEnvKeys[file] ?? []).map(([key]) => key).join(', ')})`)
+        .join(' and ')
+    const printScaffoldRecipe = () => {
+      for (const command of manualScaffoldCommands({
+        dataset: minted.datasetName,
+        projectId: minted.resourceId,
+      })) {
+        flow.line(command)
+      }
+      flow.line('Then add:')
+      printScaffoldEnvLines(Object.keys(scaffoldEnvKeys))
+    }
     let warnings: MintProjectResult['warnings']
+    let credentialsOnDisk = false
 
     if (guard.hasExistingKeys) {
+      const staleScaffoldEnv = existingScaffoldEnvFiles(process.cwd())
+
       if (json) {
         warnings = [
           '.env still holds the previous Sanity values and was not modified (this command ' +
             'never edits existing lines); update it from this payload.',
+          ...(staleScaffoldEnv.length > 0
+            ? [
+                `${describeScaffoldEnvKeys(staleScaffoldEnv)} still hold superseded values; ` +
+                  `update them from this payload too, and keep the token out of ${FRONTEND_DIR}/.env.local.`,
+              ]
+            : []),
         ]
       } else {
         flow.highlight('Update ./.env yourself, replacing the old Sanity values with these:')
         printEnvValues()
         flow.gap()
+        if (staleScaffoldEnv.length > 0) {
+          flow.note(
+            `${staleScaffoldEnv.join(' and ')} still hold superseded values, so update them too:`,
+          )
+          printScaffoldEnvLines(staleScaffoldEnv)
+          flow.gap()
+        }
       }
 
       if (guard.expiredProjectId && !forgetMintedProject(guard.expiredProjectId)) {
@@ -252,7 +317,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
         })
         // `.env` carries the robot token whether we wrote it now or it was already present
         // (skipped) — gitignore it either way, not just when keys were written this run.
-        const gitignore = ensureEnvGitignored(process.cwd())
+        const gitignore = ensureEnvGitignored(process.cwd(), '.env*')
         // Gitignore does nothing for an already-tracked file, so a tracked `.env` can still be
         // committed — check before claiming the token is protected.
         const envTracked = isEnvTracked(process.cwd())
@@ -265,17 +330,28 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
             flow.line(`${key}="${envValues[key as keyof typeof envValues]}"`)
           }
         }
+        credentialsOnDisk = SCAFFOLD_REQUIRED_ENV_KEYS.every((key) =>
+          written.wroteKeys.includes(key),
+        )
+        if (!credentialsOnDisk) {
+          flow.note(
+            `Skipping the ${STUDIO_DIR}/ and ${FRONTEND_DIR}/ scaffold: the lines above shadowed ` +
+              'the values, so ./.env carries no usable credentials and nothing here can ' +
+              'authenticate. Set them to the values shown, then scaffold with:',
+          )
+          printScaffoldRecipe()
+        }
         if (envTracked) {
           this.output.warn(
             '.env is already tracked by git; adding it to .gitignore does not untrack it, so the ' +
               'token can still be committed. Run `git rm --cached .env` to stop tracking it.',
           )
         } else if (gitignore.added) {
-          flow.line('Added .env to .gitignore so the token stays out of git.')
+          flow.line('Added .env* to .gitignore so the token stays out of git.')
         } else if (!gitignore.ignored) {
           // The write failed — .env now holds a token but may not be ignored. Never silent.
           this.output.warn(
-            "Couldn't add .env to .gitignore; add it yourself so the robot token in .env is never committed.",
+            "Couldn't add .env* to .gitignore; add it yourself so the robot token in .env is never committed.",
           )
         }
       } catch (err) {
@@ -284,7 +360,82 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
         // don't claim otherwise. Add them to .env yourself, and keep .env out of git.
         flow.highlight('Add these to ./.env yourself, and keep .env out of git:')
         printEnvValues()
+        flow.note(
+          `Skipping the ${STUDIO_DIR}/ and ${FRONTEND_DIR}/ scaffold: ./.env is what makes this ` +
+            'directory authenticate, so scaffolding without it would leave a project that cannot ' +
+            'read its own content. Write ./.env, then scaffold with:',
+        )
+        printScaffoldRecipe()
       }
+      flow.gap()
+    }
+
+    const shouldScaffold =
+      !json && this.flags.scaffold && !guard.hasExistingKeys && credentialsOnDisk
+    let scaffold: ScaffoldResult | undefined
+    if (shouldScaffold) {
+      try {
+        scaffold = await scaffoldProject({
+          dataset: minted.datasetName,
+          displayName,
+          output,
+          projectId: minted.resourceId,
+          telemetry: this.telemetry,
+          token: minted.token,
+          workDir: process.cwd(),
+        })
+      } catch (err) {
+        this.output.warn(
+          `Couldn't scaffold the project (${err instanceof Error ? err.message : err}). ` +
+            'Your project is minted and ./.env is written, so nothing needs re-minting.',
+        )
+        flow.note('Scaffold it yourself with:')
+        printScaffoldRecipe()
+      }
+    }
+
+    if (scaffold) {
+      for (const warning of scaffold.warnings) this.output.warn(warning)
+      flow.gap()
+      const printFrontendEnv = () => {
+        for (const [key, value] of Object.entries(scaffold.frontendEnv)) {
+          flow.line(`${key}="${value}"`)
+        }
+        if (scaffold.detectedFramework && scaffold.detectedFramework !== 'Next.js') {
+          flow.line(
+            `Those names follow the Next.js convention. On ${scaffold.detectedFramework}, use its ` +
+              'own public prefix for the project id and dataset.',
+          )
+        }
+      }
+
+      if (scaffold.frontendPath) {
+        flow.highlight(`Created ./${STUDIO_DIR} (Studio) and ./${FRONTEND_DIR} (frontend).`)
+        flow.line(`cd ${STUDIO_DIR} && npx sanity dev    to start the Studio on port 3333`)
+        flow.line(`cd ${FRONTEND_DIR} && npm run dev     to start the frontend on port 3000`)
+        if (!scaffold.frontendEnvWritten) {
+          flow.line(`./${FRONTEND_DIR}/.env.local wasn't written. Add these yourself:`)
+          printFrontendEnv()
+        }
+      } else if (scaffold.detectedFramework) {
+        flow.highlight(
+          `Found ${scaffold.detectedFramework} here, so only ./${STUDIO_DIR} was created.`,
+        )
+        flow.line('Add these to your app:')
+        printFrontendEnv()
+      } else {
+        flow.highlight(`Created ./${STUDIO_DIR} (Studio). The frontend was not created.`)
+        flow.line(`cd ${STUDIO_DIR} && npx sanity dev    to start the Studio on port 3333`)
+        flow.line('Scaffold a frontend yourself, then add these:')
+        printFrontendEnv()
+      }
+      flow.gap()
+      flow.note(
+        'Your dataset is private until you claim it, so reading content from your frontend needs a ' +
+          'token. Copy SANITY_AUTH_TOKEN from ./.env when you add those reads, keep them ' +
+          'server-side, and never put it under a browser-exposed prefix like NEXT_PUBLIC_ or ' +
+          'SANITY_STUDIO_: that publishes a credential with full write access.',
+      )
       flow.gap()
     }
 
@@ -352,7 +503,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
           code: 'CLAIMED_PROJECT_IN_ENV',
           exit: exitCodes.RUNTIME_ERROR,
           suggestions: [
-            'If it is yours: run `sanity login`, then remove SANITY_AUTH_TOKEN from .env to act as yourself',
+            `If it is yours: run \`sanity login\`, then remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES} to act as yourself`,
             `Mint a fresh project here anyway: \`${invoked} --force\` (.env is left untouched)`,
           ],
         },

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -374,8 +374,12 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       !json && this.flags.scaffold && !guard.hasExistingKeys && credentialsOnDisk
     let scaffold: ScaffoldResult | undefined
     if (shouldScaffold) {
+      const scaffoldController = new AbortController()
+      const abortScaffold = () => scaffoldController.abort(new Error('SIGINT'))
+      process.once('SIGINT', abortScaffold)
       try {
         scaffold = await scaffoldProject({
+          cancelSignal: scaffoldController.signal,
           dataset: minted.datasetName,
           displayName,
           output,
@@ -384,13 +388,18 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
           token: minted.token,
           workDir: process.cwd(),
         })
+        scaffoldController.signal.throwIfAborted()
       } catch (err) {
+        scaffoldController.signal.throwIfAborted()
+        if (err instanceof Error && err.message === 'SIGINT') throw err
         this.output.warn(
           `Couldn't scaffold the project (${err instanceof Error ? err.message : err}). ` +
             'Your project is minted and ./.env is written, so nothing needs re-minting.',
         )
         flow.note('Scaffold it yourself with:')
         printScaffoldRecipe()
+      } finally {
+        process.off('SIGINT', abortScaffold)
       }
     }
 

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -281,8 +281,9 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       flow.gap()
       flow.line(
         'Until then it is temporary — the project and everything in it is permanently deleted ' +
-          'at that deadline. Claiming is free, takes about a minute, and nothing you have built changes.',
+          'at that deadline.',
       )
+      flow.line('Claiming is free, takes about a minute, and nothing you have built changes.')
       flow.line(
         'Treat the link like a password: it is single-use, and whoever opens it becomes the owner.',
       )

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -4,6 +4,7 @@ import {styleText} from 'node:util'
 import {Args, Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
 import {exitCodes} from '@sanity/cli-core'
+import {findMintedProjectEnvBoundary} from '@sanity/cli-core/config'
 import {SanityCommand} from '@sanity/cli-core/SanityCommand'
 import {createFlow, input} from '@sanity/cli-core/ux'
 
@@ -200,8 +201,20 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     // How this command was invoked (`sanity new` vs `sanity projects mint`).
     const invoked = [this.config.bin, ...(this.id?.split(':') ?? [])].join(' ')
 
-    const envPath = path.join(process.cwd(), '.env')
-    const guard: GuardResult = await this.guardExistingProject(envPath, invoked)
+    const cwd = process.cwd()
+    // Guard against the same nearest credential boundary used by CLI authentication, but keep
+    // first-mint writes rooted at the invocation directory.
+    const envPath = path.join(cwd, '.env')
+    const guardEnvPath = findMintedProjectEnvBoundary(cwd)?.envPath ?? envPath
+    const guard: GuardResult = await this.guardExistingProject(guardEnvPath, invoked)
+    const guardDirectory = path.dirname(guardEnvPath)
+    const guardIsCurrentDirectory = path.resolve(guardDirectory) === path.resolve(cwd)
+    const guardEnvReference = guardIsCurrentDirectory ? './.env' : path.relative(cwd, guardEnvPath)
+    const guardJsonEnvReference = guardIsCurrentDirectory ? '.env' : guardEnvReference
+    const guardScopedReference = (relativePath: string) =>
+      guardIsCurrentDirectory
+        ? relativePath
+        : path.relative(cwd, path.join(guardDirectory, relativePath))
 
     if (!json) {
       renderNewCommandSplash(output.log)
@@ -228,10 +241,16 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     if (!json) {
       if (guard.expiredProjectId) {
         flow.note(
-          `Found an expired unclaimed project (${guard.expiredProjectId}) in .env. Minting a replacement; your .env is left untouched and new values follow.`,
+          guardIsCurrentDirectory
+            ? `Found an expired unclaimed project (${guard.expiredProjectId}) in .env. Minting a replacement; your .env is left untouched and new values follow.`
+            : `Found an expired unclaimed project (${guard.expiredProjectId}) in ${guardEnvReference}. Minting a replacement; ${guardEnvReference} is left untouched and new values follow.`,
         )
       } else if (guard.hasExistingKeys) {
-        flow.note('--force: minting a new project. Your .env is left untouched; new values follow.')
+        flow.note(
+          guardIsCurrentDirectory
+            ? '--force: minting a new project. Your .env is left untouched; new values follow.'
+            : `--force: minting a new project. ${guardEnvReference} is left untouched; new values follow.`,
+        )
       }
       if (guard.hasExistingKeys) flow.gap()
     }
@@ -295,16 +314,25 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       ],
       [STUDIO_ENV_FILE]: [['SANITY_AUTH_TOKEN', minted.token]],
     }
-    const printScaffoldEnvLines = (files: string[]) => {
+    const printScaffoldEnvLines = (
+      files: string[],
+      displayPath: (file: string) => string = (file) => file,
+    ) => {
       for (const file of files) {
         for (const [key, value] of scaffoldEnvKeys[file] ?? []) {
-          flow.line(`${file}: ${key}="${value}"`)
+          flow.line(`${displayPath(file)}: ${key}="${value}"`)
         }
       }
     }
-    const describeScaffoldEnvKeys = (files: string[]) =>
+    const describeScaffoldEnvKeys = (
+      files: string[],
+      displayPath: (file: string) => string = (file) => file,
+    ) =>
       files
-        .map((file) => `${file} (${(scaffoldEnvKeys[file] ?? []).map(([key]) => key).join(', ')})`)
+        .map(
+          (file) =>
+            `${displayPath(file)} (${(scaffoldEnvKeys[file] ?? []).map(([key]) => key).join(', ')})`,
+        )
         .join(' and ')
     const printScaffoldRecipe = () => {
       for (const command of manualScaffoldCommands({
@@ -322,33 +350,35 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     let rootTokenWritten = false
 
     if (guard.hasExistingKeys) {
-      const staleScaffoldEnv = existingScaffoldEnvFiles(process.cwd())
+      const staleScaffoldEnv = existingScaffoldEnvFiles(guardDirectory)
 
       if (json) {
         warnings = [
-          '.env still holds the previous Sanity values and was not modified (this command ' +
+          `${guardJsonEnvReference} still holds the previous Sanity values and was not modified (this command ` +
             'never edits existing lines); update it from this payload.',
           ...(staleScaffoldEnv.length > 0
             ? [
-                `${describeScaffoldEnvKeys(staleScaffoldEnv)} still hold superseded values; ` +
-                  `update them from this payload too, and keep the token out of ${FRONTEND_DIR}/.env.local.`,
+                `${describeScaffoldEnvKeys(staleScaffoldEnv, guardScopedReference)} still hold superseded values; ` +
+                  `update them from this payload too, and keep the token out of ${guardScopedReference(FRONTEND_ENV_FILE)}.`,
               ]
             : []),
         ]
       } else {
-        flow.highlight('Update ./.env yourself, replacing the old Sanity values with these:')
+        flow.highlight(
+          `Update ${guardEnvReference} yourself, replacing the old Sanity values with these:`,
+        )
         printEnvValues()
         flow.gap()
         if (staleScaffoldEnv.length > 0) {
           flow.note(
-            `${staleScaffoldEnv.join(' and ')} still hold superseded values, so update them too:`,
+            `${staleScaffoldEnv.map((file) => guardScopedReference(file)).join(' and ')} still hold superseded values, so update them too:`,
           )
-          printScaffoldEnvLines(staleScaffoldEnv)
+          printScaffoldEnvLines(staleScaffoldEnv, guardScopedReference)
           flow.gap()
         }
         if (this.flags.scaffold) {
           flow.note(
-            `Skipping the automatic scaffold because ./.env still points at the previous project.${
+            `Skipping the automatic scaffold because ${guardEnvReference} still points at the previous project.${
               staleScaffoldEnv.length === 0
                 ? ' After replacing those values, scaffold with:'
                 : ' Update the existing scaffold values above before using it.'
@@ -596,6 +626,25 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
   }
 
   private async guardExistingProject(envPath: string, invoked: string): Promise<GuardResult> {
+    const cwdEnvPath = path.join(process.cwd(), '.env')
+    const isCurrentDirectoryEnv = path.resolve(envPath) === path.resolve(cwdEnvPath)
+    const envReference = isCurrentDirectoryEnv ? '.env' : path.relative(process.cwd(), envPath)
+    const envSubject = isCurrentDirectoryEnv
+      ? "This directory's .env"
+      : `The ancestor ${envReference}`
+    const scopeSubject = isCurrentDirectoryEnv ? 'This directory' : envSubject
+    const replacementDetail = isCurrentDirectoryEnv
+      ? 'the unclaimed project lives on until it expires'
+      : `${envReference} is left untouched; the unclaimed project lives on until it expires`
+    const tokenEnvFiles = isCurrentDirectoryEnv
+      ? TOKEN_ENV_FILES
+      : `${envReference} or ${path.relative(
+          process.cwd(),
+          path.join(path.dirname(envPath), STUDIO_ENV_FILE),
+        )}`
+    const differentScopeSuggestion = isCurrentDirectoryEnv
+      ? 'Or run this command in a different directory'
+      : `Or run this command outside the project scope established by ${envReference}`
     const inspection = inspectEnvKeys(envPath, GUARDED_ENV_KEYS)
 
     // A blank `KEY=` line is invisible to the value read but still owns the line for the writer,
@@ -603,13 +652,13 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     // edits existing lines either) before spending a mint or touching the filesystem.
     if (inspection.blankKeys.length > 0) {
       throw new CLIError(
-        `This directory's .env contains blank Sanity credential placeholders: ` +
+        `${envSubject} contains blank Sanity credential placeholders: ` +
           `${inspection.blankKeys.join(', ')}. No project was minted.`,
         {
           code: 'BLANK_SANITY_ENV_VALUES',
           exit: exitCodes.RUNTIME_ERROR,
           suggestions: [
-            `Remove those blank lines from .env, or populate them, before running \`${invoked}\``,
+            `Remove those blank lines from ${envReference}, or populate them, before running \`${invoked}\``,
           ],
         },
       )
@@ -634,13 +683,13 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
 
     if (lookup?.state === 'claimed' && boundToken) {
       throw new CLIError(
-        `This directory's .env points at ${projectId ? `Sanity project ${projectId}` : 'a Sanity project'}, which has already been claimed.`,
+        `${envSubject} points at ${projectId ? `Sanity project ${projectId}` : 'a Sanity project'}, which has already been claimed.`,
         {
           code: 'CLAIMED_PROJECT_IN_ENV',
           exit: exitCodes.RUNTIME_ERROR,
           suggestions: [
-            `If it is yours: run \`sanity login\`, then remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES} to act as yourself`,
-            `Mint a fresh project here anyway: \`${invoked} --force\` (.env is left untouched)`,
+            `If it is yours: run \`sanity login\`, then remove SANITY_AUTH_TOKEN from ${tokenEnvFiles} to act as yourself`,
+            `Mint a fresh project here anyway: \`${invoked} --force\` (${envReference} is left untouched)`,
           ],
         },
       )
@@ -651,29 +700,26 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       // Only continue when project expiry verified server-side.
       const expiresAt = lookup ? (lookup.expiresAt ?? undefined) : record?.expiresAt
       throw new CLIError(
-        `This directory already has an unclaimed Sanity project${projectId ? ` (${projectId})` : ''}${describeExpiry(expiresAt ?? undefined)}.`,
+        `${scopeSubject} already has an unclaimed Sanity project${projectId ? ` (${projectId})` : ''}${describeExpiry(expiresAt ?? undefined)}.`,
         {
           code: 'UNCLAIMED_PROJECT_IN_ENV',
           exit: exitCodes.RUNTIME_ERROR,
           suggestions: [
             ...(claimUrl ? [`Claim it to keep it: ${claimUrl}`] : []),
-            `Mint a replacement anyway: \`${invoked} --force\` (the unclaimed project lives on until it expires)`,
+            `Mint a replacement anyway: \`${invoked} --force\` (${replacementDetail})`,
           ],
         },
       )
     }
 
     // Managed keys present, but nothing verifies what they belong to.
-    throw new CLIError(
-      `This directory's .env already has Sanity credentials (${foundKeys.join(', ')}).`,
-      {
-        code: 'UNVERIFIED_SANITY_CREDENTIALS',
-        exit: exitCodes.RUNTIME_ERROR,
-        suggestions: [
-          `Mint a fresh project anyway: \`${invoked} --force\` (.env is left untouched)`,
-          'Or run this command in a different directory',
-        ],
-      },
-    )
+    throw new CLIError(`${envSubject} already has Sanity credentials (${foundKeys.join(', ')}).`, {
+      code: 'UNVERIFIED_SANITY_CREDENTIALS',
+      exit: exitCodes.RUNTIME_ERROR,
+      suggestions: [
+        `Mint a fresh project anyway: \`${invoked} --force\` (${envReference} is left untouched)`,
+        differentScopeSuggestion,
+      ],
+    })
   }
 }

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -39,6 +39,21 @@ const DEFAULT_PROJECT_NAME = 'My Sanity project'
 
 const SCAFFOLD_REQUIRED_ENV_KEYS = ['SANITY_PROJECT_ID'] as const
 
+const FRONTEND_DEV_COMMANDS: Record<
+  NonNullable<ScaffoldResult['frontendPackageManager']>,
+  string
+> = {
+  bun: 'bun dev',
+  manual: 'npm run dev',
+  npm: 'npm run dev',
+  pnpm: 'pnpm dev',
+  yarn: 'yarn dev',
+}
+
+function frontendDevCommand(packageManager: ScaffoldResult['frontendPackageManager']): string {
+  return packageManager ? FRONTEND_DEV_COMMANDS[packageManager] : 'npm run dev'
+}
+
 function describeExpiry(expiresAt: string | undefined): string {
   if (!expiresAt) return ''
   const ms = new Date(expiresAt).getTime() - Date.now()
@@ -228,6 +243,20 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     flow.result(`Project ID: ${styleText('cyan', minted.resourceId)}`)
     flow.result(`Dataset:    ${styleText('cyan', minted.datasetName)}`)
     flow.gap()
+    flow.note(
+      `You must claim this project within ${styleText('yellow', '72 hours')} (by ${minted.expiresAt}) ` +
+        'or your project will be deleted.',
+    )
+    flow.line("Project credentials keep working after you've claimed.")
+    flow.line(hyperlink(styleText('cyan', minted.claimUrl), minted.claimUrl))
+    flow.gap()
+    flow.note(
+      styleText('dim', 'If an agent is running this, surface the full claim URL to the user.'),
+    )
+    flow.line(
+      styleText('dim', 'They need to click this link to claim the project before it expires.'),
+    )
+    flow.gap()
 
     const envValues = {
       SANITY_AUTH_TOKEN: minted.token,
@@ -293,6 +322,17 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
             `${staleScaffoldEnv.join(' and ')} still hold superseded values, so update them too:`,
           )
           printScaffoldEnvLines(staleScaffoldEnv)
+          flow.gap()
+        }
+        if (this.flags.scaffold) {
+          flow.note(
+            `Skipping the automatic scaffold because ./.env still points at the previous project.${
+              staleScaffoldEnv.length === 0
+                ? ' After replacing those values, scaffold with:'
+                : ' Update the existing scaffold values above before using it.'
+            }`,
+          )
+          if (staleScaffoldEnv.length === 0) printScaffoldRecipe()
           flow.gap()
         }
       }
@@ -417,11 +457,21 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
           )
         }
       }
+      const studioTokenUrl = `http://localhost:3333/#token=${encodeURIComponent(minted.token)}`
+      const printStudioInstructions = () => {
+        flow.line(`cd ${STUDIO_DIR} && npx sanity dev    to start the Studio on port 3333`)
+        flow.line(
+          `Then open ${hyperlink(styleText('cyan', studioTokenUrl), studioTokenUrl)} to enter the Studio before claiming.`,
+        )
+      }
 
       if (scaffold.frontendPath) {
         flow.highlight(`Created ./${STUDIO_DIR} (Studio) and ./${FRONTEND_DIR} (frontend).`)
-        flow.line(`cd ${STUDIO_DIR} && npx sanity dev    to start the Studio on port 3333`)
-        flow.line(`cd ${FRONTEND_DIR} && npm run dev     to start the frontend on port 3000`)
+        printStudioInstructions()
+        flow.line(
+          `cd ${FRONTEND_DIR} && ${frontendDevCommand(scaffold.frontendPackageManager)}     ` +
+            'to start the frontend on port 3000',
+        )
         if (!scaffold.frontendEnvWritten) {
           flow.line(`./${FRONTEND_DIR}/.env.local wasn't written. Add these yourself:`)
           printFrontendEnv()
@@ -430,11 +480,12 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
         flow.highlight(
           `Found ${scaffold.detectedFramework} here, so only ./${STUDIO_DIR} was created.`,
         )
+        printStudioInstructions()
         flow.line('Add these to your app:')
         printFrontendEnv()
       } else {
         flow.highlight(`Created ./${STUDIO_DIR} (Studio). The frontend was not created.`)
-        flow.line(`cd ${STUDIO_DIR} && npx sanity dev    to start the Studio on port 3333`)
+        printStudioInstructions()
         flow.line('Scaffold a frontend yourself, then add these:')
         printFrontendEnv()
       }
@@ -449,29 +500,14 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     }
 
     if (recorded === false) {
-      // The ledger is how `sanity` commands here authenticate before a config file exists; a failed
-      // write must never hide behind mint's success.
+      // Root commands can recover the token from .env, but claim reminders need the ledger.
       const msg =
-        "Couldn't save this project to the local registry; sanity commands in this directory may " +
-        'not authenticate until you set SANITY_AUTH_TOKEN from .env, add a Sanity config, or claim the project.'
+        "Couldn't save this project to the local registry, so automatic claim reminders won't " +
+        'include it. Commands in this directory can still authenticate from ./.env.'
       if (json) warnings = [...(warnings ?? []), msg]
       else this.output.warn(msg)
     }
 
-    flow.note(
-      `You must claim this project within ${styleText('yellow', '72 hours')} (by ${minted.expiresAt}) ` +
-        'or your project will be deleted.',
-    )
-    flow.line("Project credentials keep working after you've claimed.")
-    flow.line(hyperlink(styleText('cyan', minted.claimUrl), minted.claimUrl))
-    flow.gap()
-    flow.note(
-      styleText('dim', 'If an agent is running this, surface the full claim URL to the user.'),
-    )
-    flow.line(
-      styleText('dim', 'They need to click this link to claim the project before it expires.'),
-    )
-    flow.gap()
     flow.outro('Tell your agent to fetch https://sanity.new for instructions on what to do next.')
 
     return {

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -28,8 +28,8 @@ import {
   appendEnvValues,
   ensureEnvGitignored,
   GUARDED_ENV_KEYS,
+  inspectEnvKeys,
   isEnvTracked,
-  readEnvValues,
   TOKEN_ENV_FILES,
 } from '../../util/envFile.js'
 import {renderNewCommandSplash} from '../../util/newCommandSplash.js'
@@ -479,7 +479,26 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
   }
 
   private async guardExistingProject(envPath: string, invoked: string): Promise<GuardResult> {
-    const existing = readEnvValues(envPath, [...GUARDED_ENV_KEYS])
+    const inspection = inspectEnvKeys(envPath, GUARDED_ENV_KEYS)
+
+    // A blank `KEY=` line is invisible to the value read but still owns the line for the writer,
+    // so the new credentials could never be persisted. Refuse (even with --force, which never
+    // edits existing lines either) before spending a mint or touching the filesystem.
+    if (inspection.blankKeys.length > 0) {
+      throw new CLIError(
+        `This directory's .env contains blank Sanity credential placeholders: ` +
+          `${inspection.blankKeys.join(', ')}. No project was minted.`,
+        {
+          code: 'BLANK_SANITY_ENV_VALUES',
+          exit: exitCodes.RUNTIME_ERROR,
+          suggestions: [
+            `Remove those blank lines from .env, or populate them, before running \`${invoked}\``,
+          ],
+        },
+      )
+    }
+
+    const existing = inspection.values
     const foundKeys = GUARDED_ENV_KEYS.filter((key) => existing[key] !== undefined)
     if (foundKeys.length === 0) return {hasExistingKeys: false}
     if (this.flags.force) {

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -10,6 +10,7 @@ import {createFlow, input} from '@sanity/cli-core/ux'
 import {lookupClaimState, mintUnclaimedProject} from '../../services/mintProject.js'
 import {
   forgetMintedProject,
+  formatMsLeft,
   getMintedProjectRecord,
   recordMintedProject,
 } from '../../util/claimNudges.js'
@@ -25,16 +26,11 @@ import {hyperlink} from '../../util/terminalLink.js'
 
 const DEFAULT_PROJECT_NAME = 'My Sanity project'
 
-function hoursUntil(iso: string): number | undefined {
-  const ms = new Date(iso).getTime() - Date.now()
-  return Number.isFinite(ms) && ms > 0 ? Math.round(ms / 3_600_000) : undefined
-}
-
 function describeExpiry(expiresAt: string | undefined): string {
   if (!expiresAt) return ''
-  const hrs = hoursUntil(expiresAt)
-  // A past or imminent date gets no clause: stale local records must not decorate a refusal.
-  return hrs ? `, expiring in ~${hrs} hours (${expiresAt})` : ''
+  const ms = new Date(expiresAt).getTime() - Date.now()
+  if (!Number.isFinite(ms) || ms <= 0) return ''
+  return `, expiring in ${formatMsLeft(ms)} (${expiresAt})`
 }
 
 function claimTokenFromClaimUrl(claimUrl: string | undefined): string | undefined {
@@ -78,10 +74,26 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
 
   static override description =
     'Mint an unclaimed Sanity project without logging in.\n' +
-    'Writes the project id, dataset, and a robot token to .env, so `sanity` commands in this ' +
-    'directory run as the project. Claim it with a Sanity account within 72 hours to keep it — ' +
-    'everything keeps working after you claim, including the token. Use --json for a ' +
-    'machine-readable payload with no files written.'
+    '\n' +
+    'Credentials are written to ./.env (SANITY_PROJECT_ID, SANITY_DATASET, and ' +
+    'SANITY_AUTH_TOKEN, a robot token) and .env is gitignored, so `sanity` commands in this ' +
+    'directory run as the project with no account. Use --json for a machine-readable payload ' +
+    'instead: JSON mode writes no files and the caller owns the credentials.\n' +
+    '\n' +
+    'Claiming: the project must be claimed with a Sanity account within 72 hours (expiresAt) or ' +
+    'it is permanently deleted, content included. The claim URL is single-use and whoever opens ' +
+    "it takes ownership: keep it out of git and shared channels. If you're an agent, surface the link to the end user " +
+    "immediately. Everything keeps working after you've claimed, including the robot token.\n" +
+    '\n' +
+    'The robot token has full content access to this project: create, edit, publish, and deploy ' +
+    'schemas. It cannot deploy a hosted Studio, create datasets, or manage settings. The dataset ' +
+    'is private pre-claim: frontend reads must run server-side, and the token must never sit ' +
+    'under a client-exposed prefix like NEXT_PUBLIC_* or SANITY_STUDIO_*.\n' +
+    '\n' +
+    'After the claim, run `sanity login` and remove SANITY_AUTH_TOKEN from .env to act as your ' +
+    'own account; until then, CLI commands in this directory keep authenticating as the robot.\n' +
+    '\n' +
+    'Minting is rate-limited per machine. Fetch https://sanity.new for agent instructions.'
 
   static override enableJsonFlag = true
 
@@ -112,7 +124,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     force: Flags.boolean({
       default: false,
       description:
-        'Mint a new project even when .env already has Sanity credentials (the file is left untouched — the new values are printed for you to apply)',
+        'Mint a new project even when .env already has Sanity credentials (the file is left untouched; the new values are printed for you to apply)',
     }),
     yes: Flags.boolean({
       char: 'y',
@@ -166,7 +178,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     if (!json) {
       if (guard.expiredProjectId) {
         flow.note(
-          `Found an expired unclaimed project (${guard.expiredProjectId}) in .env — minting a replacement. Your .env is left untouched; new values follow.`,
+          `Found an expired unclaimed project (${guard.expiredProjectId}) in .env. Minting a replacement; your .env is left untouched and new values follow.`,
         )
       } else if (guard.hasExistingKeys) {
         flow.note('--force: minting a new project. Your .env is left untouched; new values follow.')
@@ -212,17 +224,17 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       if (json) {
         warnings = [
           '.env still holds the previous Sanity values and was not modified (this command ' +
-            'never edits existing lines) — update it from this payload.',
+            'never edits existing lines); update it from this payload.',
         ]
       } else {
-        flow.highlight('Update ./.env yourself — replace the old Sanity values with these:')
+        flow.highlight('Update ./.env yourself, replacing the old Sanity values with these:')
         printEnvValues()
         flow.gap()
       }
 
       if (guard.expiredProjectId && !forgetMintedProject(guard.expiredProjectId)) {
         const notDropped =
-          `Couldn't update the local project registry — expired project ${guard.expiredProjectId} ` +
+          `Couldn't update the local project registry: expired project ${guard.expiredProjectId} ` +
           'is still recorded, so re-running this command will mint another project against the rate limit.'
         if (json) {
           warnings = [...(warnings ?? []), notDropped]
@@ -234,7 +246,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       try {
         const written = appendEnvValues(envPath, envValues, {
           banner: [
-            `Added by \`${invoked}\` — unclaimed Sanity project, expires ${minted.expiresAt}`,
+            `Added by \`${invoked}\`: unclaimed Sanity project, expires ${minted.expiresAt}`,
             `Claim it to keep it: ${minted.claimUrl}`,
           ],
         })
@@ -248,22 +260,22 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
           flow.highlight(`Saved credentials to ./.env as ${written.wroteKeys.join(', ')}`)
         }
         if (written.skippedKeys.length > 0) {
-          flow.note(`./.env already has ${written.skippedKeys.join(', ')} — make sure they read:`)
+          flow.note(`./.env already has ${written.skippedKeys.join(', ')}; make sure they read:`)
           for (const key of written.skippedKeys) {
             flow.line(`${key}="${envValues[key as keyof typeof envValues]}"`)
           }
         }
         if (envTracked) {
           this.output.warn(
-            '.env is already tracked by git — adding it to .gitignore does not untrack it, so the ' +
+            '.env is already tracked by git; adding it to .gitignore does not untrack it, so the ' +
               'token can still be committed. Run `git rm --cached .env` to stop tracking it.',
           )
         } else if (gitignore.added) {
-          flow.line(styleText('dim', 'Added .env to .gitignore so the token stays out of git.'))
+          flow.line('Added .env to .gitignore so the token stays out of git.')
         } else if (!gitignore.ignored) {
           // The write failed — .env now holds a token but may not be ignored. Never silent.
           this.output.warn(
-            "Couldn't add .env to .gitignore — add it yourself so the robot token in .env is never committed.",
+            "Couldn't add .env to .gitignore; add it yourself so the robot token in .env is never committed.",
           )
         }
       } catch (err) {
@@ -280,23 +292,27 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       // The ledger is how `sanity` commands here authenticate before a config file exists; a failed
       // write must never hide behind mint's success.
       const msg =
-        "Couldn't save this project to the local registry — sanity commands in this directory may " +
+        "Couldn't save this project to the local registry; sanity commands in this directory may " +
         'not authenticate until you set SANITY_AUTH_TOKEN from .env, add a Sanity config, or claim the project.'
       if (json) warnings = [...(warnings ?? []), msg]
       else this.output.warn(msg)
     }
 
-    const hrs = hoursUntil(minted.expiresAt)
     flow.note(
-      hrs
-        ? `Claim your project within ${styleText('yellow', `~${hrs} hours`)} (by ${minted.expiresAt}) to keep it:`
-        : `Claim your project before ${styleText('yellow', minted.expiresAt)} to keep it:`,
+      `You must claim this project within ${styleText('yellow', '72 hours')} (by ${minted.expiresAt}) ` +
+        'or your project will be deleted.',
     )
+    flow.line("Project credentials keep working after you've claimed.")
     flow.line(hyperlink(styleText('cyan', minted.claimUrl), minted.claimUrl))
     flow.gap()
-    flow.note('Everything keeps working after you claim, including the token in .env.')
+    flow.note(
+      styleText('dim', 'If an agent is running this, surface the full claim URL to the user.'),
+    )
+    flow.line(
+      styleText('dim', 'They need to click this link to claim the project before it expires.'),
+    )
     flow.gap()
-    flow.outro('Happy coding')
+    flow.outro('Tell your agent to fetch https://sanity.new for instructions on what to do next.')
 
     return {
       apiHost: minted.apiHost,

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -32,8 +32,8 @@ import {
   isEnvTracked,
   TOKEN_ENV_FILES,
 } from '../../util/envFile.js'
+import {CLAIM_WINDOW_HOURS, SANITY_NEW_URL} from '../../util/mintProjectConstants.js'
 import {renderNewCommandSplash} from '../../util/newCommandSplash.js'
-import {hyperlink} from '../../util/terminalLink.js'
 
 const DEFAULT_PROJECT_NAME = 'My Sanity project'
 
@@ -59,6 +59,24 @@ function describeExpiry(expiresAt: string | undefined): string {
   const ms = new Date(expiresAt).getTime() - Date.now()
   if (!Number.isFinite(ms) || ms <= 0) return ''
   return `, expiring in ${formatMsLeft(ms)} (${expiresAt})`
+}
+
+function formatClaimDeadline(expiresAt: string): string {
+  const deadline = new Date(expiresAt)
+  if (!Number.isFinite(deadline.getTime())) return expiresAt
+  return (
+    new Intl.DateTimeFormat('en-GB', {
+      day: 'numeric',
+      hour: '2-digit',
+      hour12: false,
+      minute: '2-digit',
+      month: 'long',
+      timeZone: 'UTC',
+      year: 'numeric',
+    })
+      .format(deadline)
+      .replace(' at ', ', ') + ' UTC'
+  )
 }
 
 function claimTokenFromClaimUrl(claimUrl: string | undefined): string | undefined {
@@ -103,28 +121,30 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
   static override description =
     'Mint an unclaimed Sanity project without logging in.\n' +
     '\n' +
-    'Credentials are written to ./.env (SANITY_PROJECT_ID, SANITY_DATASET, and ' +
-    'SANITY_AUTH_TOKEN, a robot token) and .env is gitignored, so `sanity` commands here ' +
-    'authenticate as the project with no account. Commands that need a project id still take it ' +
-    'from a Sanity config file or --project-id, so run them inside the scaffolded Studio folder. ' +
-    'Use --json for a machine-readable payload instead: JSON mode writes no files and the caller ' +
-    'owns the credentials.\n' +
+    `By default, it scaffolds ./${STUDIO_DIR}, a Studio for editing content, and ` +
+    `./${FRONTEND_DIR}, a connected Next.js website. Use --no-scaffold to mint only the project.\n` +
     '\n' +
-    'Claiming: the project must be claimed with a Sanity account within 72 hours (expiresAt) or ' +
-    'it is permanently deleted, content included. The claim URL is single-use and whoever opens ' +
-    "it takes ownership: keep it out of git and shared channels. If you're an agent, surface the link to the end user " +
-    "immediately. Everything keeps working after you've claimed, including the robot token.\n" +
+    'Credentials are written to ./.env, which is gitignored, and to a local ledger used for CLI ' +
+    'authentication and claim reminders. Commands that need a project id still read it from a ' +
+    'Sanity config file or --project-id, so run them inside the scaffolded Studio. With --json, ' +
+    'the command writes no files, creates no scaffold or ledger entry, and returns a ' +
+    'machine-readable credential payload.\n' +
     '\n' +
-    'The robot token has full content access to this project: create, edit, publish, and deploy ' +
-    'schemas. It cannot deploy a hosted Studio, create datasets, or manage settings. The dataset ' +
-    'is private pre-claim: frontend reads must run server-side, and the token must never sit ' +
-    'under a client-exposed prefix like NEXT_PUBLIC_* or SANITY_STUDIO_*.\n' +
+    `The project must be claimed with a Sanity account within ${CLAIM_WINDOW_HOURS} hours or the ` +
+    'project and all its content are permanently deleted. The claim URL is single-use; whoever ' +
+    'opens it becomes the owner. If you are an agent: give the full claim URL to the person you ' +
+    'are working for immediately. They must open it themselves before the deadline.\n' +
+    '\n' +
+    'The robot token has full content access: it can create, edit, and publish content and deploy ' +
+    'schemas. It cannot deploy a hosted Studio, create datasets, or manage project settings. ' +
+    'Before claim, dataset reads are private and must use the token server-side; never expose it ' +
+    'to browser code. Claiming makes the dataset public and readable without the token.\n' +
     '\n' +
     `After the claim, run \`sanity login\` and remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES} ` +
-    'to act as your own account; until then, CLI commands in this directory keep ' +
-    'authenticating as the robot.\n' +
+    'to act as your own account. The robot token remains active until you remove it.\n' +
     '\n' +
-    'Minting is rate-limited per machine. Fetch https://sanity.new for agent instructions.'
+    'Minting is rate-limited per machine. Framework setup and post-claim cleanup: ' +
+    `${SANITY_NEW_URL}.`
 
   static override enableJsonFlag = true
 
@@ -160,7 +180,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     scaffold: Flags.boolean({
       allowNo: true,
       default: true,
-      description: `Scaffold a Studio into ./${STUDIO_DIR} and a Next.js frontend into ./${FRONTEND_DIR} after minting`,
+      description: `Scaffold a Studio into ./${STUDIO_DIR} and a Next.js frontend into ./${FRONTEND_DIR} after minting; use --no-scaffold to mint only the project`,
     }),
     yes: Flags.boolean({
       char: 'y',
@@ -183,29 +203,23 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     const envPath = path.join(process.cwd(), '.env')
     const guard: GuardResult = await this.guardExistingProject(envPath, invoked)
 
-    renderNewCommandSplash(output.log)
-
-    flow.intro("Let's get you set up with a Sanity project.")
-    flow.gap()
-
-    if (!this.isUnattended()) {
-      flow.note(
-        `${styleText('cyan', `${invoked} --yes`)} for a non-interactive flow with defaults.`,
-      )
+    if (!json) {
+      renderNewCommandSplash(output.log)
+      flow.intro('Setting up your Sanity project.')
       flow.gap()
+
+      if (!this.isUnattended()) {
+        flow.note(
+          `${styleText('cyan', `${invoked} --yes`)} for a non-interactive flow with defaults.`,
+        )
+        flow.gap()
+      }
     }
 
     let displayName = this.args.projectName?.trim()
-    if (displayName) {
-      flow.result(`Project name: ${styleText('cyan', displayName)}`)
-      flow.gap()
-    } else if (this.isUnattended()) {
+    if (!displayName && this.isUnattended()) {
       displayName = DEFAULT_PROJECT_NAME
-      flow.result(
-        `Project name: ${styleText('cyan', displayName)} ${styleText('dim', '(default)')}`,
-      )
-      flow.gap()
-    } else {
+    } else if (!displayName) {
       displayName =
         (await input({default: DEFAULT_PROJECT_NAME, message: 'Project name'})).trim() ||
         DEFAULT_PROJECT_NAME
@@ -218,10 +232,8 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
         )
       } else if (guard.hasExistingKeys) {
         flow.note('--force: minting a new project. Your .env is left untouched; new values follow.')
-      } else {
-        flow.note('No Sanity credentials in .env yet, adding them.')
       }
-      flow.gap()
+      if (guard.hasExistingKeys) flow.gap()
     }
 
     const spin = json ? undefined : flow.spin('Minting your project...')
@@ -232,31 +244,39 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       spin?.fail('Minting your project failed.')
       throw err
     }
-    spin?.succeed('Project minted')
-
     // `--json` writes nothing (no `.env` either), so it must not touch the ledger — the caller owns
     // the returned token. Only the interactive path records, and so keeps showing unclaimed nudges
     // until claim or expiry (e.g. for a `--force`-superseded live project that may hold content).
     const recorded = json ? undefined : recordMintedProject(minted)
+    spin?.succeed(`Created "${displayName}"`)
 
-    flow.gap()
-    flow.result(`Project ID: ${styleText('cyan', minted.resourceId)}`)
-    flow.result(`Dataset:    ${styleText('cyan', minted.datasetName)}`)
-    flow.gap()
-    flow.note(
-      `You must claim this project within ${styleText('yellow', '72 hours')} (by ${minted.expiresAt}) ` +
-        'or your project will be deleted.',
-    )
-    flow.line("Project credentials keep working after you've claimed.")
-    flow.line(hyperlink(styleText('cyan', minted.claimUrl), minted.claimUrl))
-    flow.gap()
-    flow.note(
-      styleText('dim', 'If an agent is running this, surface the full claim URL to the user.'),
-    )
-    flow.line(
-      styleText('dim', 'They need to click this link to claim the project before it expires.'),
-    )
-    flow.gap()
+    if (!json) {
+      flow.result(`Project ID: ${styleText('cyan', minted.resourceId)}`)
+      flow.result(`Dataset: ${styleText('cyan', minted.datasetName)} (where your content lives)`)
+      flow.gap()
+      flow.highlight(
+        `Claim your project by ${styleText('yellow', formatClaimDeadline(minted.expiresAt))}`,
+      )
+      flow.gap()
+      flow.link(minted.claimUrl)
+      flow.gap()
+      flow.line(
+        'Until then it is temporary — the project and everything in it is permanently deleted ' +
+          'at that deadline. Claiming is free, takes about a minute, and nothing you have built changes.',
+      )
+      flow.line(
+        'Treat the link like a password: it is single-use, and whoever opens it becomes the owner.',
+      )
+      flow.gap()
+      flow.note(
+        styleText(
+          'dim',
+          'If you are an agent: give this claim URL to the person you are working for.',
+        ),
+      )
+      flow.line(styleText('dim', 'They have to open it themselves before the deadline.'))
+      flow.gap()
+    }
 
     const envValues = {
       SANITY_AUTH_TOKEN: minted.token,
@@ -298,6 +318,8 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     }
     let warnings: MintProjectResult['warnings']
     let credentialsOnDisk = false
+    let envProtected = false
+    let rootTokenWritten = false
 
     if (guard.hasExistingKeys) {
       const staleScaffoldEnv = existingScaffoldEnvFiles(process.cwd())
@@ -361,9 +383,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
         // Gitignore does nothing for an already-tracked file, so a tracked `.env` can still be
         // committed — check before claiming the token is protected.
         const envTracked = isEnvTracked(process.cwd())
-        if (written.wroteKeys.length > 0) {
-          flow.highlight(`Saved credentials to ./.env as ${written.wroteKeys.join(', ')}`)
-        }
+        envProtected = !envTracked && gitignore.ignored
         if (written.skippedKeys.length > 0) {
           flow.note(`./.env already has ${written.skippedKeys.join(', ')}; make sure they read:`)
           for (const key of written.skippedKeys) {
@@ -373,6 +393,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
         credentialsOnDisk = SCAFFOLD_REQUIRED_ENV_KEYS.every((key) =>
           written.wroteKeys.includes(key),
         )
+        rootTokenWritten = written.wroteKeys.includes('SANITY_AUTH_TOKEN')
         if (!credentialsOnDisk) {
           flow.note(
             `Skipping the ${STUDIO_DIR}/ and ${FRONTEND_DIR}/ scaffold: the lines above shadowed ` +
@@ -413,6 +434,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     const shouldScaffold =
       !json && this.flags.scaffold && !guard.hasExistingKeys && credentialsOnDisk
     let scaffold: ScaffoldResult | undefined
+    let scaffoldFailed = false
     if (shouldScaffold) {
       const scaffoldController = new AbortController()
       const abortScaffold = () => scaffoldController.abort(new Error('SIGINT'))
@@ -436,6 +458,7 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
           `Couldn't scaffold the project (${err instanceof Error ? err.message : err}). ` +
             'Your project is minted and ./.env is written, so nothing needs re-minting.',
         )
+        scaffoldFailed = true
         flow.note('Scaffold it yourself with:')
         printScaffoldRecipe()
       } finally {
@@ -445,57 +468,54 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
 
     if (scaffold) {
       for (const warning of scaffold.warnings) this.output.warn(warning)
-      flow.gap()
       const printFrontendEnv = () => {
         for (const [key, value] of Object.entries(scaffold.frontendEnv)) {
           flow.line(`${key}="${value}"`)
         }
-        if (scaffold.detectedFramework && scaffold.detectedFramework !== 'Next.js') {
+        if (scaffold.detectedFramework && !scaffold.frontendEnvPrefix) {
           flow.line(
-            `Those names follow the Next.js convention. On ${scaffold.detectedFramework}, use its ` +
-              'own public prefix for the project id and dataset.',
+            `These fallback values use NEXT_PUBLIC_. Translate that public prefix for ${scaffold.detectedFramework} before using them.`,
           )
         }
       }
       const studioTokenUrl = `http://localhost:3333/#token=${encodeURIComponent(minted.token)}`
       const printStudioInstructions = () => {
-        flow.line(`cd ${STUDIO_DIR} && npx sanity dev    to start the Studio on port 3333`)
-        flow.line(
-          `Then open ${hyperlink(styleText('cyan', studioTokenUrl), studioTokenUrl)} to enter the Studio before claiming.`,
-        )
+        flow.line(`cd ${STUDIO_DIR} && npx sanity dev`)
+        flow.line('then open')
+        flow.link(studioTokenUrl)
+        flow.line('the token in that link signs you in — there is no account yet')
       }
 
       if (scaffold.frontendPath) {
-        flow.highlight(`Created ./${STUDIO_DIR} (Studio) and ./${FRONTEND_DIR} (frontend).`)
+        flow.highlight('Created two folders')
+        flow.line(`./${STUDIO_DIR} — your Studio, where you write and edit content`)
+        flow.line(`./${FRONTEND_DIR} — your website, a Next.js app that reads it`)
+        flow.gap()
         printStudioInstructions()
-        flow.line(
-          `cd ${FRONTEND_DIR} && ${frontendDevCommand(scaffold.frontendPackageManager)}     ` +
-            'to start the frontend on port 3000',
-        )
+        flow.line(`cd ${FRONTEND_DIR} && ${frontendDevCommand(scaffold.frontendPackageManager)}`)
+        flow.line('then open http://localhost:3000/')
         if (!scaffold.frontendEnvWritten) {
           flow.line(`./${FRONTEND_DIR}/.env.local wasn't written. Add these yourself:`)
           printFrontendEnv()
         }
       } else if (scaffold.detectedFramework) {
         flow.highlight(
-          `Found ${scaffold.detectedFramework} here, so only ./${STUDIO_DIR} was created.`,
+          `Created ./${STUDIO_DIR} for your existing ${scaffold.detectedFramework} app`,
         )
+        flow.line(`./${STUDIO_DIR} — your Studio, where you write and edit content`)
+        flow.line(`Your existing ${scaffold.detectedFramework} frontend was left unchanged.`)
+        flow.gap()
         printStudioInstructions()
         flow.line('Add these to your app:')
         printFrontendEnv()
       } else {
-        flow.highlight(`Created ./${STUDIO_DIR} (Studio). The frontend was not created.`)
+        flow.highlight(`Created ./${STUDIO_DIR}; the frontend was not created`)
+        flow.line(`./${STUDIO_DIR} — your Studio, where you write and edit content`)
+        flow.gap()
         printStudioInstructions()
         flow.line('Scaffold a frontend yourself, then add these:')
         printFrontendEnv()
       }
-      flow.gap()
-      flow.note(
-        'Your dataset is private until you claim it, so reading content from your frontend needs a ' +
-          'token. Copy SANITY_AUTH_TOKEN from ./.env when you add those reads, keep them ' +
-          'server-side, and never put it under a browser-exposed prefix like NEXT_PUBLIC_ or ' +
-          'SANITY_STUDIO_: that publishes a credential with full write access.',
-      )
       flow.gap()
     }
 
@@ -508,7 +528,59 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
       else this.output.warn(msg)
     }
 
-    flow.outro('Tell your agent to fetch https://sanity.new for instructions on what to do next.')
+    if (!json) {
+      if (!scaffold && !this.flags.scaffold) {
+        flow.highlight('Project created without scaffolding')
+        flow.line(
+          'No folders were created. Use the project ID and dataset above in your own setup.',
+        )
+        flow.gap()
+      } else if (scaffoldFailed) {
+        flow.highlight('The project is ready; automatic scaffolding did not finish')
+        flow.line('No re-mint is needed. Use the manual commands above to finish the setup.')
+        flow.gap()
+      }
+
+      const studioEnvFailed = scaffold?.warnings.some((warning) =>
+        warning.includes(`Couldn't write ${STUDIO_ENV_FILE}`),
+      )
+      const tokenLocations = [
+        ...(rootTokenWritten ? ['./.env'] : []),
+        ...(scaffold && !studioEnvFailed ? [`./${STUDIO_ENV_FILE}`] : []),
+      ]
+      if (tokenLocations.length === 0) {
+        flow.highlight('Protect the replacement access token printed above')
+        flow.line('It was not written over your existing configuration.')
+      } else {
+        flow.highlight(`Your access token is in ${tokenLocations.join(' and ')}`)
+        if (envProtected && tokenLocations.length === 2) {
+          flow.line('Both files are kept out of version control for you.')
+        } else if (!rootTokenWritten || envProtected) {
+          flow.line('That file is kept out of version control for you.')
+        } else if (tokenLocations.length === 2) {
+          flow.line(`./${STUDIO_ENV_FILE} is ignored; keep ./.env out of version control yourself.`)
+        } else {
+          flow.line('Keep that file out of version control.')
+        }
+        if (!rootTokenWritten) {
+          flow.line(
+            './.env kept its existing token; use the replacement value printed above when you update it.',
+          )
+        }
+      }
+      flow.line(
+        'The token can read and change everything in this project. Never copy it into code that runs in a browser.',
+      )
+      flow.gap()
+      flow.line(
+        'Your content is private until you claim, so anything reading it needs that token. Keep those reads server-side.',
+      )
+      flow.line('Claiming makes the dataset public and readable without the token.')
+      flow.gap()
+      flow.line(`Framework setup and what to do after claiming: ${SANITY_NEW_URL}`)
+      flow.gap()
+      flow.link(minted.claimUrl, {label: 'Claim your project:', outro: true})
+    }
 
     return {
       apiHost: minted.apiHost,

--- a/packages/@sanity/cli/src/commands/projects/mint.ts
+++ b/packages/@sanity/cli/src/commands/projects/mint.ts
@@ -205,7 +205,20 @@ export class MintProjectCommand extends SanityCommand<typeof MintProjectCommand>
     // Guard against the same nearest credential boundary used by CLI authentication, but keep
     // first-mint writes rooted at the invocation directory.
     const envPath = path.join(cwd, '.env')
-    const guardEnvPath = findMintedProjectEnvBoundary(cwd)?.envPath ?? envPath
+    let guardEnvPath: string
+    try {
+      guardEnvPath = findMintedProjectEnvBoundary(cwd)?.envPath ?? envPath
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      throw new CLIError(
+        `Could not inspect the Sanity credential boundary: ${detail}. ` +
+          'Ensure ancestor .env files are readable regular files, then re-run.',
+        {
+          code: 'CREDENTIAL_BOUNDARY_INSPECTION_FAILED',
+          exit: exitCodes.RUNTIME_ERROR,
+        },
+      )
+    }
     const guard: GuardResult = await this.guardExistingProject(guardEnvPath, invoked)
     const guardDirectory = path.dirname(guardEnvPath)
     const guardIsCurrentDirectory = path.resolve(guardDirectory) === path.resolve(cwd)

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -154,6 +154,9 @@ export const mcpPolicy: CommandPolicySet = {
   // Executes local migration code that may perform arbitrary document mutations.
   'migrations:run': deny,
 
+  // Writes credentials to ./.env and scaffolds a local project (alias of projects mint).
+  new: deny,
+
   // --web opens a browser on the machine running the MCP server.
   'openapi:get': conditionalDenyFlags('web'),
   'openapi:list': conditionalDenyFlags('web'),
@@ -169,6 +172,8 @@ export const mcpPolicy: CommandPolicySet = {
 
   'projects:create': allow,
   'projects:list': allow,
+  // Writes credentials to ./.env and scaffolds a local project.
+  'projects:mint': deny,
 
   // Loads the local Studio configuration to resolve the datasets containing each schema.
   'schemas:delete': deny,

--- a/packages/@sanity/cli/src/hooks/prerun/__tests__/claimReminders.test.ts
+++ b/packages/@sanity/cli/src/hooks/prerun/__tests__/claimReminders.test.ts
@@ -1,0 +1,40 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {claimReminders} from '../claimReminders.js'
+
+const mockRunClaimNudges = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../util/claimNudges.js', () => ({
+  runClaimNudges: mockRunClaimNudges,
+}))
+
+function runHook(commandId: string | undefined) {
+  return (claimReminders as (opts: unknown) => Promise<void>).call(
+    {},
+    {Command: commandId ? {id: commandId} : undefined},
+  )
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('#claimReminders', () => {
+  test('runs the nudge check for regular commands', async () => {
+    await runHook('versions')
+
+    expect(mockRunClaimNudges).toHaveBeenCalledTimes(1)
+  })
+
+  test.each(['new', 'projects:mint', 'project:mint'])('skips the %s command', async (id) => {
+    await runHook(id)
+
+    expect(mockRunClaimNudges).not.toHaveBeenCalled()
+  })
+
+  test('never throws when the nudge check fails', async () => {
+    mockRunClaimNudges.mockRejectedValue(new Error('config unreadable'))
+
+    await expect(runHook('versions')).resolves.toBeUndefined()
+  })
+})

--- a/packages/@sanity/cli/src/hooks/prerun/claimReminders.ts
+++ b/packages/@sanity/cli/src/hooks/prerun/claimReminders.ts
@@ -1,0 +1,27 @@
+import {type Hook} from '@oclif/core'
+import {subdebug} from '@sanity/cli-core/debug'
+
+import {runClaimNudges} from '../../util/claimNudges.js'
+
+const debug = subdebug('claimNudges')
+
+/**
+ * Commands that already put claim details front and center — nudging during them is noise.
+ */
+const SKIP_COMMANDS = new Set(['new', 'project:mint', 'projects:mint'])
+
+/**
+ * Prerun hook that reminds the user (or their agent) about minted-but-unclaimed projects
+ * approaching the end of their claim window. Writes to stderr so it never corrupts
+ * machine-readable stdout (e.g. `--json`), and silently fails — a reminder must never break the
+ * command being run.
+ */
+export const claimReminders: Hook.Prerun = async function (opts) {
+  if (SKIP_COMMANDS.has(opts.Command?.id ?? '')) return
+
+  try {
+    await runClaimNudges((line) => process.stderr.write(`${line}\n`))
+  } catch (err) {
+    debug('claim reminder check failed: %s', err)
+  }
+}

--- a/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
@@ -1,0 +1,208 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {
+  lookupClaimStateViaProject,
+  mintUnclaimedProject,
+  PROVISION_API_VERSION,
+} from '../mintProject.js'
+
+const mockFetch = vi.fn()
+
+const provisionResponse = {
+  apiHost: 'https://abc123.api.sanity.io',
+  claimToken: 'claim-token',
+  datasetName: 'production',
+  expiresAt: '2026-07-18T00:00:00.000Z',
+  links: {
+    claimApiUrl: 'https://api.sanity.io/v1/provision/claim',
+    claimUrl: 'https://www.sanity.io/claim/some-token',
+  },
+  resourceId: 'abc123',
+  resourceType: 'project',
+  token: 'sk-robot-token',
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch)
+  mockFetch.mockResolvedValue({
+    json: async () => provisionResponse,
+    ok: true,
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+  vi.clearAllMocks()
+})
+
+describe('#mintUnclaimedProject', () => {
+  test('posts display name to the provision endpoint and maps the response', async () => {
+    const minted = await mintUnclaimedProject({displayName: 'My Project'})
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `https://api.sanity.io/${PROVISION_API_VERSION}/provision`,
+      {
+        body: JSON.stringify({displayName: 'My Project', resourceType: 'project'}),
+        headers: {'Content-Type': 'application/json'},
+        method: 'POST',
+      },
+    )
+    expect(minted).toEqual({
+      apiHost: provisionResponse.apiHost,
+      claimApiUrl: provisionResponse.links.claimApiUrl,
+      claimToken: provisionResponse.claimToken,
+      claimUrl: provisionResponse.links.claimUrl,
+      datasetName: provisionResponse.datasetName,
+      expiresAt: provisionResponse.expiresAt,
+      resourceId: provisionResponse.resourceId,
+      token: provisionResponse.token,
+    })
+  })
+
+  test('trims the display name', async () => {
+    await mintUnclaimedProject({displayName: '  Padded  '})
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({displayName: 'Padded', resourceType: 'project'}),
+      }),
+    )
+  })
+
+  test('respects SANITY_API_HOST override, stripping trailing slash', async () => {
+    vi.stubEnv('SANITY_API_HOST', 'https://api.sanity.example/')
+
+    await mintUnclaimedProject({displayName: 'My Project'})
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `https://api.sanity.example/${PROVISION_API_VERSION}/provision`,
+      expect.any(Object),
+    )
+  })
+
+  test.each(['', '   ', 'x'.repeat(81)])('rejects invalid display name %j', async (displayName) => {
+    await expect(mintUnclaimedProject({displayName})).rejects.toThrow(
+      'Display name must be 1-80 characters.',
+    )
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  test('throws with status and body on HTTP error', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: async () => 'provisioning disabled',
+    })
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
+      'Mint failed (HTTP 404): provisioning disabled',
+    )
+  })
+
+  test('falls back to statusText when the error body is unreadable', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => {
+        throw new Error('no body')
+      },
+    })
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
+      'Mint failed (HTTP 500): Internal Server Error',
+    )
+  })
+
+  test('throws when the response has no claim token', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({...provisionResponse, claimToken: undefined}),
+      ok: true,
+    })
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
+      /did not return a claim token/,
+    )
+  })
+
+  test('names every missing field instead of mapping a partial 200 response', async () => {
+    // A 200 is still external input: every mapped field lands in .env or the JSON payload, so
+    // a hole must fail loudly here — not crash on `data.links` or write the literal string
+    // "undefined" as a credential.
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        ...provisionResponse,
+        links: undefined,
+        token: '',
+      }),
+      ok: true,
+    })
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
+      'Mint response is missing claimApiUrl, claimUrl, token',
+    )
+  })
+})
+
+describe('#lookupClaimStateViaProject', () => {
+  test('reads the org id from the project host as the robot', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({organizationId: 'oSystemUnclaimed'}),
+      ok: true,
+      status: 200,
+    })
+
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('claimable')
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://abc123.api.sanity.io/v2026-05-04/projects/abc123',
+      expect.objectContaining({headers: {Authorization: 'Bearer sk-robot'}}),
+    )
+  })
+
+  test('a real organization id means the project was claimed', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({organizationId: 'ocREALORG'}),
+      ok: true,
+      status: 200,
+    })
+
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('claimed')
+  })
+
+  test('404 means the project was reaped', async () => {
+    mockFetch.mockResolvedValue({ok: false, status: 404})
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('expired')
+  })
+
+  test('401 reports the token as revoked, distinct from a fail-open network error', async () => {
+    mockFetch.mockResolvedValue({ok: false, status: 401})
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('revoked')
+  })
+
+  test('fails open on other HTTP errors and on network failure', async () => {
+    mockFetch.mockResolvedValue({ok: false, status: 500})
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBeUndefined()
+
+    mockFetch.mockRejectedValue(new Error('offline'))
+    await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBeUndefined()
+  })
+
+  test('honors the SANITY_API_HOST override', async () => {
+    vi.stubEnv('SANITY_API_HOST', 'http://localhost:4321')
+    mockFetch.mockResolvedValue({
+      json: async () => ({organizationId: 'oSystemUnclaimed'}),
+      ok: true,
+      status: 200,
+    })
+
+    await lookupClaimStateViaProject('abc123', 'sk-robot')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:4321/v2026-05-04/projects/abc123',
+      expect.anything(),
+    )
+  })
+})

--- a/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
@@ -105,7 +105,7 @@ describe('#mintUnclaimedProject', () => {
     mockRequest.mockResolvedValue({body: '', headers: {}, statusCode: 429})
 
     await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
-      'Mint rate limit reached for this machine. Try again in an hour.',
+      'Mint rate limit reached for this machine. Try again later.',
     )
   })
 

--- a/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
@@ -1,12 +1,17 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {
+  lookupClaimState,
   lookupClaimStateViaProject,
   mintUnclaimedProject,
   PROVISION_API_VERSION,
 } from '../mintProject.js'
 
-const mockFetch = vi.fn()
+const mockRequest = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/cli-core/request', () => ({
+  createRequester: vi.fn().mockReturnValue(mockRequest),
+}))
 
 const provisionResponse = {
   apiHost: 'https://abc123.api.sanity.io',
@@ -22,16 +27,17 @@ const provisionResponse = {
   token: 'sk-robot-token',
 }
 
+const jsonResponse = (body: unknown, statusCode = 200) => ({
+  body: JSON.stringify(body),
+  headers: {},
+  statusCode,
+})
+
 beforeEach(() => {
-  vi.stubGlobal('fetch', mockFetch)
-  mockFetch.mockResolvedValue({
-    json: async () => provisionResponse,
-    ok: true,
-  })
+  mockRequest.mockResolvedValue(jsonResponse(provisionResponse))
 })
 
 afterEach(() => {
-  vi.unstubAllGlobals()
   vi.unstubAllEnvs()
   vi.clearAllMocks()
 })
@@ -40,14 +46,12 @@ describe('#mintUnclaimedProject', () => {
   test('posts display name to the provision endpoint and maps the response', async () => {
     const minted = await mintUnclaimedProject({displayName: 'My Project'})
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.sanity.io/${PROVISION_API_VERSION}/provision`,
-      {
-        body: JSON.stringify({displayName: 'My Project', resourceType: 'project'}),
-        headers: {'Content-Type': 'application/json'},
-        method: 'POST',
-      },
-    )
+    expect(mockRequest).toHaveBeenCalledWith({
+      body: JSON.stringify({displayName: 'My Project', resourceType: 'project'}),
+      headers: {'Content-Type': 'application/json'},
+      method: 'POST',
+      url: `https://api.sanity.io/${PROVISION_API_VERSION}/provision`,
+    })
     expect(minted).toEqual({
       apiHost: provisionResponse.apiHost,
       claimApiUrl: provisionResponse.links.claimApiUrl,
@@ -63,8 +67,7 @@ describe('#mintUnclaimedProject', () => {
   test('trims the display name', async () => {
     await mintUnclaimedProject({displayName: '  Padded  '})
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.any(String),
+    expect(mockRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         body: JSON.stringify({displayName: 'Padded', resourceType: 'project'}),
       }),
@@ -76,9 +79,10 @@ describe('#mintUnclaimedProject', () => {
 
     await mintUnclaimedProject({displayName: 'My Project'})
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      `https://api.sanity.example/${PROVISION_API_VERSION}/provision`,
-      expect.any(Object),
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: `https://api.sanity.example/${PROVISION_API_VERSION}/provision`,
+      }),
     )
   })
 
@@ -86,30 +90,39 @@ describe('#mintUnclaimedProject', () => {
     await expect(mintUnclaimedProject({displayName})).rejects.toThrow(
       'Display name must be 1-80 characters.',
     )
-    expect(mockFetch).not.toHaveBeenCalled()
+    expect(mockRequest).not.toHaveBeenCalled()
   })
 
-  test('throws with status and body on HTTP error', async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: 'Not Found',
-      text: async () => 'provisioning disabled',
-    })
+  test('a 404 means minting is disabled, not a malfunction', async () => {
+    mockRequest.mockResolvedValue({body: '', headers: {}, statusCode: 404})
 
     await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
-      'Mint failed (HTTP 404): provisioning disabled',
+      'Minting new projects is currently disabled. Try again later, or run `sanity login` and `sanity init` to create a project.',
     )
   })
 
-  test('falls back to statusText when the error body is unreadable', async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
-      text: async () => {
-        throw new Error('no body')
-      },
+  test('a 429 reports the rate limit in plain language', async () => {
+    mockRequest.mockResolvedValue({body: '', headers: {}, statusCode: 429})
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
+      'Mint rate limit reached for this machine. Try again in an hour.',
+    )
+  })
+
+  test('throws with status and body on other HTTP errors', async () => {
+    mockRequest.mockResolvedValue({body: 'server exploded', headers: {}, statusCode: 500})
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
+      'Mint failed (HTTP 500): server exploded',
+    )
+  })
+
+  test('falls back to the status message when the error body is empty', async () => {
+    mockRequest.mockResolvedValue({
+      body: '',
+      headers: {},
+      statusCode: 500,
+      statusMessage: 'Internal Server Error',
     })
 
     await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
@@ -118,13 +131,10 @@ describe('#mintUnclaimedProject', () => {
   })
 
   test('throws when the response has no claim token', async () => {
-    mockFetch.mockResolvedValue({
-      json: async () => ({...provisionResponse, claimToken: undefined}),
-      ok: true,
-    })
+    mockRequest.mockResolvedValue(jsonResponse({...provisionResponse, claimToken: undefined}))
 
     await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
-      /did not return a claim token/,
+      /did not include a claim token/,
     )
   })
 
@@ -132,14 +142,13 @@ describe('#mintUnclaimedProject', () => {
     // A 200 is still external input: every mapped field lands in .env or the JSON payload, so
     // a hole must fail loudly here — not crash on `data.links` or write the literal string
     // "undefined" as a credential.
-    mockFetch.mockResolvedValue({
-      json: async () => ({
+    mockRequest.mockResolvedValue(
+      jsonResponse({
         ...provisionResponse,
         links: undefined,
         token: '',
       }),
-      ok: true,
-    })
+    )
 
     await expect(mintUnclaimedProject({displayName: 'My Project'})).rejects.toThrow(
       'Mint response is missing claimApiUrl, claimUrl, token',
@@ -147,62 +156,86 @@ describe('#mintUnclaimedProject', () => {
   })
 })
 
-describe('#lookupClaimStateViaProject', () => {
-  test('reads the org id from the project host as the robot', async () => {
-    mockFetch.mockResolvedValue({
-      json: async () => ({organizationId: 'oSystemUnclaimed'}),
-      ok: true,
-      status: 200,
+describe('#lookupClaimState', () => {
+  test('reads state from the provision lookup with a 500ms default timeout', async () => {
+    mockRequest.mockResolvedValue(
+      jsonResponse({expiresAt: '2026-07-18T00:00:00.000Z', state: 'claimable'}),
+    )
+
+    await expect(lookupClaimState('claim-token')).resolves.toEqual({
+      expiresAt: '2026-07-18T00:00:00.000Z',
+      state: 'claimable',
     })
+    expect(mockRequest).toHaveBeenCalledWith({
+      timeout: 500,
+      url: `https://api.sanity.io/${PROVISION_API_VERSION}/provision/claim-token/lookup`,
+    })
+  })
+
+  test('fails open on HTTP errors, network failure, and unknown states', async () => {
+    mockRequest.mockResolvedValue({body: '', headers: {}, statusCode: 500})
+    await expect(lookupClaimState('claim-token')).resolves.toBeUndefined()
+
+    mockRequest.mockRejectedValue(new Error('offline'))
+    await expect(lookupClaimState('claim-token')).resolves.toBeUndefined()
+
+    mockRequest.mockResolvedValue(jsonResponse({state: 'garbage'}))
+    await expect(lookupClaimState('claim-token')).resolves.toBeUndefined()
+  })
+})
+
+describe('#lookupClaimStateViaProject', () => {
+  test('reads the org id from the project host as the robot, with a 500ms default timeout', async () => {
+    mockRequest.mockResolvedValue(jsonResponse({organizationId: 'oSystemUnclaimed'}))
 
     await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('claimable')
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://abc123.api.sanity.io/v2026-05-04/projects/abc123',
-      expect.objectContaining({headers: {Authorization: 'Bearer sk-robot'}}),
-    )
+    expect(mockRequest).toHaveBeenCalledWith({
+      headers: {Authorization: 'Bearer sk-robot'},
+      timeout: 500,
+      url: 'https://abc123.api.sanity.io/v2026-05-04/projects/abc123',
+    })
+  })
+
+  test('honors an explicit timeout override', async () => {
+    mockRequest.mockResolvedValue(jsonResponse({organizationId: 'oSystemUnclaimed'}))
+
+    await lookupClaimStateViaProject('abc123', 'sk-robot', {timeoutMs: 3000})
+
+    expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({timeout: 3000}))
   })
 
   test('a real organization id means the project was claimed', async () => {
-    mockFetch.mockResolvedValue({
-      json: async () => ({organizationId: 'ocREALORG'}),
-      ok: true,
-      status: 200,
-    })
+    mockRequest.mockResolvedValue(jsonResponse({organizationId: 'ocREALORG'}))
 
     await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('claimed')
   })
 
   test('404 means the project was reaped', async () => {
-    mockFetch.mockResolvedValue({ok: false, status: 404})
+    mockRequest.mockResolvedValue({body: '', headers: {}, statusCode: 404})
     await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('expired')
   })
 
   test('401 reports the token as revoked, distinct from a fail-open network error', async () => {
-    mockFetch.mockResolvedValue({ok: false, status: 401})
+    mockRequest.mockResolvedValue({body: '', headers: {}, statusCode: 401})
     await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBe('revoked')
   })
 
   test('fails open on other HTTP errors and on network failure', async () => {
-    mockFetch.mockResolvedValue({ok: false, status: 500})
+    mockRequest.mockResolvedValue({body: '', headers: {}, statusCode: 500})
     await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBeUndefined()
 
-    mockFetch.mockRejectedValue(new Error('offline'))
+    mockRequest.mockRejectedValue(new Error('offline'))
     await expect(lookupClaimStateViaProject('abc123', 'sk-robot')).resolves.toBeUndefined()
   })
 
   test('honors the SANITY_API_HOST override', async () => {
     vi.stubEnv('SANITY_API_HOST', 'http://localhost:4321')
-    mockFetch.mockResolvedValue({
-      json: async () => ({organizationId: 'oSystemUnclaimed'}),
-      ok: true,
-      status: 200,
-    })
+    mockRequest.mockResolvedValue(jsonResponse({organizationId: 'oSystemUnclaimed'}))
 
     await lookupClaimStateViaProject('abc123', 'sk-robot')
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'http://localhost:4321/v2026-05-04/projects/abc123',
-      expect.anything(),
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({url: 'http://localhost:4321/v2026-05-04/projects/abc123'}),
     )
   })
 })

--- a/packages/@sanity/cli/src/services/mintProject.ts
+++ b/packages/@sanity/cli/src/services/mintProject.ts
@@ -1,0 +1,166 @@
+import {subdebug} from '@sanity/cli-core/debug'
+import {isStaging} from '@sanity/cli-core/util'
+
+const debug = subdebug('projects:mint')
+
+/** Provision API version — see the unauthenticated mint-and-claim endpoint. */
+export const PROVISION_API_VERSION = 'v2026-06-23'
+
+export interface MintedProject {
+  /** Project-scoped API host, e.g. `<id>.api.sanity.io`. */
+  apiHost: string
+  /** API endpoint that performs the claim. */
+  claimApiUrl: string
+  /** Token that authorizes claiming ownership of the project. */
+  claimToken: string
+  /** URL the user opens in a browser to claim the project. */
+  claimUrl: string
+  datasetName: string
+  /** ISO timestamp after which the unclaimed project is reclaimed. */
+  expiresAt: string
+  /** The provisioned (unclaimed) project id. */
+  resourceId: string
+  /** Robot token scoped to the freshly minted, unclaimed project. */
+  token: string
+}
+
+interface ProvisionResponse {
+  apiHost: string
+  claimToken: string
+  datasetName: string
+  expiresAt: string
+  links: {claimApiUrl: string; claimUrl: string}
+  resourceId: string
+  resourceType: string
+  token: string
+}
+
+function getProvisionApiBase(): string {
+  const override = process.env.SANITY_API_HOST
+  if (override) return override.replace(/\/$/, '')
+  return isStaging() ? 'https://api.sanity.work' : 'https://api.sanity.io'
+}
+
+/** Claim state of a minted resource. `revoked` means the robot token itself was rejected. */
+export type ClaimState = 'claimable' | 'claimed' | 'expired' | 'revoked'
+
+/**
+ * Look up claim state via the provision endpoint (rate-limited: ~20/h per IP). Unauthenticated
+ * and safe to poll, but reserved for one-time checks like the pre-mint guard. Fails open and
+ * falls back to local expiry data.
+ */
+export async function lookupClaimState(
+  claimToken: string,
+  options?: {timeoutMs?: number},
+): Promise<{expiresAt: string | null; state: ClaimState} | undefined> {
+  const url = `${getProvisionApiBase()}/${PROVISION_API_VERSION}/provision/${claimToken}/lookup`
+  debug('looking up claim state at %s', url)
+
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(options?.timeoutMs ?? 1500),
+    })
+    if (!response.ok) return undefined
+
+    const data = (await response.json()) as {expiresAt?: string | null; state?: ClaimState}
+    if (data.state !== 'claimable' && data.state !== 'claimed' && data.state !== 'expired') {
+      return undefined
+    }
+    return {expiresAt: data.expiresAt ?? null, state: data.state}
+  } catch (err) {
+    debug('claim state lookup failed: %s', err)
+    return undefined
+  }
+}
+
+/**
+ * Polls for `oSystemUnclaimed` organizational membership to determine project claim status.
+ * This keeps claim state checks fast and cheap (provisioning APIs are rate-limited).
+ */
+export async function lookupClaimStateViaProject(
+  projectId: string,
+  robotToken: string,
+  options?: {timeoutMs?: number},
+): Promise<ClaimState | undefined> {
+  const override = process.env.SANITY_API_HOST
+  const base = override
+    ? override.replace(/\/$/, '')
+    : `https://${projectId}.api.sanity.${isStaging() ? 'work' : 'io'}`
+  const url = `${base}/v2026-05-04/projects/${projectId}`
+  debug('checking claim state via project host at %s', url)
+
+  try {
+    const response = await fetch(url, {
+      headers: {Authorization: `Bearer ${robotToken}`},
+      signal: AbortSignal.timeout(options?.timeoutMs ?? 1500),
+    })
+    if (response.status === 404) return 'expired'
+    // 401 is a definitive rejection of the robot token (not a fail-open network error): report it
+    // so the caller can drop the dead ledger entry, which otherwise keeps outranking a login session.
+    if (response.status === 401) return 'revoked'
+    if (!response.ok) return undefined
+
+    const data = (await response.json()) as {organizationId?: string}
+    if (!data.organizationId) return undefined
+    return data.organizationId === 'oSystemUnclaimed' ? 'claimable' : 'claimed'
+  } catch (err) {
+    debug('project claim-state check failed: %s', err)
+    return undefined
+  }
+}
+
+/**
+ * Mint an unclaimed Sanity project via the unauthenticated provision endpoint, returning a
+ * scoped robot token and a claim URL:
+ * `POST <apiHost>/<version>/provision` with `{resourceType:'project', displayName}`.
+ */
+export async function mintUnclaimedProject(options: {displayName: string}): Promise<MintedProject> {
+  const displayName = options.displayName.trim()
+  if (!displayName || displayName.length > 80) {
+    throw new Error('Display name must be 1-80 characters.')
+  }
+
+  const url = `${getProvisionApiBase()}/${PROVISION_API_VERSION}/provision`
+  debug('minting unclaimed project at %s', url)
+
+  const response = await fetch(url, {
+    body: JSON.stringify({displayName, resourceType: 'project'}),
+    headers: {'Content-Type': 'application/json'},
+    method: 'POST',
+  })
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(`Mint failed (HTTP ${response.status}): ${body || response.statusText}`)
+  }
+
+  const data = (await response.json()) as ProvisionResponse
+
+  // Mint may 404 (kill switch off) or 429 (rate limited) and return no claim token.
+  if (!data?.claimToken) {
+    throw new Error(
+      'Mint did not return a claim token (provisioning disabled, or rate limited). ' +
+        'See the provision API response.',
+    )
+  }
+
+  const minted = {
+    apiHost: data.apiHost,
+    claimApiUrl: data.links?.claimApiUrl,
+    claimToken: data.claimToken,
+    claimUrl: data.links?.claimUrl,
+    datasetName: data.datasetName,
+    expiresAt: data.expiresAt,
+    resourceId: data.resourceId,
+    token: data.token,
+  }
+  const missing = Object.entries(minted)
+    .filter(([, value]) => typeof value !== 'string' || value === '')
+    .map(([key]) => key)
+  if (missing.length > 0) {
+    throw new Error(
+      `Mint response is missing ${missing.join(', ')} — see the provision API response.`,
+    )
+  }
+  return minted as MintedProject
+}

--- a/packages/@sanity/cli/src/services/mintProject.ts
+++ b/packages/@sanity/cli/src/services/mintProject.ts
@@ -7,6 +7,8 @@ const debug = subdebug('projects:mint')
 /** Provision API version — see the unauthenticated mint-and-claim endpoint. */
 export const PROVISION_API_VERSION = 'v2026-06-23'
 
+export {CLAIM_WINDOW_HOURS} from '../util/mintProjectConstants.js'
+
 // The claim-state lookups branch on status codes (404/401 are meaningful answers, not failures),
 // so non-2xx responses must be returned rather than thrown.
 const request = createRequester({middleware: {httpErrors: false, promise: {onlyBody: false}}})
@@ -153,7 +155,7 @@ export async function mintUnclaimedProject(options: {displayName: string}): Prom
     )
   }
   if (response.statusCode === 429) {
-    throw new Error('Mint rate limit reached for this machine. Try again in an hour.')
+    throw new Error('Mint rate limit reached for this machine. Try again later.')
   }
   if (!isOk(response.statusCode)) {
     const body = typeof response.body === 'string' ? response.body : ''

--- a/packages/@sanity/cli/src/services/mintProject.ts
+++ b/packages/@sanity/cli/src/services/mintProject.ts
@@ -64,8 +64,8 @@ export type ClaimState = 'claimable' | 'claimed' | 'expired' | 'revoked'
 
 /**
  * Look up claim state via the provision endpoint (rate-limited: ~20/h per IP). Unauthenticated
- * and safe to poll, but reserved for one-time checks like the pre-mint guard. Fails open and
- * falls back to local expiry data.
+ * and safe to poll, but reserved for one-time checks like the pre-mint guard. Returns `undefined`
+ * on uncertainty; callers must not use local expiry data to authorize replacement or cleanup.
  */
 export async function lookupClaimState(
   claimToken: string,

--- a/packages/@sanity/cli/src/services/mintProject.ts
+++ b/packages/@sanity/cli/src/services/mintProject.ts
@@ -1,10 +1,26 @@
 import {subdebug} from '@sanity/cli-core/debug'
+import {createRequester} from '@sanity/cli-core/request'
 import {isStaging} from '@sanity/cli-core/util'
 
 const debug = subdebug('projects:mint')
 
 /** Provision API version — see the unauthenticated mint-and-claim endpoint. */
 export const PROVISION_API_VERSION = 'v2026-06-23'
+
+// The claim-state lookups branch on status codes (404/401 are meaningful answers, not failures),
+// so non-2xx responses must be returned rather than thrown.
+const request = createRequester({middleware: {httpErrors: false, promise: {onlyBody: false}}})
+
+const isOk = (statusCode: number) => statusCode >= 200 && statusCode < 300
+
+function parseJsonBody(body: unknown): unknown {
+  if (typeof body !== 'string') return body
+  try {
+    return JSON.parse(body)
+  } catch {
+    return undefined
+  }
+}
 
 export interface MintedProject {
   /** Project-scoped API host, e.g. `<id>.api.sanity.io`. */
@@ -57,13 +73,13 @@ export async function lookupClaimState(
   debug('looking up claim state at %s', url)
 
   try {
-    const response = await fetch(url, {
-      signal: AbortSignal.timeout(options?.timeoutMs ?? 1500),
-    })
-    if (!response.ok) return undefined
+    const response = await request({timeout: options?.timeoutMs ?? 500, url})
+    if (!isOk(response.statusCode)) return undefined
 
-    const data = (await response.json()) as {expiresAt?: string | null; state?: ClaimState}
-    if (data.state !== 'claimable' && data.state !== 'claimed' && data.state !== 'expired') {
+    const data = parseJsonBody(response.body) as
+      | {expiresAt?: string | null; state?: ClaimState}
+      | undefined
+    if (data?.state !== 'claimable' && data?.state !== 'claimed' && data?.state !== 'expired') {
       return undefined
     }
     return {expiresAt: data.expiresAt ?? null, state: data.state}
@@ -90,18 +106,19 @@ export async function lookupClaimStateViaProject(
   debug('checking claim state via project host at %s', url)
 
   try {
-    const response = await fetch(url, {
+    const response = await request({
       headers: {Authorization: `Bearer ${robotToken}`},
-      signal: AbortSignal.timeout(options?.timeoutMs ?? 1500),
+      timeout: options?.timeoutMs ?? 500,
+      url,
     })
-    if (response.status === 404) return 'expired'
+    if (response.statusCode === 404) return 'expired'
     // 401 is a definitive rejection of the robot token (not a fail-open network error): report it
     // so the caller can drop the dead ledger entry, which otherwise keeps outranking a login session.
-    if (response.status === 401) return 'revoked'
-    if (!response.ok) return undefined
+    if (response.statusCode === 401) return 'revoked'
+    if (!isOk(response.statusCode)) return undefined
 
-    const data = (await response.json()) as {organizationId?: string}
-    if (!data.organizationId) return undefined
+    const data = parseJsonBody(response.body) as {organizationId?: string} | undefined
+    if (!data?.organizationId) return undefined
     return data.organizationId === 'oSystemUnclaimed' ? 'claimable' : 'claimed'
   } catch (err) {
     debug('project claim-state check failed: %s', err)
@@ -123,25 +140,30 @@ export async function mintUnclaimedProject(options: {displayName: string}): Prom
   const url = `${getProvisionApiBase()}/${PROVISION_API_VERSION}/provision`
   debug('minting unclaimed project at %s', url)
 
-  const response = await fetch(url, {
+  const response = await request({
     body: JSON.stringify({displayName, resourceType: 'project'}),
     headers: {'Content-Type': 'application/json'},
     method: 'POST',
+    url,
   })
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => '')
-    throw new Error(`Mint failed (HTTP ${response.status}): ${body || response.statusText}`)
+  if (response.statusCode === 404) {
+    throw new Error(
+      'Minting new projects is currently disabled. Try again later, or run `sanity login` and `sanity init` to create a project.',
+    )
+  }
+  if (response.statusCode === 429) {
+    throw new Error('Mint rate limit reached for this machine. Try again in an hour.')
+  }
+  if (!isOk(response.statusCode)) {
+    const body = typeof response.body === 'string' ? response.body : ''
+    throw new Error(`Mint failed (HTTP ${response.statusCode}): ${body || response.statusMessage}`)
   }
 
-  const data = (await response.json()) as ProvisionResponse
+  const data = parseJsonBody(response.body) as ProvisionResponse | undefined
 
-  // Mint may 404 (kill switch off) or 429 (rate limited) and return no claim token.
   if (!data?.claimToken) {
-    throw new Error(
-      'Mint did not return a claim token (provisioning disabled, or rate limited). ' +
-        'See the provision API response.',
-    )
+    throw new Error('Mint response did not include a claim token; see the provision API response.')
   }
 
   const minted = {
@@ -159,7 +181,7 @@ export async function mintUnclaimedProject(options: {displayName: string}): Prom
     .map(([key]) => key)
   if (missing.length > 0) {
     throw new Error(
-      `Mint response is missing ${missing.join(', ')} — see the provision API response.`,
+      `Mint response is missing ${missing.join(', ')}; see the provision API response.`,
     )
   }
   return minted as MintedProject

--- a/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
@@ -1,0 +1,500 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {getUserConfig} from '@sanity/cli-core'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {lookupClaimStateViaProject} from '../../services/mintProject.js'
+import {
+  forgetMintedProject,
+  recordMintedProject,
+  runClaimNudges,
+  UNCLAIMED_PROJECTS_CONFIG_KEY,
+  type UnclaimedProjectRecord,
+} from '../claimNudges.js'
+
+vi.mock(import('@sanity/cli-core'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    getUserConfig: vi.fn(),
+  }
+})
+vi.mock('../../services/mintProject.js', () => ({
+  lookupClaimStateViaProject: vi.fn(),
+}))
+
+const mockGetUserConfig = vi.mocked(getUserConfig)
+const mockLookupViaProject = vi.mocked(lookupClaimStateViaProject)
+
+const HOUR = 3_600_000
+const NOW = new Date('2026-07-15T12:00:00.000Z').getTime()
+
+let store: Record<string, unknown> = {}
+
+function seedRecord(overrides: Partial<UnclaimedProjectRecord> = {}): UnclaimedProjectRecord {
+  const record: UnclaimedProjectRecord = {
+    claimToken: 'claim-token',
+    claimUrl: 'https://www.sanity.io/claim/some-token',
+    expiresAt: new Date(NOW + 47 * HOUR).toISOString(),
+    mintedAt: new Date(NOW - HOUR).toISOString(),
+    projectId: 'abc123',
+    token: 'sk-robot',
+    ...overrides,
+  }
+  const records = (store[UNCLAIMED_PROJECTS_CONFIG_KEY] ?? {}) as Record<string, unknown>
+  store[UNCLAIMED_PROJECTS_CONFIG_KEY] = {...records, [record.projectId]: record}
+  return record
+}
+
+function storedRecords(): Record<string, UnclaimedProjectRecord> {
+  return (store[UNCLAIMED_PROJECTS_CONFIG_KEY] ?? {}) as Record<string, UnclaimedProjectRecord>
+}
+
+/** Default cwd has no .env, so the ambient line stays out of waterfall-focused tests. */
+async function run(now = NOW, cwd = '/nonexistent-claim-nudges-cwd'): Promise<string> {
+  const write = vi.fn()
+  await runClaimNudges(write, now, cwd)
+  return write.mock.calls.map(([line]) => String(line)).join('\n')
+}
+
+beforeEach(() => {
+  store = {}
+  mockGetUserConfig.mockReturnValue({
+    delete: (key: string) => {
+      delete store[key]
+    },
+    get: (key: string) => store[key],
+    set: (key: string, value: unknown) => {
+      store[key] = value
+    },
+  })
+  // Live per the org read unless a test says otherwise.
+  mockLookupViaProject.mockResolvedValue('claimable')
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('#recordMintedProject', () => {
+  test('persists the minted project to the registry, token included', () => {
+    const ok = recordMintedProject({
+      apiHost: 'https://abc123.api.sanity.io',
+      claimApiUrl: 'https://api.sanity.io/v1/provision/claim',
+      claimToken: 'claim-token',
+      claimUrl: 'https://www.sanity.io/claim/some-token',
+      datasetName: 'production',
+      expiresAt: '2026-07-18T12:00:00.000Z',
+      resourceId: 'abc123',
+      token: 'sk-robot',
+    })
+
+    expect(ok).toBe(true)
+    expect(storedRecords().abc123).toMatchObject({
+      claimToken: 'claim-token',
+      claimUrl: 'https://www.sanity.io/claim/some-token',
+      expiresAt: '2026-07-18T12:00:00.000Z',
+      projectId: 'abc123',
+      token: 'sk-robot',
+    })
+  })
+
+  test('returns false (without throwing) on a config write failure', () => {
+    mockGetUserConfig.mockImplementation(() => {
+      throw new Error('disk full')
+    })
+
+    let result: boolean | undefined
+    expect(() => {
+      result = recordMintedProject({
+        apiHost: 'x',
+        claimApiUrl: 'x',
+        claimToken: 'x',
+        claimUrl: 'x',
+        datasetName: 'x',
+        expiresAt: 'x',
+        resourceId: 'x',
+        token: 'x',
+      })
+    }).not.toThrow()
+    expect(result).toBe(false)
+  })
+})
+
+describe('#forgetMintedProject', () => {
+  test('reports success, including when the record is already gone', () => {
+    seedRecord()
+
+    expect(forgetMintedProject('abc123')).toBe(true)
+    expect(storedRecords().abc123).toBeUndefined()
+    expect(forgetMintedProject('abc123')).toBe(true)
+  })
+
+  test('reports failure on an unwritable config, so callers can surface it', () => {
+    seedRecord()
+    mockGetUserConfig.mockReturnValue({
+      delete: () => {
+        throw new Error('EACCES: permission denied')
+      },
+      get: (key: string) => store[key],
+      set: () => {
+        throw new Error('EACCES: permission denied')
+      },
+    } as never)
+
+    expect(forgetMintedProject('abc123')).toBe(false)
+  })
+})
+
+describe('#runClaimNudges', () => {
+  test('a malformed registry entry never silences reminders for healthy projects', async () => {
+    const records = (store[UNCLAIMED_PROJECTS_CONFIG_KEY] ?? {}) as Record<string, unknown>
+    const mismatched = seedRecord({projectId: 'zzz999'})
+    store[UNCLAIMED_PROJECTS_CONFIG_KEY] = {
+      ...records,
+      phantom: {expiresAt: new Date(NOW + 2 * HOUR).toISOString()},
+      wrongkey: {...mismatched},
+    }
+    delete (store[UNCLAIMED_PROJECTS_CONFIG_KEY] as Record<string, unknown>).zzz999
+    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
+
+    const output = await run()
+
+    expect(output).toContain('⏳ Claim your Sanity project — abc123')
+    expect(output).not.toContain('phantom')
+    expect(output).not.toContain('zzz999')
+    expect(storedRecords().abc123.lastNudgeTier).toBe(1)
+    // The write that recorded the healthy nudge persists the filtered view.
+    expect(storedRecords().phantom).toBeUndefined()
+    expect(storedRecords().wrongkey).toBeUndefined()
+  })
+
+  test('a mint landing during the lookup window survives the registry write', async () => {
+    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
+    mockLookupViaProject.mockImplementation(async () => {
+      const records = (store[UNCLAIMED_PROJECTS_CONFIG_KEY] ?? {}) as Record<string, unknown>
+      store[UNCLAIMED_PROJECTS_CONFIG_KEY] = {
+        ...records,
+        fresh99: {
+          claimToken: 'fresh-token',
+          claimUrl: 'https://www.sanity.io/claim/fresh-token',
+          expiresAt: new Date(NOW + 71 * HOUR).toISOString(),
+          mintedAt: new Date(NOW).toISOString(),
+          projectId: 'fresh99',
+        },
+      }
+      return 'claimable'
+    })
+
+    const output = await run()
+
+    expect(output).toContain('⏳ Claim your Sanity project — abc123')
+    expect(storedRecords().abc123.lastNudgeTier).toBe(1)
+    // The concurrent mint's record survived the write.
+    expect(storedRecords().fresh99).toBeDefined()
+  })
+
+  test('does nothing when the registry is empty', async () => {
+    expect(await run()).toBe('')
+    expect(mockLookupViaProject).not.toHaveBeenCalled()
+  })
+
+  test('stays quiet with more than 48 hours remaining, without touching the network', async () => {
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+
+    expect(await run()).toBe('')
+    expect(mockLookupViaProject).not.toHaveBeenCalled()
+  })
+
+  test('tier 1 fires under 48 hours and is shown only once', async () => {
+    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
+
+    const first = await run()
+    expect(first).toContain('⏳ Claim your Sanity project')
+    expect(first).toContain('abc123')
+    expect(first).toContain('expires in about 47 hours')
+    expect(first).toContain('https://www.sanity.io/claim/some-token')
+    expect(first).not.toContain('╭') // compact lines, never a box
+    expect(first).toMatch(
+      /unless you claim it\.\nClaiming is free and keeps everything working, including the token in \.env\.\nClaim it now:/,
+    )
+    expect(storedRecords().abc123.lastNudgeTier).toBe(1)
+
+    expect(await run()).toBe('')
+    expect(mockLookupViaProject).toHaveBeenCalledTimes(1)
+  })
+
+  test('drives tier timing off the local clock (no server round-trip)', async () => {
+    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
+
+    const output = await run()
+
+    expect(output).toContain('expires in about 47 hours')
+    // The only network touch is the budget-free org read, with a short abort.
+    expect(mockLookupViaProject).toHaveBeenCalledWith('abc123', 'sk-robot', {timeoutMs: 500})
+  })
+
+  test('escalates through tiers as the deadline approaches', async () => {
+    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString(), lastNudgeTier: 1})
+
+    const tier2 = await run(NOW + 24 * HOUR)
+    expect(tier2).toContain('⏰ Project abc123 expires in about 23 hours')
+    expect(storedRecords().abc123.lastNudgeTier).toBe(2)
+
+    const tier3 = await run(NOW + 40 * HOUR)
+    expect(tier3).toContain('🚨 Project abc123 expires in about 7 hours')
+    expect(storedRecords().abc123.lastNudgeTier).toBe(3)
+
+    const tier4 = await run(NOW + 45.5 * HOUR)
+    expect(tier4).toContain('🚨 Final reminder')
+    expect(tier4).toContain('about 90 minutes')
+    expect(storedRecords().abc123.lastNudgeTier).toBe(4)
+
+    expect(await run(NOW + 46 * HOUR)).toBe('')
+  })
+
+  test('tier nudges include the agent call-to-action', async () => {
+    seedRecord({expiresAt: new Date(NOW + 23 * HOUR).toISOString()})
+
+    expect(await run()).toContain('AI agents: surface this claim link to your human now')
+  })
+
+  test('confirms and forgets a claimed project instead of nudging', async () => {
+    mockLookupViaProject.mockResolvedValue('claimed')
+    seedRecord({expiresAt: new Date(NOW + 23 * HOUR).toISOString()})
+
+    const output = await run()
+
+    expect(output).toContain('has been claimed')
+    expect(storedRecords().abc123).toBeUndefined()
+  })
+
+  test('notes and forgets a project the org read reports gone', async () => {
+    mockLookupViaProject.mockResolvedValue('expired')
+    seedRecord({expiresAt: new Date(NOW + 23 * HOUR).toISOString()})
+
+    const output = await run()
+
+    expect(output).toContain('⌛ Unclaimed Sanity project abc123 expired on')
+    expect(output).toContain('Run `sanity new --force` to mint a replacement')
+    expect(storedRecords().abc123).toBeUndefined()
+  })
+
+  test('fails open to the local clock when the org read is unavailable', async () => {
+    mockLookupViaProject.mockResolvedValue(undefined)
+    seedRecord({expiresAt: new Date(NOW + 23 * HOUR).toISOString()})
+
+    expect(await run()).toContain('⏰ Project abc123 expires in about 23 hours')
+  })
+
+  test('a record with no token nudges off the local clock alone', async () => {
+    seedRecord({expiresAt: new Date(NOW + 23 * HOUR).toISOString(), token: undefined})
+
+    expect(await run()).toContain('⏰ Project abc123 expires in about 23 hours')
+    // No token means no org read to attempt.
+    expect(mockLookupViaProject).not.toHaveBeenCalled()
+  })
+
+  test('notifies once about locally expired projects and forgets them (org read fails open)', async () => {
+    mockLookupViaProject.mockResolvedValue(undefined)
+    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
+
+    const output = await run()
+
+    expect(output).toContain('⌛ Unclaimed Sanity project abc123 expired on')
+    expect(output).toContain('Run `sanity new --force` to mint a replacement')
+    expect(storedRecords().abc123).toBeUndefined()
+    // The farewell is confirmed first — via the project host, with a short abort.
+    expect(mockLookupViaProject).toHaveBeenCalledWith('abc123', 'sk-robot', {timeoutMs: 500})
+
+    expect(await run()).toBe('')
+  })
+
+  test('locally expired but actually claimed: congratulates instead of the expiry notice', async () => {
+    mockLookupViaProject.mockResolvedValue('claimed')
+    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
+
+    const output = await run()
+
+    expect(output).toContain('has been claimed')
+    expect(output).not.toContain('expired on')
+    expect(storedRecords().abc123).toBeUndefined()
+  })
+
+  test('locally expired but still claimable per the org read: keeps the record, stays quiet', async () => {
+    mockLookupViaProject.mockResolvedValue('claimable')
+    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
+
+    const output = await run()
+
+    expect(output).toBe('')
+    // The window outlived the local estimate — kept untouched for the next run to re-check.
+    expect(storedRecords().abc123).toBeDefined()
+    expect(storedRecords().abc123.expiresAt).toBe(new Date(NOW - HOUR).toISOString())
+  })
+
+  test('a lapsed-but-claimable record never renders a bogus final reminder', async () => {
+    mockLookupViaProject.mockResolvedValue('claimable')
+    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
+
+    const output = await run()
+
+    expect(output).toBe('')
+    expect(storedRecords().abc123).toBeDefined()
+  })
+
+  test('nudges only the most urgent project per invocation', async () => {
+    seedRecord({expiresAt: new Date(NOW + 40 * HOUR).toISOString(), projectId: 'later00'})
+    seedRecord({expiresAt: new Date(NOW + 5 * HOUR).toISOString(), projectId: 'sooner0'})
+
+    const output = await run()
+
+    expect(output).toContain('sooner0')
+    expect(output).not.toContain('later00')
+    expect(storedRecords().sooner0.lastNudgeTier).toBe(3)
+    expect(storedRecords().later00.lastNudgeTier).toBeUndefined()
+  })
+})
+
+describe('#runClaimNudges ambient directory reminder', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sanity-nudge-cwd-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, {force: true, recursive: true})
+  })
+
+  test('emits a stateless line on every run in a minted directory', async () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    // Above every tier threshold, so the waterfall stays silent.
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+
+    const first = await run(NOW, dir)
+    expect(first).toContain('Unclaimed Sanity project abc123 expires in about 60 hours')
+    expect(first).toContain('https://www.sanity.io/claim/some-token')
+    expect(first.startsWith('\n')).toBe(true)
+    expect(first).toMatch(/claim it to keep it:.*\n.*https:\/\/www\.sanity\.io\/claim/)
+    expect(first).not.toContain('╭')
+    // No dedupe marker — the line repeats on the very next run.
+    expect(storedRecords().abc123.lastNudgeTier).toBeUndefined()
+    expect(await run(NOW, dir)).toBe(first)
+  })
+
+  test('yields the slot when a tiered nudge fires in the same invocation', async () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
+
+    const output = await run(NOW, dir)
+
+    expect(output).toContain('⏳ Claim your Sanity project')
+    expect(output).not.toContain('claim it to keep it:')
+  })
+
+  test('verifies via the ledger token even when .env no longer carries it (post-claim handoff)', async () => {
+    // The claim handoff says "login, then remove SANITY_AUTH_TOKEN"; the project id stays behind.
+    // The ledger still owns the token, so the org read runs and notices the claim.
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue('claimed')
+
+    const output = await run(NOW, dir)
+
+    expect(output).toContain('has been claimed')
+    expect(mockLookupViaProject).toHaveBeenCalledWith('abc123', 'sk-robot', {timeoutMs: 500})
+    expect(storedRecords().abc123).toBeUndefined()
+  })
+
+  test('still verifies and drops the cwd project when another project took the announce slot', async () => {
+    // A sibling project's expiry farewell announces first; the cwd project must still be
+    // claim-checked, or its ledger token keeps outranking a login session in getCliToken.
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()}) // cwd project, live
+    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString(), projectId: 'sibling'}) // expired sibling
+    mockLookupViaProject.mockImplementation(async (projectId: string) =>
+      projectId === 'abc123' ? 'claimed' : 'expired',
+    )
+
+    const output = await run(NOW, dir)
+
+    // The sibling's farewell took the single announce slot...
+    expect(output).toContain('Unclaimed Sanity project sibling expired')
+    // ...but the cwd project was still verified as claimed and dropped from the ledger.
+    expect(storedRecords().abc123).toBeUndefined()
+  })
+
+  test('drops the cwd project when its token is revoked, so login can take over', async () => {
+    // A revoked (401) robot token otherwise keeps outranking the login session in getCliToken.
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue('revoked')
+
+    const output = await run(NOW, dir)
+
+    expect(output).toContain('token is no longer valid')
+    expect(output).toContain('sanity login')
+    // A config dir auto-injects .env, so the dead token must be removed or it outranks the session.
+    expect(output).toContain('remove SANITY_AUTH_TOKEN from .env')
+    expect(storedRecords().abc123).toBeUndefined()
+  })
+
+  test('stays quiet when the directory points at an unregistered project', async () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="someone-elses"\n')
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+
+    expect(await run(NOW, dir)).toBe('')
+  })
+
+  test('stays quiet in directories without a .env', async () => {
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+
+    expect(await run(NOW, dir)).toBe('')
+  })
+
+  test('verifies every render through the project host with the ledger token', async () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue('claimable')
+
+    const output = await run(NOW, dir)
+
+    expect(mockLookupViaProject).toHaveBeenCalledWith('abc123', 'sk-robot', {timeoutMs: 500})
+    expect(output).toContain('Unclaimed Sanity project abc123')
+  })
+
+  test('claimed per the org read: congratulates once and drops the record', async () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue('claimed')
+
+    const output = await run(NOW, dir)
+
+    expect(output).toContain('has been claimed')
+    expect(output).not.toContain('claim it to keep it:')
+    expect(storedRecords().abc123).toBeUndefined()
+    expect(await run(NOW, dir)).toBe('')
+  })
+
+  test('expired per the org read: notes it once and drops the record', async () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue('expired')
+
+    const output = await run(NOW, dir)
+
+    expect(output).toContain('expired on')
+    expect(storedRecords().abc123).toBeUndefined()
+  })
+
+  test('fails open to the ledger when the org read is unavailable', async () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
+    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
+    mockLookupViaProject.mockResolvedValue(undefined)
+
+    expect(await run(NOW, dir)).toContain('Unclaimed Sanity project abc123')
+  })
+})

--- a/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
@@ -308,16 +308,17 @@ describe('#runClaimNudges', () => {
     expect(await run()).toBe('')
   })
 
-  test('notifies once about locally expired projects and forgets them (org read fails open)', async () => {
+  test('keeps locally expired credentials when the server state cannot be verified', async () => {
     mockLookupViaProject.mockResolvedValue(undefined)
     seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
 
     const output = await run()
 
-    expect(output).toContain('Unclaimed Sanity project abc123 expired on')
-    expect(output).toContain('Run `sanity new --force` to mint a replacement')
-    expect(storedRecords().abc123).toBeUndefined()
-    expect(await run()).toBe('')
+    expect(output).toContain("current state couldn't be verified")
+    expect(output).toContain('It may still be claimable')
+    expect(output).toContain('https://www.sanity.io/claim/some-token')
+    expect(output).not.toContain('has been deleted')
+    expect(storedRecords().abc123).toBeDefined()
   })
 
   test('a locally expired project the server still calls claimable is kept quietly', async () => {

--- a/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
@@ -1,7 +1,7 @@
 import {getUserConfig} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {lookupClaimStateViaProject} from '../../services/mintProject.js'
+import {CLAIM_WINDOW_HOURS, lookupClaimStateViaProject} from '../../services/mintProject.js'
 import {
   forgetMintedProject,
   recordMintedProject,
@@ -9,6 +9,7 @@ import {
   UNCLAIMED_PROJECTS_CONFIG_KEY,
   type UnclaimedProjectRecord,
 } from '../claimNudges.js'
+import {TOKEN_ENV_FILES} from '../envFile.js'
 
 vi.mock(import('@sanity/cli-core'), async (importOriginal) => {
   const actual = await importOriginal()
@@ -17,7 +18,8 @@ vi.mock(import('@sanity/cli-core'), async (importOriginal) => {
     getUserConfig: vi.fn(),
   }
 })
-vi.mock('../../services/mintProject.js', () => ({
+vi.mock('../../services/mintProject.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../services/mintProject.js')>()),
   lookupClaimStateViaProject: vi.fn(),
 }))
 
@@ -159,8 +161,10 @@ describe('#runClaimNudges', () => {
     )
     expect(first).toContain('https://www.sanity.io/claim/some-token')
     expect(first).toContain('permanently deleted at')
-    expect(first).toContain('If an agent is running this, surface the full claim URL to the user.')
-    expect(first).toContain('They need to click this link to claim the project before it expires.')
+    expect(first).toContain(
+      'If you are an agent: give this claim URL to the person you are working for.',
+    )
+    expect(first).toContain('They have to open it themselves before the deadline.')
     expect(first).not.toContain('╭') // compact lines, never a box
     expect(first.startsWith('\n')).toBe(true)
     // No dedupe: the identical reminder repeats on the very next run.
@@ -219,10 +223,10 @@ describe('#runClaimNudges', () => {
     expect(output).not.toContain('Unclaimed Sanity project abc123 expires')
     // The agent instruction appears once, on the aggregate, covering every link above it.
     expect(output).toContain(
-      'If an agent is running this, surface every claim URL above to the user.',
+      'If you are an agent: give every claim URL above to the person you are working for.',
     )
-    expect(output).toContain('They need to click each link to claim its project before it expires.')
-    expect(output).not.toContain('surface the full claim URL to the user.')
+    expect(output).toContain('They have to open each one themselves before its deadline.')
+    expect(output).not.toContain('give this claim URL')
   })
 
   test('pluralizes the aggregation header past two projects', async () => {
@@ -266,7 +270,7 @@ describe('#runClaimNudges', () => {
     expect(output).toContain('has been claimed')
     // The robot token in .env keeps outranking a login session; the farewell must say so.
     expect(output).toContain('still authenticate with the robot token')
-    expect(output).toContain('remove SANITY_AUTH_TOKEN from ./.env or sanity/.env.local')
+    expect(output).toContain(`remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES}`)
     expect(output).not.toContain('Claim it now:')
     expect(storedRecords().abc123).toBeUndefined()
     expect(await run()).toBe('')
@@ -278,7 +282,7 @@ describe('#runClaimNudges', () => {
 
     const output = await run()
 
-    expect(output).toContain('./.env or sanity/.env.local')
+    expect(output).toContain(TOKEN_ENV_FILES)
     expect(output).not.toMatch(/SANITY_AUTH_TOKEN from \.env\b/)
   })
 
@@ -291,7 +295,7 @@ describe('#runClaimNudges', () => {
     expect(output).toContain('token is no longer valid')
     expect(output).toContain('sanity login')
     // A config dir auto-injects .env, so the dead token must be removed or it outranks the session.
-    expect(output).toContain('remove SANITY_AUTH_TOKEN from ./.env')
+    expect(output).toContain(`remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES}`)
     expect(storedRecords().abc123).toBeUndefined()
     expect(await run()).toBe('')
   })
@@ -302,8 +306,11 @@ describe('#runClaimNudges', () => {
 
     const output = await run()
 
-    expect(output).toContain('Unclaimed Sanity project abc123 expired on')
-    expect(output).toContain('Run `sanity new --force` to mint a replacement')
+    expect(output).toContain('project abc123 expired on')
+    expect(output).toContain('server confirmed')
+    expect(output).toContain('permanently gone and no longer recoverable')
+    expect(output).toContain('Run `sanity new --force` to create a replacement')
+    expect(output).toContain(`Claim the replacement within ${CLAIM_WINDOW_HOURS} hours to keep it.`)
     expect(storedRecords().abc123).toBeUndefined()
     expect(await run()).toBe('')
   })
@@ -318,6 +325,17 @@ describe('#runClaimNudges', () => {
     expect(output).toContain('It may still be claimable')
     expect(output).toContain('https://www.sanity.io/claim/some-token')
     expect(output).not.toContain('has been deleted')
+    expect(storedRecords().abc123).toBeDefined()
+  })
+
+  test('keeps locally expired credentials when no token is available to verify state', async () => {
+    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString(), token: undefined})
+
+    const output = await run()
+
+    expect(output).toContain("current state couldn't be verified")
+    expect(output).toContain('https://www.sanity.io/claim/some-token')
+    expect(output).not.toContain('permanently gone')
     expect(storedRecords().abc123).toBeDefined()
   })
 
@@ -349,7 +367,7 @@ describe('#runClaimNudges', () => {
 
     const output = await run()
 
-    expect(output).toContain('Unclaimed Sanity project abc123 expired on')
+    expect(output).toContain('project abc123 expired on')
     // The expiry farewell dropped abc123, but the concurrent mint's record survived the write.
     expect(storedRecords().abc123).toBeUndefined()
     expect(storedRecords().fresh99).toBeDefined()

--- a/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
@@ -265,11 +265,21 @@ describe('#runClaimNudges', () => {
 
     expect(output).toContain('has been claimed')
     // The robot token in .env keeps outranking a login session; the farewell must say so.
-    expect(output).toContain('still authenticate with the robot token in .env')
-    expect(output).toContain('remove SANITY_AUTH_TOKEN from .env to act as yourself')
+    expect(output).toContain('still authenticate with the robot token')
+    expect(output).toContain('remove SANITY_AUTH_TOKEN from ./.env or sanity/.env.local')
     expect(output).not.toContain('Claim it now:')
     expect(storedRecords().abc123).toBeUndefined()
     expect(await run()).toBe('')
+  })
+
+  test('post-claim cleanup names every file a token can reach, not just .env', async () => {
+    mockLookupViaProject.mockResolvedValue('claimed')
+    seedRecord()
+
+    const output = await run()
+
+    expect(output).toContain('./.env or sanity/.env.local')
+    expect(output).not.toMatch(/SANITY_AUTH_TOKEN from \.env\b/)
   })
 
   test('drops a revoked token so login can take over', async () => {
@@ -281,7 +291,7 @@ describe('#runClaimNudges', () => {
     expect(output).toContain('token is no longer valid')
     expect(output).toContain('sanity login')
     // A config dir auto-injects .env, so the dead token must be removed or it outranks the session.
-    expect(output).toContain('remove SANITY_AUTH_TOKEN from .env')
+    expect(output).toContain('remove SANITY_AUTH_TOKEN from ./.env')
     expect(storedRecords().abc123).toBeUndefined()
     expect(await run()).toBe('')
   })

--- a/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/claimNudges.test.ts
@@ -1,7 +1,3 @@
-import fs from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
-
 import {getUserConfig} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -52,10 +48,9 @@ function storedRecords(): Record<string, UnclaimedProjectRecord> {
   return (store[UNCLAIMED_PROJECTS_CONFIG_KEY] ?? {}) as Record<string, UnclaimedProjectRecord>
 }
 
-/** Default cwd has no .env, so the ambient line stays out of waterfall-focused tests. */
-async function run(now = NOW, cwd = '/nonexistent-claim-nudges-cwd'): Promise<string> {
+async function run(now = NOW): Promise<string> {
   const write = vi.fn()
-  await runClaimNudges(write, now, cwd)
+  await runClaimNudges(write, now)
   return write.mock.calls.map(([line]) => String(line)).join('\n')
 }
 
@@ -149,6 +144,101 @@ describe('#forgetMintedProject', () => {
 })
 
 describe('#runClaimNudges', () => {
+  test('does nothing when the registry is empty', async () => {
+    expect(await run()).toBe('')
+    expect(mockLookupViaProject).not.toHaveBeenCalled()
+  })
+
+  test('reminds on every run, from the moment of mint to the end', async () => {
+    seedRecord({expiresAt: new Date(NOW + 71 * HOUR).toISOString()})
+
+    const first = await run()
+    expect(first).toContain('Unclaimed Sanity project abc123 expires in 71 hours')
+    expect(first).toContain(
+      "Claim it now: there's no downside to claiming early, and everything keeps working, including the token in .env.",
+    )
+    expect(first).toContain('https://www.sanity.io/claim/some-token')
+    expect(first).toContain('permanently deleted at')
+    expect(first).toContain('If an agent is running this, surface the full claim URL to the user.')
+    expect(first).toContain('They need to click this link to claim the project before it expires.')
+    expect(first).not.toContain('╭') // compact lines, never a box
+    expect(first.startsWith('\n')).toBe(true)
+    // No dedupe: the identical reminder repeats on the very next run.
+    expect(await run()).toBe(first)
+  })
+
+  test('the countdown tracks the clock exactly, with constant copy', async () => {
+    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
+
+    expect(await run()).toContain('expires in 47 hours')
+    expect(await run(NOW + 24 * HOUR)).toContain('expires in 23 hours')
+
+    const closeToDeadline = await run(NOW + 45.5 * HOUR)
+    expect(closeToDeadline).toContain('expires in 1 hour 30 minutes')
+    expect(closeToDeadline).not.toContain('Final reminder')
+    expect(closeToDeadline).toContain(
+      "Claim it now: there's no downside to claiming early, and everything keeps working, including the token in .env.",
+    )
+  })
+
+  test('verifies every render through the project host with the ledger token', async () => {
+    seedRecord()
+
+    await run()
+
+    expect(mockLookupViaProject).toHaveBeenCalledWith('abc123', 'sk-robot')
+  })
+
+  test('a record with no token reminds off the local clock alone', async () => {
+    seedRecord({token: undefined})
+
+    expect(await run()).toContain('Unclaimed Sanity project abc123 expires in 47 hours')
+    // No token means no org read to attempt.
+    expect(mockLookupViaProject).not.toHaveBeenCalled()
+  })
+
+  test('aggregates multiple projects: full block for the soonest, one line each for the rest', async () => {
+    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
+    seedRecord({
+      claimUrl: 'https://www.sanity.io/claim/def-token',
+      expiresAt: new Date(NOW + 20 * HOUR).toISOString(),
+      projectId: 'def456',
+    })
+
+    const output = await run()
+
+    // The soonest-to-expire project leads with headline, CTA, and URL only: the aggregate block
+    // takes over where the solo deletion line would sit.
+    expect(output).toContain('Unclaimed Sanity project def456 expires in 20 hours')
+    expect(output).not.toContain('Everything in it is permanently deleted at')
+    // The rest aggregate to a header plus one compact line per project, claim URL included.
+    expect(output).toContain(
+      '1 more unclaimed Sanity project, permanently deleted at its deadline unless you claim it:',
+    )
+    expect(output).toContain('abc123 expires in 47 hours: https://www.sanity.io/claim/some-token')
+    expect(output).not.toContain('Unclaimed Sanity project abc123 expires')
+    // The agent instruction appears once, on the aggregate, covering every link above it.
+    expect(output).toContain(
+      'If an agent is running this, surface every claim URL above to the user.',
+    )
+    expect(output).toContain('They need to click each link to claim its project before it expires.')
+    expect(output).not.toContain('surface the full claim URL to the user.')
+  })
+
+  test('pluralizes the aggregation header past two projects', async () => {
+    seedRecord()
+    seedRecord({expiresAt: new Date(NOW + 20 * HOUR).toISOString(), projectId: 'def456'})
+    seedRecord({expiresAt: new Date(NOW + 30 * HOUR).toISOString(), projectId: 'ghi789'})
+
+    const output = await run()
+
+    expect(output).toContain(
+      '2 more unclaimed Sanity projects, each permanently deleted at its deadline unless you claim it:',
+    )
+    expect(output).toContain('ghi789 expires in 30 hours:')
+    expect(output).toContain('abc123 expires in 47 hours:')
+  })
+
   test('a malformed registry entry never silences reminders for healthy projects', async () => {
     const records = (store[UNCLAIMED_PROJECTS_CONFIG_KEY] ?? {}) as Record<string, unknown>
     const mismatched = seedRecord({projectId: 'zzz999'})
@@ -158,21 +248,79 @@ describe('#runClaimNudges', () => {
       wrongkey: {...mismatched},
     }
     delete (store[UNCLAIMED_PROJECTS_CONFIG_KEY] as Record<string, unknown>).zzz999
-    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
+    seedRecord()
 
     const output = await run()
 
-    expect(output).toContain('⏳ Claim your Sanity project — abc123')
+    expect(output).toContain('Unclaimed Sanity project abc123 expires')
     expect(output).not.toContain('phantom')
     expect(output).not.toContain('zzz999')
-    expect(storedRecords().abc123.lastNudgeTier).toBe(1)
-    // The write that recorded the healthy nudge persists the filtered view.
-    expect(storedRecords().phantom).toBeUndefined()
-    expect(storedRecords().wrongkey).toBeUndefined()
+  })
+
+  test('confirms and forgets a claimed project instead of reminding', async () => {
+    mockLookupViaProject.mockResolvedValue('claimed')
+    seedRecord()
+
+    const output = await run()
+
+    expect(output).toContain('has been claimed')
+    // The robot token in .env keeps outranking a login session; the farewell must say so.
+    expect(output).toContain('still authenticate with the robot token in .env')
+    expect(output).toContain('remove SANITY_AUTH_TOKEN from .env to act as yourself')
+    expect(output).not.toContain('Claim it now:')
+    expect(storedRecords().abc123).toBeUndefined()
+    expect(await run()).toBe('')
+  })
+
+  test('drops a revoked token so login can take over', async () => {
+    mockLookupViaProject.mockResolvedValue('revoked')
+    seedRecord()
+
+    const output = await run()
+
+    expect(output).toContain('token is no longer valid')
+    expect(output).toContain('sanity login')
+    // A config dir auto-injects .env, so the dead token must be removed or it outranks the session.
+    expect(output).toContain('remove SANITY_AUTH_TOKEN from .env')
+    expect(storedRecords().abc123).toBeUndefined()
+    expect(await run()).toBe('')
+  })
+
+  test('announces server-confirmed expiry and forgets the project', async () => {
+    mockLookupViaProject.mockResolvedValue('expired')
+    seedRecord()
+
+    const output = await run()
+
+    expect(output).toContain('Unclaimed Sanity project abc123 expired on')
+    expect(output).toContain('Run `sanity new --force` to mint a replacement')
+    expect(storedRecords().abc123).toBeUndefined()
+    expect(await run()).toBe('')
+  })
+
+  test('notifies once about locally expired projects and forgets them (org read fails open)', async () => {
+    mockLookupViaProject.mockResolvedValue(undefined)
+    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
+
+    const output = await run()
+
+    expect(output).toContain('Unclaimed Sanity project abc123 expired on')
+    expect(output).toContain('Run `sanity new --force` to mint a replacement')
+    expect(storedRecords().abc123).toBeUndefined()
+    expect(await run()).toBe('')
+  })
+
+  test('a locally expired project the server still calls claimable is kept quietly', async () => {
+    // Clock skew or an extended window: the org read is the authority, so no farewell fires and
+    // the record survives for the next run to re-check.
+    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
+
+    expect(await run()).toBe('')
+    expect(storedRecords().abc123).toBeDefined()
   })
 
   test('a mint landing during the lookup window survives the registry write', async () => {
-    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
+    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
     mockLookupViaProject.mockImplementation(async () => {
       const records = (store[UNCLAIMED_PROJECTS_CONFIG_KEY] ?? {}) as Record<string, unknown>
       store[UNCLAIMED_PROJECTS_CONFIG_KEY] = {
@@ -185,316 +333,14 @@ describe('#runClaimNudges', () => {
           projectId: 'fresh99',
         },
       }
-      return 'claimable'
+      return 'expired'
     })
 
     const output = await run()
 
-    expect(output).toContain('⏳ Claim your Sanity project — abc123')
-    expect(storedRecords().abc123.lastNudgeTier).toBe(1)
-    // The concurrent mint's record survived the write.
+    expect(output).toContain('Unclaimed Sanity project abc123 expired on')
+    // The expiry farewell dropped abc123, but the concurrent mint's record survived the write.
+    expect(storedRecords().abc123).toBeUndefined()
     expect(storedRecords().fresh99).toBeDefined()
-  })
-
-  test('does nothing when the registry is empty', async () => {
-    expect(await run()).toBe('')
-    expect(mockLookupViaProject).not.toHaveBeenCalled()
-  })
-
-  test('stays quiet with more than 48 hours remaining, without touching the network', async () => {
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
-
-    expect(await run()).toBe('')
-    expect(mockLookupViaProject).not.toHaveBeenCalled()
-  })
-
-  test('tier 1 fires under 48 hours and is shown only once', async () => {
-    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
-
-    const first = await run()
-    expect(first).toContain('⏳ Claim your Sanity project')
-    expect(first).toContain('abc123')
-    expect(first).toContain('expires in about 47 hours')
-    expect(first).toContain('https://www.sanity.io/claim/some-token')
-    expect(first).not.toContain('╭') // compact lines, never a box
-    expect(first).toMatch(
-      /unless you claim it\.\nClaiming is free and keeps everything working, including the token in \.env\.\nClaim it now:/,
-    )
-    expect(storedRecords().abc123.lastNudgeTier).toBe(1)
-
-    expect(await run()).toBe('')
-    expect(mockLookupViaProject).toHaveBeenCalledTimes(1)
-  })
-
-  test('drives tier timing off the local clock (no server round-trip)', async () => {
-    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
-
-    const output = await run()
-
-    expect(output).toContain('expires in about 47 hours')
-    // The only network touch is the budget-free org read, with a short abort.
-    expect(mockLookupViaProject).toHaveBeenCalledWith('abc123', 'sk-robot', {timeoutMs: 500})
-  })
-
-  test('escalates through tiers as the deadline approaches', async () => {
-    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString(), lastNudgeTier: 1})
-
-    const tier2 = await run(NOW + 24 * HOUR)
-    expect(tier2).toContain('⏰ Project abc123 expires in about 23 hours')
-    expect(storedRecords().abc123.lastNudgeTier).toBe(2)
-
-    const tier3 = await run(NOW + 40 * HOUR)
-    expect(tier3).toContain('🚨 Project abc123 expires in about 7 hours')
-    expect(storedRecords().abc123.lastNudgeTier).toBe(3)
-
-    const tier4 = await run(NOW + 45.5 * HOUR)
-    expect(tier4).toContain('🚨 Final reminder')
-    expect(tier4).toContain('about 90 minutes')
-    expect(storedRecords().abc123.lastNudgeTier).toBe(4)
-
-    expect(await run(NOW + 46 * HOUR)).toBe('')
-  })
-
-  test('tier nudges include the agent call-to-action', async () => {
-    seedRecord({expiresAt: new Date(NOW + 23 * HOUR).toISOString()})
-
-    expect(await run()).toContain('AI agents: surface this claim link to your human now')
-  })
-
-  test('confirms and forgets a claimed project instead of nudging', async () => {
-    mockLookupViaProject.mockResolvedValue('claimed')
-    seedRecord({expiresAt: new Date(NOW + 23 * HOUR).toISOString()})
-
-    const output = await run()
-
-    expect(output).toContain('has been claimed')
-    expect(storedRecords().abc123).toBeUndefined()
-  })
-
-  test('notes and forgets a project the org read reports gone', async () => {
-    mockLookupViaProject.mockResolvedValue('expired')
-    seedRecord({expiresAt: new Date(NOW + 23 * HOUR).toISOString()})
-
-    const output = await run()
-
-    expect(output).toContain('⌛ Unclaimed Sanity project abc123 expired on')
-    expect(output).toContain('Run `sanity new --force` to mint a replacement')
-    expect(storedRecords().abc123).toBeUndefined()
-  })
-
-  test('fails open to the local clock when the org read is unavailable', async () => {
-    mockLookupViaProject.mockResolvedValue(undefined)
-    seedRecord({expiresAt: new Date(NOW + 23 * HOUR).toISOString()})
-
-    expect(await run()).toContain('⏰ Project abc123 expires in about 23 hours')
-  })
-
-  test('a record with no token nudges off the local clock alone', async () => {
-    seedRecord({expiresAt: new Date(NOW + 23 * HOUR).toISOString(), token: undefined})
-
-    expect(await run()).toContain('⏰ Project abc123 expires in about 23 hours')
-    // No token means no org read to attempt.
-    expect(mockLookupViaProject).not.toHaveBeenCalled()
-  })
-
-  test('notifies once about locally expired projects and forgets them (org read fails open)', async () => {
-    mockLookupViaProject.mockResolvedValue(undefined)
-    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
-
-    const output = await run()
-
-    expect(output).toContain('⌛ Unclaimed Sanity project abc123 expired on')
-    expect(output).toContain('Run `sanity new --force` to mint a replacement')
-    expect(storedRecords().abc123).toBeUndefined()
-    // The farewell is confirmed first — via the project host, with a short abort.
-    expect(mockLookupViaProject).toHaveBeenCalledWith('abc123', 'sk-robot', {timeoutMs: 500})
-
-    expect(await run()).toBe('')
-  })
-
-  test('locally expired but actually claimed: congratulates instead of the expiry notice', async () => {
-    mockLookupViaProject.mockResolvedValue('claimed')
-    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
-
-    const output = await run()
-
-    expect(output).toContain('has been claimed')
-    expect(output).not.toContain('expired on')
-    expect(storedRecords().abc123).toBeUndefined()
-  })
-
-  test('locally expired but still claimable per the org read: keeps the record, stays quiet', async () => {
-    mockLookupViaProject.mockResolvedValue('claimable')
-    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
-
-    const output = await run()
-
-    expect(output).toBe('')
-    // The window outlived the local estimate — kept untouched for the next run to re-check.
-    expect(storedRecords().abc123).toBeDefined()
-    expect(storedRecords().abc123.expiresAt).toBe(new Date(NOW - HOUR).toISOString())
-  })
-
-  test('a lapsed-but-claimable record never renders a bogus final reminder', async () => {
-    mockLookupViaProject.mockResolvedValue('claimable')
-    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString()})
-
-    const output = await run()
-
-    expect(output).toBe('')
-    expect(storedRecords().abc123).toBeDefined()
-  })
-
-  test('nudges only the most urgent project per invocation', async () => {
-    seedRecord({expiresAt: new Date(NOW + 40 * HOUR).toISOString(), projectId: 'later00'})
-    seedRecord({expiresAt: new Date(NOW + 5 * HOUR).toISOString(), projectId: 'sooner0'})
-
-    const output = await run()
-
-    expect(output).toContain('sooner0')
-    expect(output).not.toContain('later00')
-    expect(storedRecords().sooner0.lastNudgeTier).toBe(3)
-    expect(storedRecords().later00.lastNudgeTier).toBeUndefined()
-  })
-})
-
-describe('#runClaimNudges ambient directory reminder', () => {
-  let dir: string
-
-  beforeEach(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sanity-nudge-cwd-'))
-  })
-
-  afterEach(() => {
-    fs.rmSync(dir, {force: true, recursive: true})
-  })
-
-  test('emits a stateless line on every run in a minted directory', async () => {
-    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
-    // Above every tier threshold, so the waterfall stays silent.
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
-
-    const first = await run(NOW, dir)
-    expect(first).toContain('Unclaimed Sanity project abc123 expires in about 60 hours')
-    expect(first).toContain('https://www.sanity.io/claim/some-token')
-    expect(first.startsWith('\n')).toBe(true)
-    expect(first).toMatch(/claim it to keep it:.*\n.*https:\/\/www\.sanity\.io\/claim/)
-    expect(first).not.toContain('╭')
-    // No dedupe marker — the line repeats on the very next run.
-    expect(storedRecords().abc123.lastNudgeTier).toBeUndefined()
-    expect(await run(NOW, dir)).toBe(first)
-  })
-
-  test('yields the slot when a tiered nudge fires in the same invocation', async () => {
-    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
-    seedRecord({expiresAt: new Date(NOW + 47 * HOUR).toISOString()})
-
-    const output = await run(NOW, dir)
-
-    expect(output).toContain('⏳ Claim your Sanity project')
-    expect(output).not.toContain('claim it to keep it:')
-  })
-
-  test('verifies via the ledger token even when .env no longer carries it (post-claim handoff)', async () => {
-    // The claim handoff says "login, then remove SANITY_AUTH_TOKEN"; the project id stays behind.
-    // The ledger still owns the token, so the org read runs and notices the claim.
-    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
-    mockLookupViaProject.mockResolvedValue('claimed')
-
-    const output = await run(NOW, dir)
-
-    expect(output).toContain('has been claimed')
-    expect(mockLookupViaProject).toHaveBeenCalledWith('abc123', 'sk-robot', {timeoutMs: 500})
-    expect(storedRecords().abc123).toBeUndefined()
-  })
-
-  test('still verifies and drops the cwd project when another project took the announce slot', async () => {
-    // A sibling project's expiry farewell announces first; the cwd project must still be
-    // claim-checked, or its ledger token keeps outranking a login session in getCliToken.
-    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()}) // cwd project, live
-    seedRecord({expiresAt: new Date(NOW - HOUR).toISOString(), projectId: 'sibling'}) // expired sibling
-    mockLookupViaProject.mockImplementation(async (projectId: string) =>
-      projectId === 'abc123' ? 'claimed' : 'expired',
-    )
-
-    const output = await run(NOW, dir)
-
-    // The sibling's farewell took the single announce slot...
-    expect(output).toContain('Unclaimed Sanity project sibling expired')
-    // ...but the cwd project was still verified as claimed and dropped from the ledger.
-    expect(storedRecords().abc123).toBeUndefined()
-  })
-
-  test('drops the cwd project when its token is revoked, so login can take over', async () => {
-    // A revoked (401) robot token otherwise keeps outranking the login session in getCliToken.
-    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
-    mockLookupViaProject.mockResolvedValue('revoked')
-
-    const output = await run(NOW, dir)
-
-    expect(output).toContain('token is no longer valid')
-    expect(output).toContain('sanity login')
-    // A config dir auto-injects .env, so the dead token must be removed or it outranks the session.
-    expect(output).toContain('remove SANITY_AUTH_TOKEN from .env')
-    expect(storedRecords().abc123).toBeUndefined()
-  })
-
-  test('stays quiet when the directory points at an unregistered project', async () => {
-    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="someone-elses"\n')
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
-
-    expect(await run(NOW, dir)).toBe('')
-  })
-
-  test('stays quiet in directories without a .env', async () => {
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
-
-    expect(await run(NOW, dir)).toBe('')
-  })
-
-  test('verifies every render through the project host with the ledger token', async () => {
-    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
-    mockLookupViaProject.mockResolvedValue('claimable')
-
-    const output = await run(NOW, dir)
-
-    expect(mockLookupViaProject).toHaveBeenCalledWith('abc123', 'sk-robot', {timeoutMs: 500})
-    expect(output).toContain('Unclaimed Sanity project abc123')
-  })
-
-  test('claimed per the org read: congratulates once and drops the record', async () => {
-    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
-    mockLookupViaProject.mockResolvedValue('claimed')
-
-    const output = await run(NOW, dir)
-
-    expect(output).toContain('has been claimed')
-    expect(output).not.toContain('claim it to keep it:')
-    expect(storedRecords().abc123).toBeUndefined()
-    expect(await run(NOW, dir)).toBe('')
-  })
-
-  test('expired per the org read: notes it once and drops the record', async () => {
-    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
-    mockLookupViaProject.mockResolvedValue('expired')
-
-    const output = await run(NOW, dir)
-
-    expect(output).toContain('expired on')
-    expect(storedRecords().abc123).toBeUndefined()
-  })
-
-  test('fails open to the ledger when the org read is unavailable', async () => {
-    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_PROJECT_ID="abc123"\n')
-    seedRecord({expiresAt: new Date(NOW + 60 * HOUR).toISOString()})
-    mockLookupViaProject.mockResolvedValue(undefined)
-
-    expect(await run(NOW, dir)).toContain('Unclaimed Sanity project abc123')
   })
 })

--- a/packages/@sanity/cli/src/util/__tests__/envFile.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/envFile.test.ts
@@ -1,0 +1,195 @@
+import {execFileSync} from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {afterEach, beforeEach, describe, expect, test} from 'vitest'
+
+import {appendEnvValues, ensureEnvGitignored, isEnvTracked, readEnvValues} from '../envFile.js'
+
+const git = (dir: string, ...args: string[]) =>
+  execFileSync('git', args, {cwd: dir, stdio: 'ignore'})
+
+let dir: string
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sanity-envfile-'))
+})
+
+afterEach(() => {
+  fs.rmSync(dir, {force: true, recursive: true})
+})
+
+describe('ensureEnvGitignored', () => {
+  test('creates .gitignore with a .env entry when none exists', () => {
+    expect(ensureEnvGitignored(dir)).toEqual({added: true, ignored: true})
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf8')).toBe('.env\n')
+  })
+
+  test('appends .env to an existing .gitignore, preserving contents', () => {
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules\n*.local')
+
+    expect(ensureEnvGitignored(dir)).toEqual({added: true, ignored: true})
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf8')).toBe(
+      'node_modules\n*.local\n.env\n',
+    )
+  })
+
+  test('is a no-op when .env is already ignored (with or without a leading slash)', () => {
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules\n/.env\n')
+
+    expect(ensureEnvGitignored(dir)).toEqual({added: false, ignored: true})
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf8')).toBe('node_modules\n/.env\n')
+  })
+
+  test('reports not-ignored (never throws) on an unwritable target, so callers can warn', () => {
+    // A .gitignore that is actually a directory makes the read/write fail — must fail open, and
+    // report ignored:false so the mint flow warns instead of silently leaving the token exposed.
+    fs.mkdirSync(path.join(dir, '.gitignore'))
+
+    expect(ensureEnvGitignored(dir)).toEqual({added: false, ignored: false})
+  })
+})
+
+describe('isEnvTracked', () => {
+  test('returns false outside a git repository', () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_AUTH_TOKEN=sk\n')
+    expect(isEnvTracked(dir)).toBe(false)
+  })
+
+  test('returns false when .env exists but is untracked', () => {
+    git(dir, 'init')
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_AUTH_TOKEN=sk\n')
+    expect(isEnvTracked(dir)).toBe(false)
+  })
+
+  test('returns true once .env is tracked by git', () => {
+    git(dir, 'init')
+    fs.writeFileSync(path.join(dir, '.env'), 'SANITY_AUTH_TOKEN=sk\n')
+    git(dir, 'add', '.env')
+    expect(isEnvTracked(dir)).toBe(true)
+  })
+})
+
+describe('appendEnvValues', () => {
+  test('creates the file with banner comments and quoted values', () => {
+    const envPath = path.join(dir, '.env')
+
+    const result = appendEnvValues(
+      envPath,
+      {SANITY_DATASET: 'production', SANITY_PROJECT_ID: 'abc123'},
+      {banner: ['claim me: https://example.com/claim']},
+    )
+
+    expect(result).toEqual({
+      created: true,
+      skippedKeys: [],
+      wroteKeys: ['SANITY_DATASET', 'SANITY_PROJECT_ID'],
+    })
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(
+      '# claim me: https://example.com/claim\n' +
+        'SANITY_DATASET="production"\n' +
+        'SANITY_PROJECT_ID="abc123"\n',
+    )
+  })
+
+  test('appends to an existing file without clobbering its contents', () => {
+    const envPath = path.join(dir, '.env')
+    fs.writeFileSync(envPath, 'OTHER_KEY=other\n')
+
+    const result = appendEnvValues(envPath, {SANITY_PROJECT_ID: 'abc123'})
+
+    expect(result.created).toBe(false)
+    expect(result.wroteKeys).toEqual(['SANITY_PROJECT_ID'])
+    expect(fs.readFileSync(envPath, 'utf8')).toBe('OTHER_KEY=other\n\nSANITY_PROJECT_ID="abc123"\n')
+  })
+
+  test('never overwrites existing keys, including `export`-prefixed ones', () => {
+    const envPath = path.join(dir, '.env')
+    fs.writeFileSync(envPath, 'export SANITY_AUTH_TOKEN=keep-me\nSANITY_PROJECT_ID=existing\n')
+
+    const result = appendEnvValues(envPath, {
+      SANITY_AUTH_TOKEN: 'new-token',
+      SANITY_DATASET: 'production',
+      SANITY_PROJECT_ID: 'abc123',
+    })
+
+    expect(result.skippedKeys).toEqual(['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'])
+    expect(result.wroteKeys).toEqual(['SANITY_DATASET'])
+    const contents = fs.readFileSync(envPath, 'utf8')
+    expect(contents).toContain('export SANITY_AUTH_TOKEN=keep-me')
+    expect(contents).toContain('SANITY_PROJECT_ID=existing')
+    expect(contents).toContain('SANITY_DATASET="production"')
+    expect(contents).not.toContain('new-token')
+  })
+
+  test('a blank template line counts as existing: skipped, never edited', () => {
+    // `SANITY_PROJECT_ID=` with no value — the classic .env.example leftover. Line presence,
+    // not value presence, decides ownership: the writer must not edit or duplicate the line.
+    // (Callers surface the skipped keys' values instead — see the mint flow.)
+    const envPath = path.join(dir, '.env')
+    const original = 'SANITY_PROJECT_ID=\nSANITY_AUTH_TOKEN=""\n'
+    fs.writeFileSync(envPath, original)
+
+    const result = appendEnvValues(envPath, {
+      SANITY_AUTH_TOKEN: 'sk-new',
+      SANITY_DATASET: 'production',
+      SANITY_PROJECT_ID: 'abc123',
+    })
+
+    expect(result).toEqual({
+      created: false,
+      skippedKeys: ['SANITY_AUTH_TOKEN', 'SANITY_PROJECT_ID'],
+      wroteKeys: ['SANITY_DATASET'],
+    })
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(`${original}\nSANITY_DATASET="production"\n`)
+  })
+
+  test('writes nothing when every key already exists', () => {
+    const envPath = path.join(dir, '.env')
+    const original = 'SANITY_PROJECT_ID=existing'
+    fs.writeFileSync(envPath, original)
+
+    const result = appendEnvValues(envPath, {SANITY_PROJECT_ID: 'abc123'}, {banner: ['unused']})
+
+    expect(result).toEqual({created: false, skippedKeys: ['SANITY_PROJECT_ID'], wroteKeys: []})
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(original)
+  })
+})
+
+describe('readEnvValues', () => {
+  test('returns an empty object when the file is missing', () => {
+    expect(readEnvValues(path.join(dir, '.env'), ['SANITY_PROJECT_ID'])).toEqual({})
+  })
+
+  test('matches the runtime env grammar: quotes, comments, export, empties, last-wins', () => {
+    // One tripwire for the dotenv dependency: these are the grammar behaviors the guardrail
+    // relies on. If a dotenv major bump ever changes one, this fails before the guard can lie.
+    const envPath = path.join(dir, '.env')
+    fs.writeFileSync(
+      envPath,
+      'SANITY_PROJECT_ID="shadowed"\n' +
+        "SANITY_DATASET='pro#duction' # inline note\n" +
+        'export SANITY_AUTH_TOKEN=sk-token # robot\n' +
+        'SANITY_PROJECT_ID="abc123" # minted 2026-07-22\n' +
+        'SANITY_CLAIM_URL=\n',
+    )
+
+    expect(
+      readEnvValues(envPath, [
+        'SANITY_AUTH_TOKEN',
+        'SANITY_DATASET',
+        'SANITY_PROJECT_ID',
+        'SANITY_CLAIM_URL',
+      ]),
+    ).toEqual({
+      // export prefix accepted, unquoted inline comment stripped:
+      SANITY_AUTH_TOKEN: 'sk-token',
+      // quoted: `#` inside the quotes is data, the comment after them is not:
+      SANITY_DATASET: 'pro#duction',
+      // duplicate keys: the last assignment wins, exactly like the runtime injection:
+      SANITY_PROJECT_ID: 'abc123',
+      // SANITY_CLAIM_URL: empty value → omitted entirely
+    })
+  })
+})

--- a/packages/@sanity/cli/src/util/__tests__/envFile.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/envFile.test.ts
@@ -5,7 +5,13 @@ import path from 'node:path'
 
 import {afterEach, beforeEach, describe, expect, test} from 'vitest'
 
-import {appendEnvValues, ensureEnvGitignored, isEnvTracked, readEnvValues} from '../envFile.js'
+import {
+  appendEnvValues,
+  ensureEnvGitignored,
+  inspectEnvKeys,
+  isEnvTracked,
+  readEnvValues,
+} from '../envFile.js'
 
 const git = (dir: string, ...args: string[]) =>
   execFileSync('git', args, {cwd: dir, stdio: 'ignore'})
@@ -180,6 +186,103 @@ describe('appendEnvValues', () => {
 
     expect(result).toEqual({created: false, skippedKeys: ['SANITY_PROJECT_ID'], wroteKeys: []})
     expect(fs.readFileSync(envPath, 'utf8')).toBe(original)
+  })
+})
+
+function inspect(contents: string, keys: readonly string[] = ['SANITY_PROJECT_ID']) {
+  const envPath = path.join(dir, '.env')
+  fs.writeFileSync(envPath, contents)
+  return inspectEnvKeys(envPath, keys)
+}
+
+describe('inspectEnvKeys', () => {
+  test('reports nothing for a missing file', () => {
+    expect(inspectEnvKeys(path.join(dir, '.env'), ['SANITY_PROJECT_ID'])).toEqual({
+      blankKeys: [],
+      presentKeys: [],
+      values: {},
+    })
+  })
+
+  test('reports nothing for a key with no assignment line', () => {
+    expect(inspect('OTHER_KEY=other\n')).toEqual({blankKeys: [], presentKeys: [], values: {}})
+  })
+
+  test('a blank assignment is present but blank', () => {
+    expect(inspect('SANITY_PROJECT_ID=\n')).toEqual({
+      blankKeys: ['SANITY_PROJECT_ID'],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {},
+    })
+  })
+
+  test('a whitespace-only assignment counts as blank', () => {
+    expect(inspect('SANITY_PROJECT_ID="   "\n')).toEqual({
+      blankKeys: ['SANITY_PROJECT_ID'],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {},
+    })
+  })
+
+  test('an export-prefixed blank assignment counts as present and blank', () => {
+    expect(inspect('export SANITY_PROJECT_ID=\n')).toEqual({
+      blankKeys: ['SANITY_PROJECT_ID'],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {},
+    })
+  })
+
+  test('inline comments follow dotenv grammar: stripped unquoted, data inside quotes', () => {
+    expect(
+      inspect(
+        'SANITY_PROJECT_ID=abc123 # minted 2026-07-22\nSANITY_DATASET="pro#duction" # note\n',
+        ['SANITY_PROJECT_ID', 'SANITY_DATASET'],
+      ),
+    ).toEqual({
+      blankKeys: [],
+      presentKeys: ['SANITY_PROJECT_ID', 'SANITY_DATASET'],
+      values: {SANITY_DATASET: 'pro#duction', SANITY_PROJECT_ID: 'abc123'},
+    })
+  })
+
+  test('a line that is only an inline comment yields a blank value', () => {
+    expect(inspect('SANITY_PROJECT_ID= # fill me in\n')).toEqual({
+      blankKeys: ['SANITY_PROJECT_ID'],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {},
+    })
+  })
+
+  test('duplicate keys: a final nonblank assignment wins, so the key is not blank', () => {
+    expect(inspect('SANITY_PROJECT_ID=\nSANITY_PROJECT_ID=abc123\n')).toEqual({
+      blankKeys: [],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {SANITY_PROJECT_ID: 'abc123'},
+    })
+  })
+
+  test('duplicate keys: a final blank assignment shadows the earlier value, so the key is blank', () => {
+    expect(inspect('SANITY_PROJECT_ID=abc123\nSANITY_PROJECT_ID=\n')).toEqual({
+      blankKeys: ['SANITY_PROJECT_ID'],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {},
+    })
+  })
+
+  test('a normal nonblank value is present with its value', () => {
+    expect(inspect('SANITY_PROJECT_ID="abc123"\n')).toEqual({
+      blankKeys: [],
+      presentKeys: ['SANITY_PROJECT_ID'],
+      values: {SANITY_PROJECT_ID: 'abc123'},
+    })
+  })
+
+  test('a commented-out assignment does not count as present', () => {
+    expect(inspect('# SANITY_PROJECT_ID=abc123\n')).toEqual({
+      blankKeys: [],
+      presentKeys: [],
+      values: {},
+    })
   })
 })
 

--- a/packages/@sanity/cli/src/util/__tests__/envFile.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/envFile.test.ts
@@ -49,6 +49,32 @@ describe('ensureEnvGitignored', () => {
 
     expect(ensureEnvGitignored(dir)).toEqual({added: false, ignored: false})
   })
+
+  test('writes the given pattern, which scaffolding uses to cover the .env.local files too', () => {
+    expect(ensureEnvGitignored(dir, '.env*')).toEqual({added: true, ignored: true})
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf8')).toBe('.env*\n')
+  })
+
+  test('treats an existing .env* as already covering .env, so no duplicate entry is added', () => {
+    fs.writeFileSync(path.join(dir, '.gitignore'), '.env*\n')
+
+    expect(ensureEnvGitignored(dir)).toEqual({added: false, ignored: true})
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf8')).toBe('.env*\n')
+  })
+
+  test('a root-anchored /.env* does not count as covering, since it misses nested files', () => {
+    fs.writeFileSync(path.join(dir, '.gitignore'), '/.env*\n')
+
+    expect(ensureEnvGitignored(dir, '.env*')).toEqual({added: true, ignored: true})
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf8')).toBe('/.env*\n.env*\n')
+  })
+
+  test('a bare .env does not count as covering the .env* pattern', () => {
+    fs.writeFileSync(path.join(dir, '.gitignore'), '.env\n')
+
+    expect(ensureEnvGitignored(dir, '.env*')).toEqual({added: true, ignored: true})
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf8')).toBe('.env\n.env*\n')
+  })
 })
 
 describe('isEnvTracked', () => {

--- a/packages/@sanity/cli/src/util/claimNudges.ts
+++ b/packages/@sanity/cli/src/util/claimNudges.ts
@@ -1,0 +1,328 @@
+import path from 'node:path'
+import {styleText} from 'node:util'
+
+import {getUserConfig, UNCLAIMED_PROJECTS_CONFIG_KEY} from '@sanity/cli-core'
+import {subdebug} from '@sanity/cli-core/debug'
+import {logSymbols} from '@sanity/cli-core/ux'
+
+import {
+  type ClaimState,
+  lookupClaimStateViaProject,
+  type MintedProject,
+} from '../services/mintProject.js'
+import {readEnvValues} from './envFile.js'
+
+const debug = subdebug('claimNudges')
+
+export interface UnclaimedProjectRecord {
+  claimToken: string
+  claimUrl: string
+  expiresAt: string
+  mintedAt: string
+  projectId: string
+
+  /** Highest nudge tier already shown. */
+  lastNudgeTier?: number
+
+  /** Robot token, used to read claim state as a function of organization membership. */
+  token?: string
+}
+
+const NUDGE_TIERS = [
+  {ms: 48 * 3_600_000, tier: 1},
+  {ms: 24 * 3_600_000, tier: 2},
+  {ms: 8 * 3_600_000, tier: 3},
+  {ms: 2 * 3_600_000, tier: 4},
+] as const
+
+function tierFor(msLeft: number): number {
+  let current = 0
+  for (const {ms, tier} of NUDGE_TIERS) {
+    if (msLeft <= ms) current = tier
+  }
+  return current
+}
+
+function humanizeMsLeft(msLeft: number): string {
+  const minutes = Math.max(Math.round(msLeft / 60_000), 1)
+  if (minutes < 120) return `about ${minutes} minutes`
+  const hours = Math.round(minutes / 60)
+  return `about ${hours} hours`
+}
+
+function isWellFormed(record: unknown): record is UnclaimedProjectRecord {
+  const candidate = record as Partial<UnclaimedProjectRecord> | null
+  return (
+    typeof candidate?.claimToken === 'string' &&
+    typeof candidate?.claimUrl === 'string' &&
+    typeof candidate?.expiresAt === 'string' &&
+    typeof candidate?.projectId === 'string'
+  )
+}
+
+function readRecords(): Record<string, UnclaimedProjectRecord> {
+  const raw = getUserConfig().get(UNCLAIMED_PROJECTS_CONFIG_KEY)
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  return Object.fromEntries(
+    Object.entries(raw as Record<string, unknown>).filter(
+      ([key, record]) => isWellFormed(record) && record.projectId === key,
+    ),
+  ) as Record<string, UnclaimedProjectRecord>
+}
+
+function writeRecords(records: Record<string, UnclaimedProjectRecord>): void {
+  const config = getUserConfig()
+  if (Object.keys(records).length === 0) {
+    config.delete(UNCLAIMED_PROJECTS_CONFIG_KEY)
+  } else {
+    config.set(UNCLAIMED_PROJECTS_CONFIG_KEY, records)
+  }
+}
+
+/**
+ * Persist a minted project to the ledger. Returns whether the write succeeded: in a freshly minted
+ * directory with no Sanity config, `.env` is not auto-injected, so the ledger is the only path by
+ * which `getCliToken` can authenticate — callers must surface a failure rather than report success.
+ */
+export function recordMintedProject(minted: MintedProject): boolean {
+  try {
+    const records = readRecords()
+    records[minted.resourceId] = {
+      claimToken: minted.claimToken,
+      claimUrl: minted.claimUrl,
+      expiresAt: minted.expiresAt,
+      mintedAt: new Date().toISOString(),
+      projectId: minted.resourceId,
+      token: minted.token,
+    }
+    writeRecords(records)
+    return true
+  } catch (err) {
+    debug('failed to record minted project: %s', err)
+    return false
+  }
+}
+
+export function getMintedProjectRecord(projectId: string): UnclaimedProjectRecord | undefined {
+  try {
+    return readRecords()[projectId]
+  } catch (err) {
+    debug('failed to read minted project record: %s', err)
+    return undefined
+  }
+}
+
+/**
+ * Drop a minted project from the ledger when a re-mint supersedes an expired one,
+ * or flag failure for project re-minting visibility, to prevent silent proliferation.
+ */
+export function forgetMintedProject(projectId: string): boolean {
+  try {
+    const records = readRecords()
+    if (!(projectId in records)) return true
+    delete records[projectId]
+    writeRecords(records)
+    return true
+  } catch (err) {
+    debug('failed to forget minted project: %s', err)
+    return false
+  }
+}
+
+function renderNudge(record: UnclaimedProjectRecord, tier: number, msLeft: number): string {
+  const timeLeft = humanizeMsLeft(msLeft)
+  const agentCta = styleText(
+    'dim',
+    'AI agents: surface this claim link to your human now — it cannot be recovered after expiry.',
+  )
+
+  const urgent = tier >= 3
+  const headline =
+    tier === 1
+      ? `⏳ Claim your Sanity project — ${record.projectId} expires in ${timeLeft}`
+      : tier >= 4
+        ? `🚨 Final reminder — project ${record.projectId} expires in ${timeLeft}`
+        : `${urgent ? '🚨' : '⏰'} Project ${record.projectId} expires in ${timeLeft}`
+  const bell = tier >= 4 ? '' : ''
+  return (
+    bell +
+    `${styleText(['bold', urgent ? 'red' : 'yellow'], headline)}\n` +
+    `Everything in it is permanently deleted at ${record.expiresAt} unless you claim it.\n` +
+    `Claiming is free and keeps everything working, including the token in .env.\n` +
+    `Claim it now: ${styleText(['cyan', 'underline'], record.claimUrl)}\n` +
+    agentCta
+  )
+}
+
+function renderAmbientLine(record: UnclaimedProjectRecord, msLeft: number): string {
+  return (
+    styleText(
+      'dim',
+      `⏳ Unclaimed Sanity project ${record.projectId} expires in ${humanizeMsLeft(msLeft)} — claim it to keep it:`,
+    ) + `\n${styleText(['cyan', 'underline'], record.claimUrl)}`
+  )
+}
+
+const claimedMessage = (record: UnclaimedProjectRecord): string =>
+  `${logSymbols.success} Sanity project ${record.projectId} has been claimed — it's yours to keep.`
+const expiredMessage = (record: UnclaimedProjectRecord): string =>
+  // `--force`: the expired credentials are still in `.env`, so a plain `sanity new` is refused by
+  // the remint guard (it won't overwrite them) — `--force` mints a replacement and leaves `.env`
+  // for you to update.
+  `⌛ Unclaimed Sanity project ${record.projectId} expired on ${record.expiresAt}. Run \`sanity new --force\` to mint a replacement.`
+const revokedMessage = (record: UnclaimedProjectRecord): string =>
+  // Removing SANITY_AUTH_TOKEN matters once a Sanity config exists: `.env` is auto-injected and the
+  // dead token would otherwise outrank the new login session in getCliToken.
+  `⚠ Sanity project ${record.projectId}'s token is no longer valid. Run \`sanity login\`, then remove SANITY_AUTH_TOKEN from .env to act as yourself.`
+
+export async function runClaimNudges(
+  write: (line: string) => void,
+  now: number = Date.now(),
+  cwd: string = process.cwd(),
+): Promise<void> {
+  const records = readRecords()
+  if (Object.keys(records).length === 0) return
+
+  let announced = false
+
+  const announce = (message: string) => {
+    announced = true
+    write(`\n${message}\n`)
+  }
+
+  const touched = new Set<string>()
+  const drop = (projectId: string) => {
+    delete records[projectId]
+    touched.add(projectId)
+  }
+
+  const announceClaimed = (record: UnclaimedProjectRecord) => {
+    announce(claimedMessage(record))
+    drop(record.projectId)
+  }
+  const announceExpired = (record: UnclaimedProjectRecord) => {
+    announce(expiredMessage(record))
+    drop(record.projectId)
+  }
+  // A revoked token is dead weight in the ledger and, for the cwd project, actively blocks login by
+  // outranking the session in getCliToken — so drop it wherever it's seen.
+  const announceRevoked = (record: UnclaimedProjectRecord) => {
+    announce(revokedMessage(record))
+    drop(record.projectId)
+  }
+
+  // Fall back to local clock when unverifiable. Memoized so a project checked in one slot is not
+  // looked up again in another within the same run.
+  const confirmed = new Map<string, ClaimState | undefined>()
+  const confirm = async (record: UnclaimedProjectRecord): Promise<ClaimState | undefined> => {
+    if (!record.token) return undefined
+    if (confirmed.has(record.projectId)) return confirmed.get(record.projectId)
+    const state = await lookupClaimStateViaProject(record.projectId, record.token, {timeoutMs: 500})
+    confirmed.set(record.projectId, state)
+    return state
+  }
+
+  for (const record of Object.values(records)) {
+    if (new Date(record.expiresAt).getTime() > now) continue
+    const state = await confirm(record)
+    switch (state) {
+      case 'claimable': {
+        continue
+        break
+      }
+      case 'claimed': {
+        announceClaimed(record)
+        break
+      }
+      case 'revoked': {
+        announceRevoked(record)
+        break
+      }
+      default: {
+        announceExpired(record)
+      }
+    }
+  }
+
+  // The most urgent live project whose tier advanced since its last shown nudge.
+  const due = Object.values(records)
+    .map((record) => ({msLeft: new Date(record.expiresAt).getTime() - now, record}))
+    .filter(({msLeft, record}) => msLeft > 0 && tierFor(msLeft) > (record.lastNudgeTier ?? 0))
+    .toSorted((a, b) => a.msLeft - b.msLeft)[0]
+
+  if (!announced && due) {
+    const {msLeft, record} = due
+    const state = await confirm(record)
+    switch (state) {
+      case 'claimed': {
+        announceClaimed(record)
+        break
+      }
+      case 'expired': {
+        announceExpired(record)
+        break
+      }
+      case 'revoked': {
+        announceRevoked(record)
+        break
+      }
+      default: {
+        const tier = tierFor(msLeft)
+        announce(renderNudge(record, tier, msLeft))
+        records[record.projectId] = {...record, lastNudgeTier: tier}
+        touched.add(record.projectId)
+      }
+    }
+  }
+
+  // The directory's own project governs auth here — its ledger token can outrank a login session
+  // in getCliToken — so always verify it and drop a claimed/expired record, even when another
+  // project already took the single announce slot. Only the ambient line itself waits for the slot.
+  {
+    const {SANITY_PROJECT_ID} = readEnvValues(path.join(cwd, '.env'), ['SANITY_PROJECT_ID'])
+    const record = SANITY_PROJECT_ID ? records[SANITY_PROJECT_ID] : undefined
+    if (record) {
+      const msLeft = new Date(record.expiresAt).getTime() - now
+      if (msLeft > 0) {
+        const state = await confirm(record)
+        switch (state) {
+          case 'claimed': {
+            drop(record.projectId)
+            if (!announced) announce(claimedMessage(record))
+
+            break
+          }
+          case 'expired': {
+            drop(record.projectId)
+            if (!announced) announce(expiredMessage(record))
+
+            break
+          }
+          case 'revoked': {
+            // Drop the dead token so getCliToken falls through to the login session.
+            drop(record.projectId)
+            if (!announced) announce(revokedMessage(record))
+
+            break
+          }
+          default: {
+            if (!announced) {
+              announce(renderAmbientLine(record, msLeft))
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (touched.size > 0) {
+    const fresh = readRecords()
+    for (const id of touched) {
+      if (id in records) fresh[id] = records[id]
+      else delete fresh[id]
+    }
+    writeRecords(fresh)
+  }
+}
+
+export {UNCLAIMED_PROJECTS_CONFIG_KEY} from '@sanity/cli-core'

--- a/packages/@sanity/cli/src/util/claimNudges.ts
+++ b/packages/@sanity/cli/src/util/claimNudges.ts
@@ -1,6 +1,7 @@
 import {styleText} from 'node:util'
 
-import {getUserConfig, UNCLAIMED_PROJECTS_CONFIG_KEY} from '@sanity/cli-core'
+import {getUserConfig} from '@sanity/cli-core'
+import {UNCLAIMED_PROJECTS_CONFIG_KEY} from '@sanity/cli-core/config'
 import {subdebug} from '@sanity/cli-core/debug'
 import {logSymbols} from '@sanity/cli-core/ux'
 
@@ -177,10 +178,10 @@ export async function runClaimNudges(
     write(`\n${message}\n`)
   }
 
-  const touched = new Set<string>()
+  const dropped = new Set<string>()
   const drop = (projectId: string) => {
     delete records[projectId]
-    touched.add(projectId)
+    dropped.add(projectId)
   }
 
   // Fall back to the local clock when unverifiable.
@@ -234,14 +235,12 @@ export async function runClaimNudges(
     announce(renderAggregateReminder(rest))
   }
 
-  if (touched.size > 0) {
+  if (dropped.size > 0) {
+    // Re-read so a sibling process's writes survive; only the ids we dropped are removed.
     const fresh = readRecords()
-    for (const id of touched) {
-      if (id in records) fresh[id] = records[id]
-      else delete fresh[id]
-    }
+    for (const id of dropped) delete fresh[id]
     writeRecords(fresh)
   }
 }
 
-export {UNCLAIMED_PROJECTS_CONFIG_KEY} from '@sanity/cli-core'
+export {UNCLAIMED_PROJECTS_CONFIG_KEY} from '@sanity/cli-core/config'

--- a/packages/@sanity/cli/src/util/claimNudges.ts
+++ b/packages/@sanity/cli/src/util/claimNudges.ts
@@ -164,6 +164,8 @@ const claimedMessage = (record: UnclaimedProjectRecord): string =>
 const expiredMessage = (record: UnclaimedProjectRecord): string =>
   // `--force` mints a replacement and leaves `.env` for you to update.
   `Unclaimed Sanity project ${record.projectId} expired on ${record.expiresAt} and has been deleted. Run \`sanity new --force\` to mint a replacement, and claim it within 72 hours to keep it.`
+const unverifiedExpiryMessage = (record: UnclaimedProjectRecord): string =>
+  `${logSymbols.warning} Sanity project ${record.projectId} reached its recorded claim deadline on ${record.expiresAt}, but its current state couldn't be verified. It may still be claimable; try ${record.claimUrl}. Its local credentials have been kept so a temporary network failure cannot discard access.`
 const revokedMessage = (record: UnclaimedProjectRecord): string =>
   // The dead token is no longer valid; let the user know.
   `${logSymbols.warning} Sanity project ${record.projectId}'s token is no longer valid. Run \`sanity login\`, then remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES} to act as yourself.`
@@ -217,9 +219,10 @@ export async function runClaimNudges(
       default: {
         if (msLeft > 0) {
           live.push({msLeft, record})
-        } else if (state !== 'claimable') {
-          announce(expiredMessage(record))
-          drop(record.projectId)
+        } else if (state === undefined) {
+          // A failed lookup is not proof of deletion. Keep the claim URL and robot token until
+          // the server confirms a terminal state; a later run can reconcile the record.
+          announce(unverifiedExpiryMessage(record))
         }
         // Locally expired but confirmed claimable (clock skew or an extended window): keep the
         // record quietly and let the next run re-check.

--- a/packages/@sanity/cli/src/util/claimNudges.ts
+++ b/packages/@sanity/cli/src/util/claimNudges.ts
@@ -11,6 +11,7 @@ import {
   type MintedProject,
 } from '../services/mintProject.js'
 import {TOKEN_ENV_FILES} from './envFile.js'
+import {CLAIM_WINDOW_HOURS} from './mintProjectConstants.js'
 
 const debug = subdebug('claimNudges')
 
@@ -121,9 +122,12 @@ function renderReminder(
   {solo = true} = {},
 ): string {
   const agentCta =
-    styleText('dim', 'If an agent is running this, surface the full claim URL to the user.') +
+    styleText(
+      'dim',
+      'If you are an agent: give this claim URL to the person you are working for.',
+    ) +
     '\n' +
-    styleText('dim', 'They need to click this link to claim the project before it expires.')
+    styleText('dim', 'They have to open it themselves before the deadline.')
 
   const urgent = msLeft <= 24 * 3_600_000
   const headline = `Unclaimed Sanity project ${record.projectId} expires in ${formatMsLeft(msLeft)}`
@@ -151,9 +155,12 @@ function renderAggregateReminder(live: Array<{msLeft: number; record: UnclaimedP
   return (
     `${header}\n\n` +
     `${lines.join('\n')}\n\n` +
-    styleText('dim', 'If an agent is running this, surface every claim URL above to the user.') +
+    styleText(
+      'dim',
+      'If you are an agent: give every claim URL above to the person you are working for.',
+    ) +
     '\n' +
-    styleText('dim', 'They need to click each link to claim its project before it expires.')
+    styleText('dim', 'They have to open each one themselves before its deadline.')
   )
 }
 
@@ -163,7 +170,7 @@ const claimedMessage = (record: UnclaimedProjectRecord): string =>
   `CLI commands here still authenticate with the robot token. Run \`sanity login\`, then remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES} to act as yourself.`
 const expiredMessage = (record: UnclaimedProjectRecord): string =>
   // `--force` mints a replacement and leaves `.env` for you to update.
-  `Unclaimed Sanity project ${record.projectId} expired on ${record.expiresAt} and has been deleted. Run \`sanity new --force\` to mint a replacement, and claim it within 72 hours to keep it.`
+  `The server confirmed that unclaimed Sanity project ${record.projectId} expired on ${record.expiresAt}. Its project and content are permanently gone and no longer recoverable. Run \`sanity new --force\` to create a replacement. Claim the replacement within ${CLAIM_WINDOW_HOURS} hours to keep it.`
 const unverifiedExpiryMessage = (record: UnclaimedProjectRecord): string =>
   `${logSymbols.warning} Sanity project ${record.projectId} reached its recorded claim deadline on ${record.expiresAt}, but its current state couldn't be verified. It may still be claimable; try ${record.claimUrl}. Its local credentials have been kept so a temporary network failure cannot discard access.`
 const revokedMessage = (record: UnclaimedProjectRecord): string =>

--- a/packages/@sanity/cli/src/util/claimNudges.ts
+++ b/packages/@sanity/cli/src/util/claimNudges.ts
@@ -10,6 +10,7 @@ import {
   lookupClaimStateViaProject,
   type MintedProject,
 } from '../services/mintProject.js'
+import {TOKEN_ENV_FILES} from './envFile.js'
 
 const debug = subdebug('claimNudges')
 
@@ -159,13 +160,13 @@ function renderAggregateReminder(live: Array<{msLeft: number; record: UnclaimedP
 const claimedMessage = (record: UnclaimedProjectRecord): string =>
   // The robot token stays in `.env` after claim; let the user know.
   `${logSymbols.success} Sanity project ${record.projectId} has been claimed. It's yours to keep.\n` +
-  `CLI commands here still authenticate with the robot token in .env. Run \`sanity login\`, then remove SANITY_AUTH_TOKEN from .env to act as yourself.`
+  `CLI commands here still authenticate with the robot token. Run \`sanity login\`, then remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES} to act as yourself.`
 const expiredMessage = (record: UnclaimedProjectRecord): string =>
   // `--force` mints a replacement and leaves `.env` for you to update.
   `Unclaimed Sanity project ${record.projectId} expired on ${record.expiresAt} and has been deleted. Run \`sanity new --force\` to mint a replacement, and claim it within 72 hours to keep it.`
 const revokedMessage = (record: UnclaimedProjectRecord): string =>
   // The dead token is no longer valid; let the user know.
-  `${logSymbols.warning} Sanity project ${record.projectId}'s token is no longer valid. Run \`sanity login\`, then remove SANITY_AUTH_TOKEN from .env to act as yourself.`
+  `${logSymbols.warning} Sanity project ${record.projectId}'s token is no longer valid. Run \`sanity login\`, then remove SANITY_AUTH_TOKEN from ${TOKEN_ENV_FILES} to act as yourself.`
 
 export async function runClaimNudges(
   write: (line: string) => void,

--- a/packages/@sanity/cli/src/util/claimNudges.ts
+++ b/packages/@sanity/cli/src/util/claimNudges.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import {styleText} from 'node:util'
 
 import {getUserConfig, UNCLAIMED_PROJECTS_CONFIG_KEY} from '@sanity/cli-core'
@@ -10,7 +9,6 @@ import {
   lookupClaimStateViaProject,
   type MintedProject,
 } from '../services/mintProject.js'
-import {readEnvValues} from './envFile.js'
 
 const debug = subdebug('claimNudges')
 
@@ -21,33 +19,19 @@ export interface UnclaimedProjectRecord {
   mintedAt: string
   projectId: string
 
-  /** Highest nudge tier already shown. */
-  lastNudgeTier?: number
-
   /** Robot token, used to read claim state as a function of organization membership. */
   token?: string
 }
 
-const NUDGE_TIERS = [
-  {ms: 48 * 3_600_000, tier: 1},
-  {ms: 24 * 3_600_000, tier: 2},
-  {ms: 8 * 3_600_000, tier: 3},
-  {ms: 2 * 3_600_000, tier: 4},
-] as const
+const unit = (n: number, name: string) => `${n} ${name}${n === 1 ? '' : 's'}`
 
-function tierFor(msLeft: number): number {
-  let current = 0
-  for (const {ms, tier} of NUDGE_TIERS) {
-    if (msLeft <= ms) current = tier
-  }
-  return current
-}
-
-function humanizeMsLeft(msLeft: number): string {
-  const minutes = Math.max(Math.round(msLeft / 60_000), 1)
-  if (minutes < 120) return `about ${minutes} minutes`
-  const hours = Math.round(minutes / 60)
-  return `about ${hours} hours`
+export function formatMsLeft(msLeft: number): string {
+  const totalMinutes = Math.max(Math.floor(msLeft / 60_000), 1)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  if (hours === 0) return unit(minutes, 'minute')
+  if (minutes === 0) return unit(hours, 'hour')
+  return `${unit(hours, 'hour')} ${unit(minutes, 'minute')}`
 }
 
 function isWellFormed(record: unknown): record is UnclaimedProjectRecord {
@@ -129,64 +113,67 @@ export function forgetMintedProject(projectId: string): boolean {
   }
 }
 
-function renderNudge(record: UnclaimedProjectRecord, tier: number, msLeft: number): string {
-  const timeLeft = humanizeMsLeft(msLeft)
-  const agentCta = styleText(
-    'dim',
-    'AI agents: surface this claim link to your human now — it cannot be recovered after expiry.',
-  )
+function renderReminder(
+  record: UnclaimedProjectRecord,
+  msLeft: number,
+  {solo = true} = {},
+): string {
+  const agentCta =
+    styleText('dim', 'If an agent is running this, surface the full claim URL to the user.') +
+    '\n' +
+    styleText('dim', 'They need to click this link to claim the project before it expires.')
 
-  const urgent = tier >= 3
-  const headline =
-    tier === 1
-      ? `⏳ Claim your Sanity project — ${record.projectId} expires in ${timeLeft}`
-      : tier >= 4
-        ? `🚨 Final reminder — project ${record.projectId} expires in ${timeLeft}`
-        : `${urgent ? '🚨' : '⏰'} Project ${record.projectId} expires in ${timeLeft}`
-  const bell = tier >= 4 ? '' : ''
-  return (
-    bell +
+  const urgent = msLeft <= 24 * 3_600_000
+  const headline = `Unclaimed Sanity project ${record.projectId} expires in ${formatMsLeft(msLeft)}`
+  const base =
     `${styleText(['bold', urgent ? 'red' : 'yellow'], headline)}\n` +
+    `Claim it now: there's no downside to claiming early, and everything keeps working, including the token in .env.\n` +
+    styleText(['cyan', 'underline'], record.claimUrl)
+  if (!solo) return base
+  return (
+    `${base}\n\n` +
     `Everything in it is permanently deleted at ${record.expiresAt} unless you claim it.\n` +
-    `Claiming is free and keeps everything working, including the token in .env.\n` +
-    `Claim it now: ${styleText(['cyan', 'underline'], record.claimUrl)}\n` +
     agentCta
   )
 }
 
-function renderAmbientLine(record: UnclaimedProjectRecord, msLeft: number): string {
+function renderAggregateReminder(live: Array<{msLeft: number; record: UnclaimedProjectRecord}>) {
+  const header =
+    live.length === 1
+      ? '1 more unclaimed Sanity project, permanently deleted at its deadline unless you claim it:'
+      : `${live.length} more unclaimed Sanity projects, each permanently deleted at its deadline unless you claim it:`
+  const lines = live.map(
+    ({msLeft, record}) =>
+      `${styleText('cyan', record.projectId)} expires in ${formatMsLeft(msLeft)}: ${styleText(['cyan', 'underline'], record.claimUrl)}`,
+  )
   return (
-    styleText(
-      'dim',
-      `⏳ Unclaimed Sanity project ${record.projectId} expires in ${humanizeMsLeft(msLeft)} — claim it to keep it:`,
-    ) + `\n${styleText(['cyan', 'underline'], record.claimUrl)}`
+    `${header}\n\n` +
+    `${lines.join('\n')}\n\n` +
+    styleText('dim', 'If an agent is running this, surface every claim URL above to the user.') +
+    '\n' +
+    styleText('dim', 'They need to click each link to claim its project before it expires.')
   )
 }
 
 const claimedMessage = (record: UnclaimedProjectRecord): string =>
-  `${logSymbols.success} Sanity project ${record.projectId} has been claimed — it's yours to keep.`
+  // The robot token stays in `.env` after claim; let the user know.
+  `${logSymbols.success} Sanity project ${record.projectId} has been claimed. It's yours to keep.\n` +
+  `CLI commands here still authenticate with the robot token in .env. Run \`sanity login\`, then remove SANITY_AUTH_TOKEN from .env to act as yourself.`
 const expiredMessage = (record: UnclaimedProjectRecord): string =>
-  // `--force`: the expired credentials are still in `.env`, so a plain `sanity new` is refused by
-  // the remint guard (it won't overwrite them) — `--force` mints a replacement and leaves `.env`
-  // for you to update.
-  `⌛ Unclaimed Sanity project ${record.projectId} expired on ${record.expiresAt}. Run \`sanity new --force\` to mint a replacement.`
+  // `--force` mints a replacement and leaves `.env` for you to update.
+  `Unclaimed Sanity project ${record.projectId} expired on ${record.expiresAt} and has been deleted. Run \`sanity new --force\` to mint a replacement, and claim it within 72 hours to keep it.`
 const revokedMessage = (record: UnclaimedProjectRecord): string =>
-  // Removing SANITY_AUTH_TOKEN matters once a Sanity config exists: `.env` is auto-injected and the
-  // dead token would otherwise outrank the new login session in getCliToken.
-  `⚠ Sanity project ${record.projectId}'s token is no longer valid. Run \`sanity login\`, then remove SANITY_AUTH_TOKEN from .env to act as yourself.`
+  // The dead token is no longer valid; let the user know.
+  `${logSymbols.warning} Sanity project ${record.projectId}'s token is no longer valid. Run \`sanity login\`, then remove SANITY_AUTH_TOKEN from .env to act as yourself.`
 
 export async function runClaimNudges(
   write: (line: string) => void,
   now: number = Date.now(),
-  cwd: string = process.cwd(),
 ): Promise<void> {
   const records = readRecords()
   if (Object.keys(records).length === 0) return
 
-  let announced = false
-
   const announce = (message: string) => {
-    announced = true
     write(`\n${message}\n`)
   }
 
@@ -196,123 +183,55 @@ export async function runClaimNudges(
     touched.add(projectId)
   }
 
-  const announceClaimed = (record: UnclaimedProjectRecord) => {
-    announce(claimedMessage(record))
-    drop(record.projectId)
-  }
-  const announceExpired = (record: UnclaimedProjectRecord) => {
-    announce(expiredMessage(record))
-    drop(record.projectId)
-  }
-  // A revoked token is dead weight in the ledger and, for the cwd project, actively blocks login by
-  // outranking the session in getCliToken — so drop it wherever it's seen.
-  const announceRevoked = (record: UnclaimedProjectRecord) => {
-    announce(revokedMessage(record))
-    drop(record.projectId)
-  }
-
-  // Fall back to local clock when unverifiable. Memoized so a project checked in one slot is not
-  // looked up again in another within the same run.
-  const confirmed = new Map<string, ClaimState | undefined>()
+  // Fall back to the local clock when unverifiable.
   const confirm = async (record: UnclaimedProjectRecord): Promise<ClaimState | undefined> => {
     if (!record.token) return undefined
-    if (confirmed.has(record.projectId)) return confirmed.get(record.projectId)
-    const state = await lookupClaimStateViaProject(record.projectId, record.token, {timeoutMs: 500})
-    confirmed.set(record.projectId, state)
-    return state
+    return lookupClaimStateViaProject(record.projectId, record.token)
   }
 
-  for (const record of Object.values(records)) {
-    if (new Date(record.expiresAt).getTime() > now) continue
-    const state = await confirm(record)
-    switch (state) {
-      case 'claimable': {
-        continue
-        break
-      }
-      case 'claimed': {
-        announceClaimed(record)
-        break
-      }
-      case 'revoked': {
-        announceRevoked(record)
-        break
-      }
-      default: {
-        announceExpired(record)
-      }
-    }
-  }
+  const live: Array<{msLeft: number; record: UnclaimedProjectRecord}> = []
+  const entries = Object.values(records)
+  const states = await Promise.all(entries.map((record) => confirm(record)))
 
-  // The most urgent live project whose tier advanced since its last shown nudge.
-  const due = Object.values(records)
-    .map((record) => ({msLeft: new Date(record.expiresAt).getTime() - now, record}))
-    .filter(({msLeft, record}) => msLeft > 0 && tierFor(msLeft) > (record.lastNudgeTier ?? 0))
-    .toSorted((a, b) => a.msLeft - b.msLeft)[0]
-
-  if (!announced && due) {
-    const {msLeft, record} = due
-    const state = await confirm(record)
+  for (const [index, record] of entries.entries()) {
+    const msLeft = new Date(record.expiresAt).getTime() - now
+    const state = states[index]
     switch (state) {
       case 'claimed': {
-        announceClaimed(record)
+        announce(claimedMessage(record))
+        drop(record.projectId)
         break
       }
       case 'expired': {
-        announceExpired(record)
+        announce(expiredMessage(record))
+        drop(record.projectId)
         break
       }
       case 'revoked': {
-        announceRevoked(record)
+        announce(revokedMessage(record))
+        drop(record.projectId)
         break
       }
       default: {
-        const tier = tierFor(msLeft)
-        announce(renderNudge(record, tier, msLeft))
-        records[record.projectId] = {...record, lastNudgeTier: tier}
-        touched.add(record.projectId)
+        if (msLeft > 0) {
+          live.push({msLeft, record})
+        } else if (state !== 'claimable') {
+          announce(expiredMessage(record))
+          drop(record.projectId)
+        }
+        // Locally expired but confirmed claimable (clock skew or an extended window): keep the
+        // record quietly and let the next run re-check.
       }
     }
   }
 
-  // The directory's own project governs auth here — its ledger token can outrank a login session
-  // in getCliToken — so always verify it and drop a claimed/expired record, even when another
-  // project already took the single announce slot. Only the ambient line itself waits for the slot.
-  {
-    const {SANITY_PROJECT_ID} = readEnvValues(path.join(cwd, '.env'), ['SANITY_PROJECT_ID'])
-    const record = SANITY_PROJECT_ID ? records[SANITY_PROJECT_ID] : undefined
-    if (record) {
-      const msLeft = new Date(record.expiresAt).getTime() - now
-      if (msLeft > 0) {
-        const state = await confirm(record)
-        switch (state) {
-          case 'claimed': {
-            drop(record.projectId)
-            if (!announced) announce(claimedMessage(record))
-
-            break
-          }
-          case 'expired': {
-            drop(record.projectId)
-            if (!announced) announce(expiredMessage(record))
-
-            break
-          }
-          case 'revoked': {
-            // Drop the dead token so getCliToken falls through to the login session.
-            drop(record.projectId)
-            if (!announced) announce(revokedMessage(record))
-
-            break
-          }
-          default: {
-            if (!announced) {
-              announce(renderAmbientLine(record, msLeft))
-            }
-          }
-        }
-      }
-    }
+  live.sort((a, b) => a.msLeft - b.msLeft)
+  const [lead, ...rest] = live
+  if (lead && rest.length === 0) {
+    announce(renderReminder(lead.record, lead.msLeft))
+  } else if (lead) {
+    announce(renderReminder(lead.record, lead.msLeft, {solo: false}))
+    announce(renderAggregateReminder(rest))
   }
 
   if (touched.size > 0) {

--- a/packages/@sanity/cli/src/util/envFile.ts
+++ b/packages/@sanity/cli/src/util/envFile.ts
@@ -1,0 +1,99 @@
+import {execFileSync} from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {parse as parseDotenv} from 'dotenv'
+
+/**
+ * Keys that mark a directory as already belonging to a Sanity project. When any are present,
+ * `sanity new`'s remint guard refuses (it won't overwrite credentials), so other surfaces (e.g.
+ * `sanity init`) should not steer users toward `sanity new` here either. `SANITY_DATASET` is
+ * excluded — it's a common exemplar variable.
+ */
+export const GUARDED_ENV_KEYS = [
+  'SANITY_AUTH_TOKEN',
+  'SANITY_PROJECT_ID',
+  'SANITY_CLAIM_URL',
+] as const
+
+/**
+ * Whether `.env` is already tracked by git in `dir`. Gitignore only affects untracked files, so a
+ * tracked `.env` will still be committed no matter what `.gitignore` says — callers must warn and
+ * tell the user to untrack it. Fails open to `false` (git missing, not a repo, `.env` untracked).
+ */
+export function isEnvTracked(dir: string): boolean {
+  try {
+    execFileSync('git', ['ls-files', '--error-unmatch', '.env'], {cwd: dir, stdio: 'ignore'})
+    return true
+  } catch {
+    return false
+  }
+}
+
+export interface EnvWriteResult {
+  /** Whether the file was created by this write (as opposed to appended to). */
+  created: boolean
+  /** Keys already present in the file, left untouched. */
+  skippedKeys: string[]
+  /** Keys appended by this write, in the order given. */
+  wroteKeys: string[]
+}
+
+function hasKey(contents: string, key: string): boolean {
+  return new RegExp(String.raw`^\s*(?:export\s+)?${key}\s*=`, 'm').test(contents)
+}
+
+export function readEnvValues(envPath: string, keys: string[]): Partial<Record<string, string>> {
+  if (!fs.existsSync(envPath)) return {}
+  const parsed = parseDotenv(fs.readFileSync(envPath, 'utf8'))
+
+  const values: Partial<Record<string, string>> = {}
+  for (const key of keys) {
+    const value = parsed[key]?.trim()
+    if (value) values[key] = value
+  }
+  return values
+}
+
+export function appendEnvValues(
+  envPath: string,
+  values: Record<string, string>,
+  options?: {banner?: string[]},
+): EnvWriteResult {
+  const existing = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf8') : undefined
+
+  const wroteKeys = Object.keys(values).filter((key) => !hasKey(existing ?? '', key))
+  const skippedKeys = Object.keys(values).filter((key) => hasKey(existing ?? '', key))
+
+  if (wroteKeys.length > 0) {
+    const banner = (options?.banner ?? []).map((line) => `# ${line}`)
+    const block = [...banner, ...wroteKeys.map((key) => `${key}="${values[key]}"`)].join('\n')
+    const separator = existing ? (existing.endsWith('\n') ? '\n' : '\n\n') : ''
+    fs.appendFileSync(envPath, `${separator}${block}\n`)
+  }
+
+  return {created: existing === undefined, skippedKeys, wroteKeys}
+}
+
+/**
+ * Ensure `.env` is gitignored in `dir`. `ignored` reports whether `.env` is definitely covered
+ * afterwards; callers must warn when it is false, since a failed write can leave a token committable
+ * and there is no way to distinguish that from success without it. `added` is true only when this
+ * call wrote the entry (so "already ignored" stays quiet).
+ */
+export function ensureEnvGitignored(dir: string): {added: boolean; ignored: boolean} {
+  try {
+    const gitignorePath = path.join(dir, '.gitignore')
+    const existing = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, 'utf8') : ''
+    const alreadyIgnored = existing
+      .split('\n')
+      .some((line) => line.trim().replace(/^\//, '') === '.env')
+    if (alreadyIgnored) return {added: false, ignored: true}
+
+    const separator = existing && !existing.endsWith('\n') ? '\n' : ''
+    fs.appendFileSync(gitignorePath, `${separator}.env\n`)
+    return {added: true, ignored: true}
+  } catch {
+    return {added: false, ignored: false}
+  }
+}

--- a/packages/@sanity/cli/src/util/envFile.ts
+++ b/packages/@sanity/cli/src/util/envFile.ts
@@ -16,6 +16,8 @@ export const GUARDED_ENV_KEYS = [
   'SANITY_CLAIM_URL',
 ] as const
 
+export const TOKEN_ENV_FILES = './.env or sanity/.env.local'
+
 /**
  * Whether `.env` is already tracked by git in `dir`. Gitignore only affects untracked files, so a
  * tracked `.env` will still be committed no matter what `.gitignore` says — callers must warn and
@@ -76,22 +78,23 @@ export function appendEnvValues(
 }
 
 /**
- * Ensure `.env` is gitignored in `dir`. `ignored` reports whether `.env` is definitely covered
- * afterwards; callers must warn when it is false, since a failed write can leave a token committable
- * and there is no way to distinguish that from success without it. `added` is true only when this
- * call wrote the entry (so "already ignored" stays quiet).
+ * Ensure `pattern` is gitignored in `dir`. `ignored` is false when a failed write may have left the
+ * file committable; `added` is true only when this call wrote the entry.
  */
-export function ensureEnvGitignored(dir: string): {added: boolean; ignored: boolean} {
+export function ensureEnvGitignored(
+  dir: string,
+  pattern: string = '.env',
+): {added: boolean; ignored: boolean} {
   try {
     const gitignorePath = path.join(dir, '.gitignore')
     const existing = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, 'utf8') : ''
-    const alreadyIgnored = existing
-      .split('\n')
-      .some((line) => line.trim().replace(/^\//, '') === '.env')
+    // Git matches a slash-free pattern at any depth; a root-anchored `/.env*` misses nested files.
+    const covers = new Set(pattern === '.env' ? ['.env', '/.env', '.env*'] : [pattern])
+    const alreadyIgnored = existing.split('\n').some((line) => covers.has(line.trim()))
     if (alreadyIgnored) return {added: false, ignored: true}
 
     const separator = existing && !existing.endsWith('\n') ? '\n' : ''
-    fs.appendFileSync(gitignorePath, `${separator}.env\n`)
+    fs.appendFileSync(gitignorePath, `${separator}${pattern}\n`)
     return {added: true, ignored: true}
   } catch {
     return {added: false, ignored: false}

--- a/packages/@sanity/cli/src/util/envFile.ts
+++ b/packages/@sanity/cli/src/util/envFile.ts
@@ -45,16 +45,41 @@ function hasKey(contents: string, key: string): boolean {
   return new RegExp(String.raw`^\s*(?:export\s+)?${key}\s*=`, 'm').test(contents)
 }
 
-export function readEnvValues(envPath: string, keys: string[]): Partial<Record<string, string>> {
-  if (!fs.existsSync(envPath)) return {}
-  const parsed = parseDotenv(fs.readFileSync(envPath, 'utf8'))
+export interface EnvKeyInspection {
+  /** Keys present as assignment lines whose effective dotenv value is absent or blank. */
+  blankKeys: string[]
+  /** Keys with assignment syntax in the file (including `export KEY=`), blank or not. */
+  presentKeys: string[]
+  /** Effective nonblank values, following dotenv grammar (last assignment wins). */
+  values: Partial<Record<string, string>>
+}
 
+/**
+ * Inspect `keys` in the env file at `envPath` under both definitions of "exists" used by the env
+ * helpers: assignment-line presence (what `appendEnvValues` refuses to overwrite) and effective
+ * dotenv value (what `readEnvValues` returns). `blankKeys` is the gap between the two: lines the
+ * writer will skip but that carry no usable value.
+ */
+export function inspectEnvKeys(envPath: string, keys: readonly string[]): EnvKeyInspection {
+  if (!fs.existsSync(envPath)) return {blankKeys: [], presentKeys: [], values: {}}
+  const contents = fs.readFileSync(envPath, 'utf8')
+  const parsed = parseDotenv(contents)
+
+  const presentKeys = keys.filter((key) => hasKey(contents, key))
   const values: Partial<Record<string, string>> = {}
   for (const key of keys) {
     const value = parsed[key]?.trim()
     if (value) values[key] = value
   }
-  return values
+  return {
+    blankKeys: presentKeys.filter((key) => values[key] === undefined),
+    presentKeys,
+    values,
+  }
+}
+
+export function readEnvValues(envPath: string, keys: string[]): Partial<Record<string, string>> {
+  return inspectEnvKeys(envPath, keys).values
 }
 
 export function appendEnvValues(

--- a/packages/@sanity/cli/src/util/mintProjectConstants.ts
+++ b/packages/@sanity/cli/src/util/mintProjectConstants.ts
@@ -1,0 +1,4 @@
+/** Product window in which an unclaimed project must be claimed. */
+export const CLAIM_WINDOW_HOURS = 72
+
+export const SANITY_NEW_URL = 'https://sanity.new'

--- a/packages/@sanity/cli/src/util/newCommandSplash.ts
+++ b/packages/@sanity/cli/src/util/newCommandSplash.ts
@@ -1,0 +1,56 @@
+import {styleText} from 'node:util'
+
+import {hyperlink} from './terminalLink.js'
+
+type LogFn = (message?: string) => void
+
+const ART = [
+  '          -          #:      @@@@',
+  '         @@@      @@@@@    -@@@=   @@@',
+  '       @@@@   %@@@@@@.    @@@@ %@@@@@@',
+  '      @@@% @@@@@@@#     %@@@@@@@@@-',
+  '    @@@@@@@@@@@@@      @@@@@@@@.',
+  '   @@@@@@@= @@@#     @@@@@@@        @@@@@',
+  '   @@@@   @@@@    @@@@@@         @@@@@@@',
+  '         @@@@ @@@@@@@@        @@@@@@@@',
+  '       +@@@@@@@@@@@@@      @@@@@@@@@@',
+  '      @@@@@@@@ @@@@     @@@@@@ @@@@',
+  '     @@@@@%  *@@@%  .@@@@@%  .@@@@ .@@@@',
+  '      .-    @@@@ .@@@@@%    #@@@.@@@@@@@@',
+  '          *@@@@@@@@@%      @@@@@@@@#@@@@',
+  '         @@@@@@@@        #@@@@@@#  @@@@',
+  '       @@@@@@@           @@@@#    @@@@',
+  '      #@@@@               *      @@@+',
+  '                                  =',
+]
+
+// Built per render, not at module load: `hyperlink` decides OSC 8 support from stdout at call
+// time, so freezing the links at import would bake in whatever stdout was during module init.
+const LINK_URLS = ['https://sanity.new', 'https://sanity.io/learn']
+const renderLinks = () => LINK_URLS.map((url) => hyperlink(styleText('cyan', url), url))
+
+/** Art row the link tree starts on when rendered to the right of the squiggle. */
+const LINKS_START_ROW = 5
+
+/** Column the link tree starts in, with buffer for the widest art row. */
+const LINKS_COLUMN = Math.max(...ART.map((line) => line.length)) + 5
+
+/** Visible width of the widest link. */
+const LINKS_WIDTH = Math.max(...LINK_URLS.map((url) => url.length))
+
+export function renderNewCommandSplash(log: LogFn): void {
+  const columns = process.stdout.columns
+  const sideBySide = !columns || columns >= LINKS_COLUMN + LINKS_WIDTH
+  const links = renderLinks()
+
+  log('')
+  for (const [row, line] of ART.entries()) {
+    const link = sideBySide ? links[row - LINKS_START_ROW] : undefined
+    log(link ? `${styleText('cyan', line.padEnd(LINKS_COLUMN))}${link}` : styleText('cyan', line))
+  }
+  if (!sideBySide) {
+    log('')
+    for (const link of links) log(`   ${link}`)
+  }
+  log('')
+}

--- a/packages/@sanity/cli/src/util/newCommandSplash.ts
+++ b/packages/@sanity/cli/src/util/newCommandSplash.ts
@@ -1,7 +1,5 @@
 import {styleText} from 'node:util'
 
-import {hyperlink} from './terminalLink.js'
-
 type LogFn = (message?: string) => void
 
 const ART = [
@@ -24,33 +22,8 @@ const ART = [
   '                                  =',
 ]
 
-// Built per render, not at module load: `hyperlink` decides OSC 8 support from stdout at call
-// time, so freezing the links at import would bake in whatever stdout was during module init.
-const LINK_URLS = ['https://sanity.new', 'https://sanity.io/learn']
-const renderLinks = () => LINK_URLS.map((url) => hyperlink(styleText('cyan', url), url))
-
-/** Art row the link tree starts on when rendered to the right of the squiggle. */
-const LINKS_START_ROW = 5
-
-/** Column the link tree starts in, with buffer for the widest art row. */
-const LINKS_COLUMN = Math.max(...ART.map((line) => line.length)) + 5
-
-/** Visible width of the widest link. */
-const LINKS_WIDTH = Math.max(...LINK_URLS.map((url) => url.length))
-
 export function renderNewCommandSplash(log: LogFn): void {
-  const columns = process.stdout.columns
-  const sideBySide = !columns || columns >= LINKS_COLUMN + LINKS_WIDTH
-  const links = renderLinks()
-
   log('')
-  for (const [row, line] of ART.entries()) {
-    const link = sideBySide ? links[row - LINKS_START_ROW] : undefined
-    log(link ? `${styleText('cyan', line.padEnd(LINKS_COLUMN))}${link}` : styleText('cyan', line))
-  }
-  if (!sideBySide) {
-    log('')
-    for (const link of links) log(`   ${link}`)
-  }
+  for (const line of ART) log(styleText('cyan', line))
   log('')
 }

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/installPackages.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/installPackages.test.ts
@@ -73,6 +73,10 @@ describe('installDeclaredPackages', () => {
     expect(mockSpinnerInstance.start).toHaveBeenCalled()
     expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
     expect(mockSpinnerInstance.fail).not.toHaveBeenCalled()
+    expect(mockSpinner).toHaveBeenCalledWith({
+      discardStdin: true,
+      text: 'Running npm install\n',
+    })
   })
 
   test('installs with yarn successfully', async () => {
@@ -346,6 +350,10 @@ describe('installNewPackages', () => {
       ['install', '--save', 'next-sanity'],
       expect.objectContaining({cancelSignal: controller.signal}),
     )
+    expect(mockSpinner).toHaveBeenCalledWith({
+      discardStdin: false,
+      text: 'Running npm install --save next-sanity\n',
+    })
     expect(mockSpinnerInstance.fail).toHaveBeenCalledOnce()
     expect(mockSpinnerInstance.succeed).not.toHaveBeenCalled()
   })

--- a/packages/@sanity/cli/src/util/packageManager/__tests__/installPackages.test.ts
+++ b/packages/@sanity/cli/src/util/packageManager/__tests__/installPackages.test.ts
@@ -330,6 +330,25 @@ describe('installNewPackages', () => {
     })
     expect(mockSpinnerInstance.succeed).toHaveBeenCalled()
   })
+
+  test('propagates cancellation when the package manager exits successfully', async () => {
+    const controller = new AbortController()
+    const options = {packageManager: 'npm' as const, packages: ['next-sanity']}
+    controller.abort(new Error('SIGINT'))
+    mockExeca.mockResolvedValueOnce({exitCode: 0, failed: false} as Result)
+
+    await expect(
+      installNewPackages(options, {...context, cancelSignal: controller.signal}),
+    ).rejects.toThrow('SIGINT')
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'npm',
+      ['install', '--save', 'next-sanity'],
+      expect.objectContaining({cancelSignal: controller.signal}),
+    )
+    expect(mockSpinnerInstance.fail).toHaveBeenCalledOnce()
+    expect(mockSpinnerInstance.succeed).not.toHaveBeenCalled()
+  })
 })
 
 describe('pnpm ignored build scripts', () => {

--- a/packages/@sanity/cli/src/util/packageManager/installPackages.ts
+++ b/packages/@sanity/cli/src/util/packageManager/installPackages.ts
@@ -143,10 +143,10 @@ export async function installDeclaredPackages(
 
 export async function installNewPackages(
   options: InstallOptions,
-  context: {cancelSignal?: AbortSignal; output: Output; workDir: string},
+  context: {cancelSignal?: AbortSignal; output: Output; timeout?: number; workDir: string},
 ): Promise<void> {
   const {packageManager, packages} = options
-  const {cancelSignal, output, workDir} = context
+  const {cancelSignal, output, timeout, workDir} = context
   const execOptions: Options = {
     cancelSignal,
     cwd: workDir,
@@ -154,6 +154,7 @@ export async function installNewPackages(
     env: getPartialEnvWithNpmPath(workDir),
     reject: false,
     stdio: 'pipe',
+    timeout,
   }
 
   if (packageManager === 'manual') {

--- a/packages/@sanity/cli/src/util/packageManager/installPackages.ts
+++ b/packages/@sanity/cli/src/util/packageManager/installPackages.ts
@@ -71,7 +71,10 @@ async function executePackageManagerCommand(
   output: Output,
   errorMessage: string,
 ): Promise<void> {
-  const progress = spinner(`Running ${packageManager} ${args.join(' ')}\n`).start()
+  const progress = spinner({
+    discardStdin: !execOptions.cancelSignal,
+    text: `Running ${packageManager} ${args.join(' ')}\n`,
+  }).start()
 
   const result = await execa(packageManager, args, execOptions)
 

--- a/packages/@sanity/cli/src/util/packageManager/installPackages.ts
+++ b/packages/@sanity/cli/src/util/packageManager/installPackages.ts
@@ -75,6 +75,11 @@ async function executePackageManagerCommand(
 
   const result = await execa(packageManager, args, execOptions)
 
+  if (execOptions.cancelSignal?.aborted) {
+    progress.fail()
+    execOptions.cancelSignal.throwIfAborted()
+  }
+
   if (result?.exitCode || result?.failed) {
     // pnpm exits non-zero if dependency build scripts were skipped, even though
     // the install itself succeeded. Treat it as a success, but point to
@@ -135,11 +140,12 @@ export async function installDeclaredPackages(
 
 export async function installNewPackages(
   options: InstallOptions,
-  context: {output: Output; workDir: string},
+  context: {cancelSignal?: AbortSignal; output: Output; workDir: string},
 ): Promise<void> {
   const {packageManager, packages} = options
-  const {output, workDir} = context
+  const {cancelSignal, output, workDir} = context
   const execOptions: Options = {
+    cancelSignal,
     cwd: workDir,
     encoding: 'utf8',
     env: getPartialEnvWithNpmPath(workDir),

--- a/packages/@sanity/cli/src/util/terminalLink.ts
+++ b/packages/@sanity/cli/src/util/terminalLink.ts
@@ -1,0 +1,13 @@
+import {styleText} from 'node:util'
+
+/**
+ * Wrap `text` in an OSC 8 terminal hyperlink to `url`. Only emits the escape sequence when
+ * stdout is a TTY — piped output (agents, logs) gets the bare text, no escape bytes. Terminals
+ * without OSC 8 support ignore the sequence and render the (underlined) text
+ * unchanged; `text` may already carry ANSI color styling.
+ */
+export function hyperlink(text: string, url: string): string {
+  return process.stdout.isTTY
+    ? `\u001B]8;;${url}\u0007${styleText('underline', text)}\u001B]8;;\u0007`
+    : text
+}

--- a/packages/@sanity/cli/test/integration/commands/exec-with-user-token.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/exec-with-user-token.test.ts
@@ -60,7 +60,7 @@ describe('exec --with-user-token', {timeout: 15 * 1000}, () => {
   let scriptPath: string
 
   beforeEach(async () => {
-    exampleDir = await testFixture('basic-studio')
+    exampleDir = await testFixture('basic-studio', {useSystemTmp: true})
     process.chdir(exampleDir)
 
     scriptPath = join(exampleDir, 'test-script.ts')

--- a/packages/@sanity/cli/test/integration/hooks/prerun/injectEnvVariables.test.ts
+++ b/packages/@sanity/cli/test/integration/hooks/prerun/injectEnvVariables.test.ts
@@ -60,7 +60,7 @@ describe('#injectEnvVariables', () => {
     expect(process.env.MY_CUSTOM_VAR).toBe('test2')
   })
 
-  test('should not inject a mint-root token into a descendant frontend', async () => {
+  test('should not inject a mint-root token into a generated frontend without Sanity config', async () => {
     const mintRoot = await testFixture('basic-functions')
     const frontendRoot = join(mintRoot, 'web')
     const cwd = join(frontendRoot, 'src')

--- a/packages/@sanity/cli/test/integration/hooks/prerun/injectEnvVariables.test.ts
+++ b/packages/@sanity/cli/test/integration/hooks/prerun/injectEnvVariables.test.ts
@@ -1,4 +1,4 @@
-import {writeFile} from 'node:fs/promises'
+import {mkdir, writeFile} from 'node:fs/promises'
 import {join} from 'node:path'
 
 import {testFixture, testHook} from '@sanity/cli-test'
@@ -58,6 +58,30 @@ describe('#injectEnvVariables', () => {
 
     expect(process.env.SANITY_APP_TEST_VAR).toBe('test')
     expect(process.env.MY_CUSTOM_VAR).toBe('test2')
+  })
+
+  test('should not inject a mint-root token into a descendant frontend', async () => {
+    const mintRoot = await testFixture('basic-functions')
+    const frontendRoot = join(mintRoot, 'web')
+    const cwd = join(frontendRoot, 'src')
+    await mkdir(cwd, {recursive: true})
+    await writeFile(
+      join(mintRoot, '.env'),
+      'SANITY_PROJECT_ID=root-project\nSANITY_AUTH_TOKEN=sk-root-robot\n',
+    )
+    delete process.env.SANITY_AUTH_TOKEN
+    delete process.env.SANITY_PROJECT_ID
+    process.chdir(cwd)
+
+    const {Command, config} = await getCommandAndConfig('learn')
+
+    await testHook<'prerun'>(injectEnvVariables, {
+      Command,
+      config,
+    })
+
+    expect(process.env.SANITY_AUTH_TOKEN).toBeUndefined()
+    expect(process.env.SANITY_PROJECT_ID).toBeUndefined()
   })
 
   test('should warn when running in production environment', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1052,6 +1052,9 @@ importers:
       vite-node:
         specifier: 'catalog:'
         version: 6.0.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)
+      wrap-ansi:
+        specifier: ^9.0.2
+        version: 9.0.2
       zod:
         specifier: 'catalog:'
         version: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1010,6 +1010,9 @@ importers:
       debug:
         specifier: 'catalog:'
         version: 4.4.3(supports-color@8.1.1)
+      dotenv:
+        specifier: 'catalog:'
+        version: 17.4.2
       empathic:
         specifier: 'catalog:'
         version: 2.0.1


### PR DESCRIPTION
### Description

this PR adds `sanity new` as an alias of `sanity projects mint`. high level, we're allowing humans and agents to create projects without an account, through public apis that produce a claim URL that allows transfer of a newly-created project to the user's desired organization within 72hrs of creation

### What's included

- `sanity new` mints a new project and issues a robot token that can be used to drive programmatic content lake operations
- reminders are periodically surfaced on cli commands until the project is claimed or expires
- a `nextjs` project is scaffolded, and claims metadata is woven into scaffold-accessible environment
- `sanity init` hints at `sanity new` availability so humans and agents can discover and leverage the new behavior
- minor changes to existing cli behavior to play nicely with `sanity new`

### For reviewers

we initially gave a stacked diff a try, but the result was a bit unwieldy: `sanity new` functionality is deep intertwined, and easier to review with agentic support if it's broken into commits on a single diff as per early feedback. we've reshipped as a series of commits instead, and recommend reviewing commit-by-commit or pointing a review agent at the pr to do a holistic pass

### Testing

we added unit coverage and conducted manual uat to exercise all branching logic related to credential management

<img width="865" height="988" alt="Screenshot 2026-07-28 at 4 19 52 AM" src="https://github.com/user-attachments/assets/f65b82ee-a4b3-454b-84af-741d972f26f5" />
<img width="866" height="537" alt="Screenshot 2026-07-28 at 4 20 14 AM" src="https://github.com/user-attachments/assets/25c08685-6e61-49f0-96fc-e102839942ad" />

### Notes for release

Add `sanity new` to mint an unclaimed Sanity project without logging in, scaffold a Studio and a Next.js frontend for it, and claim it with a Sanity account within 72 hours to keep it. Pass `--no-scaffold` to mint without scaffolding, or `--json` for a machine-readable payload that writes no files.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes CLI authentication precedence, token caching, and login/logout revocation paths while introducing long-lived robot tokens in `.env` and user config—security-sensitive and easy to misconfigure across nested directories.
> 
> **Overview**
> Introduces **`sanity new`** (a top-level alias over project minting) so users and agents can create an unclaimed Sanity project without logging in, receive a robot token and claim URL, and optionally scaffold **`./sanity`** plus **`./web`** (Next.js via `create-next-app`, `next-sanity`). **`--json`** and **`--no-scaffold`** support agent-style and project-only flows; mint guards refuse remints when ancestor `.env` credential boundaries already exist (including blank guarded placeholders).
> 
> **Credential handling** is centralized in **`resolveCliCredential`**: environment `SANITY_AUTH_TOKEN`, then minted-project identity from the nearest ancestor `.env` boundary plus an **`unclaimedProjects`** ledger (with `.env` recovery), then the stored login session. **`getCliToken`** delegates to that stack; cache invalidation covers ledger writes. **Login** revokes the stored session via **`getCliUserConfig`**, not the active robot/env token, and warns when env or mint tokens still outrank the new session. **Logout** only revokes the stored session and explains when env/ledger robots remain active.
> 
> **`sanity init`** gains a “two ways to start” banner (suppressed in minted directories), mint-aware unattended errors, and clearer handling when a robot token authenticates without a user email. A **`createFlow`** helper adds rail-style CLI output for mint narration; a **claim reminders** prerun hook is registered in oclif config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9dde7d8d468d4cd8c79c008fc0fb35559564237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



