### PR TITLE
fix(cli): note --skip-history before prompting in dataset copy

### DIFF
--- a/.changeset/dataset-copy-skip-history-note-earlier.md
+++ b/.changeset/dataset-copy-skip-history-note-earlier.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+`sanity datasets copy` now mentions `--skip-history` before prompting for the source and target datasets, instead of after the copy job has already started. A copy can't be canceled once it begins, so the note previously arrived too late to act on.

--- a/.changeset/dataset-copy-skip-history-note-earlier.md
+++ b/.changeset/dataset-copy-skip-history-note-earlier.md
@@ -2,4 +2,4 @@
 "@sanity/cli": patch
 ---
 
-`sanity datasets copy` now mentions `--skip-history` before prompting for the source and target datasets, instead of after the copy job has already started. A copy can't be canceled once it begins, so the note previously arrived too late to act on.
+`sanity datasets copy` now mentions `--skip-history` before prompting for the source and target datasets, instead of after the copy job has already started.

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -280,6 +280,46 @@ describe('#dataset:copy', () => {
       )
     })
 
+    test('notes the --skip-history flag before prompting, while it is still actionable', async () => {
+      mockListDatasets.mockResolvedValue([
+        createMockDataset('production'),
+        createMockDataset('staging'),
+      ])
+      mockCopyDataset.mockResolvedValue({jobId: 'job-789'})
+      mockFollowCopyJob.mockReturnValue(of({progress: 100, type: 'progress'}))
+      mockPromptForDatasetName.mockResolvedValue('backup')
+
+      const noteOrder: string[] = []
+      vi.mocked(mocks.SanityCmdOutput.log).mockImplementation((message?: string) => {
+        if (message && /--skip-history/.test(message)) noteOrder.push('note')
+      })
+      mockPromptForDataset.mockImplementation(() => {
+        noteOrder.push('prompt')
+        return Promise.resolve('production')
+      })
+
+      await CopyDatasetCommand.run([])
+
+      // The note is only useful ahead of the prompts — the copy can't be canceled
+      // once started, so it must not trail the operation.
+      expect(noteOrder).toEqual(['note', 'prompt'])
+    })
+
+    test('does not note the --skip-history flag when it is already set', async () => {
+      mockListDatasets.mockResolvedValue([
+        createMockDataset('production'),
+        createMockDataset('staging'),
+      ])
+      mockCopyDataset.mockResolvedValue({jobId: 'job-790'})
+      mockFollowCopyJob.mockReturnValue(of({progress: 100, type: 'progress'}))
+
+      await CopyDatasetCommand.run(['production', 'backup', '--skip-history'])
+
+      expect(mocks.SanityCmdOutput.log).not.toHaveBeenCalledWith(
+        expect.stringMatching(/--skip-history/),
+      )
+    })
+
     test('prompts for source and target datasets when not provided', async () => {
       mockListDatasets.mockResolvedValue([
         createMockDataset('production'),

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -258,6 +258,15 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
     const skipHistory = Boolean(flags['skip-history'])
     const skipContentReleases = Boolean(flags['skip-content-releases'])
 
+    // Surfaced before any prompting so the flag is still actionable: a copy job
+    // can't be canceled once started, so mentioning it after the job kicks off
+    // leaves nothing to decide.
+    if (!skipHistory) {
+      this.output.log(
+        `Note: You can run this command with flag '--skip-history'. The flag will reduce copy time in larger datasets.`,
+      )
+    }
+
     // Get and validate source dataset
     let sourceDataset = args.source
     if (sourceDataset) {
@@ -317,12 +326,6 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
       this.output.log(
         `Copying dataset ${styleText('green', sourceDataset)} to ${styleText('green', targetDataset)}...`,
       )
-
-      if (!skipHistory) {
-        this.output.log(
-          `Note: You can run this command with flag '--skip-history'. The flag will reduce copy time in larger datasets.`,
-        )
-      }
 
       const response = await copyDataset({
         projectId,


### PR DESCRIPTION
### Description

Closes AIGRO-5214.

`sanity datasets copy` printed its `--skip-history` hint *after* `copyDataset()` had already fired, so it landed once the job was running. A copy job can't be canceled once started (the CLI exposes `--list`, `--attach` and `--detach`, but no cancel), so the note arrived with nothing left to decide.

Moved it ahead of the source/target prompts, so an interactive user sees it while they can still Ctrl-C and re-run with the flag.

### What to review

- `commands/datasets/copy.ts` — the note moves from inside the copy `try` block up to just after the flags are read, before dataset validation and prompting. Still guarded on `!skipHistory`; wording unchanged.

Two things I want to flag honestly, since they bound how much this buys:

1. **`--skip-history` is already documented in `--help`** — both as a flag and as a worked example whose description reads *"faster for large datasets"*. So this helps the user who didn't read help and is watching the terminal, not discoverability in general.
2. **This is a log line, not a prompt.** The original request mentioned prompting when the dataset is *large*, which isn't implementable as specified — `listDatasets` surfaces no size or document count, so there's no signal for "large" without an extra API call, and prompting unconditionally would need `isUnattended()` gating to avoid hanging agents and CI.

Discussed both with the requester; printing earlier is the agreed scope for this PR. The underlying pain (no way to cancel a running copy) is a Content Lake API gap and out of scope here.

### Testing

- Two new unit tests in `datasets/__tests__/copy.test.ts`: one asserts the note is emitted *before* the source prompt (records call ordering — fails on the old code, which produced `['prompt', 'note']`), one asserts no note when `--skip-history` is already passed.
- `pnpm test:unit --project=@sanity/cli` — 3322 tests, 0 failures.
- `pnpm check:types` and `pnpm check:lint` pass.

### Notes for release

`sanity datasets copy` now mentions `--skip-history` before prompting for the source and target datasets, instead of after the copy job has already started. A copy can't be canceled once it begins, so the note previously arrived too late to act on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI log ordering and tests only; no changes to copy job parameters or API calls beyond when the hint is printed.
> 
> **Overview**
> **`sanity datasets copy`** now prints the existing `--skip-history` hint **before** dataset validation and interactive prompts, instead of right after the copy job starts.
> 
> The message text and `!skipHistory` guard are unchanged; only the timing moves so interactive users can still abort and re-run with the flag. Copy API behavior is untouched.
> 
> Tests assert log order (`note` before `prompt`) and that no hint appears when `--skip-history` is already passed. A patch changeset documents the UX fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f6cd07a1d279e5c2c8e648b364f35bda6b2c21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->