### PR TITLE
feat: return commandId in InvokeSanityCliResult

### DIFF
--- a/.changeset/pr-1609.md
+++ b/.changeset/pr-1609.md
@@ -1,9 +1,6 @@
 <!-- auto-generated -->
 ---
-'@sanity/cli-build': minor
-'@sanity/cli-core': minor
 '@sanity/cli': minor
-'@sanity/workbench-cli': minor
 ---
 
 feat: return commandId in InvokeSanityCliResult

--- a/.changeset/pr-1609.md
+++ b/.changeset/pr-1609.md
@@ -1,6 +1,9 @@
 <!-- auto-generated -->
 ---
+'@sanity/cli-build': minor
+'@sanity/cli-core': minor
 '@sanity/cli': minor
+'@sanity/workbench-cli': minor
 ---
 
 feat: return commandId in InvokeSanityCliResult

--- a/.changeset/pr-1609.md
+++ b/.changeset/pr-1609.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat: return commandId in InvokeSanityCliResult

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -73,7 +73,11 @@ describe('invokeSanityCli', () => {
     // root (where package.json and the oclif manifest live), not some other
     // ancestor directory, when a caller doesn't supply `config` (as every
     // other test in this file does).
-    const result = await invokeSanityCli({args: '--help', source: 'mcp', token: 'user-token'})
+    const result = await invokeSanityCli({
+      args: '--help',
+      source: 'mcp',
+      token: 'user-token',
+    })
 
     expect(result.exitCode).toBe(0)
     expect(result.output).toContain('USAGE')
@@ -81,7 +85,10 @@ describe('invokeSanityCli', () => {
   })
 
   test('runs a command from string args, using the provided token', async () => {
-    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: `/projects/${projectId}/cors`,
+    })
       .matchHeader('authorization', 'Bearer user-token')
       .reply(200, [corsOrigin('https://example.com')])
 
@@ -92,11 +99,18 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result).toEqual({exitCode: 0, output: 'https://example.com'})
+    expect(result).toEqual({
+      commandId: 'cors:list',
+      exitCode: 0,
+      output: 'https://example.com',
+    })
   })
 
   test('accepts a pre-split argv array', async () => {
-    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: `/projects/${projectId}/cors`,
+    })
       .matchHeader('authorization', 'Bearer user-token')
       .reply(200, [corsOrigin('https://example.com')])
 
@@ -107,11 +121,18 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result).toEqual({exitCode: 0, output: 'https://example.com'})
+    expect(result).toEqual({
+      commandId: 'cors:list',
+      exitCode: 0,
+      output: 'https://example.com',
+    })
   })
 
   test('tolerates a leading `sanity` token and quoted values', async () => {
-    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: `/projects/${projectId}/cors`,
+    })
       .matchHeader('authorization', 'Bearer user-token')
       .reply(200, [corsOrigin('https://example.com')])
 
@@ -122,7 +143,11 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result).toEqual({exitCode: 0, output: 'https://example.com'})
+    expect(result).toEqual({
+      commandId: 'cors:list',
+      exitCode: 0,
+      output: 'https://example.com',
+    })
   })
 
   test.each([
@@ -144,7 +169,10 @@ describe('invokeSanityCli', () => {
   })
 
   test('supports colon-separated command ids', async () => {
-    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: `/projects/${projectId}/cors`,
+    })
       .matchHeader('authorization', 'Bearer user-token')
       .reply(200, [corsOrigin('https://example.com')])
 
@@ -155,7 +183,11 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result).toEqual({exitCode: 0, output: 'https://example.com'})
+    expect(result).toEqual({
+      commandId: 'cors:list',
+      exitCode: 0,
+      output: 'https://example.com',
+    })
   })
 
   test('concurrent invocations use their own environment, token, and output', async () => {
@@ -189,14 +221,29 @@ describe('invokeSanityCli', () => {
       }),
     ])
 
-    expect(resultA).toEqual({exitCode: 0, output: 'https://user-a.example.com'})
-    expect(resultB).toEqual({exitCode: 0, output: 'https://user-b.example.com'})
+    expect(resultA).toEqual({
+      commandId: 'cors:list',
+      exitCode: 0,
+      output: 'https://user-a.example.com',
+    })
+    expect(resultB).toEqual({
+      commandId: 'cors:list',
+      exitCode: 0,
+      output: 'https://user-b.example.com',
+    })
   })
 
   test('reports command failures through exitCode and output without throwing', async () => {
-    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
+    mockApi({
+      apiVersion: CORS_API_VERSION,
+      uri: `/projects/${projectId}/cors`,
+    })
       .matchHeader('authorization', 'Bearer bogus-token')
-      .reply(401, {error: 'Unauthorized', message: 'Session not found', statusCode: 401})
+      .reply(401, {
+        error: 'Unauthorized',
+        message: 'Session not found',
+        statusCode: 401,
+      })
 
     const previousExitCode = process.exitCode
     const result = await invokeSanityCli({
@@ -207,6 +254,7 @@ describe('invokeSanityCli', () => {
     })
 
     expect(result.exitCode).toBe(1)
+    expect(result.commandId).toBe('cors:list')
     expect(result.output).toContain('CORS origins list retrieval failed')
     expect(result.output).toContain('Session not found')
     // A failed invocation must not change the host process's exit status
@@ -222,6 +270,7 @@ describe('invokeSanityCli', () => {
     })
 
     expect(result.exitCode).toBe(2)
+    expect(result.commandId).toBe('cors:list')
     expect(result.output).toContain('Nonexistent flag')
   })
 
@@ -276,9 +325,15 @@ describe('invokeSanityCli', () => {
     'schemas list', // denied: requires a local project
     'bogus stuff', // does not exist at all
   ])('`%s` is rejected as unknown or unsupported', async (args) => {
-    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+    const result = await invokeSanityCli({
+      args,
+      config,
+      source: 'mcp',
+      token: 'user-token',
+    })
 
     expect(result.exitCode).toBe(2)
+    expect(result.commandId).toBeUndefined()
     expect(result.output).toContain(`Unknown or unsupported command: ${args}`)
     expect(result.output).toContain('cors list')
   })
@@ -302,7 +357,12 @@ describe('invokeSanityCli', () => {
   })
 
   test('rejects empty args', async () => {
-    const result = await invokeSanityCli({args: '', config, source: 'mcp', token: 'user-token'})
+    const result = await invokeSanityCli({
+      args: '',
+      config,
+      source: 'mcp',
+      token: 'user-token',
+    })
 
     expect(result.exitCode).toBe(2)
     expect(result.output).toContain('Unknown or unsupported command')
@@ -320,7 +380,9 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result).toEqual({exitCode: 0, output: 'https://example.com'})
+    expect(result.exitCode).toBe(2)
+    expect(result.commandId).toBeUndefined()
+    expect(result.output).toContain('Unterminated double quote')
   })
 
   test.each([
@@ -329,9 +391,15 @@ describe('invokeSanityCli', () => {
     ['api users/me --input body.json', '--input'], // --input reads the host's filesystem or stdin
     ['api users/me --token other-user-token', '--token'], // --token overrides the MCP user's token
   ])('`%s` is refused by a conditional policy naming the flag', async (args, deniedFlag) => {
-    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+    const result = await invokeSanityCli({
+      args,
+      config,
+      source: 'mcp',
+      token: 'user-token',
+    })
 
     expect(result.exitCode).toBe(2)
+    expect(result.commandId).toBe(args.startsWith('docs') ? 'docs:read' : 'graphql:undeploy')
     expect(result.output).toContain('is not supported here')
     expect(result.output).toContain(deniedFlag)
   })
@@ -394,9 +462,15 @@ describe('invokeSanityCli', () => {
   test.each(['--help', 'help', 'sanity --help'])(
     '`%s` renders root help scoped to the policy surface',
     async (args) => {
-      const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+      const result = await invokeSanityCli({
+        args,
+        config,
+        source: 'mcp',
+        token: 'user-token',
+      })
 
       expect(result.exitCode).toBe(0)
+      expect(result.commandId).toBeUndefined()
       expect(result.output).toContain('USAGE')
       expect(result.output).toContain('TOPICS')
       expect(result.output).toContain('Manage CORS origins for your project')
@@ -413,9 +487,15 @@ describe('invokeSanityCli', () => {
   test.each(['cors --help', 'help cors'])(
     '`%s` renders topic help listing only invokable commands',
     async (args) => {
-      const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+      const result = await invokeSanityCli({
+        args,
+        config,
+        source: 'mcp',
+        token: 'user-token',
+      })
 
       expect(result.exitCode).toBe(0)
+      expect(result.commandId).toBeUndefined()
       expect(result.output).toContain('Manage CORS origins for your project')
       expect(result.output).toContain('cors add')
       expect(result.output).toContain('cors delete')
@@ -453,14 +533,33 @@ describe('invokeSanityCli', () => {
   test.each(['cors list --help', 'help cors list', 'cors:list --help'])(
     '`%s` renders command help with usage and flags',
     async (args) => {
-      const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+      const result = await invokeSanityCli({
+        args,
+        config,
+        source: 'mcp',
+        token: 'user-token',
+      })
 
       expect(result.exitCode).toBe(0)
+      expect(result.commandId).toBe('cors:list')
       expect(result.output).toContain('List CORS origins for the project')
       expect(result.output).toContain('USAGE')
       expect(result.output).toContain('--project-id')
     },
   )
+
+  test('reports a root command id for command-specific help', async () => {
+    const result = await invokeSanityCli({
+      args: 'api --help',
+      config,
+      source: 'mcp',
+      token: 'user-token',
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.commandId).toBe('api')
+    expect(result.output).toContain('USAGE')
+  })
 
   test.each([
     ['docs read --help', '--web'],
@@ -468,7 +567,12 @@ describe('invokeSanityCli', () => {
   ])('`%s` omits the policy-denied %s flag', async (args, deniedFlag) => {
     // Help must not advertise surface the policy refuses: the flag disappears
     // from FLAGS/USAGE and examples demonstrating it are dropped.
-    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+    const result = await invokeSanityCli({
+      args,
+      config,
+      source: 'mcp',
+      token: 'user-token',
+    })
 
     expect(result.exitCode).toBe(0)
     expect(result.output).toContain('USAGE')
@@ -507,9 +611,15 @@ describe('invokeSanityCli', () => {
     'datasets export --help', // real command under a visible topic, denied
     'bogus --help', // does not exist at all
   ])('`%s` is rejected identically to an unknown command', async (args) => {
-    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+    const result = await invokeSanityCli({
+      args,
+      config,
+      source: 'mcp',
+      token: 'user-token',
+    })
 
     expect(result.exitCode).toBe(2)
+    expect(result.commandId).toBeUndefined()
     expect(result.output).toContain('Unknown or unsupported command')
     expect(result.output).toContain('Available commands:')
     expect(result.output).toContain('cors add')

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -73,11 +73,7 @@ describe('invokeSanityCli', () => {
     // root (where package.json and the oclif manifest live), not some other
     // ancestor directory, when a caller doesn't supply `config` (as every
     // other test in this file does).
-    const result = await invokeSanityCli({
-      args: '--help',
-      source: 'mcp',
-      token: 'user-token',
-    })
+    const result = await invokeSanityCli({args: '--help', source: 'mcp', token: 'user-token'})
 
     expect(result.exitCode).toBe(0)
     expect(result.output).toContain('USAGE')
@@ -85,10 +81,7 @@ describe('invokeSanityCli', () => {
   })
 
   test('runs a command from string args, using the provided token', async () => {
-    mockApi({
-      apiVersion: CORS_API_VERSION,
-      uri: `/projects/${projectId}/cors`,
-    })
+    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
       .matchHeader('authorization', 'Bearer user-token')
       .reply(200, [corsOrigin('https://example.com')])
 
@@ -99,18 +92,11 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result).toEqual({
-      commandId: 'cors:list',
-      exitCode: 0,
-      output: 'https://example.com',
-    })
+    expect(result).toEqual({commandId: 'cors:list', exitCode: 0, output: 'https://example.com'})
   })
 
   test('accepts a pre-split argv array', async () => {
-    mockApi({
-      apiVersion: CORS_API_VERSION,
-      uri: `/projects/${projectId}/cors`,
-    })
+    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
       .matchHeader('authorization', 'Bearer user-token')
       .reply(200, [corsOrigin('https://example.com')])
 
@@ -121,18 +107,11 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result).toEqual({
-      commandId: 'cors:list',
-      exitCode: 0,
-      output: 'https://example.com',
-    })
+    expect(result).toEqual({commandId: 'cors:list', exitCode: 0, output: 'https://example.com'})
   })
 
   test('tolerates a leading `sanity` token and quoted values', async () => {
-    mockApi({
-      apiVersion: CORS_API_VERSION,
-      uri: `/projects/${projectId}/cors`,
-    })
+    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
       .matchHeader('authorization', 'Bearer user-token')
       .reply(200, [corsOrigin('https://example.com')])
 
@@ -143,11 +122,7 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result).toEqual({
-      commandId: 'cors:list',
-      exitCode: 0,
-      output: 'https://example.com',
-    })
+    expect(result).toEqual({commandId: 'cors:list', exitCode: 0, output: 'https://example.com'})
   })
 
   test.each([
@@ -165,14 +140,11 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result).toEqual({exitCode: 0, output: 'https://example.com'})
+    expect(result).toEqual({commandId: 'cors:list', exitCode: 0, output: 'https://example.com'})
   })
 
   test('supports colon-separated command ids', async () => {
-    mockApi({
-      apiVersion: CORS_API_VERSION,
-      uri: `/projects/${projectId}/cors`,
-    })
+    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
       .matchHeader('authorization', 'Bearer user-token')
       .reply(200, [corsOrigin('https://example.com')])
 
@@ -183,11 +155,7 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result).toEqual({
-      commandId: 'cors:list',
-      exitCode: 0,
-      output: 'https://example.com',
-    })
+    expect(result).toEqual({commandId: 'cors:list', exitCode: 0, output: 'https://example.com'})
   })
 
   test('concurrent invocations use their own environment, token, and output', async () => {
@@ -234,16 +202,9 @@ describe('invokeSanityCli', () => {
   })
 
   test('reports command failures through exitCode and output without throwing', async () => {
-    mockApi({
-      apiVersion: CORS_API_VERSION,
-      uri: `/projects/${projectId}/cors`,
-    })
+    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
       .matchHeader('authorization', 'Bearer bogus-token')
-      .reply(401, {
-        error: 'Unauthorized',
-        message: 'Session not found',
-        statusCode: 401,
-      })
+      .reply(401, {error: 'Unauthorized', message: 'Session not found', statusCode: 401})
 
     const previousExitCode = process.exitCode
     const result = await invokeSanityCli({
@@ -325,12 +286,7 @@ describe('invokeSanityCli', () => {
     'schemas list', // denied: requires a local project
     'bogus stuff', // does not exist at all
   ])('`%s` is rejected as unknown or unsupported', async (args) => {
-    const result = await invokeSanityCli({
-      args,
-      config,
-      source: 'mcp',
-      token: 'user-token',
-    })
+    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
     expect(result.exitCode).toBe(2)
     expect(result.commandId).toBeUndefined()
@@ -357,12 +313,7 @@ describe('invokeSanityCli', () => {
   })
 
   test('rejects empty args', async () => {
-    const result = await invokeSanityCli({
-      args: '',
-      config,
-      source: 'mcp',
-      token: 'user-token',
-    })
+    const result = await invokeSanityCli({args: '', config, source: 'mcp', token: 'user-token'})
 
     expect(result.exitCode).toBe(2)
     expect(result.output).toContain('Unknown or unsupported command')
@@ -380,28 +331,21 @@ describe('invokeSanityCli', () => {
       token: 'user-token',
     })
 
-    expect(result.exitCode).toBe(2)
-    expect(result.commandId).toBeUndefined()
-    expect(result.output).toContain('Unterminated double quote')
+    expect(result).toEqual({commandId: 'cors:list', exitCode: 0, output: 'https://example.com'})
   })
 
   test.each([
-    ['docs read /docs/studio/installation --web', '--web'], // --web opens a browser on the host
-    ['graphql undeploy --api ios --force', '--api'], // --api loads local GraphQL definitions
-    ['api users/me --input body.json', '--input'], // --input reads the host's filesystem or stdin
-    ['api users/me --token other-user-token', '--token'], // --token overrides the MCP user's token
-  ])('`%s` is refused by a conditional policy naming the flag', async (args, deniedFlag) => {
-    const result = await invokeSanityCli({
-      args,
-      config,
-      source: 'mcp',
-      token: 'user-token',
-    })
+    ['docs read /docs/studio/installation --web', '--web', 'docs:read'], // --web opens a browser on the host
+    ['graphql undeploy --api ios --force', '--api', 'graphql:undeploy'], // --api loads local GraphQL definitions
+    ['api users/me --input body.json', '--input', 'api'], // --input reads the host's filesystem or stdin
+    ['api users/me --token other-user-token', '--token', 'api'], // --token overrides the MCP user's token
+  ])('`%s` is refused by a conditional policy naming the flag', async (args, flag, commandId) => {
+    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
     expect(result.exitCode).toBe(2)
-    expect(result.commandId).toBe(args.startsWith('docs') ? 'docs:read' : 'graphql:undeploy')
+    expect(result.commandId).toBe(commandId)
     expect(result.output).toContain('is not supported here')
-    expect(result.output).toContain(deniedFlag)
+    expect(result.output).toContain(flag)
   })
 
   test.each([
@@ -462,12 +406,7 @@ describe('invokeSanityCli', () => {
   test.each(['--help', 'help', 'sanity --help'])(
     '`%s` renders root help scoped to the policy surface',
     async (args) => {
-      const result = await invokeSanityCli({
-        args,
-        config,
-        source: 'mcp',
-        token: 'user-token',
-      })
+      const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
       expect(result.exitCode).toBe(0)
       expect(result.commandId).toBeUndefined()
@@ -487,12 +426,7 @@ describe('invokeSanityCli', () => {
   test.each(['cors --help', 'help cors'])(
     '`%s` renders topic help listing only invokable commands',
     async (args) => {
-      const result = await invokeSanityCli({
-        args,
-        config,
-        source: 'mcp',
-        token: 'user-token',
-      })
+      const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
       expect(result.exitCode).toBe(0)
       expect(result.commandId).toBeUndefined()
@@ -533,12 +467,7 @@ describe('invokeSanityCli', () => {
   test.each(['cors list --help', 'help cors list', 'cors:list --help'])(
     '`%s` renders command help with usage and flags',
     async (args) => {
-      const result = await invokeSanityCli({
-        args,
-        config,
-        source: 'mcp',
-        token: 'user-token',
-      })
+      const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
       expect(result.exitCode).toBe(0)
       expect(result.commandId).toBe('cors:list')
@@ -567,12 +496,7 @@ describe('invokeSanityCli', () => {
   ])('`%s` omits the policy-denied %s flag', async (args, deniedFlag) => {
     // Help must not advertise surface the policy refuses: the flag disappears
     // from FLAGS/USAGE and examples demonstrating it are dropped.
-    const result = await invokeSanityCli({
-      args,
-      config,
-      source: 'mcp',
-      token: 'user-token',
-    })
+    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
     expect(result.exitCode).toBe(0)
     expect(result.output).toContain('USAGE')
@@ -611,12 +535,7 @@ describe('invokeSanityCli', () => {
     'datasets export --help', // real command under a visible topic, denied
     'bogus --help', // does not exist at all
   ])('`%s` is rejected identically to an unknown command', async (args) => {
-    const result = await invokeSanityCli({
-      args,
-      config,
-      source: 'mcp',
-      token: 'user-token',
-    })
+    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
     expect(result.exitCode).toBe(2)
     expect(result.commandId).toBeUndefined()

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/help.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/help.ts
@@ -78,6 +78,7 @@ function withoutDeniedFlags(command: Command.Loadable, policy?: CommandPolicy): 
  * to the process streams.
  */
 class InvokableHelp extends Help {
+  public commandId: string | undefined
   public readonly lines: string[] = []
 
   private readonly commandIds: Set<string>
@@ -115,6 +116,7 @@ class InvokableHelp extends Help {
 
   public override async showCommandHelp(command: Command.Loadable): Promise<void> {
     if (!this.commandIds.has(command.id)) throw new NotInvokableError(command.id)
+    this.commandId = command.id
     return super.showCommandHelp(withoutDeniedFlags(command, this.policySet[command.id]))
   }
 
@@ -140,7 +142,7 @@ export async function renderInvokableHelp(
   config: Config,
   argv: string[],
   policySet: CommandPolicySet,
-): Promise<string | undefined> {
+): Promise<{commandId?: string; output: string} | undefined> {
   const help = new InvokableHelp(config, policySet)
   try {
     await help.showHelp(argv)
@@ -151,7 +153,10 @@ export async function renderInvokableHelp(
     if (err instanceof NotInvokableError || err.oclif) return undefined
     throw err
   }
-  return help.lines.join('\n').trimEnd()
+  return {
+    ...(help.commandId && {commandId: help.commandId}),
+    output: help.lines.join('\n').trimEnd(),
+  }
 }
 
 /**

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
@@ -106,6 +106,12 @@ export interface InvokeSanityCliResult {
 
   /** Combined stdout and stderr output, in emission order. */
   output: string
+
+  /**
+   * Canonical oclif command id when the invocation resolved to a command
+   * exposed by the selected policy (for example, `datasets:create`).
+   */
+  commandId?: string
 }
 
 let cachedConfig: Promise<Config> | undefined
@@ -166,8 +172,8 @@ export async function invokeSanityCli({
       // Drop a leading `help` so the rest is the subject, mirroring how
       // oclif's dispatch consumes the token before the help command sees argv
       const helpArgv = argv[0] === 'help' ? argv.slice(1) : argv
-      const output = await renderInvokableHelp(resolvedConfig, helpArgv, policySet)
-      if (output !== undefined) return {exitCode: exitCodes.SUCCESS, output}
+      const result = await renderInvokableHelp(resolvedConfig, helpArgv, policySet)
+      if (result) return {...result, exitCode: exitCodes.SUCCESS}
       const helpFlags = getHelpFlagAdditions(resolvedConfig)
       return unknownCommandResult(
         helpArgv.filter((token) => !helpFlags.includes(token)),
@@ -210,6 +216,7 @@ export async function invokeSanityCli({
     }
   } catch (err) {
     return {
+      commandId,
       exitCode: exitCodes.USAGE_ERROR,
       output: err instanceof Error ? err.message : String(err),
     }
@@ -229,6 +236,7 @@ export async function invokeSanityCli({
     }
 
     return {
+      commandId,
       exitCode: exitCodes.USAGE_ERROR,
       output,
     }
@@ -241,18 +249,19 @@ export async function invokeSanityCli({
     await runWithCliExecutionContext({sanityEnv, stderr: sink, stdout: sink, token}, () =>
       CommandClass.run(commandArgv, resolvedConfig),
     )
-    return {exitCode: exitCodes.SUCCESS, output: output.join('\n')}
+    return {commandId, exitCode: exitCodes.SUCCESS, output: output.join('\n')}
   } catch (err) {
     const exit = err.oclif?.exit
 
     // `this.exit(0)` throws an ExitError but is a successful outcome
     if (exit === exitCodes.SUCCESS) {
-      return {exitCode: exitCodes.SUCCESS, output: output.join('\n')}
+      return {commandId, exitCode: exitCodes.SUCCESS, output: output.join('\n')}
     }
 
     const message = prettyPrintError(err) || String(err)
     if (message) output.push(message)
     return {
+      commandId,
       exitCode: typeof exit === 'number' ? exit : exitCodes.RUNTIME_ERROR,
       output: output.join('\n'),
     }


### PR DESCRIPTION
Return commandId from invokeCli

This makes it so the caller (MCP) is able to see which command was parsed out of the input string, without needing to handle that itself.



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional field on an internal programmatic API; behavior changes are limited to richer return metadata with no new command execution paths.
> 
> **Overview**
> Adds optional **`commandId`** to **`InvokeSanityCliResult`** and populates it whenever **`invokeSanityCli`** resolves a policy-visible command—including success, runtime failure, flag parse errors, and conditional policy refusals. Unknown or fully denied invocations still omit **`commandId`**.
> 
> For **help**, **`renderInvokableHelp`** now returns **`{ output, commandId? }`**: command-specific help (e.g. `cors list --help`) sets the resolved id; root/topic help leaves it unset; root-command help like **`api --help`** reports **`api`**. Tests and a minor **`@sanity/cli`** changeset cover the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a959010b73c1c28b429453cbb1da80df2d61e0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->