### PR TITLE
refactor: simplify how api command is validated in mcpPolicy

### DIFF
--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -526,6 +526,18 @@ describe('invokeSanityCli', () => {
     expect(validate({field: ['key=value', 'body=@-']})).toBe(false)
   })
 
+  test('the api policy stops checking after finding a host-reading field', () => {
+    const policy = commandPolicies.mcp.api
+    const flags = {
+      field: ['body=@payload.json'],
+      get header(): never {
+        throw new Error('header should not be read')
+      },
+    }
+
+    expect(policy.validate({args: {}, flags})).toBe(false)
+  })
+
   test('conditional policies see parsed flags, not raw tokens', async () => {
     // `--web` after `--` is a positional argument, not a flag, so the policy
     // must not refuse it. The command is strict, so oclif's parser rejects

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -511,6 +511,7 @@ describe('invokeSanityCli', () => {
 
     expect(validate({})).toBe(true)
     expect(validate({field: ['key=value', 'count=1']})).toBe(true)
+    expect(validate({field: [42, 'invalid']})).toBe(true)
     expect(validate({header: ['Content-Type: application/json', 'X-Custom: value']})).toBe(true)
     expect(validate({header: [42, 'invalid']})).toBe(true)
     // Raw `-f` fields are always verbatim strings — `@` has no meaning there.

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -6,23 +6,25 @@ import {
   deny,
 } from './policy.js'
 
-/**
- * A typed `-F/--field` value of `@<file>` or `@-` makes the `api` command
- * read the host's filesystem or stdin (raw `-f` fields are always verbatim).
- */
-function fieldReadsFromHost(field: unknown): boolean {
-  if (typeof field !== 'string') return false
-  const separatorIndex = field.indexOf('=')
-  return separatorIndex > 0 && field[separatorIndex + 1] === '@'
-}
+function apiValidator({flags}: {flags: Readonly<Record<string, unknown>>}): boolean {
+  const fields: unknown[] = Array.isArray(flags.field) ? flags.field : []
+  const headers: unknown[] = Array.isArray(flags.header) ? flags.header : []
 
-/** A `-H/--header` value that replaces the invocation's authentication. */
-function headerOverridesAuthentication(header: unknown): boolean {
-  if (typeof header !== 'string') return false
-  const separatorIndex = header.indexOf(':')
-  return (
-    separatorIndex > 0 && header.slice(0, separatorIndex).trim().toLowerCase() === 'authorization'
-  )
+  const fieldReadsFromHost = fields.some((field) => {
+    if (typeof field !== 'string') return false
+    const separatorIndex = field.indexOf('=')
+    return separatorIndex > 0 && field[separatorIndex + 1] === '@'
+  })
+
+  const headerOverridesAuthentication = headers.some((header) => {
+    if (typeof header !== 'string') return false
+    const separatorIndex = header.indexOf(':')
+    return (
+      separatorIndex > 0 && header.slice(0, separatorIndex).trim().toLowerCase() === 'authorization'
+    )
+  })
+
+  return !fieldReadsFromHost && !headerOverridesAuthentication
 }
 
 /**
@@ -44,10 +46,7 @@ export const mcpPolicy: CommandPolicySet = {
   // `-F key=@<file>` / `-F key=@-` field values do the same.
   api: conditionalPolicy({
     deniedFlags: ['input', 'token'],
-    validate: ({flags}) =>
-      (!Array.isArray(flags.field) || !flags.field.some((field) => fieldReadsFromHost(field))) &&
-      (!Array.isArray(flags.header) ||
-        !flags.header.some((header) => headerOverridesAuthentication(header))),
+    validate: apiValidator,
   }),
 
   'backups:disable': allow,

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -8,13 +8,15 @@ import {
 
 function apiValidator({flags}: {flags: Readonly<Record<string, unknown>>}): boolean {
   const fields: unknown[] = Array.isArray(flags.field) ? flags.field : []
-  const headers: unknown[] = Array.isArray(flags.header) ? flags.header : []
 
   const fieldReadsFromHost = fields.some((field) => {
     if (typeof field !== 'string') return false
     const separatorIndex = field.indexOf('=')
     return separatorIndex > 0 && field[separatorIndex + 1] === '@'
   })
+  if (fieldReadsFromHost) return false
+
+  const headers: unknown[] = Array.isArray(flags.header) ? flags.header : []
 
   const headerOverridesAuthentication = headers.some((header) => {
     if (typeof header !== 'string') return false
@@ -24,7 +26,7 @@ function apiValidator({flags}: {flags: Readonly<Record<string, unknown>>}): bool
     )
   })
 
-  return !fieldReadsFromHost && !headerOverridesAuthentication
+  return !headerOverridesAuthentication
 }
 
 /**


### PR DESCRIPTION
Low priority refactor to improve maintainability of how we validate the `api` command in `mcpPolicy`
Addresses this feedback https://github.com/sanity-io/cli/pull/1611#discussion_r3675073340

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to MCP policy validation with matching unit tests; no new capabilities or security rule changes.
> 
> **Overview**
> Refactors MCP **`api`** command policy validation by replacing separate **`fieldReadsFromHost`** / **`headerOverridesAuthentication`** helpers and a nested inline **`validate`** expression with a single **`apiValidator`** that scans **`field`** then **`header`** flags and **returns early** when a host-reading **`@`** field value is found.
> 
> Behavior for blocking **`input`**, **`token`**, **`Authorization`** headers, and **`key=@file`** / **`key=@-`** fields is unchanged; tests add coverage for non-string **`field`** entries and assert headers are not evaluated after a denied field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd88c261f150251ad68f4b9c33049429e84547a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->