### PR TITLE
fix(cli): skip "did you mean?" prompt on unknown commands in unattended mode

### DIFF
--- a/.changeset/pr-1616.md
+++ b/.changeset/pr-1616.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(cli): skip "did you mean?" prompt on unknown commands in unattended mode

--- a/packages/@sanity/cli/src/hooks/commandNotFound/__tests__/topicAliases.test.ts
+++ b/packages/@sanity/cli/src/hooks/commandNotFound/__tests__/topicAliases.test.ts
@@ -1,7 +1,20 @@
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {isInteractive} from '@sanity/cli-core'
+import {afterEach, describe, expect, type Mock, test, vi} from 'vitest'
 
 import {getCommandAndConfig} from '../../../../test/helpers/getCommandAndConfig.js'
 import hook from '../topicAliases.js'
+
+vi.mock('@sanity/cli-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
+  // Default to interactive so alias-rewrite tests exercise the normal path;
+  // unattended tests flip this per-case.
+  isInteractive: vi.fn(() => true),
+}))
+
+const notFoundHook = vi.hoisted(() => vi.fn())
+vi.mock('@oclif/plugin-not-found', () => ({default: notFoundHook}))
+
+const isInteractiveMock = isInteractive as Mock
 
 const {config} = await getCommandAndConfig('help')
 
@@ -17,6 +30,7 @@ const context = {
 describe('commandNotFound topic aliases hook', () => {
   afterEach(() => {
     vi.clearAllMocks()
+    isInteractiveMock.mockReturnValue(true)
   })
 
   describe('singular -> plural alias (directory was renamed)', () => {
@@ -141,15 +155,79 @@ describe('commandNotFound topic aliases hook', () => {
     test('falls through for completely unknown command', async () => {
       await hook.call(context, {argv: [], config, context, id: 'notarealcommand'})
 
-      // plugin-not-found calls context.warn with "is not a sanity command"
-      expect(context.warn).toHaveBeenCalledWith(expect.stringContaining('is not a'))
+      expect(notFoundHook).toHaveBeenCalledWith(expect.objectContaining({id: 'notarealcommand'}))
+      expect(context.warn).not.toHaveBeenCalled()
     })
 
     test('does not rewrite topics without aliases', async () => {
       // "corss" is not a known alias, so it falls through to plugin-not-found
       await hook.call(context, {argv: [], config, context, id: 'corss:list'})
 
-      expect(context.warn).toHaveBeenCalledWith(expect.stringContaining('is not a'))
+      expect(notFoundHook).toHaveBeenCalledWith(expect.objectContaining({id: 'corss:list'}))
+    })
+  })
+
+  describe('unattended invocations skip the "did you mean?" prompt', () => {
+    test('non-interactive terminal: warns and errors without invoking plugin-not-found', async () => {
+      isInteractiveMock.mockReturnValue(false)
+
+      await hook.call(context, {argv: [], config, context, id: 'notarealcommand'})
+
+      expect(notFoundHook).not.toHaveBeenCalled()
+      expect(context.warn).toHaveBeenCalledWith('notarealcommand is not a sanity command.')
+      expect(context.error).toHaveBeenCalledWith(
+        'Run sanity help for a list of available commands.',
+        {exit: 127},
+      )
+    })
+
+    test('mentions the topic in the help pointer when the topic exists', async () => {
+      isInteractiveMock.mockReturnValue(false)
+
+      await hook.call(context, {argv: [], config, context, id: 'datasets:notarealcommand'})
+
+      expect(notFoundHook).not.toHaveBeenCalled()
+      expect(context.warn).toHaveBeenCalledWith('datasets notarealcommand is not a sanity command.')
+      expect(context.error).toHaveBeenCalledWith(
+        'Run sanity help datasets for a list of available commands.',
+        {exit: 127},
+      )
+    })
+
+    test.each(['--yes', '-y', '--json'])(
+      '%s in argv: skips the prompt even in an interactive terminal',
+      async (flag) => {
+        await hook.call(context, {argv: [flag], config, context, id: 'notarealcommand'})
+
+        expect(notFoundHook).not.toHaveBeenCalled()
+        expect(context.warn).toHaveBeenCalledWith('notarealcommand is not a sanity command.')
+        expect(context.error).toHaveBeenCalledWith(
+          'Run sanity help for a list of available commands.',
+          {exit: 127},
+        )
+      },
+    )
+
+    test('non-flag argv in an interactive terminal still falls through to plugin-not-found', async () => {
+      await hook.call(context, {argv: ['some-arg'], config, context, id: 'notarealcommand'})
+
+      expect(notFoundHook).toHaveBeenCalledWith(
+        expect.objectContaining({argv: ['some-arg'], id: 'notarealcommand'}),
+      )
+      expect(context.warn).not.toHaveBeenCalled()
+      expect(context.error).not.toHaveBeenCalled()
+    })
+
+    test('non-interactive terminal does not affect alias rewrites', async () => {
+      isInteractiveMock.mockReturnValue(false)
+      const runCommand = vi.spyOn(config, 'runCommand').mockResolvedValue(undefined)
+
+      await hook.call(context, {argv: [], config, context, id: 'dataset:list'})
+
+      expect(runCommand).toHaveBeenCalledWith('datasets:list', [])
+      expect(notFoundHook).not.toHaveBeenCalled()
+      expect(context.warn).not.toHaveBeenCalled()
+      runCommand.mockRestore()
     })
   })
 

--- a/packages/@sanity/cli/src/hooks/commandNotFound/topicAliases.ts
+++ b/packages/@sanity/cli/src/hooks/commandNotFound/topicAliases.ts
@@ -10,15 +10,21 @@
  * Flow:
  * 1. Check if the unrecognized name is a known alias (eg "dataset" for "datasets")
  * 2. If yes: rewrite and run the resolved command (or show topic help for bare topics)
- * 3. If no: fall back to oclif plugin-not-found's "did you mean?" behavior
+ * 3. If no, and the invocation is unattended (non-interactive terminal, or
+ *    --yes/--json in argv): warn and error out without prompting
+ * 4. Otherwise: fall back to oclif plugin-not-found's "did you mean?" behavior
  */
 
-import {type Hook, toStandardizedId} from '@oclif/core'
-import {subdebug} from '@sanity/cli-core'
+import {type Hook, toConfiguredId, toStandardizedId} from '@oclif/core'
+import {isInteractive, subdebug} from '@sanity/cli-core'
 
 import {topicAliases} from '../../topicAliases.js'
 
 const debug = subdebug('hooks:topicAliases')
+
+// Flags that request unattended behavior. The typo'd command never parses its
+// flags (it doesn't exist), so we scan the raw argv tokens instead.
+const unattendedFlags = new Set(['--json', '--yes', '-y'])
 
 // Build a lookup from alias names to candidate topics.
 // This hook only fires for names oclif doesn't recognize. Since canonical
@@ -67,7 +73,20 @@ const hook: Hook.CommandNotFound = async function (opts) {
     }
   }
 
-  // No alias match - fall back to oclif plugin-not-found's "did you mean?" behavior
+  // No alias match. plugin-not-found's "did you mean?" prompt guards on a bare
+  // `process.stdin.isTTY` check, which is looser than our unattended semantics:
+  // it would still prompt (blocking for its 10s timeout) under CI, TERM=dumb,
+  // or when the user passed --yes/--json. In those cases, skip the prompt and
+  // emit the same warning + help pointer the plugin prints for non-TTY stdin.
+  const argv = opts.argv ?? []
+  if (!isInteractive() || argv.some((arg) => unattendedFlags.has(arg))) {
+    debug('Unattended invocation, skipping "did you mean?" prompt for: %s', standardId)
+    this.warn(`${toConfiguredId(standardId, config)} is not a ${config.bin} command.`)
+    const binHelp = config.findTopic(topic) ? `${config.bin} help ${topic}` : `${config.bin} help`
+    return this.error(`Run ${binHelp} for a list of available commands.`, {exit: 127})
+  }
+
+  // Interactive terminal - fall back to plugin-not-found's "did you mean?" behavior
   // eslint-disable-next-line no-restricted-syntax -- package import, not a file path
   const {default: notFoundHook} = await import('@oclif/plugin-not-found')
   return notFoundHook.call(this, opts)


### PR DESCRIPTION
### Description

When an unknown command is entered (e.g. `sanity openapi gett`), the commandNotFound hook falls back to `@oclif/plugin-not-found`, which shows an interactive "Did you mean …?" prompt. The plugin guards that prompt with a bare `process.stdin.isTTY` check, which is looser than our own unattended-mode semantics (`isInteractive()` / `isUnattended()`). With a TTY attached, the prompt would still appear — blocking for the plugin's 10-second timeout and polluting captured output with prompt escape codes — when:

- the `CI` env var is set (some CI runners and terminal-wrapping agents allocate a pty)
- `TERM=dumb`
- the user passed `--yes`/`-y`/`--json` (these are never parsed since the typo'd command doesn't exist)

This PR short-circuits the fallback in the `topicAliases` commandNotFound hook: when the invocation is unattended (`!isInteractive()`, or `--yes`/`-y`/`--json` present in argv), it emits the same warning + `Run sanity help …` pointer the plugin prints for non-TTY stdin and exits with code 127, without ever loading the prompt. Interactive terminals keep the existing "Did you mean?" behavior, and topic alias rewrites (`sanity dataset list` → `sanity datasets list`) are unaffected.

Note: the MCP/programmatic path (`invokeSanityCli`) never reaches this hook — it resolves commands itself — so this only affects the terminal CLI.

### What to review

- `packages/@sanity/cli/src/hooks/commandNotFound/topicAliases.ts` — the unattended short-circuit before the plugin-not-found fallback
- Whether scanning raw argv tokens for `--yes`/`-y`/`--json` is an acceptable heuristic (the flags can't be parsed properly since the command doesn't exist)

### Testing

Unit tests added covering: non-interactive terminal, each unattended flag, the topic-aware help pointer, interactive fall-through to plugin-not-found, and that alias rewrites are unaffected by non-interactive mode.

Verified manually against the built CLI:

- `script -q /dev/null env CI=1 npx sanity openapi gett` — before: prompt shown, blocked ~11s; after: warning + error immediately, exit 127
- `script -q /dev/null npx sanity openapi gett --yes` — same improvement
- `npx sanity openapi gett < /dev/null` — unchanged (already prompt-free)
- `script -q /dev/null npx sanity openapi gett` (interactive pty) — prompt still shown, behavior unchanged

### Notes for release

Fixed the CLI blocking on an interactive "Did you mean …?" prompt for unknown commands when running in CI, with a non-interactive terminal, or with `--yes`/`--json`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to unknown-command handling in one hook; interactive behavior and alias rewrites are preserved, with broad unit test coverage.
> 
> **Overview**
> Unknown commands that are not topic aliases no longer delegate to `@oclif/plugin-not-found` when the run is **unattended**. The `topicAliases` command-not-found hook now treats non-interactive sessions (`isInteractive()`) and raw argv tokens `--yes`, `-y`, or `--json` as unattended, prints the same “not a command” warning and `sanity help` pointer, and exits with code **127** without the blocking “Did you mean?” prompt.
> 
> **Interactive** terminals without those flags still load `plugin-not-found` for suggestions. Topic alias rewrites and bare-topic help are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd18ea1e5eecbf6e41e9bca396bdb50e2707c91a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->