### PR TITLE
fix(workbench): output federation static assets to static dir

### DIFF
--- a/.changeset/pr-1594.md
+++ b/.changeset/pr-1594.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/workbench-cli': patch
+---
+
+fix(workbench): output federation static assets to static dir

--- a/.changeset/pr-1594.md
+++ b/.changeset/pr-1594.md
@@ -1,5 +1,6 @@
 <!-- auto-generated -->
 ---
+'@sanity/cli': patch
 '@sanity/workbench-cli': patch
 ---
 

--- a/packages/@sanity/cli/test/integration/commands/build.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/build.studio.test.ts
@@ -113,7 +113,6 @@ describe('#build studio', {timeout: (platform() === 'win32' ? 120 : 60) * 1000},
       const distFiles = await readdir(join(cwd, 'dist'))
 
       expect(distFiles).not.toContain('index.html')
-      expect(distFiles).not.toContain('static')
       expect(distFiles).not.toContain('vendor')
 
       // Remote entry stays unhashed so the manifest can reference a stable name
@@ -124,9 +123,11 @@ describe('#build studio', {timeout: (platform() === 'win32' ? 120 : 60) * 1000},
       expect(manifest).toHaveProperty('id')
       expect(manifest).toHaveProperty('name')
 
-      // Chunks themselves are hashed
-      expect(distFiles).toContain('assets')
-      const assetFiles = await readdir(join(cwd, 'dist', 'assets'))
+      // Hashed chunks are emitted to the `static` dir (assetsDir), not the Vite
+      // default `assets` — this keeps federation output aligned with the studio
+      // static layout the deploy/serve tooling expects.
+      expect(distFiles).toContain('static')
+      const assetFiles = await readdir(join(cwd, 'dist', 'static'))
       expect(assetFiles.some((f) => /^remote-entry-.+\.js$/.test(f))).toBe(true)
 
       // The build output must satisfy the deploy gate: `sanity deploy` runs

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-environment.node.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-environment.node.test.ts
@@ -29,6 +29,7 @@ describe('sanityEnvironmentPlugin', () => {
 
     expect(config.environments.client).toBeUndefined()
     expect(config.environments.federation.build.emptyOutDir).toBe(false)
+    expect(config.environments.federation.build.assetsDir).toBe('static')
     expect(await buildOrder(config)).toEqual(['federation-env'])
   })
 

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-environment.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-environment.ts
@@ -47,6 +47,7 @@ export function sanityEnvironmentPlugin(options: EnvironmentOptions): Plugin {
             : {}),
           [FEDERATION_DIR_NAME]: {
             build: {
+              assetsDir: 'static',
               copyPublicDir: false,
               emptyOutDir: false,
               outDir: `dist`,


### PR DESCRIPTION
### Description

Federation builds output their static assets to `dist/assets/`, while every other build in the toolchain — the client SPA and the classic Studio build — uses `dist/static/`. This aligns the federation build with that convention so all builds are consistent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build output layout change only; aligns federation with existing static-dir conventions and is covered by integration tests including deploy gate checks.
> 
> **Overview**
> Federation Vite builds now set **`assetsDir: 'static'`** on the federation environment so hashed chunks land in **`dist/static/`** instead of Vite’s default **`dist/assets/`**, matching the client SPA and classic Studio layout that deploy/serve tooling expects.
> 
> Integration coverage for federated studios now asserts a **`static`** folder (with hashed `remote-entry-*.js` inside) rather than **`assets`**, and the plugin unit test checks the federation env exposes **`assetsDir: 'static'`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e90a4649f04fcd97f0102172c1d16eb6c0e6b1d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->