### PR TITLE
fix(workbench): align the local dev config version with Brett

### DIFF
--- a/.changeset/config-version-string.md
+++ b/.changeset/config-version-string.md
@@ -1,0 +1,5 @@
+---
+"@sanity/workbench-cli": patch
+---
+
+Forward a string `version` on local dev configs, matching the one Brett returns for a deployed config.

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -258,7 +258,7 @@ describe('deriveConfigs', () => {
         ],
         id: expect.any(String),
         moduleName: 'test-app',
-        version: 1,
+        version: '1',
       },
     ])
   })
@@ -310,7 +310,7 @@ describe('deriveConfigEntries', () => {
           {name: 'language', src: './src/language.ts', title: 'Language'},
         ],
         id: 'cfg-hash',
-        version: 1,
+        version: '1',
       }),
     ).toEqual([
       {name: 'description', src: './src/description.ts'},
@@ -320,13 +320,13 @@ describe('deriveConfigEntries', () => {
 
   test('an empty field set yields no entries', () => {
     expect(
-      deriveConfigEntries({appType: 'media-library', fields: [], id: 'cfg-hash', version: 1}),
+      deriveConfigEntries({appType: 'media-library', fields: [], id: 'cfg-hash', version: '1'}),
     ).toEqual([])
   })
 
   test('throws on an app type it cannot handle', () => {
     expect(() =>
-      deriveConfigEntries({appType: 'core-app', fields: [], id: 'cfg-hash', version: 1}),
+      deriveConfigEntries({appType: 'core-app', fields: [], id: 'cfg-hash', version: '1'}),
     ).toThrow(/unknown config appType: core-app/i)
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
@@ -20,7 +20,7 @@ const mlConfig = (fields: DevServerConfig['fields']): DevServerConfig => ({
   appType: 'media-library',
   fields,
   id: 'cfg-hash',
-  version: 1,
+  version: '1',
 })
 const config = mlConfig([{name: 'd', src: './src/d.ts', title: 'D'}])
 const server = (

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startWorkbenchDevServer.test.ts
@@ -630,7 +630,7 @@ describe('startWorkbenchDevServer', () => {
       watchCallback([
         {host: 'localhost', id: 'app-1', pid: 2, port: 3334, type: 'studio'},
         {
-          configs: [{...config, id: 'cfg-hash', moduleName: 'media-library', version: 1}],
+          configs: [{...config, id: 'cfg-hash', moduleName: 'media-library', version: '1'}],
           host: 'localhost',
           pid: 3,
           port: 3337,
@@ -656,7 +656,7 @@ describe('startWorkbenchDevServer', () => {
             id: 'cfg-hash',
             moduleName: 'media-library',
             remoteURL: 'http://localhost:3337',
-            version: 1,
+            version: '1',
           },
         ],
       })

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -101,8 +101,8 @@ export function deriveConfigEntries(config: DevServerConfig): {name: string; src
  * repoint rebuilds. `appType` routes the config to the singleton (no app id to
  * key on). `id` is a content hash of the entry — it fills the
  * installation-config id slot deployed apps get from the applications API,
- * and the workbench keys change detection on it. `version` is the config
- * contract version the generated module exports, known before the module runs.
+ * and the workbench keys change detection on it. `version` is a string, like
+ * the one Brett returns on a deployed `activeConfig`.
  */
 export async function deriveConfigs(app: CliConfig['app']): Promise<DevServerConfig[]> {
   if (!isWorkbenchApp(app)) return []
@@ -117,7 +117,7 @@ export async function deriveConfigs(app: CliConfig['app']): Promise<DevServerCon
       title: field.title,
     })),
     moduleName: app.name,
-    version: MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION,
+    version: String(MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION),
   }
   return [{...entry, id: await contentHash(JSON.stringify(entry))}]
 }

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -106,9 +106,9 @@ const devServerManifestSchema = z.object({
         // The app's `unstable_defineApp` name — the module-federation alias the
         // workbench loads this config's live values from.
         moduleName: z.optional(z.string()),
-        // Config contract version the generated module exports, so the
-        // workbench knows what it can resolve before loading the module.
-        version: z.number(),
+        // The version the workbench federates this config's module under —
+        // a string, like the one Brett returns on a deployed `activeConfig`.
+        version: z.string(),
       }),
     ),
   ),


### PR DESCRIPTION
### Description

Brett stores an installation config's version as text (`text('version').notNull()`) and returns it as a string on `activeConfig.version`; `POST /installations/:id/configs` declares the multipart field as `{type: 'string'}`. The CLI's deploy path already sends a string there.

The local dev registry typed the same field as `z.number()` and forwarded it verbatim to the workbench, so the workbench saw a number from a dev server and a string from a deploy.

### Testing

Existing unit coverage for `deriveConfigs`, `exposesSetId` and the dev-server payload updated to the string form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 33f2af4ee19de399a567e5e8662fdc1db914b411. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->