### PR TITLE
feat(workbench): derive federation shared dependencies from the app's package.json

### DIFF
--- a/.changeset/workbench-shared-dependencies.md
+++ b/.changeset/workbench-shared-dependencies.md
@@ -1,0 +1,5 @@
+---
+'@sanity/workbench-cli': patch
+---
+
+feat(workbench): share compatible react, `@sanity/ui`, `@sanity/sdk`, `@sanity/sdk-react` and `styled-components` copies from the host's federation share scope

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/__tests__/shared-dependencies.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/__tests__/shared-dependencies.test.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {type PackageJson} from '@sanity/cli-core'
+import {afterEach, beforeEach, describe, expect, test} from 'vitest'
+
+import {deriveSharedDependencies} from '../shared-dependencies.js'
+
+describe('deriveSharedDependencies', () => {
+  let projectDir: string
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-shared-deps-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(projectDir, {force: true, recursive: true})
+  })
+
+  /** Write an installed package, optionally nested inside another one. */
+  function install(
+    name: string,
+    version: string,
+    options: {dependencies?: Record<string, string>; under?: string} = {},
+  ) {
+    const base = options.under
+      ? path.join(projectDir, 'node_modules', options.under, 'node_modules')
+      : path.join(projectDir, 'node_modules')
+    const dir = path.join(base, name)
+    fs.mkdirSync(dir, {recursive: true})
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({dependencies: options.dependencies, name, version}),
+    )
+  }
+
+  function derive(pkgJson: Partial<PackageJson>) {
+    fs.writeFileSync(
+      path.join(projectDir, 'package.json'),
+      JSON.stringify({name: 'app', version: '1.0.0', ...pkgJson}),
+    )
+    return deriveSharedDependencies({pkgJson: pkgJson as PackageJson, projectDir})
+  }
+
+  test('shares the candidates the app declares and has installed', () => {
+    install('react', '19.2.7')
+    install('styled-components', '6.4.3')
+
+    expect(derive({dependencies: {react: '^19.2.5', 'styled-components': '^6.4.0'}})).toEqual({
+      react: {requiredVersion: '19.2.7'},
+      'styled-components': {},
+    })
+  })
+
+  test('ignores packages the app does not declare', () => {
+    install('react', '19.2.7')
+    install('@sanity/ui', '3.4.1')
+
+    expect(derive({dependencies: {react: '^19.2.5'}})).toEqual({react: {requiredVersion: '19.2.7'}})
+  })
+
+  test('includes a candidate declared only as a devDependency', () => {
+    install('@sanity/ui', '3.4.1')
+
+    expect(derive({devDependencies: {'@sanity/ui': '^3'}})).toEqual({'@sanity/ui': {}})
+  })
+
+  // An unresolvable key still lands in the container init, which fails the build.
+  test('skips a declared candidate that is not installed', () => {
+    expect(derive({dependencies: {'@sanity/ui': '^3'}})).toEqual({})
+  })
+
+  // One share key serves every import of the package and is built from the
+  // top-level copy, so a second major loses exports its consumers need.
+  test('skips a candidate that resolves to two majors in the tree', () => {
+    install('@sanity/ui', '4.0.0-static.46')
+    install('sanity', '6.6.0')
+    install('@sanity/ui', '3.4.1', {under: 'sanity'})
+
+    expect(derive({dependencies: {'@sanity/ui': '^4', sanity: '^6'}})).toEqual({})
+  })
+
+  test('shares a candidate nested at the same major', () => {
+    install('@sanity/ui', '3.6.0')
+    install('sanity', '6.6.0')
+    install('@sanity/ui', '3.4.1', {under: 'sanity'})
+
+    expect(derive({dependencies: {'@sanity/ui': '^3', sanity: '^6'}})).toEqual({'@sanity/ui': {}})
+  })
+
+  // Module federation drops these in dev only, which would leave dev and build
+  // with different share maps.
+  test('drops a candidate that another selected candidate depends on', () => {
+    install('@sanity/sdk', '2.18.0')
+    install('@sanity/sdk-react', '2.18.0', {dependencies: {'@sanity/sdk': '2.18.0'}})
+
+    expect(derive({dependencies: {'@sanity/sdk': '^2', '@sanity/sdk-react': '^2'}})).toEqual({
+      '@sanity/sdk-react': {},
+    })
+  })
+
+  // react-dom stays bundled while it can't be shared, and React requires the pair
+  // to be the same version, so a caret range would accept a mismatched host copy.
+  test('pins react to an exact version and leaves react-dom unshared', () => {
+    install('react', '19.2.7')
+    install('react-dom', '19.2.7')
+
+    expect(derive({dependencies: {react: '^19.2.5', 'react-dom': '^19.2.5'}})).toEqual({
+      react: {requiredVersion: '19.2.7'},
+    })
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugin.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugin.ts
@@ -14,6 +14,7 @@ import {
   type FederationRuntimeOptions,
   sanityFederationRuntime,
 } from './plugins/plugin-sanity-federation-runtime.js'
+import {deriveSharedDependencies} from './shared-dependencies.js'
 
 interface FederationPluginOptionsBase extends Omit<Partial<FederationOptions>, 'exposes'> {
   exposes?: WorkbenchExposes
@@ -123,6 +124,10 @@ export const federation = (options: FederationPluginOptions): PluginOption => {
     sanityEnvironmentPlugin({clientInput, input: entryPath}),
     sanityFederationRuntime(runtimeOptions),
     sanityExtensionArtifacts({artifacts}),
-    sanityModuleFederation({exposes: federationExposes, name}),
+    sanityModuleFederation({
+      exposes: federationExposes,
+      name,
+      shared: pkgJson && deriveSharedDependencies({pkgJson, projectDir: workDir}),
+    }),
   ]
 }

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-module-federation.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-module-federation.ts
@@ -6,7 +6,7 @@ import {FEDERATION_DIR_NAME, FEDERATION_FILE_NAME} from '../constants.js'
 /**
  * @internal
  */
-export interface FederationOptions extends Pick<ModuleFederationOptions, 'exposes'> {
+export interface FederationOptions extends Pick<ModuleFederationOptions, 'exposes' | 'shared'> {
   /**
    * namespace of the federation build, used as the global variable name for the exposed modules
    * e.g `@acme/studio` would then allow you to import modules like `import ("@acme/studio/Button")`
@@ -15,7 +15,7 @@ export interface FederationOptions extends Pick<ModuleFederationOptions, 'expose
   name: string
 }
 
-export function sanityModuleFederation({exposes, name}: FederationOptions): PluginOption {
+export function sanityModuleFederation({exposes, name, shared}: FederationOptions): PluginOption {
   const mfPlugins = moduleFederation({
     dev: {
       disableDynamicRemoteTypeHints: true,
@@ -37,13 +37,13 @@ export function sanityModuleFederation({exposes, name}: FederationOptions): Plug
     // Resolves the remote entry path relative to the manifest rather than the
     // host origin.
     publicPath: 'auto',
-    // @module-federation/vite auto-shares every package.json dependency
-    // that exposes an `exports` field. That breaks for workspace packages with
-    // subpath-only exports (no `.` entry) like `@sanity/cli-build` and
-    // `@sanity/workbench`, because vite tries to resolve them as bare imports
-    // and fails. Workbench remotes manage runtime sharing through the host's
-    // federation runtime, so we opt out of auto-share entirely.
-    shared: {},
+    // Never left undefined: that turns on upstream auto-share, which shares every
+    // package.json dependency exposing an `exports` field as a singleton. It
+    // resolves each key as a bare import, so subpath-only-exports packages like
+    // `@sanity/cli-build` fail the build, and it forces version unification on
+    // remotes that are deployed independently. `deriveSharedDependencies` picks
+    // the keys instead.
+    shared: shared ?? {},
   })
 
   // module-federation delivers its dts plugin as a Promise resolving to an

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/shared-dependencies.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/shared-dependencies.ts
@@ -1,0 +1,140 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {type PackageJson} from '@sanity/cli-core'
+
+/**
+ * Packages a workbench remote consumes from the host's share scope when a host
+ * provides one, and bundles itself when none does.
+ *
+ * `react-dom` is missing on purpose. Module federation expands the bare key into
+ * `react-dom/server` through its common-subpath table, and materialising that
+ * share leaks a child-process handle: `sanity build` writes correct output,
+ * reports success, then never exits. Reproduced on the module-federation vite
+ * plugin 1.18.1 and 1.19.1, in any app whose graph reaches `react-dom/server`
+ * (`sanity` does). Add it back once that's fixed upstream.
+ */
+const CANDIDATES = ['react', '@sanity/ui', '@sanity/sdk', '@sanity/sdk-react', 'styled-components']
+
+/**
+ * The `node_modules` directories Node would search from `fromDir`, nearest first.
+ *
+ * Walked by hand rather than through `require.resolve.paths`, which also appends
+ * the global and `NODE_PATH` folders. Under pnpm that reaches the hidden hoisted
+ * `.pnpm/node_modules`, where every transitive package looks locally installed.
+ */
+function nodeModulesChain(fromDir: string): string[] {
+  const chain: string[] = []
+  let dir = path.resolve(fromDir)
+  for (;;) {
+    if (path.basename(dir) !== 'node_modules') chain.push(path.join(dir, 'node_modules'))
+    const parent = path.dirname(dir)
+    if (parent === dir) return chain
+    dir = parent
+  }
+}
+
+/** Locate an installed package's directory, as resolved from `fromDir`. */
+function packageDir(name: string, fromDir: string): string | undefined {
+  for (const nodeModules of nodeModulesChain(fromDir)) {
+    const dir = path.join(nodeModules, name)
+    // Real path, so a pnpm symlink and its store target compare equal.
+    if (fs.existsSync(path.join(dir, 'package.json'))) return fs.realpathSync(dir)
+  }
+  return undefined
+}
+
+function readPackage(dir: string): PackageJson | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'))
+  } catch {
+    return undefined
+  }
+}
+
+/** The range within which a package keeps its export surface, per semver. */
+function compatibleRange(version: string): string {
+  const [major, minor] = version.split('.')
+  return major === '0' ? `0.${minor}` : major
+}
+
+/**
+ * The share map for an app's federation build: the candidates it actually has,
+ * minus the ones sharing would break.
+ *
+ * A share key is per specifier, not per resolved version, so every import of a
+ * package in the remote's graph is rewritten to one virtual module built from the
+ * top-level copy. That makes two majors in the same tree unshareable: the other
+ * major's consumers lose exports the top-level copy doesn't have (`@sanity/ui` v3
+ * `ThemeProvider` under a v4 top-level copy fails the build outright). Module
+ * federation can express this per module via `include`/`exclude` version filters,
+ * but the vite plugin drops them as of 1.19.1, so the decision happens here.
+ *
+ * @internal
+ */
+export function deriveSharedDependencies(options: {
+  pkgJson: PackageJson
+  projectDir: string
+}): Record<string, {requiredVersion?: string}> {
+  const {pkgJson, projectDir} = options
+
+  // All three fields: `@sanity/ui` is a types-only devDependency in apps that
+  // resolve it from the host at runtime, and it still gets bundled.
+  const declared = new Set([
+    ...Object.keys(pkgJson.dependencies ?? {}),
+    ...Object.keys(pkgJson.devDependencies ?? {}),
+    ...Object.keys(pkgJson.peerDependencies ?? {}),
+  ])
+
+  // ponytail: only the app's direct dependencies are searched for a second copy.
+  // A candidate nested deeper (a dependency of a dependency) is missed, and fails
+  // the build loudly on a missing export rather than silently. Walk the full tree
+  // if that shows up in practice.
+  const dependencyDirs = [...declared]
+    .map((name) => packageDir(name, projectDir))
+    .filter((dir): dir is string => dir !== undefined)
+
+  const selected = new Map<string, {dir: string; version: string}>()
+
+  for (const name of CANDIDATES) {
+    if (!declared.has(name)) continue
+
+    const dir = packageDir(name, projectDir)
+    // An unresolvable key still lands in the container init, which fails the build.
+    if (!dir) continue
+    const version = readPackage(dir)?.version
+    if (!version) continue
+
+    const hasOtherMajor = dependencyDirs.some((dependencyDir) => {
+      const nested = packageDir(name, dependencyDir)
+      if (!nested || nested === dir) return false
+      const nestedVersion = readPackage(nested)?.version
+      return (
+        nestedVersion !== undefined && compatibleRange(nestedVersion) !== compatibleRange(version)
+      )
+    })
+    if (hasOtherMajor) continue
+
+    selected.set(name, {dir, version})
+  }
+
+  // Module federation drops a share that another share depends on, but only in
+  // dev (initialisation order), which would leave dev and build with different
+  // maps. `@sanity/sdk` under `@sanity/sdk-react` hits this. Drop it in both.
+  for (const [name, {dir}] of selected) {
+    for (const dependency of Object.keys(readPackage(dir)?.dependencies ?? {})) {
+      if (dependency !== name) selected.delete(dependency)
+    }
+  }
+
+  return Object.fromEntries(
+    [...selected].map(([name, {version}]) => [
+      name,
+      // While `react-dom` stays bundled, react may only dedupe against an
+      // identical copy: React requires the pair to be the same version, and the
+      // default caret range would accept a host react its react-dom isn't built
+      // against. Everything else takes module federation's default `^installed`.
+      name === 'react' ? {requiredVersion: version} : {},
+    ]),
+  )
+}


### PR DESCRIPTION
### Description

Every workbench remote bundles its own react and `@sanity/ui`, so a session with several remotes loads several copies, and a plugin module rendered inside another app's tree hits dual-React crashes. Nothing could redirect those imports: the build passed `shared: {}`, so the remotes compiled plain bundled imports with no share-scope lookup for a host to satisfy.

Remotes now consume the copies they can safely share from the host's federation share scope, falling back to their own when no host provides one. Versions negotiate rather than unify, so remotes deployed independently keep working when they sit on different versions.

A candidate is shared when the app declares it, it resolves, every copy in the tree is within one major, and it isn't a dependency of another selected candidate. The last two rules carry the weight:

- A share key is per specifier, not per resolved version, so every import collapses onto one virtual module built from the top-level copy. Two majors in the same tree means the other major's consumers lose exports they need, which fails the build (`@sanity/ui` v3 `ThemeProvider` under a v4 top-level copy). Module federation can express this per module through `include`/`exclude` version filters, but the vite plugin drops them as of 1.19.1.
- Module federation drops a share that another share depends on, but only in dev, which would leave dev and build with different maps. `@sanity/sdk` under `@sanity/sdk-react` hits exactly this.

`react-dom` is left out on purpose. Sharing it expands into a `react-dom/server` share through module federation's common-subpath table, and materialising that leaks a child-process handle: `sanity build` writes correct output, reports success, then never exits. Reproduced on the vite plugin 1.18.1 and 1.19.1 in any app whose graph reaches `react-dom/server`, which `sanity` does. It's worth ~177 KB per remote, so it gets its own follow-up once that's fixed upstream.

Nothing provides a share scope yet, so this stays inert until the workbench shell seeds one. Until then a core app's output grows about 5.7% (57 KB on `dev/drop-desk`) from the extracted fallback chunks; that reverses once a host provides and the fallbacks stop being fetched.

Part of SDK-2170.

### What to review

The four selection rules in `shared-dependencies.ts`, and the resolution walk. Resolution deliberately walks the `node_modules` ancestor chain by hand instead of using `require.resolve.paths`, which also appends the global and `NODE_PATH` folders — under pnpm that reaches the hidden hoisted `.pnpm/node_modules`, where every transitive package looks locally installed.

Derived maps from real builds, both exiting cleanly:

| App                         | Shares                                                           |
| --------------------------- | ---------------------------------------------------------------- |
| `fixtures/federated-studio` | `react` (exact 19.2.7), `styled-components`, plus react subpaths |
| workbench `dev/drop-desk`   | `react` (exact), `@sanity/sdk-react`, plus react subpaths        |

drop-desk declares `@sanity/ui` and it is correctly skipped: its top-level copy is `4.0.0-static.46` while `sanity` nests v3. `@sanity/sdk` is correctly dropped as a nested candidate.

react carries an exact `requiredVersion` rather than the default caret range, because its react-dom stays bundled and React requires the pair to be the same version.

### Testing

8 unit tests over the selection rules, plus the two real builds above.