### PR TITLE
fix(cli): prevent custom API tokens in `sanity api` command via MCP

### DIFF
--- a/.changeset/clever-bikes-roll.md
+++ b/.changeset/clever-bikes-roll.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+fix(cli): deny `sanity api --token` for MCP policy command set

--- a/.changeset/clever-bikes-roll.md
+++ b/.changeset/clever-bikes-roll.md
@@ -2,4 +2,4 @@
 "@sanity/cli": patch
 ---
 
-fix(cli): deny `sanity api --token` for MCP policy command set
+fix(cli): update MCP policy command set to prevent authentication overrides for `sanity api`

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -315,7 +315,17 @@ describe('invokeSanityCli', () => {
     const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
     expect(result.exitCode).toBe(2)
-    expect(result.output).toContain('is not supported here')
+    expect(result.output).toBe('This invocation of `api` is not supported here')
+  })
+
+  test.each([
+    ['long flag', 'api users/me --header "Authorization: Bearer other-user-token"'],
+    ['short flag with mixed casing', 'api users/me -H "aUtHoRiZaTiOn: Basic credentials"'],
+  ])('`api` Authorization headers using the %s are refused', async (_style, args) => {
+    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toBe('This invocation of `api` is not supported here')
   })
 
   test('the api policy refuses authentication overrides and host input channels', () => {
@@ -324,12 +334,16 @@ describe('invokeSanityCli', () => {
 
     expect(validate({})).toBe(true)
     expect(validate({field: ['key=value', 'count=1']})).toBe(true)
+    expect(validate({header: ['Content-Type: application/json', 'X-Custom: value']})).toBe(true)
+    expect(validate({header: [42, 'invalid']})).toBe(true)
     // Raw `-f` fields are always verbatim strings — `@` has no meaning there.
     expect(validate({'raw-field': ['key=@payload.json']})).toBe(true)
 
     expect(validate({input: 'payload.json'})).toBe(false)
     expect(validate({input: '-'})).toBe(false)
     expect(validate({token: 'other-user-token'})).toBe(false)
+    expect(validate({header: ['Authorization: Bearer other-user-token']})).toBe(false)
+    expect(validate({header: [' aUtHoRiZaTiOn : Basic credentials']})).toBe(false)
     expect(validate({field: ['body=@payload.json']})).toBe(false)
     expect(validate({field: ['key=value', 'body=@-']})).toBe(false)
   })

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -299,6 +299,7 @@ describe('invokeSanityCli', () => {
     ['docs read /docs/studio/installation --web', '--web'], // --web opens a browser on the host
     ['graphql undeploy --api ios --force', '--api'], // --api loads local GraphQL definitions
     ['api users/me --input body.json', '--input'], // --input reads the host's filesystem or stdin
+    ['api users/me --token other-user-token', '--token'], // --token overrides the MCP user's token
   ])('`%s` is refused by a conditional policy naming the flag', async (args, deniedFlag) => {
     const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
@@ -317,7 +318,7 @@ describe('invokeSanityCli', () => {
     expect(result.output).toContain('is not supported here')
   })
 
-  test('the api policy refuses only the host input channels', () => {
+  test('the api policy refuses authentication overrides and host input channels', () => {
     const policy = commandPolicies.mcp.api
     const validate = (flags: Record<string, unknown>) => policy.validate({args: {}, flags})
 
@@ -328,6 +329,7 @@ describe('invokeSanityCli', () => {
 
     expect(validate({input: 'payload.json'})).toBe(false)
     expect(validate({input: '-'})).toBe(false)
+    expect(validate({token: 'other-user-token'})).toBe(false)
     expect(validate({field: ['body=@payload.json']})).toBe(false)
     expect(validate({field: ['key=value', 'body=@-']})).toBe(false)
   })
@@ -429,6 +431,18 @@ describe('invokeSanityCli', () => {
     expect(result.exitCode).toBe(0)
     expect(result.output).toContain('USAGE')
     expect(result.output).not.toContain(deniedFlag)
+  })
+
+  test('`api --help` omits the policy-denied --token flag definition', async () => {
+    const result = await invokeSanityCli({
+      args: 'api --help',
+      config,
+      source: 'mcp',
+      token: 'user-token',
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.output).not.toContain('-t, --token=')
   })
 
   test('help output is stable across invocations sharing a config', async () => {

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -16,6 +16,15 @@ function fieldReadsFromHost(field: unknown): boolean {
   return separatorIndex > 0 && field[separatorIndex + 1] === '@'
 }
 
+/** A `-H/--header` value that replaces the invocation's authentication. */
+function headerOverridesAuthentication(header: unknown): boolean {
+  if (typeof header !== 'string') return false
+  const separatorIndex = header.indexOf(':')
+  return (
+    separatorIndex > 0 && header.slice(0, separatorIndex).trim().toLowerCase() === 'authorization'
+  )
+}
+
 /**
  * MCP programmatic mode disables local project/config discovery (see the CLI
  * execution context). Missing project or dataset values may therefore produce
@@ -30,13 +39,15 @@ function fieldReadsFromHost(field: unknown): boolean {
 export const mcpPolicy: CommandPolicySet = {
   // Special exception, this can be very dangerous but is also super useful
   // to expose. Refuse authentication overrides and host input channels:
-  // `--token` replaces the MCP user's token, `--input` reads the request body
-  // from the host's filesystem or stdin, and `-F key=@<file>` / `-F key=@-`
-  // field values do the same.
+  // `--token` and an Authorization header replace the MCP user's token,
+  // `--input` reads the request body from the host's filesystem or stdin, and
+  // `-F key=@<file>` / `-F key=@-` field values do the same.
   api: conditionalPolicy({
     deniedFlags: ['input', 'token'],
     validate: ({flags}) =>
-      !Array.isArray(flags.field) || !flags.field.some((field) => fieldReadsFromHost(field)),
+      (!Array.isArray(flags.field) || !flags.field.some((field) => fieldReadsFromHost(field))) &&
+      (!Array.isArray(flags.header) ||
+        !flags.header.some((header) => headerOverridesAuthentication(header))),
   }),
 
   'backups:disable': allow,

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -29,11 +29,12 @@ function fieldReadsFromHost(field: unknown): boolean {
  */
 export const mcpPolicy: CommandPolicySet = {
   // Special exception, this can be very dangerous but is also super useful
-  // to expose. Only the host input channels are refused: `--input` reads the
-  // request body from the host's filesystem or stdin, and `-F key=@<file>` /
-  // `-F key=@-` field values do the same.
+  // to expose. Refuse authentication overrides and host input channels:
+  // `--token` replaces the MCP user's token, `--input` reads the request body
+  // from the host's filesystem or stdin, and `-F key=@<file>` / `-F key=@-`
+  // field values do the same.
   api: conditionalPolicy({
-    deniedFlags: ['input'],
+    deniedFlags: ['input', 'token'],
     validate: ({flags}) =>
       !Array.isArray(flags.field) || !flags.field.some((field) => fieldReadsFromHost(field)),
   }),

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
@@ -214,7 +214,9 @@ export async function invokeSanityCli({
       const usedDeniedFlags = policy.deniedFlags.filter(
         (name) => invocation.flags[name] !== undefined && invocation.flags[name] !== false,
       )
-      output = `\nThe ${usedDeniedFlags.map((name) => `--${name}`).join(', ')} flag is not supported here for \`${displayId}\``
+      if (usedDeniedFlags.length > 0) {
+        output = `\nThe ${usedDeniedFlags.map((name) => `--${name}`).join(', ')} flag is not supported here for \`${displayId}\``
+      }
     }
 
     return {


### PR DESCRIPTION
Disallow `run_sanity_cli('api --token')` and `run_sanity_cli('api --header Authorization')`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the MCP security boundary for a powerful proxy command by blocking credential override paths that could escalate beyond the MCP user’s token.
> 
> **Overview**
> Tightens the MCP policy for **`sanity api`** so invocations cannot replace the MCP user’s credentials. **`--token`** is now a denied flag (blocked at runtime and omitted from **`api --help`**), and **`Authorization`** values on **`-H` / `--header`** are rejected (case-insensitive header name, including mixed casing and surrounding whitespace).
> 
> **`invokeSanityCli`** only emits the per-flag “not supported here” message when a listed **`deniedFlags`** entry was actually used; other policy failures (e.g. auth headers or **`@`** field/input paths) keep the generic unsupported-invocation message.
> 
> Tests cover **`--token`**, long/short **`Authorization`** headers, help hiding **`--token`**, and updated unit expectations for the **`api`** policy validator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571e7d64f3634a9d37e1ae6d646d6933879a096d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->