### PR TITLE
fix(workbench): forward an app interface for a local workbench studio

### DIFF
--- a/.changeset/studio-app-interface.md
+++ b/.changeset/studio-app-interface.md
@@ -1,0 +1,5 @@
+---
+"@sanity/workbench-cli": patch
+---
+
+Forward an `app` interface for a locally running workbench studio, matching what its build exposes and what a deploy submits.

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -209,7 +209,7 @@ describe('deriveInterfaces', () => {
     )
   })
 
-  test('a studio without entry still derives its panels/workers', () => {
+  test('derives a studio app interface from the generated entry, after its panels/workers', () => {
     const app = workbenchApp({views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}]})
     expect(deriveInterfaces(app, {isApp: false})).toEqual([
       {
@@ -221,6 +221,15 @@ describe('deriveInterfaces', () => {
         title: 'feed',
         type: 'panel',
         version: '1',
+      },
+      {
+        id: 'test-app-app-test-app',
+        metadata: null,
+        moduleId: 'App',
+        name: 'test-app',
+        src: './.sanity/federation/remote-entry.jsx',
+        title: 'Test App',
+        type: 'app',
       },
     ])
   })

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -20,12 +20,8 @@ export type DevServerInterface = NonNullable<DevServerManifest['interfaces']>[nu
 export type DevServerConfig = NonNullable<DevServerManifest['configs']>[number]
 
 /**
- * Map a workbench app's declarations to its registry interface records:
- * `views` → panels, `services` → workers, plus the `app` view for whatever the
- * build exposes as `./App`. Each mirrors a deployed record so the workbench loads
- * a local interface like a deployed one. `undefined` for a non-branded app; a
- * studio that declares `entry` is rejected (studio app views aren't implemented
- * yet — its `app` view renders the studio config).
+ * Map a workbench app's declarations to its registry interface records. A studio
+ * that declares `entry` is rejected (studio app views aren't implemented yet).
  */
 export function deriveInterfaces(
   app: CliConfig['app'],

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -7,7 +7,11 @@ import {
   VIEW_CONTRACT_VERSION,
 } from '../../contract.js'
 import {isWorkbenchApp, readConfig} from '../../defineApp.js'
+import {FEDERATION_FILE_NAME, RUNTIME_DIR} from '../build/vite/constants.js'
 import {type DevServerManifest} from './registry.js'
+
+/** What a studio exposes as `./App` — the generated entry that renders `sanity.config.ts`. */
+const GENERATED_ENTRY = `./${RUNTIME_DIR}/${FEDERATION_FILE_NAME}.jsx`
 
 /** One forwarded interface record on the dev-server registry entry. */
 export type DevServerInterface = NonNullable<DevServerManifest['interfaces']>[number]
@@ -17,10 +21,11 @@ export type DevServerConfig = NonNullable<DevServerManifest['configs']>[number]
 
 /**
  * Map a workbench app's declarations to its registry interface records:
- * `views` → panels, `services` → workers, `entry` → the `app` view. Each mirrors
- * a deployed record so the workbench loads a local interface like a deployed one.
- * `undefined` for a non-branded app; a studio that declares `entry` is rejected
- * (studio app views aren't implemented yet).
+ * `views` → panels, `services` → workers, plus the `app` view for whatever the
+ * build exposes as `./App`. Each mirrors a deployed record so the workbench loads
+ * a local interface like a deployed one. `undefined` for a non-branded app; a
+ * studio that declares `entry` is rejected (studio app views aren't implemented
+ * yet — its `app` view renders the studio config).
  */
 export function deriveInterfaces(
   app: CliConfig['app'],
@@ -60,8 +65,12 @@ export function deriveInterfaces(
     }),
   )
 
+  // Tracks what the build exposes as `./App`: an app's declared `entry`, and a
+  // studio's generated entry. A dock-only app (no `entry`) exposes none.
+  const appEntry = options.isApp ? app.entry : GENERATED_ENTRY
+
   const appView: DevServerInterface[] =
-    app.entry === undefined
+    appEntry === undefined
       ? []
       : [
           {
@@ -69,7 +78,7 @@ export function deriveInterfaces(
             metadata: null,
             moduleId: interfaceModuleId('app', app.name),
             name: app.name,
-            src: app.entry,
+            src: appEntry,
             title: app.title,
             type: 'app',
           },


### PR DESCRIPTION
### Description

Studios don't report an interface `type: app` today, because they don't define their entry, and we generate it for them.

This PR ensures we generate an app interface for them too.

### What to review

`deriveInterfaces` is what both `sanity dev` and `sanity start`/preview register with, so this changes the registry entry for a federated studio (and its exposes-set id, which shifts once).

### Testing

Unit coverage in `deriveInterfaces.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dev/preview registry and federation exposes-set identity for studios; behavior is localized to workbench-cli with unit tests, but can affect how local studios load in the workbench.
> 
> **Overview**
> **Local workbench studios now register a `type: app` interface** on the dev-server registry, aligned with build `./App` exposure and deploy behavior.
> 
> `deriveInterfaces` chooses the app entry source by kind: SDK apps still use declared `entry` (dock-only apps with no entry still omit the app interface), while studios use the generated federation entry at `./.sanity/federation/remote-entry.jsx` with `moduleId: App`, appended after panels and workers. Studios that declare their own `entry` remain rejected.
> 
> Because `sanity dev` / preview use this mapping, a federated studio’s registry entry gains the app interface and its exposes-set id can change once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8764d992fbe02d51978602e8c56690815e7492fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->