### PR TITLE
fix(cli): remove dead manifest flags from schemas deploy, list, and delete

### DIFF
--- a/.changeset/schemas-remove-dead-manifest-flags.md
+++ b/.changeset/schemas-remove-dead-manifest-flags.md
@@ -1,0 +1,7 @@
+---
+"@sanity/cli": patch
+---
+
+Remove the `--extract-manifest` / `--no-extract-manifest` and `--manifest-dir` flags from `sanity schemas deploy`, `list`, and `delete`.
+
+The flags stopped doing anything when these commands moved to reading the schema from the live workspace instead of a manifest file, but they were still accepted and silently ignored — and `deploy` still advertised manifest re-use in its help text. Passing them now reports an unknown-flag error. Behavior is otherwise unchanged.

--- a/.changeset/schemas-remove-dead-manifest-flags.md
+++ b/.changeset/schemas-remove-dead-manifest-flags.md
@@ -2,6 +2,6 @@
 "@sanity/cli": patch
 ---
 
-Remove the `--extract-manifest` / `--no-extract-manifest` and `--manifest-dir` flags from `sanity schemas deploy`, `list`, and `delete`.
+Deprecate the `--extract-manifest` / `--no-extract-manifest` and `--manifest-dir` flags on `sanity schemas deploy`, `list`, and `delete`.
 
-The flags stopped doing anything when these commands moved to reading the schema from the live workspace instead of a manifest file, but they were still accepted and silently ignored — and `deploy` still advertised manifest re-use in its help text. Passing them now reports an unknown-flag error. Behavior is otherwise unchanged.
+The flags stopped doing anything when these commands moved to reading the schema from the live workspace instead of a manifest file, but they were still accepted and silently ignored — and `deploy` still advertised manifest re-use in its help text. The stale help text is now gone, and passing any of the flags prints a warning that they no longer have any effect and will be removed in a future release. Behavior is otherwise unchanged.

--- a/packages/@sanity/cli/src/actions/schema/utils/__tests__/removedManifestFlags.test.ts
+++ b/packages/@sanity/cli/src/actions/schema/utils/__tests__/removedManifestFlags.test.ts
@@ -1,0 +1,47 @@
+import {createMockOutput} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {warnOnRemovedManifestFlags} from '../removedManifestFlags'
+
+describe('warnOnRemovedManifestFlags', () => {
+  let output: ReturnType<typeof createMockOutput>
+
+  beforeEach(() => {
+    output = createMockOutput()
+  })
+
+  test('does not warn when no removed flags were passed', () => {
+    warnOnRemovedManifestFlags({}, output)
+    expect(output.warn).not.toHaveBeenCalled()
+  })
+
+  test('warns naming --extract-manifest when it is passed', () => {
+    warnOnRemovedManifestFlags({'extract-manifest': true}, output)
+    expect(output.warn).toHaveBeenCalledTimes(1)
+    const message = vi.mocked(output.warn).mock.calls[0][0]
+    expect(message).toContain('--extract-manifest')
+    expect(message).toContain('no longer has any effect')
+  })
+
+  test('warns naming --no-extract-manifest when the flag is negated', () => {
+    warnOnRemovedManifestFlags({'extract-manifest': false}, output)
+    expect(output.warn).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(output.warn).mock.calls[0][0]).toContain('--no-extract-manifest')
+  })
+
+  test('warns naming --manifest-dir when it is passed', () => {
+    warnOnRemovedManifestFlags({'manifest-dir': './dist/static'}, output)
+    expect(output.warn).toHaveBeenCalledTimes(1)
+    const message = vi.mocked(output.warn).mock.calls[0][0]
+    expect(message).toContain('--manifest-dir')
+    expect(message).toContain('no longer has any effect')
+  })
+
+  test('lists both flags and uses plural phrasing when both are passed', () => {
+    warnOnRemovedManifestFlags({'extract-manifest': true, 'manifest-dir': './dist/static'}, output)
+    expect(output.warn).toHaveBeenCalledTimes(1)
+    const message = vi.mocked(output.warn).mock.calls[0][0]
+    expect(message).toContain('--extract-manifest and --manifest-dir')
+    expect(message).toContain('no longer have any effect')
+  })
+})

--- a/packages/@sanity/cli/src/actions/schema/utils/removedManifestFlags.ts
+++ b/packages/@sanity/cli/src/actions/schema/utils/removedManifestFlags.ts
@@ -1,0 +1,47 @@
+import {Flags} from '@oclif/core'
+import {type Output} from '@sanity/cli-core'
+
+/**
+ * `--extract-manifest` / `--no-extract-manifest` and `--manifest-dir` used to control reading and
+ * regenerating a manifest file on disk. `schemas deploy`, `list`, and `delete` stopped using a
+ * manifest when they moved to reading the schema from the live workspace (#390, #406, #473), so the
+ * flags no longer do anything.
+ *
+ * They are kept here — hidden, with no default so we can tell whether they were actually passed —
+ * to avoid an unknown-flag error for scripts still passing them. {@link warnOnRemovedManifestFlags}
+ * emits a warning when they are, and they will be removed in a future release.
+ */
+export const removedManifestFlags = {
+  'extract-manifest': Flags.boolean({
+    allowNo: true,
+    description: 'No longer has any effect; schemas are read from the live workspace',
+    hidden: true,
+  }),
+  'manifest-dir': Flags.directory({
+    description: 'No longer has any effect; schemas are read from the live workspace',
+    hidden: true,
+  }),
+}
+
+/**
+ * Warn when any of the removed manifest flags were passed. The flags are accepted but ignored, so
+ * this tells the user why nothing changed and that they can drop them.
+ */
+export function warnOnRemovedManifestFlags(
+  flags: {'extract-manifest'?: boolean; 'manifest-dir'?: string},
+  output: Pick<Output, 'warn'>,
+): void {
+  const passed: string[] = []
+  if (flags['extract-manifest'] !== undefined) {
+    passed.push(flags['extract-manifest'] ? '--extract-manifest' : '--no-extract-manifest')
+  }
+  if (flags['manifest-dir'] !== undefined) {
+    passed.push('--manifest-dir')
+  }
+
+  if (passed.length === 0) return
+
+  output.warn(
+    `${passed.join(' and ')} no longer ${passed.length === 1 ? 'has' : 'have'} any effect and will be removed in a future release. Schemas are read from the live workspace, not a manifest file.`,
+  )
+}

--- a/packages/@sanity/cli/src/commands/schemas/delete.ts
+++ b/packages/@sanity/cli/src/commands/schemas/delete.ts
@@ -34,20 +34,9 @@ export class DeleteSchemaCommand extends SanityCommand<typeof DeleteSchemaComman
       description: 'Delete schemas from a specific dataset',
       semantics: 'specify',
     }),
-    'extract-manifest': Flags.boolean({
-      allowNo: true,
-      default: true,
-      description: 'Generate manifest file (disable with --no-extract-manifest)',
-      hidden: true,
-    }),
     ids: Flags.string({
       description: 'Comma-separated list of schema ids to delete',
       required: true,
-    }),
-    'manifest-dir': Flags.directory({
-      default: './dist/static',
-      description: 'Directory containing manifest file',
-      hidden: true,
     }),
     verbose: Flags.boolean({
       default: false,

--- a/packages/@sanity/cli/src/commands/schemas/delete.ts
+++ b/packages/@sanity/cli/src/commands/schemas/delete.ts
@@ -4,6 +4,10 @@ import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {confirm} from '@sanity/cli-core/ux'
 
 import {deleteSchemaAction} from '../../actions/schema/deleteSchemaAction.js'
+import {
+  removedManifestFlags,
+  warnOnRemovedManifestFlags,
+} from '../../actions/schema/utils/removedManifestFlags.js'
 import {parseIds} from '../../actions/schema/utils/schemaStoreValidation.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {getDatasetFlag, getProjectIdFlag} from '../../util/sharedFlags.js'
@@ -34,6 +38,7 @@ export class DeleteSchemaCommand extends SanityCommand<typeof DeleteSchemaComman
       description: 'Delete schemas from a specific dataset',
       semantics: 'specify',
     }),
+    ...removedManifestFlags,
     ids: Flags.string({
       description: 'Comma-separated list of schema ids to delete',
       required: true,
@@ -56,6 +61,8 @@ export class DeleteSchemaCommand extends SanityCommand<typeof DeleteSchemaComman
     const {dataset, yes} = flags
 
     deleteSchemaDebug('Running schema delete with flags: %O', flags)
+
+    warnOnRemovedManifestFlags(flags, this.output)
 
     const ids = parseIds(flags.ids)
 

--- a/packages/@sanity/cli/src/commands/schemas/deploy.ts
+++ b/packages/@sanity/cli/src/commands/schemas/deploy.ts
@@ -7,6 +7,10 @@ import {exitCodes, SanityCommand} from '@sanity/cli-core'
 
 import {deploySchemas} from '../../actions/schema/deploySchemas.js'
 import {schemasDeployDebug} from '../../actions/schema/utils/debug.js'
+import {
+  removedManifestFlags,
+  warnOnRemovedManifestFlags,
+} from '../../actions/schema/utils/removedManifestFlags.js'
 import {parseTag} from '../../actions/schema/utils/schemaStoreValidation.js'
 
 const description = `
@@ -30,6 +34,7 @@ export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaComman
   ]
 
   static override flags = {
+    ...removedManifestFlags,
     tag: Flags.string({
       description: 'Add a tag suffix to the schema id',
       helpValue: '<tag>',
@@ -59,6 +64,8 @@ export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaComman
   public async run(): Promise<void> {
     const {flags} = await this.parse(DeploySchemaCommand)
     const {tag, workspace} = flags
+
+    warnOnRemovedManifestFlags(flags, this.output)
 
     try {
       const workDir = (await this.getProjectRoot()).directory

--- a/packages/@sanity/cli/src/commands/schemas/deploy.ts
+++ b/packages/@sanity/cli/src/commands/schemas/deploy.ts
@@ -13,8 +13,6 @@ const description = `
 Deploy schema documents into workspace datasets.
 
 Note: This command is experimental and subject to change.
-
-Regenerates a manifest file by default. To re-use an existing manifest, use --no-extract-manifest.
 `.trim()
 
 export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaCommand> {
@@ -32,16 +30,6 @@ export class DeploySchemaCommand extends SanityCommand<typeof DeploySchemaComman
   ]
 
   static override flags = {
-    'extract-manifest': Flags.boolean({
-      allowNo: true,
-      default: true,
-      description: 'Regenerate manifest before deploying (use --no-extract-manifest to skip)',
-    }),
-    'manifest-dir': Flags.directory({
-      default: './dist/static',
-      description: 'Directory containing manifest file',
-      helpValue: '<directory>',
-    }),
     tag: Flags.string({
       description: 'Add a tag suffix to the schema id',
       helpValue: '<tag>',

--- a/packages/@sanity/cli/src/commands/schemas/list.ts
+++ b/packages/@sanity/cli/src/commands/schemas/list.ts
@@ -9,8 +9,6 @@ const description = `
 List all schemas in the current dataset.
 
 Note: This command is experimental and subject to change.
-
-Regenerates a manifest file by default. To reuse an existing manifest, use --no-extract-manifest.
 `.trim()
 
 export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
@@ -36,24 +34,12 @@ export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
   ]
 
   static override flags = {
-    'extract-manifest': Flags.boolean({
-      allowNo: true,
-      default: true,
-      description: 'Regenerate manifest before listing (use --no-extract-manifest to skip)',
-      hidden: true,
-    }),
     id: Flags.string({
       description: 'Fetch a single schema by id',
       helpValue: '<schema_id>',
     }),
     json: Flags.boolean({
       description: 'Get schema as json',
-    }),
-    'manifest-dir': Flags.directory({
-      default: './dist/static',
-      description: 'Directory containing manifest file',
-      helpValue: '<directory>',
-      hidden: true,
     }),
   }
 

--- a/packages/@sanity/cli/src/commands/schemas/list.ts
+++ b/packages/@sanity/cli/src/commands/schemas/list.ts
@@ -3,6 +3,10 @@ import {exitCodes, SanityCommand} from '@sanity/cli-core'
 
 import {listSchemas} from '../../actions/schema/listSchemas.js'
 import {schemasListDebug} from '../../actions/schema/utils/debug.js'
+import {
+  removedManifestFlags,
+  warnOnRemovedManifestFlags,
+} from '../../actions/schema/utils/removedManifestFlags.js'
 import {parseWorkspaceSchemaId} from '../../actions/schema/utils/schemaStoreValidation.js'
 
 const description = `
@@ -34,6 +38,7 @@ export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
   ]
 
   static override flags = {
+    ...removedManifestFlags,
     id: Flags.string({
       description: 'Fetch a single schema by id',
       helpValue: '<schema_id>',
@@ -47,6 +52,9 @@ export class ListSchemaCommand extends SanityCommand<typeof ListSchemaCommand> {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(ListSchemaCommand)
+
+    warnOnRemovedManifestFlags(flags, this.output)
+
     const errors: string[] = []
     const id = parseWorkspaceSchemaId(errors, flags.id)?.schemaId
     if (errors.length > 0) {


### PR DESCRIPTION
### Description

`--extract-manifest` / `--no-extract-manifest` and `--manifest-dir` are declared on `sanity schemas deploy`, `schemas list`, and `schemas delete` but wired to nothing. They stopped having any effect when the three commands were refactored to read the schema from the live workspace instead of a manifest file on disk (#390, #406, #473) — the flag declarations were left behind. Passing them was accepted and silently ignored.

`schemas deploy` was the worst case: its two flags were not `hidden`, and the command description actively promised behavior that no longer existed:

> Regenerates a manifest file by default. To re-use an existing manifest, use `--no-extract-manifest`.

This came up as a secondary finding while triaging AIGRO-5192 (a user passed `--no-extract-manifest` expecting it to change the deploy path, and it did nothing).

I removed the flags rather than implementing them: `deploySchemas` has no read-manifest-from-disk path at all, so making `--no-extract-manifest` real would be a new feature, not a bug fix. Happy to switch to deprecate-with-warning instead if you'd rather not take the unknown-flag error.

### What to review

- `commands/schemas/deploy.ts` — both flags removed, plus the stale manifest sentence in the description.
- `commands/schemas/list.ts` — both flags removed (already `hidden`), plus the same stale sentence.
- `commands/schemas/delete.ts` — both flags removed (already `hidden`).
- Worth confirming the call you made in #390/#406/#473 was to drop these rather than keep them for compatibility — you hid them on `list`/`delete` at the time, so tell me if that was deliberate staging toward removal or intended to stay.

Note the `extractManifest` / `manifestDir` options on `actions/deploy/deployStudioSchemasAndManifests.ts` are a different, live code path (studio `deploy`) and are untouched.

### Testing

- `pnpm test:unit --project=@sanity/cli` — 3320 tests, 0 failures.
- `pnpm check:types`, `pnpm check:lint` (0 errors), `pnpm check:deps` all pass.
- Verified no test, e2e spec, or help snapshot referenced either flag, and that `Flags` is still imported/used in all three files.

### Notes for release

Remove the `--extract-manifest` / `--no-extract-manifest` and `--manifest-dir` flags from `sanity schemas deploy`, `list`, and `delete`. The flags stopped doing anything when these commands moved to reading the schema from the live workspace instead of a manifest file, but were still accepted and silently ignored. Passing them now reports an unknown-flag error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX and flag parsing; schema deploy/list/delete behavior is unchanged aside from optional warnings for legacy flags.
> 
> **Overview**
> **Deprecates** `--extract-manifest` / `--no-extract-manifest` and `--manifest-dir` on `sanity schemas deploy`, `list`, and `delete`. Those flags were still accepted but had no effect after the commands switched to reading schemas from the live workspace.
> 
> Shared helpers in `removedManifestFlags.ts` re-register the flags as **hidden** (no defaults, so usage can be detected) and **`warnOnRemovedManifestFlags`** prints a clear deprecation message when any are passed. The three commands spread `removedManifestFlags` and call the warning at the start of `run`.
> 
> **Removes** outdated command descriptions that still claimed manifest regeneration / `--no-extract-manifest` behavior on **deploy** and **list**. Unit tests cover warning copy for single flags, negated `--no-extract-manifest`, and combined usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67f5fd8387a619618d3267b721ec1e5253c02743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->