### PR TITLE
feat(cli): show synced Shopify metafields in the Shopify templates

### DIFF
--- a/.changeset/pr-1615.md
+++ b/.changeset/pr-1615.md
@@ -3,4 +3,4 @@
 '@sanity/cli': minor
 ---
 
-feat(templates): show synced Shopify metafields in the Studio
+feat(cli): show synced Shopify metafields in the Shopify templates

--- a/.changeset/pr-1615.md
+++ b/.changeset/pr-1615.md
@@ -3,4 +3,4 @@
 '@sanity/cli': minor
 ---
 
-feat(cli): surface synced Shopify metafields in the Shopify studio templates
+feat(templates): show synced Shopify metafields in the Studio

--- a/.changeset/pr-1615.md
+++ b/.changeset/pr-1615.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): surface synced Shopify metafields in the Shopify studio templates

--- a/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/ShopifyMetafield.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/ShopifyMetafield.tsx
@@ -1,0 +1,55 @@
+import {LockIcon} from '@sanity/icons'
+import {Box, Card, Code, Flex, Stack, Text} from '@sanity/ui'
+import {type ObjectInputProps} from 'sanity'
+import {formatMetafieldValue} from '../../utils/formatMetafieldValue'
+
+type Metafield = {
+  namespace?: string
+  key?: string
+  type?: string
+  value?: unknown
+}
+
+/**
+ * Read-only display for a single Shopify metafield.
+ *
+ * `value` is deliberately not declared as a field on the `shopifyMetafield` schema type: its shape
+ * depends on the Shopify metafield type and Sanity has no field type that accepts every variant. We
+ * read it off the raw object value instead and render it as text.
+ */
+const ShopifyMetafield = (props: ObjectInputProps) => {
+  const {namespace, key, type, value} = (props.value || {}) as Metafield
+
+  const formattedValue = formatMetafieldValue(value)
+
+  return (
+    <Card padding={3} radius={2} shadow={1} tone="transparent">
+      <Stack space={3}>
+        <Flex align="center" gap={2}>
+          <Text size={1} weight="semibold">
+            {[namespace, key].filter(Boolean).join('.') || 'Metafield'}
+          </Text>
+          {type && (
+            <Text muted size={1}>
+              <code>{type}</code>
+            </Text>
+          )}
+          <Text muted size={1}>
+            <LockIcon />
+          </Text>
+        </Flex>
+        {formattedValue ? (
+          <Box overflow="auto">
+            <Code size={1}>{formattedValue}</Code>
+          </Box>
+        ) : (
+          <Text muted size={1}>
+            No value
+          </Text>
+        )}
+      </Stack>
+    </Card>
+  )
+}
+
+export default ShopifyMetafield

--- a/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/ShopifyMetafield.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/ShopifyMetafield.tsx
@@ -15,12 +15,15 @@ type Metafield = {
  *
  * `value` is deliberately not declared as a field on the `shopifyMetafield` schema type: its shape
  * depends on the Shopify metafield type and Sanity has no field type that accepts every variant. We
- * read it off the raw object value instead and render it as text.
+ * read it off the raw object value instead and format it according to the metafield's type.
  */
 const ShopifyMetafield = (props: ObjectInputProps) => {
   const {namespace, key, type, value} = (props.value || {}) as Metafield
 
-  const formattedValue = formatMetafieldValue(value)
+  const formattedValue = formatMetafieldValue(type, value)
+  // Only `json` and `rich_text_field` values keep their line breaks; everything else formats to a
+  // single line and reads better as plain text.
+  const isMultiline = formattedValue.includes('\n')
 
   return (
     <Card padding={3} radius={2} shadow={1} tone="transparent">
@@ -40,7 +43,11 @@ const ShopifyMetafield = (props: ObjectInputProps) => {
         </Flex>
         {formattedValue ? (
           <Box overflow="auto">
-            <Code size={1}>{formattedValue}</Code>
+            {isMultiline ? (
+              <Code size={1}>{formattedValue}</Code>
+            ) : (
+              <Text size={1}>{formattedValue}</Text>
+            )}
           </Box>
         ) : (
           <Text muted size={1}>

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/index.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/index.ts
@@ -13,6 +13,7 @@ import priceRange from './objects/priceRange'
 import proxyString from './objects/proxyString'
 import shopifyCollection from './objects/shopifyCollection'
 import shopifyCollectionRule from './objects/shopifyCollectionRule'
+import shopifyMetafield from './objects/shopifyMetafield'
 import shopifyProduct from './objects/shopifyProduct'
 import shopifyProductVariant from './objects/shopifyProductVariant'
 
@@ -35,6 +36,7 @@ export const schemaTypes = [
   proxyString,
   shopifyCollection,
   shopifyCollectionRule,
+  shopifyMetafield,
   shopifyProduct,
   shopifyProductVariant,
 

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/shopifyCollection.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/shopifyCollection.ts
@@ -14,6 +14,14 @@ export default defineType({
       name: 'status',
       title: 'Status',
     },
+    {
+      name: 'metafields',
+      title: 'Metafields',
+      options: {
+        collapsed: true,
+        collapsible: true,
+      },
+    },
   ],
   fields: [
     // Created at
@@ -97,6 +105,18 @@ export default defineType({
       name: 'sortOrder',
       title: 'Sort order',
       type: 'string',
+    }),
+    // Metafields
+    defineField({
+      fieldset: 'metafields',
+      name: 'metafields',
+      title: 'Metafields',
+      type: 'array',
+      description:
+        'Shopify metafields, for the namespaces selected in Sanity Connect. Replaced in full on every sync',
+      // Keep this a single-member array: Sanity resolves members without a `_type` to the sole
+      // member type, and synced metafields carry only a `_key`.
+      of: [{type: 'shopifyMetafield'}],
     }),
     // Shop details
     defineField({

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/shopifyMetafield.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/shopifyMetafield.ts
@@ -43,7 +43,7 @@ export default defineType({
     },
     prepare({key, namespace, type, value}) {
       return {
-        subtitle: formatMetafieldValuePreview(value) || type,
+        subtitle: formatMetafieldValuePreview(type, value) || type,
         title: [namespace, key].filter(Boolean).join('.'),
       }
     },

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/shopifyMetafield.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/shopifyMetafield.ts
@@ -1,0 +1,51 @@
+import {TagIcon} from '@sanity/icons'
+import {defineField, defineType} from 'sanity'
+
+import ShopifyMetafield from '../../components/inputs/ShopifyMetafield'
+import {formatMetafieldValuePreview} from '../../utils/formatMetafieldValue'
+
+export default defineType({
+  title: 'Metafield',
+  name: 'shopifyMetafield',
+  type: 'object',
+  icon: TagIcon,
+  readOnly: true,
+  components: {
+    input: ShopifyMetafield,
+  },
+  fields: [
+    // Namespace
+    defineField({
+      title: 'Namespace',
+      name: 'namespace',
+      type: 'string',
+    }),
+    // Key
+    defineField({
+      title: 'Key',
+      name: 'key',
+      type: 'string',
+    }),
+    // Type
+    defineField({
+      title: 'Type',
+      name: 'type',
+      type: 'string',
+      description: 'Shopify metafield type, e.g. single_line_text_field',
+    }),
+  ],
+  preview: {
+    select: {
+      key: 'key',
+      namespace: 'namespace',
+      type: 'type',
+      value: 'value',
+    },
+    prepare({key, namespace, type, value}) {
+      return {
+        subtitle: formatMetafieldValuePreview(value) || type,
+        title: [namespace, key].filter(Boolean).join('.'),
+      }
+    },
+  },
+})

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/shopifyProduct.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/shopifyProduct.ts
@@ -29,6 +29,14 @@ export default defineType({
         collapsible: true,
       },
     },
+    {
+      name: 'metafields',
+      title: 'Metafields',
+      options: {
+        collapsed: true,
+        collapsible: true,
+      },
+    },
   ],
   fields: [
     // Created at
@@ -153,6 +161,18 @@ export default defineType({
           to: [{type: 'productVariant'}],
         },
       ],
+    }),
+    // Metafields
+    defineField({
+      fieldset: 'metafields',
+      name: 'metafields',
+      title: 'Metafields',
+      type: 'array',
+      description:
+        'Shopify metafields, for the namespaces selected in Sanity Connect. Replaced in full on every sync',
+      // Keep this a single-member array: Sanity resolves members without a `_type` to the sole
+      // member type, and synced metafields carry only a `_key`.
+      of: [{type: 'shopifyMetafield'}],
     }),
     // Shop details
     defineField({

--- a/packages/@sanity/cli/templates/shopify-online-storefront/utils/formatMetafieldValue.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/utils/formatMetafieldValue.ts
@@ -1,0 +1,25 @@
+/**
+ * Shopify metafield values are synced deserialized, so a single metafield can hold a string,
+ * number, boolean, list or JSON object depending on its Shopify type. Render them all as text:
+ * scalars as-is, everything else as indented JSON.
+ */
+export const formatMetafieldValue = (value: unknown) => {
+  if (value === null || typeof value === 'undefined') {
+    return ''
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  return JSON.stringify(value, null, 2)
+}
+
+/**
+ * Single-line variant, for array item previews.
+ */
+export const formatMetafieldValuePreview = (value: unknown) => {
+  return formatMetafieldValue(value).replace(/\s+/g, ' ').trim()
+}

--- a/packages/@sanity/cli/templates/shopify-online-storefront/utils/formatMetafieldValue.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/utils/formatMetafieldValue.ts
@@ -1,12 +1,77 @@
 /**
- * Shopify metafield values are synced deserialized, so a single metafield can hold a string,
- * number, boolean, list or JSON object depending on its Shopify type. Render them all as text:
- * scalars as-is, everything else as indented JSON.
+ * Shopify metafield values are synced deserialized, so the shape of `value` depends on the
+ * metafield's Shopify `type`: a scalar for text and number types, an object for measurements, money
+ * and ratings, an array for `list.*` types. These helpers turn any of them into readable text.
  */
-export const formatMetafieldValue = (value: unknown) => {
-  if (value === null || typeof value === 'undefined') {
+
+// GraphQL measurement unit enums, as synced, mapped to their conventional symbols. Units missing
+// from this map are rendered as-is rather than guessed at.
+const MEASUREMENT_UNITS: Record<string, string> = {
+  // Length
+  MILLIMETERS: 'mm',
+  CENTIMETERS: 'cm',
+  METERS: 'm',
+  INCHES: 'in',
+  FEET: 'ft',
+  YARDS: 'yd',
+  // Weight
+  GRAMS: 'g',
+  KILOGRAMS: 'kg',
+  OUNCES: 'oz',
+  POUNDS: 'lb',
+  // Volume
+  MILLILITERS: 'ml',
+  CENTILITERS: 'cl',
+  LITERS: 'l',
+  CUBIC_METERS: 'm³',
+  FLUID_OUNCES: 'fl oz',
+  PINTS: 'pt',
+  QUARTS: 'qt',
+  GALLONS: 'gal',
+  IMPERIAL_FLUID_OUNCES: 'imp fl oz',
+  IMPERIAL_PINTS: 'imp pt',
+  IMPERIAL_QUARTS: 'imp qt',
+  IMPERIAL_GALLONS: 'imp gal',
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isBlank = (value: unknown) => value === null || typeof value === 'undefined'
+
+const formatSingleValue = (type: string, value: unknown): string => {
+  if (isBlank(value)) {
     return ''
   }
+
+  switch (type) {
+    case 'dimension':
+    case 'weight':
+    case 'volume': {
+      if (!isRecord(value) || isBlank(value.value)) break
+      const unit =
+        typeof value.unit === 'string' ? (MEASUREMENT_UNITS[value.unit] ?? value.unit) : ''
+      return unit ? `${value.value} ${unit}` : `${value.value}`
+    }
+    case 'money': {
+      if (!isRecord(value) || isBlank(value.amount)) break
+      const currency = value.currency_code
+      return typeof currency === 'string' && currency
+        ? `${value.amount} ${currency}`
+        : `${value.amount}`
+    }
+    case 'rating': {
+      if (!isRecord(value) || isBlank(value.value)) break
+      return isBlank(value.scale_max) ? `${value.value}` : `${value.value} / ${value.scale_max}`
+    }
+    // Structured types with no meaningful one-line form
+    case 'json':
+    case 'rich_text_field':
+      return JSON.stringify(value, null, 2)
+  }
+
+  // Text, url, color, dates, ids and references are all scalars, and dates are left in their synced
+  // ISO form so they stay unambiguous.
   if (typeof value === 'string') {
     return value
   }
@@ -17,9 +82,26 @@ export const formatMetafieldValue = (value: unknown) => {
   return JSON.stringify(value, null, 2)
 }
 
+export const formatMetafieldValue = (type: string | undefined, value: unknown) => {
+  if (isBlank(value)) {
+    return ''
+  }
+
+  // `list.<type>` metafields hold an array of the member type
+  const memberType = type?.startsWith('list.') ? type.slice('list.'.length) : undefined
+  if (memberType && Array.isArray(value)) {
+    return value
+      .map((member) => formatSingleValue(memberType, member))
+      .filter((formatted) => formatted !== '')
+      .join(', ')
+  }
+
+  return formatSingleValue(type ?? '', value)
+}
+
 /**
  * Single-line variant, for array item previews.
  */
-export const formatMetafieldValuePreview = (value: unknown) => {
-  return formatMetafieldValue(value).replace(/\s+/g, ' ').trim()
+export const formatMetafieldValuePreview = (type: string | undefined, value: unknown) => {
+  return formatMetafieldValue(type, value).replace(/\s+/g, ' ').trim()
 }

--- a/packages/@sanity/cli/templates/shopify/components/inputs/ShopifyMetafield.tsx
+++ b/packages/@sanity/cli/templates/shopify/components/inputs/ShopifyMetafield.tsx
@@ -1,0 +1,53 @@
+import {LockIcon} from '@sanity/icons'
+import {Box, Card, Code, Flex, Stack, Text} from '@sanity/ui'
+import {type ObjectInputProps} from 'sanity'
+import {formatMetafieldValue} from '../../utils/formatMetafieldValue'
+
+type Metafield = {
+  namespace?: string
+  key?: string
+  type?: string
+  value?: unknown
+}
+
+/**
+ * Read-only display for a single Shopify metafield.
+ *
+ * `value` is deliberately not declared as a field on the `shopifyMetafield` schema type: its shape
+ * depends on the Shopify metafield type and Sanity has no field type that accepts every variant. We
+ * read it off the raw object value instead and render it as text.
+ */
+export default function ShopifyMetafieldInput(props: ObjectInputProps) {
+  const {namespace, key, type, value} = (props.value || {}) as Metafield
+
+  const formattedValue = formatMetafieldValue(value)
+
+  return (
+    <Card padding={3} radius={2} shadow={1} tone="transparent">
+      <Stack space={3}>
+        <Flex align="center" gap={2}>
+          <Text size={1} weight="semibold">
+            {[namespace, key].filter(Boolean).join('.') || 'Metafield'}
+          </Text>
+          {type && (
+            <Text muted size={1}>
+              <code>{type}</code>
+            </Text>
+          )}
+          <Text muted size={1}>
+            <LockIcon />
+          </Text>
+        </Flex>
+        {formattedValue ? (
+          <Box overflow="auto">
+            <Code size={1}>{formattedValue}</Code>
+          </Box>
+        ) : (
+          <Text muted size={1}>
+            No value
+          </Text>
+        )}
+      </Stack>
+    </Card>
+  )
+}

--- a/packages/@sanity/cli/templates/shopify/components/inputs/ShopifyMetafield.tsx
+++ b/packages/@sanity/cli/templates/shopify/components/inputs/ShopifyMetafield.tsx
@@ -15,12 +15,15 @@ type Metafield = {
  *
  * `value` is deliberately not declared as a field on the `shopifyMetafield` schema type: its shape
  * depends on the Shopify metafield type and Sanity has no field type that accepts every variant. We
- * read it off the raw object value instead and render it as text.
+ * read it off the raw object value instead and format it according to the metafield's type.
  */
 export default function ShopifyMetafieldInput(props: ObjectInputProps) {
   const {namespace, key, type, value} = (props.value || {}) as Metafield
 
-  const formattedValue = formatMetafieldValue(value)
+  const formattedValue = formatMetafieldValue(type, value)
+  // Only `json` and `rich_text_field` values keep their line breaks; everything else formats to a
+  // single line and reads better as plain text.
+  const isMultiline = formattedValue.includes('\n')
 
   return (
     <Card padding={3} radius={2} shadow={1} tone="transparent">
@@ -40,7 +43,11 @@ export default function ShopifyMetafieldInput(props: ObjectInputProps) {
         </Flex>
         {formattedValue ? (
           <Box overflow="auto">
-            <Code size={1}>{formattedValue}</Code>
+            {isMultiline ? (
+              <Code size={1}>{formattedValue}</Code>
+            ) : (
+              <Text size={1}>{formattedValue}</Text>
+            )}
           </Box>
         ) : (
           <Text muted size={1}>

--- a/packages/@sanity/cli/templates/shopify/docs/features.md
+++ b/packages/@sanity/cli/templates/shopify/docs/features.md
@@ -12,6 +12,26 @@ Inside `/schemaTypes` you'll find schema definitions for all the content types.
 - `/schemaTypes/documents/`: Document types determines the shape of the JSON documents that's stored in your content lake. This is where you define the content forms for things like collections, products, product variants, as well as articles.
 - `/schemaTypes/objects/`: General purpose & re-usable content structures, such as links, custom product options and modules.
 
+## Shopify metafields
+
+If you've selected metafield namespaces to import in Sanity Connect, your product and collection metafields are synced to `store.metafields` and surfaced under a **Metafields** fieldset on the corresponding document.
+
+Each entry holds the metafield's `namespace`, `key`, Shopify `type` and `value`:
+
+```json
+{
+  "_key": "custom.snowboard_length",
+  "namespace": "custom",
+  "key": "snowboard_length",
+  "type": "dimension",
+  "value": {"value": 180, "unit": "CENTIMETERS"}
+}
+```
+
+Values arrive deserialized, so `value` holds whatever the metafield's Shopify type implies — a string, number, boolean, list or JSON object. Because no single Sanity field type covers all of those, `value` isn't declared on the `shopifyMetafield` schema type; `/components/inputs/ShopifyMetafield.tsx` reads it from the raw value and renders it as text instead.
+
+Metafields are read-only in the Studio and the whole array is replaced on every sync, so any edits you make here are overwritten. Variant metafields and metaobjects aren't synced.
+
 ## Structure
 
 Sanity Studio will automatically list all your [document types][docs-document-types] out of the box. Sometimes you want a more streamlined editor experience. That's why you'll find a custom [structure][docs-structure] that's defined in `/structure`. It does the following things:

--- a/packages/@sanity/cli/templates/shopify/docs/features.md
+++ b/packages/@sanity/cli/templates/shopify/docs/features.md
@@ -28,7 +28,20 @@ Each entry holds the metafield's `namespace`, `key`, Shopify `type` and `value`:
 }
 ```
 
-Values arrive deserialized, so `value` holds whatever the metafield's Shopify type implies — a string, number, boolean, list or JSON object. Because no single Sanity field type covers all of those, `value` isn't declared on the `shopifyMetafield` schema type; `/components/inputs/ShopifyMetafield.tsx` reads it from the raw value and renders it as text instead.
+Values arrive deserialized, so `value` holds whatever the metafield's Shopify type implies — a string, number, boolean, list or JSON object. Because no single Sanity field type covers all of those, `value` isn't declared on the `shopifyMetafield` schema type; `/components/inputs/ShopifyMetafield.tsx` reads it from the raw value instead.
+
+`/utils/formatMetafieldValue.ts` formats it using the metafield's `type`:
+
+| Metafield type                  | Synced value                                   | Displayed as                    |
+| ------------------------------- | ---------------------------------------------- | ------------------------------- |
+| `dimension`, `weight`, `volume` | `{"value": 180, "unit": "CENTIMETERS"}`        | `180 cm`                        |
+| `money`                         | `{"amount": "649.00", "currency_code": "USD"}` | `649.00 USD`                    |
+| `rating`                        | `{"value": "4.7", "scale_max": "5.0"}`         | `4.7 / 5.0`                     |
+| `list.*`                        | `["Poplar core", "Carbon stringers"]`          | `Poplar core, Carbon stringers` |
+| `json`, `rich_text_field`       | `{"camber": "hybrid"}`                         | indented JSON                   |
+| everything else                 | `"Advanced"`, `7`, `true`                      | as-is                           |
+
+Measurement units not in the map are shown unchanged rather than guessed at, matching how the importer normalizes them. Dates keep their synced ISO form so they stay unambiguous.
 
 Metafields are read-only in the Studio and the whole array is replaced on every sync, so any edits you make here are overwritten. Variant metafields and metaobjects aren't synced.
 

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/index.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/index.ts
@@ -37,6 +37,7 @@ import {productWithVariantType} from './objects/shopify/productWithVariantType'
 import {proxyStringType} from './objects/shopify/proxyStringType'
 import {seoType} from './objects/seoType'
 import {shopifyCollectionType} from './objects/shopify/shopifyCollectionType'
+import {shopifyMetafieldType} from './objects/shopify/shopifyMetafieldType'
 import {shopifyProductType} from './objects/shopify/shopifyProductType'
 import {shopifyProductVariantType} from './objects/shopify/shopifyProductVariantType'
 import {shopType} from './objects/shopify/shopType'
@@ -81,6 +82,7 @@ const objects = [
   proxyStringType,
   seoType,
   shopifyCollectionType,
+  shopifyMetafieldType,
   shopifyProductType,
   shopifyProductVariantType,
   shopType,

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/shopifyCollectionType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/shopifyCollectionType.ts
@@ -1,4 +1,4 @@
-import {defineField} from 'sanity'
+import {defineArrayMember, defineField} from 'sanity'
 
 export const shopifyCollectionType = defineField({
   name: 'shopifyCollection',
@@ -13,6 +13,14 @@ export const shopifyCollectionType = defineField({
     {
       name: 'status',
       title: 'Status',
+    },
+    {
+      name: 'metafields',
+      title: 'Metafields',
+      options: {
+        collapsed: true,
+        collapsible: true,
+      },
     },
   ],
   fields: [
@@ -79,6 +87,16 @@ export const shopifyCollectionType = defineField({
     defineField({
       name: 'sortOrder',
       type: 'string',
+    }),
+    defineField({
+      fieldset: 'metafields',
+      name: 'metafields',
+      type: 'array',
+      description:
+        'Shopify metafields, for the namespaces selected in Sanity Connect. Replaced in full on every sync',
+      // Keep this a single-member array: Sanity resolves members without a `_type` to the sole
+      // member type, and synced metafields carry only a `_key`.
+      of: [defineArrayMember({type: 'shopifyMetafield'})],
     }),
   ],
 })

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/shopifyMetafieldType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/shopifyMetafieldType.ts
@@ -37,7 +37,7 @@ export const shopifyMetafieldType = defineField({
     },
     prepare({key, namespace, type, value}) {
       return {
-        subtitle: formatMetafieldValuePreview(value) || type,
+        subtitle: formatMetafieldValuePreview(type, value) || type,
         title: [namespace, key].filter(Boolean).join('.'),
       }
     },

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/shopifyMetafieldType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/shopifyMetafieldType.ts
@@ -1,0 +1,45 @@
+import {TagIcon} from '@sanity/icons'
+import {defineField} from 'sanity'
+
+import ShopifyMetafieldInput from '../../../components/inputs/ShopifyMetafield'
+import {formatMetafieldValuePreview} from '../../../utils/formatMetafieldValue'
+
+export const shopifyMetafieldType = defineField({
+  title: 'Metafield',
+  name: 'shopifyMetafield',
+  type: 'object',
+  icon: TagIcon,
+  readOnly: true,
+  components: {
+    input: ShopifyMetafieldInput,
+  },
+  fields: [
+    defineField({
+      name: 'namespace',
+      type: 'string',
+    }),
+    defineField({
+      name: 'key',
+      type: 'string',
+    }),
+    defineField({
+      name: 'type',
+      type: 'string',
+      description: 'Shopify metafield type, e.g. single_line_text_field',
+    }),
+  ],
+  preview: {
+    select: {
+      key: 'key',
+      namespace: 'namespace',
+      type: 'type',
+      value: 'value',
+    },
+    prepare({key, namespace, type, value}) {
+      return {
+        subtitle: formatMetafieldValuePreview(value) || type,
+        title: [namespace, key].filter(Boolean).join('.'),
+      }
+    },
+  },
+})

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/shopifyProductType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/shopifyProductType.ts
@@ -29,6 +29,14 @@ export const shopifyProductType = defineField({
         collapsible: true,
       },
     },
+    {
+      name: 'metafields',
+      title: 'Metafields',
+      options: {
+        collapsed: true,
+        collapsible: true,
+      },
+    },
   ],
   fields: [
     defineField({
@@ -126,6 +134,16 @@ export const shopifyProductType = defineField({
           to: [{type: 'productVariant'}],
         }),
       ],
+    }),
+    defineField({
+      fieldset: 'metafields',
+      name: 'metafields',
+      type: 'array',
+      description:
+        'Shopify metafields, for the namespaces selected in Sanity Connect. Replaced in full on every sync',
+      // Keep this a single-member array: Sanity resolves members without a `_type` to the sole
+      // member type, and synced metafields carry only a `_key`.
+      of: [defineArrayMember({type: 'shopifyMetafield'})],
     }),
   ],
 })

--- a/packages/@sanity/cli/templates/shopify/utils/formatMetafieldValue.ts
+++ b/packages/@sanity/cli/templates/shopify/utils/formatMetafieldValue.ts
@@ -1,0 +1,25 @@
+/**
+ * Shopify metafield values are synced deserialized, so a single metafield can hold a string,
+ * number, boolean, list or JSON object depending on its Shopify type. Render them all as text:
+ * scalars as-is, everything else as indented JSON.
+ */
+export const formatMetafieldValue = (value: unknown) => {
+  if (value === null || typeof value === 'undefined') {
+    return ''
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  return JSON.stringify(value, null, 2)
+}
+
+/**
+ * Single-line variant, for array item previews.
+ */
+export const formatMetafieldValuePreview = (value: unknown) => {
+  return formatMetafieldValue(value).replace(/\s+/g, ' ').trim()
+}

--- a/packages/@sanity/cli/templates/shopify/utils/formatMetafieldValue.ts
+++ b/packages/@sanity/cli/templates/shopify/utils/formatMetafieldValue.ts
@@ -1,12 +1,77 @@
 /**
- * Shopify metafield values are synced deserialized, so a single metafield can hold a string,
- * number, boolean, list or JSON object depending on its Shopify type. Render them all as text:
- * scalars as-is, everything else as indented JSON.
+ * Shopify metafield values are synced deserialized, so the shape of `value` depends on the
+ * metafield's Shopify `type`: a scalar for text and number types, an object for measurements, money
+ * and ratings, an array for `list.*` types. These helpers turn any of them into readable text.
  */
-export const formatMetafieldValue = (value: unknown) => {
-  if (value === null || typeof value === 'undefined') {
+
+// GraphQL measurement unit enums, as synced, mapped to their conventional symbols. Units missing
+// from this map are rendered as-is rather than guessed at.
+const MEASUREMENT_UNITS: Record<string, string> = {
+  // Length
+  MILLIMETERS: 'mm',
+  CENTIMETERS: 'cm',
+  METERS: 'm',
+  INCHES: 'in',
+  FEET: 'ft',
+  YARDS: 'yd',
+  // Weight
+  GRAMS: 'g',
+  KILOGRAMS: 'kg',
+  OUNCES: 'oz',
+  POUNDS: 'lb',
+  // Volume
+  MILLILITERS: 'ml',
+  CENTILITERS: 'cl',
+  LITERS: 'l',
+  CUBIC_METERS: 'm³',
+  FLUID_OUNCES: 'fl oz',
+  PINTS: 'pt',
+  QUARTS: 'qt',
+  GALLONS: 'gal',
+  IMPERIAL_FLUID_OUNCES: 'imp fl oz',
+  IMPERIAL_PINTS: 'imp pt',
+  IMPERIAL_QUARTS: 'imp qt',
+  IMPERIAL_GALLONS: 'imp gal',
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isBlank = (value: unknown) => value === null || typeof value === 'undefined'
+
+const formatSingleValue = (type: string, value: unknown): string => {
+  if (isBlank(value)) {
     return ''
   }
+
+  switch (type) {
+    case 'dimension':
+    case 'weight':
+    case 'volume': {
+      if (!isRecord(value) || isBlank(value.value)) break
+      const unit =
+        typeof value.unit === 'string' ? (MEASUREMENT_UNITS[value.unit] ?? value.unit) : ''
+      return unit ? `${value.value} ${unit}` : `${value.value}`
+    }
+    case 'money': {
+      if (!isRecord(value) || isBlank(value.amount)) break
+      const currency = value.currency_code
+      return typeof currency === 'string' && currency
+        ? `${value.amount} ${currency}`
+        : `${value.amount}`
+    }
+    case 'rating': {
+      if (!isRecord(value) || isBlank(value.value)) break
+      return isBlank(value.scale_max) ? `${value.value}` : `${value.value} / ${value.scale_max}`
+    }
+    // Structured types with no meaningful one-line form
+    case 'json':
+    case 'rich_text_field':
+      return JSON.stringify(value, null, 2)
+  }
+
+  // Text, url, color, dates, ids and references are all scalars, and dates are left in their synced
+  // ISO form so they stay unambiguous.
   if (typeof value === 'string') {
     return value
   }
@@ -17,9 +82,26 @@ export const formatMetafieldValue = (value: unknown) => {
   return JSON.stringify(value, null, 2)
 }
 
+export const formatMetafieldValue = (type: string | undefined, value: unknown) => {
+  if (isBlank(value)) {
+    return ''
+  }
+
+  // `list.<type>` metafields hold an array of the member type
+  const memberType = type?.startsWith('list.') ? type.slice('list.'.length) : undefined
+  if (memberType && Array.isArray(value)) {
+    return value
+      .map((member) => formatSingleValue(memberType, member))
+      .filter((formatted) => formatted !== '')
+      .join(', ')
+  }
+
+  return formatSingleValue(type ?? '', value)
+}
+
 /**
  * Single-line variant, for array item previews.
  */
-export const formatMetafieldValuePreview = (value: unknown) => {
-  return formatMetafieldValue(value).replace(/\s+/g, ' ').trim()
+export const formatMetafieldValuePreview = (type: string | undefined, value: unknown) => {
+  return formatMetafieldValue(type, value).replace(/\s+/g, ' ').trim()
 }


### PR DESCRIPTION
### Description

Sanity Connect imports product and collection metafields into `store.metafields` (BIL-859, BIL-860), but neither Shopify template declared that field, so the Studio rendered it as an unknown field and editors could not read the values. Both templates now show it as a read-only list.

The importer writes an array of `{_key, namespace, key, type, value}`, with `_key` set to `<namespace>.<key>`. Two properties of that data drive the design:

- **Members carry a `_key` but no `_type`.** The `_type: 'shopifyMetafield'` change is still an open follow-up on BIL-842. Each array therefore declares exactly one member type: `resolveTypeName` returns `"object"` for an object with no `_type`, and `getItemType` then falls back to `of[0]` only when `of.length === 1`. Existing synced data validates with no migration, but adding a second member type to either array would break it.
- **`value` is deserialized from GraphQL `jsonValue`**, so one metafield may hold a string, number, boolean, list or object. No Sanity field type accepts all of those — declaring `value` as `string` renders an incompatible-type warning for every `number_integer`, `boolean`, `list.*` and `json` metafield. So `value` is not declared as a field, and a small read-only input reads it off the raw object value instead.

Since the synced `type` says what shape `value` has, `utils/formatMetafieldValue.ts` formats each type rather than dumping JSON:

| Metafield type | Synced value | Displayed as |
| --- | --- | --- |
| `dimension`, `weight`, `volume` | `{"value": 180, "unit": "CENTIMETERS"}` | `180 cm` |
| `money` | `{"amount": "649.00", "currency_code": "USD"}` | `649.00 USD` |
| `rating` | `{"value": "4.7", "scale_max": "5.0"}` | `4.7 / 5.0` |
| `list.*` | `["Poplar core", "Carbon stringers"]` | `Poplar core, Carbon stringers` |
| `json`, `rich_text_field` | `{"camber": "hybrid"}` | indented JSON |
| everything else | `"Advanced"`, `7`, `true` | as-is |

`json` and `rich_text_field` are the only values rendered in a code block; everything else formats to one line and renders as text. Measurement units missing from the unit map render unchanged rather than being guessed at, matching how the importer normalizes them (BIL-870). Dates keep their synced ISO form so they stay unambiguous.

Both templates gain a `shopifyMetafield` object type, a `components/inputs/ShopifyMetafield.tsx` renderer and the `formatMetafieldValue` helper. `store.metafields` is added to the product and collection `store` objects under a new collapsible Metafields fieldset. `templates/shopify/docs/features.md` gains a section describing the shape, the formatting table and the read-only behaviour.

Closes the Studio-template follow-up on [BIL-842](https://linear.app/sanity/issue/BIL-842), previously tracked as BIL-892.

### What to review

The type name must stay exactly `shopifyMetafield`. That is the contract with the importer's pending `_type` change.

To see it rendered, scaffold a studio from `templates/shopify` and import a product whose `store` holds metafields like these:

```json
"metafields": [
  {"_key": "custom.flex_rating", "namespace": "custom", "key": "flex_rating", "type": "number_integer", "value": 7},
  {"_key": "custom.materials", "namespace": "custom", "key": "materials", "type": "list.single_line_text_field", "value": ["Poplar core", "Carbon stringers"]},
  {"_key": "custom.snowboard_length", "namespace": "custom", "key": "snowboard_length", "type": "dimension", "value": {"value": 180, "unit": "CENTIMETERS"}},
  {"_key": "custom.msrp", "namespace": "custom", "key": "msrp", "type": "money", "value": {"amount": "649.00", "currency_code": "USD"}},
  {"_key": "custom.spec_sheet", "namespace": "custom", "key": "spec_sheet", "type": "json", "value": {"camber": "hybrid"}},
  {"_key": "custom.empty_note", "namespace": "custom", "key": "empty_note", "type": "single_line_text_field", "value": ""}
]
```

Then open Shopify sync -> Shopify -> Metafields and check that each value reads as the table above describes, that `custom.empty_note` shows "No value", and that a product with no `store.metafields` shows an empty fieldset rather than a warning. These members deliberately have no `_type`, which is the case worth confirming.

Scaffolding needs `sanity@5` today. The templates pin `sanity-plugin-hotspot-array@^3.0.2` (peer `^4 || ^5`) and `sanity-plugin-media@^4.1.1` (peer `^3.78 || ^4 || ^5`), so npm fails with `ERESOLVE` against `sanity@6`, which is what `latest` now resolves to. Pre-existing and filed separately.

Affected: `packages/@sanity/cli/templates/shopify` and `packages/@sanity/cli/templates/shopify-online-storefront`. No CLI source changes. Variant metafields and metaobjects are out of scope, because the importer does not emit them, so `productVariant` is unchanged.

### Testing

No automated tests. `templates/` has no test or type coverage in this repo: `check:types` is scoped to `@sanity/cli` `src` and `test`, and `test:unit --changed` matches zero tests for a template-only change. A type error in these files would not fail CI, which is worth knowing when reviewing.

Verified manually instead:

- `check:format`, `check:lint` (0 errors) and `check:types` pass. `pnpm test:unit --project=@sanity/cli` gives 3380 passed / 0 failed.
- Ran `formatMetafieldValue` against 31 assertions out-of-tree covering every branch: each measurement type, unknown units, a `0` value, money with and without a currency, ratings with and without a scale, `list.*` of both scalars and objects, an empty list, blank and empty-string values, and four type/value mismatches to confirm none of them throw.
- Typechecked the changed template files out-of-tree against real `sanity@6.7.0` and `@sanity/ui@3`, which are not installable in this repo. Clean, including `components.input` on an object type, `ObjectInputProps`, and the `preview.prepare` signature.
- Confirmed the `_type` fallback in the shipped `sanity@6.7.0` source rather than assuming it: `resolveTypeName` in `@sanity/util/lib/content.js` and the `of.length === 1` branch of `getItemType`.
- Ran a studio built from the modified `shopify` template against a real dataset, and confirmed by GROQ query that none of the imported metafield members carry a `_type`.

Not verified: the visual rendering of `ShopifyMetafield.tsx`. Layout, spacing and icon choices are unreviewed.
