### PR TITLE
fix(cli): handle PrettyPrintableErrors thrown in invokeSanityCli()

### DIFF
--- a/.changeset/ten-tables-boil.md
+++ b/.changeset/ten-tables-boil.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+fix(cli): handle `PrettyPrintableError`s thrown during `invokeSanityCli()` execution, including error code, suggestions, and references

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -243,6 +243,27 @@ describe('invokeSanityCli', () => {
     }
   })
 
+  test('preserves actionable details from command errors', async () => {
+    const result = await invokeSanityCli({
+      args: 'backups list',
+      config,
+      source: 'mcp',
+      token: 'user-token',
+    })
+
+    expect(result.exitCode).toBe(1)
+    expect(result.output).toMatchInlineSnapshot(`
+      "ProjectRootNotFoundError: Unable to determine project ID
+      Code: PROJECT_ROOT_NOT_FOUND
+      Try this:
+        * Providing a project ID: --project-id <project-id>
+        * Running this command from within a Sanity project directory
+        * Running in an interactive terminal to get a project selection prompt
+      Caused by: NonInteractiveError: Cannot run "select" prompt in a non-interactive environment. Provide the required value via flags or environment variables, or run in an interactive terminal.
+      Code: NON_INTERACTIVE"
+    `)
+  })
+
   test.each([
     'login', // denied: performs an authentication flow
     'schemas list', // denied: requires a local project

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
@@ -34,6 +34,7 @@ import {
   isConditionalInvocationPolicy,
 } from './commandPolicies/policy.js'
 import {isHelpRequest, renderInvokableHelp} from './help.js'
+import {prettyPrintError} from './prettyPrintError.js'
 
 /**
  * Load the oclif `Config` for this package, needed to resolve, load, and run
@@ -239,7 +240,7 @@ export async function invokeSanityCli({
       return {exitCode: exitCodes.SUCCESS, output: output.join('\n')}
     }
 
-    const message = err instanceof Error ? err.message : String(err)
+    const message = prettyPrintError(err) || String(err)
     if (message) output.push(message)
     return {
       exitCode: typeof exit === 'number' ? exit : exitCodes.RUNTIME_ERROR,

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/prettyPrintError.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/prettyPrintError.ts
@@ -1,0 +1,45 @@
+import {type Interfaces} from '@oclif/core'
+
+const formatSuggestions = (suggestions?: string[]): string | undefined => {
+  const label = 'Try this:'
+  if (!suggestions || suggestions.length === 0) return undefined
+  if (suggestions.length === 1) return `${label} ${suggestions[0]}`
+
+  const multiple = suggestions.map((suggestion) => `  * ${suggestion}`).join('\n')
+  return `${label}\n${multiple}`
+}
+
+type CombinedError = Error & Interfaces.PrettyPrintableError
+
+function isCombinedError(error: unknown): error is CombinedError {
+  return error !== null && typeof error === 'object' && 'name' in error && 'message' in error
+}
+
+/**
+ * Adapted from oclif's unexported `prettyPrint` implementation:
+ * https://github.com/oclif/core/blob/4.11.14/src/errors/errors/pretty-print.ts
+ *
+ * Terminal wrapping, indentation, ANSI decoration, and debug stack handling are omitted so programmatic callers receive stable plain text.
+ */
+export function prettyPrintError(error: unknown): string {
+  const prettyPrintedErrors: string[] = []
+  let currentError = error
+  let isDeep = false
+
+  while (isCombinedError(currentError)) {
+    const {code, message, name: errorSuffix, ref, suggestions} = currentError
+    const formattedHeader = message ? `${errorSuffix || 'Error'}: ${message}` : undefined
+    const formattedCode = code ? `Code: ${code}` : undefined
+    const formattedSuggestions = formatSuggestions(suggestions)
+    const formattedReference = ref ? `Reference: ${ref}` : undefined
+    const formatted = [formattedHeader, formattedCode, formattedSuggestions, formattedReference]
+      .filter(Boolean)
+      .join('\n')
+
+    prettyPrintedErrors.push(`${isDeep ? 'Caused by: ' : ''}${formatted}`)
+    isDeep = true
+    currentError = currentError.cause ?? null
+  }
+
+  return prettyPrintedErrors.join('\n')
+}


### PR DESCRIPTION
Errors implementing oclif's `PrettyPrintableError` interface include lots of goodies, like reference links, suggestions, and error codes. These are great for anyone debugging why a command failed, but because they're stored separately from `error.message`, the existing `invokeSanityCli()` error handling/formatting logic missed them.

This change makes it so that instead of seeing output like this
```
$ sanity backups list
Unable to determine project ID
```

You now get
```
$ sanity backups list
ProjectRootNotFoundError: Unable to determine project ID
Code: PROJECT_ROOT_NOT_FOUND
Try this:
  * Providing a project ID: --project-id <project-id>
  * Running this command from within a Sanity project directory
  * Running in an interactive terminal to get a project selection prompt
Caused by: NonInteractiveError: Cannot run "select" prompt in a non-interactive environment. Provide the required value via flags or environment variables, or run in an interactive terminal.
Code: NON_INTERACTIVE
```

Much nicer :)

---

Implementation is mostly just taken from oclif's internal pretty printing util, but adapted to not do any terminal specific things (ex. ANSI codes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to error string formatting in invokeSanityCli; no auth or command execution behavior changes.
> 
> **Overview**
> Programmatic CLI invocations (e.g. MCP) now return **full oclif-style error text** instead of only `error.message`.
> 
> `invokeSanityCli()` uses a new `prettyPrintError()` helper (based on oclif’s internal formatter, without ANSI/terminal behavior) to include **error name**, **codes**, **“Try this” suggestions**, **references**, and **`Caused by`** chains from `PrettyPrintableError` / `error.cause`. A regression test snapshots the richer output for a failing `backups list` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa5df7bc4de624256bc89d04941a2cd28c9dccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->