### PR TITLE
feat: support providing sanityEnv to execution context

### DIFF
--- a/.changeset/pr-1608.md
+++ b/.changeset/pr-1608.md
@@ -1,0 +1,9 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+'@sanity/cli-core': minor
+'@sanity/cli': minor
+'@sanity/workbench-cli': minor
+---
+
+feat: support providing sanityEnv to execution context

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/getAutoUpdatesImportMap.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/getAutoUpdatesImportMap.test.ts
@@ -1,10 +1,15 @@
-import {describe, expect, test} from 'vitest'
+import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {
   getAutoUpdatesCssUrls,
   getAutoUpdatesImportMap,
   getModuleUrl,
 } from '../getAutoUpdatesImportMap.js'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
 
 describe('getAutoUpdateImportMap() without app id', () => {
   test('works with sanity package', () => {
@@ -174,5 +179,16 @@ describe('getModuleUrl', () => {
 
     expect(res).toContain('/v1/modules/by-app/my-app-id/')
     expect(res).not.toContain('/default/')
+  })
+
+  test('uses the invocation environment for the default module endpoint', () => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+    vi.stubEnv('SANITY_MODULES_HOST', undefined)
+
+    const res = runWithCliExecutionContext({sanityEnv: 'staging'}, () =>
+      getModuleUrl({name: 'sanity', version: '3.40.0'}, {timestamp: 1}),
+    )
+
+    expect(res).toContain('https://sanity-cdn.work/')
   })
 })

--- a/packages/@sanity/cli-build/src/actions/build/decorateIndexWithBridgeScript.ts
+++ b/packages/@sanity/cli-build/src/actions/build/decorateIndexWithBridgeScript.ts
@@ -1,3 +1,5 @@
+import {isStaging} from '@sanity/cli-core/util'
+
 /**
  * Decorates the given HTML template with a script
  * tag that loads the bridge component to communicate
@@ -6,17 +8,14 @@
  * @internal
  */
 export function decorateIndexWithBridgeScript(template: string): string {
-  const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production'
-
   /**
-   * The URL to the bridge script is determined by the
-   * `SANITY_INTERNAL_ENV` environment variable. So if you deploy
-   * a studio to the staging ENV then you'll get the correct script.
+   * The URL to the bridge script is determined by the active Sanity
+   * environment. So if you deploy a studio to the staging environment,
+   * then you'll get the correct script.
    */
-  const scriptURL =
-    sanityEnv === 'production'
-      ? 'https://core.sanity-cdn.com/bridge.js'
-      : 'https://core.sanity-cdn.work/bridge.js'
+  const scriptURL = isStaging()
+    ? 'https://core.sanity-cdn.work/bridge.js'
+    : 'https://core.sanity-cdn.com/bridge.js'
 
   return template.replace(
     '</head>',

--- a/packages/@sanity/cli-build/src/actions/build/getAutoUpdatesImportMap.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getAutoUpdatesImportMap.ts
@@ -1,8 +1,11 @@
-const MODULES_HOST =
-  process.env.SANITY_MODULES_HOST ||
-  (process.env.SANITY_INTERNAL_ENV === 'staging'
-    ? 'https://sanity-cdn.work'
-    : 'https://sanity-cdn.com')
+import {isStaging} from '@sanity/cli-core/util'
+
+function getModulesHost() {
+  return (
+    process.env.SANITY_MODULES_HOST ||
+    (isStaging() ? 'https://sanity-cdn.work' : 'https://sanity-cdn.com')
+  )
+}
 
 function currentUnixTime(): number {
   return Math.floor(Date.now() / 1000)
@@ -51,7 +54,7 @@ export function getModuleUrl(
 
 function getLegacyModuleUrl(pkg: Package, options: {baseUrl?: string; timestamp: number}) {
   const encodedMinVer = encodeURIComponent(`^${pkg.version}`)
-  return `${options.baseUrl || MODULES_HOST}/v1/modules/${rewriteScopedPackage(pkg.name)}/default/${encodedMinVer}/t${options.timestamp}`
+  return `${options.baseUrl || getModulesHost()}/v1/modules/${rewriteScopedPackage(pkg.name)}/default/${encodedMinVer}/t${options.timestamp}`
 }
 
 function getByAppModuleUrl(
@@ -59,7 +62,7 @@ function getByAppModuleUrl(
   options: {appId: string; baseUrl?: string; timestamp: number},
 ) {
   const encodedMinVer = encodeURIComponent(`^${pkg.version}`)
-  return `${options.baseUrl || MODULES_HOST}/v1/modules/by-app/${options.appId}/t${options.timestamp}/${encodedMinVer}/${rewriteScopedPackage(pkg.name)}`
+  return `${options.baseUrl || getModulesHost()}/v1/modules/by-app/${options.appId}/t${options.timestamp}/${encodedMinVer}/${rewriteScopedPackage(pkg.name)}`
 }
 
 /**

--- a/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
+++ b/packages/@sanity/cli-build/src/actions/build/getViteConfig.ts
@@ -4,6 +4,7 @@ import babel from '@rolldown/plugin-babel'
 import {findProjectRoot} from '@sanity/cli-core/config'
 import {getCliTelemetry} from '@sanity/cli-core/telemetry'
 import {type CliConfig, type UserViteConfig} from '@sanity/cli-core/types'
+import {isStaging} from '@sanity/cli-core/util'
 import {
   type WorkbenchExposes,
   workbenchOptimizeDeps,
@@ -186,7 +187,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     configFile: false,
     define: {
       __SANITY_BUILD_TIMESTAMP__: JSON.stringify(Date.now()),
-      __SANITY_STAGING__: process.env.SANITY_INTERNAL_ENV === 'staging',
+      __SANITY_STAGING__: isStaging(),
       'process.env.MODE': JSON.stringify(mode),
       'process.env.PKG_BUILD_VERSION': JSON.stringify(process.env.PKG_BUILD_VERSION),
       /**

--- a/packages/@sanity/cli-build/tsconfig.json
+++ b/packages/@sanity/cli-build/tsconfig.json
@@ -7,6 +7,9 @@
     "paths": {
       "@sanity/cli-core": ["./node_modules/@sanity/cli-core/src/_exports/index.ts"],
       "@sanity/cli-core/apiClient": ["./node_modules/@sanity/cli-core/src/apiClient.ts"],
+      "@sanity/cli-core/executionContext": [
+        "./node_modules/@sanity/cli-core/src/executionContext.ts"
+      ],
       "@sanity/cli-core/ExitCodes": ["./node_modules/@sanity/cli-core/src/exitCodes.ts"],
       "@sanity/cli-core/SanityCommand": ["./node_modules/@sanity/cli-core/src/SanityCommand.ts"],
       "@sanity/cli-core/*": ["./node_modules/@sanity/cli-core/src/_exports/*"],

--- a/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {getGlobalCliClient, getProjectCliClient} from '../apiClient.js'
+import {runWithCliExecutionContext} from '../executionContext.js'
 
 const mockCreateClient = vi.hoisted(() => vi.fn())
 const mockRequesterClone = vi.hoisted(() => vi.fn())
@@ -142,6 +143,40 @@ describe('getGlobalCliClient', () => {
       }),
     )
   })
+
+  test('invocation production environment overrides process staging environment', async () => {
+    mockCreateClient.mockResolvedValue({})
+    mockGetCliToken.mockResolvedValue('stored-token')
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'staging')
+
+    await runWithCliExecutionContext({sanityEnv: 'production'}, () =>
+      getGlobalCliClient({apiVersion: '2021-06-07'}),
+    )
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        apiHost: expect.anything(),
+      }),
+    )
+  })
+
+  test('explicit client apiHost overrides invocation environment', async () => {
+    mockCreateClient.mockResolvedValue({})
+    mockGetCliToken.mockResolvedValue('stored-token')
+
+    await runWithCliExecutionContext({sanityEnv: 'staging'}, () =>
+      getGlobalCliClient({
+        apiHost: 'https://api.sanity.io',
+        apiVersion: '2021-06-07',
+      }),
+    )
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiHost: 'https://api.sanity.io',
+      }),
+    )
+  })
 })
 
 describe('getProjectCliClient', () => {
@@ -245,6 +280,25 @@ describe('getProjectCliClient', () => {
     expect(mockCreateClient).toHaveBeenCalledWith(
       expect.not.objectContaining({
         apiHost: expect.anything(),
+      }),
+    )
+  })
+
+  test('invocation staging environment overrides process production environment', async () => {
+    mockCreateClient.mockResolvedValue({})
+    mockGetCliToken.mockResolvedValue('stored-token')
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+
+    await runWithCliExecutionContext({sanityEnv: 'staging'}, () =>
+      getProjectCliClient({
+        apiVersion: '2021-06-07',
+        projectId: 'test-project',
+      }),
+    )
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiHost: 'https://api.sanity.work',
       }),
     )
   })

--- a/packages/@sanity/cli-core/src/__tests__/executionContext.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/executionContext.test.ts
@@ -8,7 +8,7 @@ describe('executionContext', () => {
   })
 
   test('context is visible inside the async call graph and gone after', async () => {
-    const context = {token: 'test-token'}
+    const context = {sanityEnv: 'staging', token: 'test-token'} as const
     await runWithCliExecutionContext(context, async () => {
       expect(getCliExecutionContext()).toBe(context)
       await Promise.resolve()
@@ -18,21 +18,24 @@ describe('executionContext', () => {
   })
 
   test('concurrent contexts are isolated from each other', async () => {
-    const seen: Record<string, string | undefined> = {}
+    const seen: Record<string, {sanityEnv?: string; token?: string}> = {}
     const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
     await Promise.all([
-      runWithCliExecutionContext({token: 'token-a'}, async () => {
+      runWithCliExecutionContext({sanityEnv: 'production', token: 'token-a'}, async () => {
         await sleep(15)
-        seen.a = getCliExecutionContext()?.token
+        seen.a = {...getCliExecutionContext()}
       }),
-      runWithCliExecutionContext({token: 'token-b'}, async () => {
+      runWithCliExecutionContext({sanityEnv: 'staging', token: 'token-b'}, async () => {
         await sleep(5)
-        seen.b = getCliExecutionContext()?.token
+        seen.b = {...getCliExecutionContext()}
       }),
     ])
 
-    expect(seen).toEqual({a: 'token-a', b: 'token-b'})
+    expect(seen).toEqual({
+      a: {sanityEnv: 'production', token: 'token-a'},
+      b: {sanityEnv: 'staging', token: 'token-b'},
+    })
   })
 
   test('makes isInteractive report non-interactive', async () => {

--- a/packages/@sanity/cli-core/src/apiClient.ts
+++ b/packages/@sanity/cli-core/src/apiClient.ts
@@ -13,10 +13,9 @@ import {
 import {getCliToken} from './config/cli/cliUserConfig.js'
 import {generateHelpUrl} from './util/generateHelpUrl.js'
 import {getSanityUrl} from './util/getSanityUrl.js'
+import {isStaging} from './util/isStaging.js'
 
-const apiHosts: Record<string, string | undefined> = {
-  staging: 'https://api.sanity.work',
-}
+const STAGING_API_HOST = 'https://api.sanity.work'
 
 const CLI_REQUEST_TAG_PREFIX = 'sanity.cli'
 
@@ -61,9 +60,7 @@ export async function getGlobalCliClient({
   const requester = defaultRequester.clone()
   requester.use(authErrors())
 
-  const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production'
-
-  const apiHost = apiHosts[sanityEnv]
+  const apiHost = isStaging() ? STAGING_API_HOST : undefined
 
   // Use the provided token if set, otherwise fall back to the stored CLI token (unless unauthenticated)
   const token = providedToken || (unauthenticated ? undefined : await getCliToken())
@@ -129,9 +126,7 @@ export async function getProjectCliClient({
   const requester = defaultRequester.clone()
   requester.use(authErrors(config.projectId))
 
-  const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production'
-
-  const apiHost = apiHosts[sanityEnv]
+  const apiHost = isStaging() ? STAGING_API_HOST : undefined
 
   // Use the provided token if it is set, otherwise get the token from the config file
   const token = providedToken || (await getCliToken())

--- a/packages/@sanity/cli-core/src/executionContext.ts
+++ b/packages/@sanity/cli-core/src/executionContext.ts
@@ -1,6 +1,13 @@
 import {AsyncLocalStorage} from 'node:async_hooks'
 
 /**
+ * Sanity deployment environment used by a programmatic CLI invocation.
+ *
+ * @public
+ */
+export type SanityEnvironment = 'production' | 'staging'
+
+/**
  * Explicit, per-invocation execution context for running CLI commands
  * programmatically (e.g. from an MCP server or another embedding host).
  *
@@ -23,6 +30,12 @@ import {AsyncLocalStorage} from 'node:async_hooks'
  * @public
  */
 export interface CliExecutionContext {
+  /**
+   * Sanity deployment environment to use for this invocation.
+   * Overrides `SANITY_INTERNAL_ENV`.
+   */
+  sanityEnv?: SanityEnvironment
+
   /**
    * Sink for output the command would otherwise write to `process.stderr`.
    * Called once per line, without a trailing newline.

--- a/packages/@sanity/cli-core/src/util/__tests__/getSanityUrl.test.ts
+++ b/packages/@sanity/cli-core/src/util/__tests__/getSanityUrl.test.ts
@@ -1,8 +1,13 @@
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
+import {runWithCliExecutionContext} from '../../executionContext.js'
 import {getSanityUrl} from '../getSanityUrl.js'
 
 describe('getSanityUrl', () => {
+  beforeEach(() => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+  })
+
   afterEach(() => {
     vi.unstubAllEnvs()
   })
@@ -28,6 +33,14 @@ describe('getSanityUrl', () => {
   test('returns production domain when SANITY_INTERNAL_ENV is not staging', () => {
     vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
     expect(getSanityUrl('/test')).toBe('https://www.sanity.io/test')
+  })
+
+  test('prefers the invocation environment over SANITY_INTERNAL_ENV', () => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+
+    const url = runWithCliExecutionContext({sanityEnv: 'staging'}, () => getSanityUrl('/docs/api'))
+
+    expect(url).toBe('https://www.sanity.work/docs/api')
   })
 
   test('prepends leading slash when path is missing one', () => {

--- a/packages/@sanity/cli-core/src/util/getSanityUrl.ts
+++ b/packages/@sanity/cli-core/src/util/getSanityUrl.ts
@@ -1,12 +1,11 @@
 // Pure in-memory implementation. Widely exported.
+import {isStaging} from './isStaging.js'
+
 /**
  * @internal
  * @returns The Sanity URL for the given path, using the correct domain based on the environment
  */
 export function getSanityUrl(path = '/') {
-  const domain =
-    process.env.SANITY_INTERNAL_ENV === 'staging'
-      ? 'https://www.sanity.work'
-      : 'https://www.sanity.io'
+  const domain = isStaging() ? 'https://www.sanity.work' : 'https://www.sanity.io'
   return `${domain}${path.startsWith('/') ? path : `/${path}`}`
 }

--- a/packages/@sanity/cli-core/src/util/isStaging.ts
+++ b/packages/@sanity/cli-core/src/util/isStaging.ts
@@ -7,5 +7,9 @@ import {getCliExecutionContext} from '../executionContext.js'
  * @internal
  */
 export function isStaging(): boolean {
-  return (getCliExecutionContext()?.sanityEnv ?? process.env.SANITY_INTERNAL_ENV) === 'staging'
+  const context = getCliExecutionContext()
+
+  if (context) return context.sanityEnv === 'staging'
+
+  return process.env.SANITY_INTERNAL_ENV === 'staging'
 }

--- a/packages/@sanity/cli-core/src/util/isStaging.ts
+++ b/packages/@sanity/cli-core/src/util/isStaging.ts
@@ -1,3 +1,5 @@
+import {getCliExecutionContext} from '../executionContext.js'
+
 /**
  * Checks if the environment is staging.
  *
@@ -5,5 +7,5 @@
  * @internal
  */
 export function isStaging(): boolean {
-  return process.env.SANITY_INTERNAL_ENV === 'staging'
+  return (getCliExecutionContext()?.sanityEnv ?? process.env.SANITY_INTERNAL_ENV) === 'staging'
 }

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -23,6 +23,7 @@ beforeAll(async () => {
   // Keep tests hermetic: never let token resolution fall back to the
   // developer's real stored CLI login.
   vi.stubEnv('SANITY_CLI_CONFIG_PATH', '/nonexistent/sanity-cli-test-config.json')
+  vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
 
   config = await Config.load(fileURLToPath(new URL('../../..', import.meta.url)))
 })
@@ -157,12 +158,16 @@ describe('invokeSanityCli', () => {
     expect(result).toEqual({exitCode: 0, output: 'https://example.com'})
   })
 
-  test('concurrent invocations use their own token and capture their own output', async () => {
+  test('concurrent invocations use their own environment, token, and output', async () => {
     mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/project-a/cors`})
       .matchHeader('authorization', 'Bearer token-a')
       .delay(50)
       .reply(200, [{...corsOrigin('https://user-a.example.com'), projectId: 'project-a'}])
-    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/project-b/cors`})
+    mockApi({
+      apiHost: 'https://api.sanity.work',
+      apiVersion: CORS_API_VERSION,
+      uri: `/projects/project-b/cors`,
+    })
       .matchHeader('authorization', 'Bearer token-b')
       .delay(5)
       .reply(200, [{...corsOrigin('https://user-b.example.com'), projectId: 'project-b'}])
@@ -171,12 +176,14 @@ describe('invokeSanityCli', () => {
       invokeSanityCli({
         args: 'cors list --project-id project-a',
         config,
+        sanityEnv: 'production',
         source: 'mcp',
         token: 'token-a',
       }),
       invokeSanityCli({
         args: 'cors list --project-id project-b',
         config,
+        sanityEnv: 'staging',
         source: 'mcp',
         token: 'token-b',
       }),

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
@@ -23,7 +23,7 @@
 import {Config, Parser} from '@oclif/core'
 import {getHelpFlagAdditions, normalizeArgv} from '@oclif/core/help'
 import {CLI_TELEMETRY_SYMBOL, exitCodes, noopLogger, setCliTelemetry} from '@sanity/cli-core'
-import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
+import {runWithCliExecutionContext, type SanityEnvironment} from '@sanity/cli-core/executionContext'
 import {parseArgsStringToArgv} from 'string-argv'
 
 import {commandPolicies} from './commandPolicies/index.js'
@@ -88,6 +88,13 @@ export interface InvokeSanityCliOptions {
    * package's config, loaded once and cached across invocations.
    */
   config?: Config
+
+  /**
+   * Sanity deployment environment for this invocation. Scoped to this call
+   * via the CLI execution context and defaults to `SANITY_INTERNAL_ENV` (or
+   * production when it is unset).
+   */
+  sanityEnv?: SanityEnvironment
 }
 
 /**
@@ -126,6 +133,7 @@ function stripFlagQuotes(rawToken: string): string {
 export async function invokeSanityCli({
   args,
   config,
+  sanityEnv,
   source,
   token,
 }: InvokeSanityCliOptions): Promise<InvokeSanityCliResult> {
@@ -230,7 +238,7 @@ export async function invokeSanityCli({
   const sink = (line: string) => output.push(line)
 
   try {
-    await runWithCliExecutionContext({stderr: sink, stdout: sink, token}, () =>
+    await runWithCliExecutionContext({sanityEnv, stderr: sink, stdout: sink, token}, () =>
       CommandClass.run(commandArgv, resolvedConfig),
     )
     return {exitCode: exitCodes.SUCCESS, output: output.join('\n')}

--- a/packages/@sanity/cli/src/util/__tests__/warnAboutMissingAppId.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/warnAboutMissingAppId.test.ts
@@ -1,5 +1,6 @@
 import {Output} from '@sanity/cli-core'
-import {describe, expect, test, vi} from 'vitest'
+import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {warnAboutMissingAppId} from '../warnAboutMissingAppId'
 
@@ -9,6 +10,11 @@ describe('warnAboutMissingAppId', () => {
     log: vi.fn(),
     warn: vi.fn(),
   } as unknown as Output
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
 
   test('should log the expected warning when called', () => {
     warnAboutMissingAppId({
@@ -31,5 +37,21 @@ describe('warnAboutMissingAppId', () => {
 
     expect(mockOutput.warn).toBeCalledWith(expect.stringContaining('No appId configured'))
     expect(mockOutput.warn).toBeCalledWith(expect.stringContaining('https://www.sanity.io/manage'))
+  })
+
+  test('uses the invocation environment for the manage URL', () => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+
+    runWithCliExecutionContext({sanityEnv: 'staging'}, () =>
+      warnAboutMissingAppId({
+        appType: 'studio',
+        output: mockOutput,
+        projectId: 'project-id',
+      }),
+    )
+
+    expect(mockOutput.warn).toBeCalledWith(
+      expect.stringContaining('https://sanity.work/manage/project/project-id/studios'),
+    )
   })
 })

--- a/packages/@sanity/cli/src/util/getSanityEnv.ts
+++ b/packages/@sanity/cli/src/util/getSanityEnv.ts
@@ -1,4 +1,9 @@
 import {getCliExecutionContext} from '@sanity/cli-core/executionContext'
 
-export const getSanityEnv = () =>
-  getCliExecutionContext()?.sanityEnv ?? process.env.SANITY_INTERNAL_ENV ?? 'production'
+export function getSanityEnv() {
+  const context = getCliExecutionContext()
+
+  if (context) return context.sanityEnv ?? 'production'
+
+  return process.env.SANITY_INTERNAL_ENV ?? 'production'
+}

--- a/packages/@sanity/cli/src/util/getSanityEnv.ts
+++ b/packages/@sanity/cli/src/util/getSanityEnv.ts
@@ -1,1 +1,4 @@
-export const getSanityEnv = () => process.env.SANITY_INTERNAL_ENV || 'production'
+import {getCliExecutionContext} from '@sanity/cli-core/executionContext'
+
+export const getSanityEnv = () =>
+  getCliExecutionContext()?.sanityEnv ?? process.env.SANITY_INTERNAL_ENV ?? 'production'

--- a/packages/@sanity/cli/src/util/warnAboutMissingAppId.ts
+++ b/packages/@sanity/cli/src/util/warnAboutMissingAppId.ts
@@ -2,10 +2,8 @@ import path from 'node:path'
 import {styleText} from 'node:util'
 
 import {type Output} from '@sanity/cli-core'
+import {isStaging} from '@sanity/cli-core/util'
 import {logSymbols} from '@sanity/cli-core/ux'
-
-const baseUrl =
-  process.env.SANITY_INTERNAL_ENV === 'staging' ? 'https://sanity.work' : 'https://www.sanity.io'
 
 export function warnAboutMissingAppId({
   appType,
@@ -18,6 +16,7 @@ export function warnAboutMissingAppId({
   output: Output
   projectId?: string
 }) {
+  const baseUrl = isStaging() ? 'https://sanity.work' : 'https://www.sanity.io'
   const manageUrl = `${baseUrl}/manage${projectId ? `/project/${projectId}/studios` : ''}`
   const cliConfigFile = cliConfigPath ? path.basename(cliConfigPath) : 'sanity.cli.ts/.js'
   output.warn(

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/writeWorkbenchRuntime.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/writeWorkbenchRuntime.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import {join} from 'node:path'
 
+import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {writeWorkbenchRuntime} from '../writeWorkbenchRuntime.js'
@@ -82,6 +83,18 @@ describe('writeWorkbenchRuntime', () => {
 
       const html = written('index.html')
       expect(html).toContain(`<script>globalThis.__SANITY_STAGING__ = ${expected}</script>`)
+    })
+
+    test('prefers the invocation environment', async () => {
+      vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+
+      await runWithCliExecutionContext({sanityEnv: 'staging'}, () =>
+        writeWorkbenchRuntime({cwd: CWD, reactStrictMode: false}),
+      )
+
+      expect(written('index.html')).toContain(
+        '<script>globalThis.__SANITY_STAGING__ = true</script>',
+      )
     })
   })
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/startWorkbenchDevServer.ts
@@ -1,4 +1,5 @@
 import {type CliConfig, type Output, resolveLocalPackage, subdebug} from '@sanity/cli-core'
+import {isStaging} from '@sanity/cli-core/util'
 import viteReact from '@vitejs/plugin-react'
 import {createServer, type InlineConfig, type Plugin, type ViteDevServer} from 'vite'
 import {z} from 'zod/mini'
@@ -275,7 +276,7 @@ async function createWorkbenchViteServer(
     cacheDir,
     configFile: false,
     define: {
-      __SANITY_STAGING__: process.env.SANITY_INTERNAL_ENV === 'staging',
+      __SANITY_STAGING__: isStaging(),
       'import.meta.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL': JSON.stringify(remoteUrl),
     },
     logLevel: 'warn',

--- a/packages/@sanity/workbench-cli/src/actions/dev/writeWorkbenchRuntime.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/writeWorkbenchRuntime.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import {subdebug} from '@sanity/cli-core'
+import {isStaging} from '@sanity/cli-core/util'
 
 const devDebug = subdebug('dev')
 
@@ -64,10 +65,7 @@ export async function writeWorkbenchRuntime(options: {
   // `define` never reaches pre-bundled dependencies like the SDK.
   const indexHtml = indexHtmlTemplate
     .replace(/%SANITY_WORKBENCH_PREFETCH_HINTS%/, prefetchHints)
-    .replace(
-      /%SANITY_WORKBENCH_STAGING%/,
-      JSON.stringify(process.env.SANITY_INTERNAL_ENV === 'staging'),
-    )
+    .replace(/%SANITY_WORKBENCH_STAGING%/, JSON.stringify(isStaging()))
 
   devDebug('Making workbench runtime directory')
   await fs.mkdir(workbenchDir, {recursive: true})

--- a/packages/@sanity/workbench-cli/tsconfig.json
+++ b/packages/@sanity/workbench-cli/tsconfig.json
@@ -6,6 +6,9 @@
     "jsx": "react-jsx",
     "paths": {
       "@sanity/cli-core": ["./node_modules/@sanity/cli-core/src/_exports/index.ts"],
+      "@sanity/cli-core/executionContext": [
+        "./node_modules/@sanity/cli-core/src/executionContext.ts"
+      ],
       "@sanity/cli-core/*": ["./node_modules/@sanity/cli-core/src/_exports/*"]
     }
   }


### PR DESCRIPTION
Make it so the MCP server running in staging can run the CLI also in staging mode

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which API hosts, CDN URLs, and staging flags apply during programmatic CLI runs; incorrect `sanityEnv` could send MCP or embedded callers to the wrong environment, though the interactive CLI path is unchanged.
> 
> **Overview**
> Adds optional **`sanityEnv`** (`production` | `staging`) to **`CliExecutionContext`**, so hosts like an MCP server can run **`invokeSanityCli`** against staging without mutating **`SANITY_INTERNAL_ENV`**.
> 
> **`isStaging()`** now treats an active execution context as authoritative: staging only when **`context.sanityEnv === 'staging'`**; otherwise it falls back to **`SANITY_INTERNAL_ENV`**. Call sites that previously read the env directly (API clients, **`getSanityUrl`**, auto-update module CDN hosts, bridge script injection, Vite **`__SANITY_STAGING__`**, workbench runtime, manage URLs) route through **`isStaging()`** or **`getSanityEnv()`** so the same per-invocation override applies consistently.
> 
> **`invokeSanityCli`** accepts **`sanityEnv`** and passes it into **`runWithCliExecutionContext`** alongside token and output sinks, enabling isolated concurrent invocations (e.g. production vs staging API hosts in integration tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b456f0580696769a43416a0e34850d1d2486005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->