### PR TITLE
fix(deploy): report app id when a workbench slug is taken

### DIFF
--- a/.changeset/deploy-slug-taken.md
+++ b/.changeset/deploy-slug-taken.md
@@ -1,0 +1,6 @@
+---
+'@sanity/cli': patch
+'@sanity/workbench-cli': patch
+---
+
+fix(deploy): when a workbench app's slug is already taken, report the existing app id and how to reuse it via `deployment.appId`

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -13,6 +13,7 @@ import {
   checkAutoUpdates,
   checkStudioTarget,
   type DeployCheck,
+  describeAppTarget,
 } from '../deployChecks.js'
 import {resolveAppDeployTarget, resolveStudioDeployTarget} from '../resolveDeployTarget.js'
 import {type DeployFlags} from '../types.js'
@@ -351,6 +352,33 @@ describe('checkAppTarget (workbench backend)', () => {
       slug: 'drop-desk',
       title: 'New App',
       url: null,
+    })
+  })
+})
+
+describe('describeAppTarget', () => {
+  test('slug-taken → fail names the existing app id and how to reuse it', () => {
+    const check = describeAppTarget({
+      existing: {
+        appHost: 'agent',
+        id: 'existing-1',
+        organizationId: 'org-1',
+        title: 'Agent',
+        url: 'https://org-1.sanity.run/application/existing-1',
+      },
+      type: 'slug-taken',
+    })
+
+    expect(check).toMatchObject({exitCode: exitCodes.USAGE_ERROR, status: 'fail'})
+    expect(check.message).toContain('already exists at slug "agent"')
+    expect(check.message).toContain('existing-1')
+    expect(check.solution).toContain("appId: 'existing-1'")
+    // The resolved app id is machine-readable in the target too, for --json.
+    expect(check.target).toEqual({
+      action: 'update',
+      applicationId: 'existing-1',
+      title: 'Agent',
+      url: 'https://org-1.sanity.run/application/existing-1',
     })
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/resolveDeployTarget.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/resolveDeployTarget.test.ts
@@ -1,6 +1,22 @@
-import {describe, expect, test} from 'vitest'
+import {getApplication, listApplications} from '@sanity/workbench-cli/deploy'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {resolveAppDeployTarget, resolveStudioDeployTarget} from '../resolveDeployTarget.js'
+import {
+  resolveAppDeployTarget,
+  resolveStudioDeployTarget,
+  resolveWorkbenchApp,
+} from '../resolveDeployTarget.js'
+
+vi.mock(import('@sanity/workbench-cli/deploy'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  getApplication: vi.fn(),
+  listApplications: vi.fn(),
+}))
+
+const mockGetApplication = vi.mocked(getApplication)
+const mockListApplications = vi.mocked(listApplications)
+
+beforeEach(() => vi.clearAllMocks())
 
 // These cases all short-circuit before any user-application lookup — they cover
 // the host/URL validation and the missing-config guards, no API access needed.
@@ -114,5 +130,68 @@ describe('resolveAppDeployTarget', () => {
     const result = await resolveAppDeployTarget({appId: undefined, organizationId: undefined})
 
     expect(result).toEqual({message: 'app.organizationId is missing', type: 'blocked'})
+  })
+})
+
+describe('resolveWorkbenchApp', () => {
+  const app = {
+    id: 'app-1',
+    organizationId: 'org-1',
+    slug: 'agent',
+    title: 'Agent',
+    type: 'coreApp' as const,
+  }
+
+  test('a configured appId is looked up by id, no org listing', async () => {
+    mockGetApplication.mockResolvedValue(app)
+
+    const result = await resolveWorkbenchApp({
+      appId: 'app-1',
+      organizationId: 'org-1',
+      slug: 'agent',
+    })
+
+    expect(result).toMatchObject({application: {id: 'app-1'}, type: 'found'})
+    expect(mockListApplications).not.toHaveBeenCalled()
+  })
+
+  test('no appId, slug free in the org → would-create', async () => {
+    mockListApplications.mockResolvedValue([{...app, slug: 'other'}])
+
+    const result = await resolveWorkbenchApp({
+      appId: undefined,
+      organizationId: 'org-1',
+      slug: 'agent',
+    })
+
+    expect(result).toEqual({type: 'would-create'})
+  })
+
+  test('no appId, slug already taken → slug-taken carries the existing app id', async () => {
+    mockListApplications.mockResolvedValue([app])
+
+    const result = await resolveWorkbenchApp({
+      appId: undefined,
+      organizationId: 'org-1',
+      slug: 'agent',
+    })
+
+    expect(result).toEqual({
+      existing: {
+        appHost: 'agent',
+        id: 'app-1',
+        organizationId: 'org-1',
+        title: 'Agent',
+        url: 'https://org-1.sanity.run/application/app-1',
+      },
+      type: 'slug-taken',
+    })
+  })
+
+  test('no appId and no org → would-create without listing', async () => {
+    const result = await resolveWorkbenchApp({appId: undefined, slug: 'agent'})
+
+    expect(result).toEqual({type: 'would-create'})
+    expect(mockListApplications).not.toHaveBeenCalled()
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -130,6 +130,7 @@ async function runAppDeployment(
     await checkAppTarget(reporter, {
       appId,
       isWorkbenchApp: true,
+      organizationId,
       slug: workbench.slug,
       title: appTitle,
     })

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -226,6 +226,23 @@ export function describeAppTarget(
         status: 'fail',
       }
     }
+    // A deployment with no `appId` collides with an app already at this slug —
+    // point at the existing app's id so a redeploy targets it instead of failing.
+    case 'slug-taken': {
+      const {existing: application} = resolution
+      return {
+        exitCode: exitCodes.USAGE_ERROR,
+        message: `An application already exists at slug "${application.appHost}" in this organization (app ID ${application.id})`,
+        solution: `Add \`deployment: {appId: '${application.id}'}\` to sanity.cli.ts to redeploy it`,
+        status: 'fail',
+        target: {
+          action: 'update',
+          applicationId: application.id,
+          title: application.title,
+          url: application.url ?? null,
+        },
+      }
+    }
     // Without --title, creating an app needs a prompt no unattended run can answer
     case 'would-create': {
       if (title) {
@@ -266,7 +283,13 @@ export function describeAppTargetError(err: unknown, organizationId: string | un
 export async function checkAppTarget(
   reporter: DeployCheckReporter,
   options:
-    | {appId: string | undefined; isWorkbenchApp: true; slug?: string; title?: string}
+    | {
+        appId: string | undefined
+        isWorkbenchApp: true
+        organizationId?: string
+        slug?: string
+        title?: string
+      }
     | {
         appId: string | undefined
         isWorkbenchApp?: false
@@ -276,12 +299,13 @@ export async function checkAppTarget(
 ): Promise<DeployTarget | null> {
   const {title} = options
   if (options.isWorkbenchApp) {
-    const {appId, slug} = options
+    const {appId, organizationId, slug} = options
     return runStep(reporter, {
       debug: deployDebug,
       name: 'target',
       work: async () => {
-        const check = describeAppTarget(await resolveWorkbenchApp({appId}), {slug, title})
+        const resolution = await resolveWorkbenchApp({appId, organizationId, slug})
+        const check = describeAppTarget(resolution, {slug, title})
         reporter.report(check)
         return check.target ?? null
       },

--- a/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
+++ b/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
@@ -1,4 +1,4 @@
-import {getApplication, getApplicationUrl} from '@sanity/workbench-cli/deploy'
+import {getApplication, getApplicationUrl, listApplications} from '@sanity/workbench-cli/deploy'
 
 import {
   getUserApplication,
@@ -51,6 +51,7 @@ export type StudioDeployTargetResolution<App = DeployTargetApp> =
 
 export type AppDeployTargetResolution<App = DeployTargetCoreApp> =
   | CommonDeployTargetResolution<App>
+  | {existing: App; type: 'slug-taken'}
   | {type: 'would-create'}
 
 /**
@@ -162,15 +163,40 @@ export async function resolveAppDeployTarget(options: {
 
 /**
  * The dry-run counterpart to a workbench app's create-on-deploy: a configured
- * `appId` is looked up read-only, otherwise a coreApp would be created.
+ * `appId` is looked up read-only. Without one, a first deploy would create the
+ * app at its slug — but if the org already holds an app at that slug (a
+ * singleton redeployed without `deployment.appId`), a create would fail, so the
+ * existing app is resolved instead and the report points at its id.
  * @internal
  */
 export async function resolveWorkbenchApp({
   appId,
+  organizationId,
+  slug,
 }: {
   appId: string | undefined
+  organizationId?: string
+  slug?: string
 }): Promise<AppDeployTargetResolution> {
-  return appId ? resolveAppById(appId) : {type: 'would-create'}
+  if (appId) return resolveAppById(appId)
+
+  if (organizationId && slug) {
+    const existing = (await listApplications(organizationId)).find((app) => app.slug === slug)
+    if (existing) {
+      return {
+        existing: {
+          appHost: existing.slug ?? '',
+          id: existing.id,
+          organizationId: existing.organizationId,
+          title: existing.title,
+          url: getApplicationUrl(existing),
+        },
+        type: 'slug-taken',
+      }
+    }
+  }
+
+  return {type: 'would-create'}
 }
 
 /**

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -18,6 +18,7 @@ const mockGetLocalPackageVersion = vi.hoisted(() => vi.fn())
 const mockCheckBuiltOutput = vi.hoisted(() => vi.fn())
 const mockCreateCoreApp = vi.hoisted(() => vi.fn())
 const mockDeployWorkbenchApp = vi.hoisted(() => vi.fn())
+const mockListApplications = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
@@ -40,6 +41,7 @@ vi.mock(import('@sanity/workbench-cli/deploy'), async (importOriginal) => ({
   checkBuiltOutput: mockCheckBuiltOutput,
   createCoreApp: mockCreateCoreApp,
   deployWorkbenchApp: mockDeployWorkbenchApp,
+  listApplications: mockListApplications,
 }))
 
 vi.mock(
@@ -104,6 +106,8 @@ describe('#deploy app', () => {
     })
     mockCheckDir.mockResolvedValue()
     mockCheckBuiltOutput.mockResolvedValue(undefined)
+    // No existing app at the app's slug, so a first deploy creates one.
+    mockListApplications.mockResolvedValue([])
     // Default to empty manifest for app deployments
     mockExtractCoreAppManifest.mockResolvedValue(undefined)
   })

--- a/packages/@sanity/workbench-cli/src/_exports/deploy.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/deploy.ts
@@ -23,4 +23,5 @@ export {
   getApplication,
   getApplicationUrl,
   getWorkbenchUrl,
+  listApplications,
 } from '../services/applications.js'

--- a/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
+++ b/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
@@ -13,6 +13,7 @@ import {
   getApplication,
   getApplicationUrl,
   getWorkbenchUrl,
+  listApplications,
   updateApplication,
 } from '../applications.js'
 
@@ -71,6 +72,23 @@ describe('getApplication', () => {
   test('rethrows any non-404 error', async () => {
     mockClient.request.mockRejectedValueOnce({statusCode: 500})
     await expect(getApplication('app_1')).rejects.toMatchObject({statusCode: 500})
+  })
+})
+
+describe('listApplications', () => {
+  test('GETs the organization’s applications in one page (limit=none)', async () => {
+    const apps = [
+      {id: 'app_1', organizationId: 'org-1', slug: 'agent', title: 'Agent', type: 'coreApp'},
+      {id: 'app_2', organizationId: 'org-1', slug: 'media-library', title: 'ML', type: 'coreApp'},
+    ]
+    mockClient.request.mockResolvedValueOnce({data: apps})
+
+    expect(await listApplications('org-1')).toEqual(apps)
+    expect(getGlobalCliClient).toHaveBeenCalledWith({apiVersion: 'vX', requireUser: true})
+    expect(mockClient.request).toHaveBeenCalledWith({
+      query: {limit: 'none', organizationId: 'org-1'},
+      uri: '/applications',
+    })
   })
 })
 

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -75,6 +75,16 @@ export async function getApplication(applicationId: string): Promise<Application
   }
 }
 
+/** Every application in an organization, in one page (`limit=none`). */
+export async function listApplications(organizationId: string): Promise<Application[]> {
+  const client = await getClient()
+  const {data}: {data: Application[]} = await client.request({
+    query: {limit: 'none', organizationId},
+    uri: '/applications',
+  })
+  return data
+}
+
 /**
  * Create an application record (no deployment), so the CLI can build with the
  * returned id, then ship it via {@link createDeployment}.


### PR DESCRIPTION
### Description

A workbench app deployed without `deployment.appId` tries to create an app at its `slug` on every deploy. Once an app already holds that slug (most commonly a singleton), the API rejects the create with a message like `Singleton with slug "agent" already exists in this organization` — which doesn't tell you which app already exists or how to point at it. See [this failed deploy](https://github.com/sanity-io/sanity-agent/actions/runs/30078588890/job/89434753698).

Now, before creating, a workbench deploy with no `appId` lists the org's applications and — if one already sits at the slug — resolves that existing app instead. The check reports its id and the exact `deployment.appId` edit to reuse it.

Because this rides the shared deploy-target check, the same diagnosis feeds the human error, `--dry-run`, and `--json` (the resolved app id lands in `target.applicationId`). Gated to workbench apps.

### Testing

Unit tests cover the new service call, the resolver verdict, and the check rendering (including the id in the JSON target).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to workbench deploy pre-checks and a read-only org listing; fails fast with clearer errors and does not change successful deploy or non-workbench paths.
> 
> **Overview**
> **Improves workbench deploy diagnostics when `deployment.appId` is missing but the org already has an app at the configured slug** (typical for singleton redeploys).
> 
> Adds `listApplications` in workbench-cli and extends `resolveWorkbenchApp` to list the org and return a new **`slug-taken`** verdict when a slug matches. `describeAppTarget` turns that into a failed deploy-target check with the existing **app ID**, a copy-paste `deployment.appId` snippet, and `target.applicationId` for **`--dry-run` / `--json`**. Workbench `checkAppTarget` now receives **`organizationId`** from `deployApp`.
> 
> Deploy still **stops before create/build** on slug collision; it does not auto-redeploy to the found app. Plain (non-workbench) core app deploy behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ec57fea8ebeeca3ecfb24988d6d8cb2b440bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->