### PR TITLE
fix(cli): stop printing "null" as the user when authenticating with a token

### DIFF
--- a/.changeset/user-display-name-token-auth.md
+++ b/.changeset/user-display-name-token-auth.md
@@ -1,0 +1,6 @@
+---
+"@sanity/cli": patch
+"@sanity/cli-core": patch
+---
+
+Stop rendering a literal `null` when authenticating with an API token. Token auth resolves to a user with no email, so `sanity init` printed `You are logged in as null using Sanity-token`, wrote `"author": "Name <null>"` into the generated `package.json`, and `sanity debug` reported `Email: null`. User-facing output now falls back to the account name, and `SanityOrgUser.email` is correctly typed as nullable.

--- a/.changeset/user-display-name-token-auth.md
+++ b/.changeset/user-display-name-token-auth.md
@@ -3,4 +3,4 @@
 "@sanity/cli-core": patch
 ---
 
-Stop rendering a literal `null` when authenticating with an API token. Token auth resolves to a user with no email, so `sanity init` printed `You are logged in as null using Sanity-token`, wrote `"author": "Name <null>"` into the generated `package.json`, and `sanity debug` reported `Email: null`. User-facing output now falls back to the account name, and `SanityOrgUser.email` is correctly typed as nullable.
+Show the account name instead of `null` when authenticating with an API token, which has no email address.

--- a/packages/@sanity/cli-core/src/types.ts
+++ b/packages/@sanity/cli-core/src/types.ts
@@ -11,10 +11,16 @@ export type RequireProps<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K
 // @todo
 // Replace with SanityUser type from client once implemented
 export type SanityOrgUser = {
-  email: string
+  /**
+   * Null when authenticating with an API token rather than a user account —
+   * robot tokens resolve to a user whose `email` and `familyName` are null.
+   * Use `getUserDisplayName()` for anything user-facing.
+   */
+  email: string | null
   id: string
   name: string
   profileImage?: string
-  provider: 'github' | 'google' | 'sanity' | `saml-${string}`
+  /** `sanity-token` is returned when authenticating with an API token. */
+  provider: 'github' | 'google' | 'sanity' | 'sanity-token' | `saml-${string}`
   tosAcceptedAt?: string
 }

--- a/packages/@sanity/cli/src/actions/auth/__tests__/getProviderName.test.ts
+++ b/packages/@sanity/cli/src/actions/auth/__tests__/getProviderName.test.ts
@@ -14,15 +14,6 @@ function createUser(overrides: Partial<SanityOrgUser> = {}): SanityOrgUser {
 }
 
 describe('getProviderName', () => {
-  test.each([
-    ['google', 'Google'],
-    ['github', 'GitHub'],
-    ['sanity', 'Email'],
-    ['saml-acme', 'SAML'],
-  ])('maps %s to %s', (provider, expected) => {
-    expect(getProviderName(provider)).toBe(expected)
-  })
-
   test('reads as prose for API tokens, rather than "Sanity-token"', () => {
     expect(getProviderName('sanity-token')).toBe('an API token')
   })
@@ -48,9 +39,5 @@ describe('getUserDisplayName', () => {
 
   test('falls back to the id when neither email nor name is usable', () => {
     expect(getUserDisplayName(createUser({email: null, name: ''}))).toBe('abc123')
-  })
-
-  test('never renders a literal "null"', () => {
-    expect(getUserDisplayName(createUser({email: null}))).not.toMatch(/null/)
   })
 })

--- a/packages/@sanity/cli/src/actions/auth/__tests__/getProviderName.test.ts
+++ b/packages/@sanity/cli/src/actions/auth/__tests__/getProviderName.test.ts
@@ -1,0 +1,56 @@
+import {type SanityOrgUser} from '@sanity/cli-core'
+import {describe, expect, test} from 'vitest'
+
+import {getProviderName, getUserDisplayName} from '../getProviderName.js'
+
+function createUser(overrides: Partial<SanityOrgUser> = {}): SanityOrgUser {
+  return {
+    email: 'someone@example.com',
+    id: 'abc123',
+    name: 'Someone',
+    provider: 'sanity',
+    ...overrides,
+  }
+}
+
+describe('getProviderName', () => {
+  test.each([
+    ['google', 'Google'],
+    ['github', 'GitHub'],
+    ['sanity', 'Email'],
+    ['saml-acme', 'SAML'],
+  ])('maps %s to %s', (provider, expected) => {
+    expect(getProviderName(provider)).toBe(expected)
+  })
+
+  test('reads as prose for API tokens, rather than "Sanity-token"', () => {
+    expect(getProviderName('sanity-token')).toBe('an API token')
+  })
+
+  test('title-cases unknown providers', () => {
+    expect(getProviderName('somenewprovider')).toBe('Somenewprovider')
+  })
+})
+
+describe('getUserDisplayName', () => {
+  test('prefers the email', () => {
+    expect(getUserDisplayName(createUser())).toBe('someone@example.com')
+  })
+
+  // API tokens resolve to a user with a null email — the reason this helper exists.
+  test('falls back to the name when the email is null', () => {
+    expect(
+      getUserDisplayName(
+        createUser({email: null, name: 'CI Robot (Robot)', provider: 'sanity-token'}),
+      ),
+    ).toBe('CI Robot (Robot)')
+  })
+
+  test('falls back to the id when neither email nor name is usable', () => {
+    expect(getUserDisplayName(createUser({email: null, name: ''}))).toBe('abc123')
+  })
+
+  test('never renders a literal "null"', () => {
+    expect(getUserDisplayName(createUser({email: null}))).not.toMatch(/null/)
+  })
+})

--- a/packages/@sanity/cli/src/actions/auth/getProviderName.ts
+++ b/packages/@sanity/cli/src/actions/auth/getProviderName.ts
@@ -1,3 +1,5 @@
+import {type SanityOrgUser} from '@sanity/cli-core'
+
 /**
  * Try to get a (prettier) name for a provider by ID.
  *
@@ -9,6 +11,21 @@ export function getProviderName(provider: string): string {
   if (provider === 'google') return 'Google'
   if (provider === 'github') return 'GitHub'
   if (provider === 'sanity') return 'Email'
+  if (provider === 'sanity-token') return 'an API token'
   if (provider.startsWith('saml-')) return 'SAML'
   return provider.charAt(0).toUpperCase() + provider.slice(1)
+}
+
+/**
+ * Get a human-readable identifier for a user, preferring email.
+ *
+ * API tokens resolve to a user with a null `email`, so falling back to the
+ * name (and finally the id) keeps a literal "null" out of user-facing output.
+ *
+ * @param user - The user to describe.
+ * @returns The user's email, or their name, or their id.
+ * @internal
+ */
+export function getUserDisplayName(user: SanityOrgUser): string {
+  return user.email || user.name || user.id
 }

--- a/packages/@sanity/cli/src/actions/debug/types.ts
+++ b/packages/@sanity/cli/src/actions/debug/types.ts
@@ -1,5 +1,6 @@
 export interface UserInfo {
-  email: string
+  /** Null when authenticating with an API token rather than a user account. */
+  email: string | null
   id: string
   name: string
   provider: string

--- a/packages/@sanity/cli/src/actions/init/initAction.ts
+++ b/packages/@sanity/cli/src/actions/init/initAction.ts
@@ -18,7 +18,7 @@ import {detectFrameworkRecord} from '../../util/detectFramework.js'
 import {formatCliErrorMessages} from '../../util/formatCliErrorMessages.js'
 import {getProjectDefaults} from '../../util/getProjectDefaults.js'
 import {validateSession} from '../auth/ensureAuthenticated.js'
-import {getProviderName} from '../auth/getProviderName.js'
+import {getProviderName, getUserDisplayName} from '../auth/getProviderName.js'
 import {login} from '../auth/login/login.js'
 import {LOGIN_REQUIRED_MESSAGE} from '../auth/login/loginInstructions.js'
 import {detectAvailableEditors} from '../mcp/detectAvailableEditors.js'
@@ -391,7 +391,7 @@ async function ensureAuthenticated(
   if (user) {
     trace.log({alreadyLoggedIn: true, step: 'login'})
     output.log(
-      `${logSymbols.success} You are logged in as ${user.email} using ${getProviderName(user.provider)}`,
+      `${logSymbols.success} You are logged in as ${getUserDisplayName(user)} using ${getProviderName(user.provider)}`,
     )
     return {user}
   }
@@ -416,7 +416,7 @@ async function ensureAuthenticated(
   const loggedInUser = await getCliUser()
 
   output.log(
-    `${logSymbols.success} You are logged in as ${loggedInUser.email} using ${getProviderName(loggedInUser.provider)}`,
+    `${logSymbols.success} You are logged in as ${getUserDisplayName(loggedInUser)} using ${getProviderName(loggedInUser.provider)}`,
   )
   return {user: loggedInUser}
 }

--- a/packages/@sanity/cli/src/commands/debug.ts
+++ b/packages/@sanity/cli/src/commands/debug.ts
@@ -231,7 +231,7 @@ export class Debug extends SanityCommand<typeof Debug> {
 
     const padTo = 8 // "Provider" is the longest key
     this.log(formatKeyValue('Name', user.name, {padTo}))
-    this.log(formatKeyValue('Email', user.email, {padTo}))
+    this.log(formatKeyValue('Email', user.email ?? '(none)', {padTo}))
     this.log(formatKeyValue('ID', user.id, {padTo}))
     this.log(formatKeyValue('Provider', user.provider, {padTo}))
     this.log('')

--- a/packages/@sanity/cli/src/util/getProjectDefaults.ts
+++ b/packages/@sanity/cli/src/util/getProjectDefaults.ts
@@ -65,7 +65,10 @@ async function getSanityUserInfo(): Promise<string | undefined> {
 
   try {
     const user = await getCliUser()
-    return user ? `${user.name} <${user.email}>` : undefined
+    if (!user) return undefined
+    // API tokens resolve to a user with no email; `Name <null>` isn't valid
+    // npm author syntax, so emit the bare name instead.
+    return user.email ? `${user.name} <${user.email}>` : user.name
   } catch {
     return undefined
   }


### PR DESCRIPTION
### Description

Closes AIGRO-5269. Found while verifying AIGRO-5071 (now closed).

An API token resolves to a user with `email: null` and `provider: 'sanity-token'` — confirmed against `/v2025-08-30/users/me` with a real `developer`-role robot token:

```
id:       'p-hN9kdnhZSVMU'
name:     '… (Robot)'
email:     null
provider: 'sanity-token'
```

But `SanityOrgUser.email` was typed as a non-optional `string`, so TypeScript actively concealed this at every site that formatted a user. On token auth — the path agents and CI take — that produced:

| where | before |
| -- | -- |
| `sanity init` success line | `✔ You are logged in as null using Sanity-token` |
| generated `package.json` | `"author": "Name <null>"` |
| `sanity debug` | `Email: null` |

The package.json one is the worst of the three: it persists into the user's project rather than scrolling past in a terminal, and `Name <null>` isn't valid npm author syntax.

### What to review

- `cli-core/src/types.ts` — `email: string | null`, and `provider` widened to include `'sanity-token'`. **This is the load-bearing change**; the rest only typechecks honestly because of it. Widening it surfaced one real consumer (`actions/debug/types.ts`), which had copied the same wrong assumption.
- `actions/auth/getProviderName.ts` — adds `getUserDisplayName()` (email → name → id). Also maps `sanity-token` to `an API token`, since the generic branch was title-casing it into `Sanity-token`.
- `util/getProjectDefaults.ts:68` — emits the bare name when there's no email, instead of `Name <null>`.
- `commands/debug.ts:234` — `(none)` rather than `null`. Note `debug --json` still emits a real `null` here, which seems right for machine output.

One judgment call worth a second opinion: I put `getUserDisplayName` in `getProviderName.ts` since both are small user-formatting helpers used together at the same call sites. Happy to split it into its own module if you'd rather keep that file single-purpose.

### Testing

- New `actions/auth/__tests__/getProviderName.test.ts` — 10 cases covering the provider map, the `sanity-token` mapping, the full fallback chain, and an explicit assertion that output never contains `null`. There was no prior coverage of either function.
- `pnpm test:unit --project=@sanity/cli --project=@sanity/cli-core` — 3330 tests, 0 failures.
- `pnpm check:types`, `pnpm check:lint`, `pnpm check:deps` all pass.

Not covered by automated tests: an end-to-end `sanity init` under a robot token to see the generated package.json. The formatting logic is unit-tested, but I haven't watched the file get written.

### Notes for release

Stop rendering a literal `null` when authenticating with an API token. Token auth resolves to a user with no email, so `sanity init` printed `You are logged in as null using Sanity-token`, wrote `"author": "Name <null>"` into the generated `package.json`, and `sanity debug` reported `Email: null`. User-facing output now falls back to the account name, and `SanityOrgUser.email` is correctly typed as nullable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI formatting and type widening for token users; no auth or API behavior changes.
> 
> **Overview**
> **Fixes user-facing CLI output when auth uses an API token** (robot users have `email: null` and `provider: 'sanity-token'`).
> 
> `SanityOrgUser` in **cli-core** now types `email` as `string | null` and adds `'sanity-token'` to `provider`. New **`getUserDisplayName()`** (email → name → id) and **`sanity-token` → "an API token"** in `getProviderName` drive **`sanity init`** login success lines. **`getProjectDefaults`** writes the bare account name into `package.json` author when there is no email (avoids `Name <null>`). **`sanity debug`** shows `Email: (none)` instead of `null` in human-readable output.
> 
> Unit tests cover provider mapping and the display-name fallback chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598a9f2a580a5653bf23148201be23432cb14681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->