### PR TITLE
fix: Stricter context for cli invoke

### DIFF
--- a/.changeset/pr-1618.md
+++ b/.changeset/pr-1618.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': patch
+'@sanity/cli': patch
+---
+
+fix: Stricter context for cli invoke

--- a/packages/@sanity/cli-core/src/SanityCommand.ts
+++ b/packages/@sanity/cli-core/src/SanityCommand.ts
@@ -224,6 +224,11 @@ export abstract class SanityCommand<T extends typeof Command>
    * @returns The project root result.
    */
   public getProjectRoot(): Promise<ProjectRootResult> {
+    if (getCliExecutionContext()) {
+      throw new ProjectRootNotFoundError(
+        'Project root resolution from the filesystem is disabled for programmatic invocations',
+      )
+    }
     return findProjectRoot(process.cwd())
   }
 
@@ -306,6 +311,19 @@ export abstract class SanityCommand<T extends typeof Command>
    */
   public resolveIsInteractive(): boolean {
     return isInteractive()
+  }
+
+  /**
+   * Execute an already-constructed command without oclif's static runner:
+   * `Command.run()` performs a full `Config.load()` — filesystem reads, env
+   * consultation, and a process-global config cache write — on every call,
+   * which programmatic invocations must not repeat per request.
+   */
+  public runInExecutionContext<TResult>(): Promise<TResult> {
+    if (!getCliExecutionContext()) {
+      throw new Error('runInExecutionContext requires a CLI execution context')
+    }
+    return this._run<TResult>()
   }
 
   /**

--- a/packages/@sanity/cli-core/src/__tests__/SanityCommand.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/SanityCommand.test.ts
@@ -240,6 +240,26 @@ describe('SanityCommand', () => {
   })
 
   describe('catch (error handling)', () => {
+    test('checks context before reading process.cwd for project resolution', async () => {
+      const cwd = vi.spyOn(process, 'cwd').mockImplementation(() => {
+        throw new Error('host cwd accessed')
+      })
+      const cmdClass = createMockedRunCommand({
+        run: async function () {
+          await this.getProjectRoot()
+        },
+      })
+
+      try {
+        await expect(runWithCliExecutionContext({}, () => cmdClass.run([]))).rejects.toThrow(
+          'Project root resolution from the filesystem is disabled',
+        )
+        expect(cwd).not.toHaveBeenCalled()
+      } finally {
+        cwd.mockRestore()
+      }
+    })
+
     test('under an execution context, a command failure does not touch process.exitCode', async () => {
       const previousExitCode = process.exitCode
       const cmdClass = createMockedRunCommand({

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
@@ -114,12 +114,15 @@ describe('cliUserConfig', () => {
       expect(mockGetCliUserConfig).not.toHaveBeenCalled()
     })
 
-    test('execution context without token falls back to normal resolution', async () => {
+    test('execution context without token never falls back to host resolution', async () => {
+      vi.mocked(getCachedToken).mockReturnValue('cached-token')
       vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
 
       const token = await runWithCliExecutionContext({}, () => getCliToken())
 
-      expect(token).toBe('env-token')
+      expect(token).toBeUndefined()
+      expect(getCachedToken).not.toHaveBeenCalled()
+      expect(mockGetCliUserConfig).not.toHaveBeenCalled()
     })
 
     test('should re-read after clearCliTokenCache', async () => {
@@ -252,6 +255,13 @@ describe('cliUserConfig', () => {
   })
 
   describe('getUserConfig', () => {
+    test('is unavailable under an execution context', () => {
+      expect(() => runWithCliExecutionContext({}, () => getUserConfig())).toThrow(
+        'Host CLI user configuration is unavailable',
+      )
+      expect(readJsonFileSync).not.toHaveBeenCalled()
+    })
+
     test('get returns raw value from file', () => {
       vi.mocked(readJsonFileSync).mockReturnValueOnce({
         myKey: 'myValue',

--- a/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
@@ -30,10 +30,8 @@ export async function getCliToken(): Promise<string | undefined> {
   // server) takes precedence and must bypass the process-wide cache entirely:
   // reading the cache would leak another invocation's token, and writing it
   // would leak this one's.
-  const contextToken = getCliExecutionContext()?.token
-  if (contextToken) {
-    return contextToken
-  }
+  const context = getCliExecutionContext()
+  if (context) return context.token
 
   const cached = getCachedToken()
   if (cached !== undefined) {
@@ -64,6 +62,7 @@ const cliUserConfigSchema = {
  * @internal
  */
 export function setCliUserConfig(prop: 'authToken', value: string | undefined): void {
+  assertCanAccessHostUserConfig()
   const config = readConfig()
   const result = cliUserConfigSchema[prop].safeParse(value)
   if (!result.success) {
@@ -98,6 +97,7 @@ export function setCliUserConfig(prop: 'authToken', value: string | undefined): 
  * @returns The value of the given property
  */
 export function getCliUserConfig(prop: 'authToken'): string | undefined {
+  assertCanAccessHostUserConfig()
   const config = readConfig()
   const result = cliUserConfigSchema[prop].safeParse(config[prop])
   if (!result.success) {
@@ -125,6 +125,7 @@ export function getCliUserConfig(prop: 'authToken'): string | undefined {
  * @public
  */
 export function getUserConfig(): ConfigStore {
+  assertCanAccessHostUserConfig()
   return {
     get(key: string): unknown {
       const config = readConfig()
@@ -147,6 +148,12 @@ export function getUserConfig(): ConfigStore {
       writeJsonFileSync(getCliUserConfigPath(), rest, {pretty: true})
       if (key === 'authToken') clearCliTokenCache()
     },
+  }
+}
+
+function assertCanAccessHostUserConfig(): void {
+  if (getCliExecutionContext()) {
+    throw new Error('Host CLI user configuration is unavailable during programmatic invocations')
   }
 }
 

--- a/packages/@sanity/cli-core/src/telemetry/__tests__/getCliTelemetry.test.ts
+++ b/packages/@sanity/cli-core/src/telemetry/__tests__/getCliTelemetry.test.ts
@@ -1,5 +1,6 @@
 import {afterEach, describe, expect, test} from 'vitest'
 
+import {runWithCliExecutionContext} from '../../executionContext.js'
 import {
   clearCliTelemetry,
   CLI_TELEMETRY_SYMBOL,
@@ -28,6 +29,17 @@ describe('#getCliTelemetry', () => {
 
   test('returns noop logger when not initialized', () => {
     const result = getCliTelemetry()
+
+    expect(result).toBe(noopLogger)
+  })
+
+  test('returns noop logger without reading host telemetry state under an execution context', () => {
+    const mockTelemetry = {
+      log: () => {},
+    } as unknown as CLITelemetryStore
+    setCliTelemetry(mockTelemetry)
+
+    const result = runWithCliExecutionContext({}, () => getCliTelemetry())
 
     expect(result).toBe(noopLogger)
   })

--- a/packages/@sanity/cli-core/src/telemetry/getCliTelemetry.ts
+++ b/packages/@sanity/cli-core/src/telemetry/getCliTelemetry.ts
@@ -1,5 +1,6 @@
 import {ux} from '@oclif/core' // TODO: should telemetry helpers be importing oclif? cli-build imports this... we should remove this.
 
+import {getCliExecutionContext} from '../executionContext.js'
 import {noopLogger} from './noopTelemetry.js'
 import {type CLITelemetryStore} from './types.js'
 
@@ -31,6 +32,10 @@ function getState(): CliTelemetryState | undefined {
  */
 // TODO: change this API so that it accepts a channel for passing warnings through, otherwise this is pumped through OCLIF UX via singleton
 export function getCliTelemetry(): CLITelemetryStore {
+  // Programmatic invocations must neither consume nor replace telemetry state
+  // owned by the embedding host.
+  if (getCliExecutionContext()) return noopLogger
+
   const state = getState()
   // This should never happen, but if it does, we return a noop logger to avoid errors.
   if (!state) {
@@ -61,6 +66,7 @@ export function setCliTelemetry(
  * @internal
  */
 export function reportCliTraceError(error: Error): void {
+  if (getCliExecutionContext()) return
   getState()?.reportTraceError?.(error)
 }
 

--- a/packages/@sanity/cli-core/src/ux/__tests__/spinner.test.ts
+++ b/packages/@sanity/cli-core/src/ux/__tests__/spinner.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, test, vi} from 'vitest'
+
+import {runWithCliExecutionContext} from '../../executionContext.js'
+import {spinner, spinnerPromise} from '../spinner.js'
+
+describe('spinner', () => {
+  test('is silent and chainable under an execution context', () => {
+    const write = vi.spyOn(process.stderr, 'write')
+
+    try {
+      runWithCliExecutionContext({}, () => {
+        const instance = spinner('Working').start()
+        instance.text = 'Still working'
+        expect(instance.succeed('Done')).toBe(instance)
+        expect(instance.isSpinning).toBe(false)
+      })
+      expect(write).not.toHaveBeenCalled()
+    } finally {
+      write.mockRestore()
+    }
+  })
+
+  test('runs spinner promise actions without process output under a context', async () => {
+    const write = vi.spyOn(process.stderr, 'write')
+
+    try {
+      const result = await runWithCliExecutionContext({}, () =>
+        spinnerPromise(async (instance) => {
+          instance.text = 'Working'
+          return 42
+        }),
+      )
+      expect(result).toBe(42)
+      expect(write).not.toHaveBeenCalled()
+    } finally {
+      write.mockRestore()
+    }
+  })
+})

--- a/packages/@sanity/cli-core/src/ux/spinner.ts
+++ b/packages/@sanity/cli-core/src/ux/spinner.ts
@@ -1,8 +1,46 @@
-export {
-  default as spinner,
-  type Spinner,
-  type Ora as SpinnerInstance,
-  type Options as SpinnerOptions,
-  oraPromise as spinnerPromise,
-  type PromiseOptions as SpinnerPromiseOptions,
+import ora, {
+  type Options,
+  type Ora,
+  oraPromise,
+  type Spinner as OraSpinner,
+  type PromiseOptions,
 } from 'ora'
+
+import {getCliExecutionContext} from '../executionContext.js'
+
+function silentSpinner(options?: Options | string): Ora {
+  const instance = {
+    clear: () => instance,
+    fail: () => instance,
+    frame: () => '',
+    info: () => instance,
+    isSpinning: false,
+    prefixText: typeof options === 'object' ? (options.prefixText ?? '') : '',
+    render: () => instance,
+    start: () => instance,
+    stop: () => instance,
+    stopAndPersist: () => instance,
+    succeed: () => instance,
+    suffixText: typeof options === 'object' ? (options.suffixText ?? '') : '',
+    text: typeof options === 'string' ? options : (options?.text ?? ''),
+    warn: () => instance,
+  }
+  return instance as unknown as Ora
+}
+
+export function spinner(options?: Options | string): Ora {
+  return getCliExecutionContext() ? silentSpinner(options) : ora(options)
+}
+
+export function spinnerPromise<T>(
+  action: ((instance: Ora) => PromiseLike<T>) | PromiseLike<T>,
+  options?: PromiseOptions<T> | string,
+): Promise<T> {
+  if (!getCliExecutionContext()) return oraPromise(action, options)
+  return Promise.resolve(typeof action === 'function' ? action(silentSpinner(options)) : action)
+}
+
+export type Spinner = OraSpinner
+export type SpinnerInstance = Ora
+export type SpinnerOptions = Options
+export type SpinnerPromiseOptions<T> = PromiseOptions<T>

--- a/packages/@sanity/cli/src/actions/telemetry/__tests__/resolveConsent.test.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/__tests__/resolveConsent.test.ts
@@ -1,3 +1,4 @@
+import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {resolveConsent} from '../resolveConsent.js'
@@ -55,6 +56,17 @@ describe('actions telemetry resolveConsent', () => {
     mockFetchTelemetry.mockResolvedValue({status: 'granted'})
     const res = await resolveConsent()
     expect(res.status).toEqual('granted')
+  })
+  test('ignores host CI and DO_NOT_TRACK state under an execution context', async () => {
+    mockIsCi.mockReturnValue(true)
+    vi.stubEnv('DO_NOT_TRACK', 'true')
+    mockFetchTelemetry.mockResolvedValue({status: 'granted'})
+
+    const res = await runWithCliExecutionContext({token: 'context-token'}, () => resolveConsent())
+
+    expect(res.status).toEqual('granted')
+    expect(mockIsCi).not.toHaveBeenCalled()
+    expect(mockFetchTelemetry).toHaveBeenCalled()
   })
   test('should return undetermined status from telemetry fetch if it throws', async () => {
     mockFetchTelemetry.mockRejectedValue({message: 'boom'})

--- a/packages/@sanity/cli/src/actions/telemetry/resolveConsent.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/resolveConsent.ts
@@ -1,4 +1,5 @@
 import {type ConsentInformation, getCliToken, isCi} from '@sanity/cli-core'
+import {getCliExecutionContext} from '@sanity/cli-core/executionContext'
 
 import {
   fetchTelemetryConsent,
@@ -18,12 +19,14 @@ function parseApiConsentStatus(value: unknown): ValidApiConsentStatus {
 
 export async function resolveConsent(): Promise<ConsentInformation> {
   telemetryDebug('Resolving consent…')
-  if (isCi()) {
+  const hasCliExecutionContext = Boolean(getCliExecutionContext())
+
+  if (!hasCliExecutionContext && isCi()) {
     telemetryDebug('CI environment detected, treating telemetry consent as denied')
     return {status: 'denied'}
   }
 
-  if (isTrueish(process.env.DO_NOT_TRACK)) {
+  if (!hasCliExecutionContext && isTrueish(process.env.DO_NOT_TRACK)) {
     telemetryDebug('DO_NOT_TRACK is set, consent is denied')
     return {
       reason: 'localOverride',

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -1,3 +1,4 @@
+import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
 import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
 import {spinnerText} from '@sanity/cli-test/mocks/cli-core/ux'
@@ -442,6 +443,26 @@ describe('#dataset:copy', () => {
         expect.stringMatching(/job job-detach completed/i),
       )
       expect(mockFollowCopyJob).not.toHaveBeenCalled()
+    })
+
+    test('does not mutate host signal listeners under an execution context', async () => {
+      mockListDatasets.mockResolvedValue([
+        createMockDataset('production'),
+        createMockDataset('staging'),
+      ])
+      mockCopyDataset.mockResolvedValue({jobId: 'job-context'})
+      mockFollowCopyJob.mockReturnValue(of({progress: 100, type: 'progress'}))
+      const once = vi.spyOn(process, 'once')
+      const off = vi.spyOn(process, 'off')
+
+      try {
+        await runWithCliExecutionContext({}, () => CopyDatasetCommand.run(['production', 'backup']))
+        expect(once).not.toHaveBeenCalledWith('SIGINT', expect.any(Function))
+        expect(off).not.toHaveBeenCalledWith('SIGINT', expect.any(Function))
+      } finally {
+        once.mockRestore()
+        off.mockRestore()
+      }
     })
 
     test('handles copy dataset errors', async () => {

--- a/packages/@sanity/cli/src/commands/datasets/copy.ts
+++ b/packages/@sanity/cli/src/commands/datasets/copy.ts
@@ -4,6 +4,7 @@ import {Args, Flags} from '@oclif/core'
 import {exit} from '@oclif/core/errors'
 import {exitCodes} from '@sanity/cli-core'
 import {subdebug} from '@sanity/cli-core/debug'
+import {getCliExecutionContext} from '@sanity/cli-core/executionContext'
 import {SanityCommand} from '@sanity/cli-core/SanityCommand'
 import {spinner} from '@sanity/cli-core/ux'
 import {Table} from 'console-table-printer'
@@ -382,6 +383,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
 
   private async subscribeToProgress(projectId: string, jobId: string): Promise<void> {
     const spin = spinner('').start()
+    const hasCliExecutionContext = Boolean(getCliExecutionContext())
 
     return new Promise<void>((resolve, reject) => {
       const sigintHandler = () => {
@@ -392,12 +394,12 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
 
       const subscription = followCopyJobProgress({jobId, projectId}).subscribe({
         complete: () => {
-          process.off('SIGINT', sigintHandler)
+          if (!hasCliExecutionContext) process.off('SIGINT', sigintHandler)
           spin.succeed('Copy finished.')
           resolve()
         },
         error: (err) => {
-          process.off('SIGINT', sigintHandler)
+          if (!hasCliExecutionContext) process.off('SIGINT', sigintHandler)
           spin.fail('Copy failed.')
           reject(err)
         },
@@ -408,7 +410,7 @@ export class CopyDatasetCommand extends SanityCommand<typeof CopyDatasetCommand>
         },
       })
 
-      process.once('SIGINT', sigintHandler)
+      if (!hasCliExecutionContext) process.once('SIGINT', sigintHandler)
     })
   }
 }

--- a/packages/@sanity/cli/src/commands/documents/__tests__/query.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/query.test.ts
@@ -1,4 +1,5 @@
 import {ProjectRootNotFoundError} from '@sanity/cli-core'
+import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
 import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
@@ -104,6 +105,19 @@ describe('#documents:query', () => {
     expect(mockFetch).toHaveBeenCalledWith('*[_type == "movie"]')
   })
 
+  test('does not read the API version environment variable under an execution context', async () => {
+    vi.stubEnv('SANITY_CLI_QUERY_API_VERSION', 'v2023-01-01')
+    mockFetch.mockResolvedValue([{_id: 'test'}])
+
+    await runWithCliExecutionContext({token: 'context-token'}, () =>
+      testCommand(QueryDocumentCommand, ['*[_type == "movie"]'], {mocks: defaultMocks}),
+    )
+
+    expect(mockGetProjectCliClient).toHaveBeenCalledWith(
+      expect.objectContaining({apiVersion: '2025-08-15'}),
+    )
+  })
+
   test('uses anonymous flag to skip authentication', async () => {
     const mockResults = [{_id: 'test', title: 'Test'}]
 
@@ -207,6 +221,9 @@ describe('#documents:query', () => {
 
     expect(stdout).toContain('"_id": "test"')
     expect(mockFetch).toHaveBeenCalledWith('*[_type == "movie"]')
+    expect(mockGetProjectCliClient).toHaveBeenCalledWith(
+      expect.objectContaining({apiVersion: envApiVersion}),
+    )
   })
 
   describe('outside project context', () => {

--- a/packages/@sanity/cli/src/commands/documents/query.ts
+++ b/packages/@sanity/cli/src/commands/documents/query.ts
@@ -6,6 +6,7 @@ import {
   SanityCommand,
   subdebug,
 } from '@sanity/cli-core'
+import {getCliExecutionContext} from '@sanity/cli-core/executionContext'
 
 import {DOCUMENTS_API_VERSION} from '../../actions/documents/constants.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
@@ -54,7 +55,6 @@ export class QueryDocumentCommand extends SanityCommand<typeof QueryDocumentComm
     }),
     'api-version': Flags.string({
       description: `API version to use (defaults to ${DOCUMENTS_API_VERSION})`,
-      env: 'SANITY_CLI_QUERY_API_VERSION',
     }),
     pretty: Flags.boolean({
       default: false,
@@ -91,9 +91,12 @@ export class QueryDocumentCommand extends SanityCommand<typeof QueryDocumentComm
     }
 
     const targetDataset = dataset || cliConfig.api?.dataset
-    const targetApiVersion = apiVersion || DOCUMENTS_API_VERSION
+    const configuredApiVersion =
+      apiVersion ??
+      (getCliExecutionContext() ? undefined : process.env.SANITY_CLI_QUERY_API_VERSION)
+    const targetApiVersion = configuredApiVersion || DOCUMENTS_API_VERSION
 
-    if (!apiVersion) {
+    if (!configuredApiVersion) {
       this.warn(`--api-version not specified, using \`${DOCUMENTS_API_VERSION}\``)
     }
 

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -113,7 +113,11 @@ describe('invokeSanityCli', () => {
         token: 'invocation-token',
       })
 
-      expect(result).toEqual({exitCode: 0, output: 'https://isolated.example.com'})
+      expect(result).toEqual({
+        commandId: 'cors:list',
+        exitCode: 0,
+        output: 'https://isolated.example.com',
+      })
       expect(cwd).not.toHaveBeenCalled()
       expect(stdout).not.toHaveBeenCalled()
       expect(stderr).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -1,6 +1,7 @@
 import {fileURLToPath} from 'node:url'
 
 import {Config} from '@oclif/core'
+import {CLI_TELEMETRY_SYMBOL} from '@sanity/cli-core'
 import {mockApi} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
 import {afterAll, afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
@@ -78,6 +79,61 @@ describe('invokeSanityCli', () => {
     expect(result.exitCode).toBe(0)
     expect(result.output).toContain('USAGE')
     expect(result.output).toContain('Manage CORS origins for your project')
+  })
+
+  test('an allowed invocation does not consult or mutate representative host state', async () => {
+    mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
+      .matchHeader('authorization', 'Bearer invocation-token')
+      .reply(200, [corsOrigin('https://isolated.example.com')])
+
+    const globalRegistry = globalThis as Record<symbol, unknown>
+    const previousTelemetry = globalRegistry[CLI_TELEMETRY_SYMBOL]
+    const hostTelemetry = {log: vi.fn()}
+    globalRegistry[CLI_TELEMETRY_SYMBOL] = hostTelemetry
+    const previousEnv = {
+      authToken: process.env.SANITY_AUTH_TOKEN,
+      sanityEnv: process.env.SANITY_INTERNAL_ENV,
+    }
+    process.env.SANITY_AUTH_TOKEN = 'host-token'
+    process.env.SANITY_INTERNAL_ENV = 'staging'
+
+    const cwd = vi.spyOn(process, 'cwd').mockImplementation(() => {
+      throw new Error('host cwd accessed')
+    })
+    const stdout = vi.spyOn(process.stdout, 'write')
+    const stderr = vi.spyOn(process.stderr, 'write')
+    const once = vi.spyOn(process, 'once')
+    const off = vi.spyOn(process, 'off')
+
+    try {
+      const result = await invokeSanityCli({
+        args: `cors list --project-id ${projectId}`,
+        sanityEnv: 'production',
+        source: 'mcp',
+        token: 'invocation-token',
+      })
+
+      expect(result).toEqual({exitCode: 0, output: 'https://isolated.example.com'})
+      expect(cwd).not.toHaveBeenCalled()
+      expect(stdout).not.toHaveBeenCalled()
+      expect(stderr).not.toHaveBeenCalled()
+      expect(once).not.toHaveBeenCalledWith('SIGINT', expect.any(Function))
+      expect(off).not.toHaveBeenCalledWith('SIGINT', expect.any(Function))
+      expect(globalRegistry[CLI_TELEMETRY_SYMBOL]).toBe(hostTelemetry)
+      expect(process.env.SANITY_AUTH_TOKEN).toBe('host-token')
+      expect(process.env.SANITY_INTERNAL_ENV).toBe('staging')
+    } finally {
+      cwd.mockRestore()
+      stdout.mockRestore()
+      stderr.mockRestore()
+      once.mockRestore()
+      off.mockRestore()
+      globalRegistry[CLI_TELEMETRY_SYMBOL] = previousTelemetry
+      if (previousEnv.authToken === undefined) delete process.env.SANITY_AUTH_TOKEN
+      else process.env.SANITY_AUTH_TOKEN = previousEnv.authToken
+      if (previousEnv.sanityEnv === undefined) delete process.env.SANITY_INTERNAL_ENV
+      else process.env.SANITY_INTERNAL_ENV = previousEnv.sanityEnv
+    }
   })
 
   test('runs a command from string args, using the provided token', async () => {

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
@@ -20,10 +20,11 @@
  * (or `help`) renders root help listing the invokable topics, and a subject
  * (`cors --help`, `cors list --help`) renders topic or command help.
  */
-import {Config, Parser} from '@oclif/core'
+import {Command, Config, Parser, settings} from '@oclif/core'
 import {getHelpFlagAdditions, normalizeArgv} from '@oclif/core/help'
-import {CLI_TELEMETRY_SYMBOL, exitCodes, noopLogger, setCliTelemetry} from '@sanity/cli-core'
+import {exitCodes} from '@sanity/cli-core'
 import {runWithCliExecutionContext, type SanityEnvironment} from '@sanity/cli-core/executionContext'
+import {type SanityCommand} from '@sanity/cli-core/SanityCommand'
 import {parseArgsStringToArgv} from 'string-argv'
 
 import {commandPolicies} from './commandPolicies/index.js'
@@ -36,14 +37,45 @@ import {
 import {isHelpRequest, renderInvokableHelp} from './help.js'
 import {prettyPrintError} from './prettyPrintError.js'
 
+type InvokableCommand = Pick<SanityCommand<typeof Command>, 'runInExecutionContext'>
+
+/**
+ * Instantiate a policy-approved command for isolated execution.
+ *
+ * Every invokable command extends `SanityCommand`, whose
+ * `runInExecutionContext()` runs the instance without oclif's static
+ * `Command.run()` — the static runner re-enters `Config.load()` (filesystem
+ * reads and a process-global config cache write) on every call. The manifest
+ * types command classes as the abstract oclif `Command`, hence the
+ * constructor cast. The method is probed rather than checked with
+ * `instanceof`, because command modules may load from the compiled build
+ * while this module runs from source, giving `SanityCommand` two identities.
+ */
+function instantiateCommand(
+  CommandClass: Command.Class,
+  argv: string[],
+  config: Config,
+): InvokableCommand {
+  const ConcreteCommand = CommandClass as unknown as new (argv: string[], config: Config) => Command
+  const command = new ConcreteCommand(argv, config) as Command & Partial<InvokableCommand>
+  if (typeof command.runInExecutionContext !== 'function') {
+    throw new TypeError(`Command "${CommandClass.id}" does not support isolated execution`)
+  }
+  return command as InvokableCommand
+}
+
 /**
  * Load the oclif `Config` for this package, needed to resolve, load, and run
  * commands. Loading it once and reusing it across invocations avoids
- * re-reading the command manifest per call.
+ * re-reading the command manifest per call. It only reads this package's own
+ * installed files — process-lifetime initialization, not per-invocation host
+ * state — so it happens outside any execution context.
  */
 function loadCliCommandConfig(): Promise<Config> {
   return Config.load(import.meta.url)
 }
+
+let cachedConfig: Promise<Config> | undefined
 
 function unknownCommandResult(argv: string[], policySet: CommandPolicySet): InvokeSanityCliResult {
   const available = Object.entries(policySet)
@@ -91,8 +123,8 @@ export interface InvokeSanityCliOptions {
 
   /**
    * Sanity deployment environment for this invocation. Scoped to this call
-   * via the CLI execution context and defaults to `SANITY_INTERNAL_ENV` (or
-   * production when it is unset).
+   * via the CLI execution context and defaults to production. The embedding
+   * process's `SANITY_INTERNAL_ENV` is never consulted.
    */
   sanityEnv?: SanityEnvironment
 }
@@ -114,8 +146,6 @@ export interface InvokeSanityCliResult {
   commandId?: string
 }
 
-let cachedConfig: Promise<Config> | undefined
-
 /**
  * Unlike a shell, string-argv keeps quotes that are glued to unquoted text:
  * `--name="my project"` tokenizes with the quotes intact. Strip a matching
@@ -136,22 +166,33 @@ function stripFlagQuotes(rawToken: string): string {
  *
  * @internal
  */
-export async function invokeSanityCli({
-  args,
-  config,
-  sanityEnv,
-  source,
-  token,
-}: InvokeSanityCliOptions): Promise<InvokeSanityCliResult> {
-  const resolvedConfig = config ?? (await (cachedConfig ??= loadCliCommandConfig()))
-  const policySet = commandPolicies[source]
+export async function invokeSanityCli(
+  options: InvokeSanityCliOptions,
+): Promise<InvokeSanityCliResult> {
+  // Always load compiled command modules. Oclif's dev-mode source resolution
+  // otherwise probes tsconfigs (reading the filesystem and process.cwd) on
+  // every command load, and may register ts-node process-wide.
+  settings.enableAutoTranspile = false
 
-  // Commands log through the global telemetry store; default it to a noop
-  // store so embedding hosts need no telemetry wiring (and see no warnings),
-  // without clobbering a store the host may have installed itself.
-  if (!(globalThis as Record<symbol, unknown>)[CLI_TELEMETRY_SYMBOL]) {
-    setCliTelemetry(noopLogger)
-  }
+  const resolvedConfig = options.config ?? (await (cachedConfig ??= loadCliCommandConfig()))
+  const output: string[] = []
+  const sink = (line: string) => output.push(line)
+  const {sanityEnv, token} = options
+
+  // Establish the isolation boundary before rendering help, loading command
+  // modules, parsing, or executing. Any code reached by an external
+  // invocation can therefore fail closed on context.
+  return runWithCliExecutionContext({sanityEnv, stderr: sink, stdout: sink, token}, () =>
+    invokeSanityCliInContext(options, resolvedConfig, output),
+  )
+}
+
+async function invokeSanityCliInContext(
+  {args, source}: InvokeSanityCliOptions,
+  resolvedConfig: Config,
+  output: string[],
+): Promise<InvokeSanityCliResult> {
+  const policySet = commandPolicies[source]
 
   // Pre-split argv arrays are taken verbatim; only string input goes through
   // shell-style tokenization and quote normalization.
@@ -242,13 +283,9 @@ export async function invokeSanityCli({
     }
   }
 
-  const output: string[] = []
-  const sink = (line: string) => output.push(line)
-
   try {
-    await runWithCliExecutionContext({sanityEnv, stderr: sink, stdout: sink, token}, () =>
-      CommandClass.run(commandArgv, resolvedConfig),
-    )
+    const command = instantiateCommand(CommandClass, commandArgv, resolvedConfig)
+    await command.runInExecutionContext()
     return {commandId, exitCode: exitCodes.SUCCESS, output: output.join('\n')}
   } catch (err) {
     const exit = err.oclif?.exit

--- a/packages/@sanity/cli/src/services/__tests__/telemetry.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/telemetry.test.ts
@@ -1,4 +1,5 @@
 import {getUserConfig} from '@sanity/cli-core'
+import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
 import {mockApi} from '@sanity/cli-test'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -23,13 +24,14 @@ function createInMemoryConfigStore() {
 const testConfigStore = createInMemoryConfigStore()
 
 const mockGetCliToken = vi.hoisted(() => vi.fn<() => Promise<string | undefined>>())
+const mockGetUserConfig = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
   return {
     ...actual,
     getCliToken: mockGetCliToken,
-    getUserConfig: vi.fn(() => testConfigStore),
+    getUserConfig: mockGetUserConfig,
   }
 })
 
@@ -60,6 +62,7 @@ describe('#fetchTelemetryConsent', () => {
   beforeEach(() => {
     testConfigStore.clear()
     mockGetCliToken.mockResolvedValue('test-token')
+    mockGetUserConfig.mockReturnValue(testConfigStore)
   })
 
   afterEach(() => {
@@ -75,6 +78,21 @@ describe('#fetchTelemetryConsent', () => {
     const consent = await fetchTelemetryConsent()
 
     expect(consent).toEqual({status: 'granted'})
+  })
+
+  test('bypasses the host config cache under an execution context', async () => {
+    mockApi({
+      apiVersion: TELEMETRY_API_VERSION,
+      query: {tag: 'sanity.cli.telemetry-consent'},
+      uri: '/intake/telemetry-status',
+    }).reply(200, {status: 'granted'})
+
+    const consent = await runWithCliExecutionContext({token: 'context-token'}, () =>
+      fetchTelemetryConsent(),
+    )
+
+    expect(consent).toEqual({status: 'granted'})
+    expect(mockGetUserConfig).not.toHaveBeenCalled()
   })
 
   test('should cache consent under a token-scoped key', async () => {

--- a/packages/@sanity/cli/src/services/telemetry.ts
+++ b/packages/@sanity/cli/src/services/telemetry.ts
@@ -1,6 +1,7 @@
 import {createHash} from 'node:crypto'
 
 import {getCliToken, getGlobalCliClient, getUserConfig} from '@sanity/cli-core'
+import {getCliExecutionContext} from '@sanity/cli-core/executionContext'
 import {type TelemetryEvent} from '@sanity/telemetry'
 
 import {telemetryDebug} from '../actions/telemetry/telemetryDebug.js'
@@ -95,6 +96,10 @@ export function getTelemetryConsentCacheKey(token: string | undefined): string {
 export async function fetchTelemetryConsent(): Promise<{
   status: ValidApiConsentStatus
 }> {
+  // Programmatic invocations must not use the host user's disk-backed consent
+  // cache. The request is already authenticated with the invocation token.
+  if (getCliExecutionContext()) return getTelemetryConsent()
+
   const token = await getCliToken()
   const cacheKey = getTelemetryConsentCacheKey(token)
 


### PR DESCRIPTION
### Description

`invokeSanityCli` is embedded in multi-tenant hosts (the MCP server), where concurrent invocations run in one process with different tokens. An audit of the programmatic invocation path found several places where an external invocation could read or mutate host process state, and one credential-leak risk:

- **Token fallback (worst finding):** when an execution context existed but had no truthy token, `getCliToken()` fell back to the process-wide token cache, `SANITY_AUTH_TOKEN`, and `~/.config/sanity/config.json` — meaning a tenant invocation could silently run with the host's credentials.
- **Context started too late:** the execution context was only established around command execution, so config loading, command module import, flag parsing, and help rendering all ran outside the isolation boundary.
- **Host filesystem/env reads:** `getProjectRoot()` called `process.cwd()` before consulting the context; `telemetry status` read/wrote the host user config; telemetry consent honored host `CI`/`DO_NOT_TRACK`; `documents query` read host `SANITY_CLI_QUERY_API_VERSION`.
- **Host process mutation:** `datasets copy` installed a `SIGINT` listener on the host process; spinners wrote to `process.stdout`/`stderr`; telemetry used a process-global registry; oclif's static `Command.run()` re-enters `Config.load()` (filesystem reads plus a process-global config cache write) on every call, and oclif's dev-mode auto-transpile probes tsconfigs and `process.cwd()` on every command load.

This PR makes external invocations fail closed on the execution context instead:

- The execution context is established at the very start of `invokeSanityCli`, before help rendering, command module loading, parsing, or execution.
- Under any active context, token resolution uses only the context token — never the host token cache, env, or user config. Host user config access (`getUserConfig`, `get`/`setCliUserConfig`) throws under a context, as does filesystem project-root resolution.
- Spinners route through the context's output sinks; telemetry is scoped per invocation (no global registry reads or writes); consent ignores host `CI`/`DO_NOT_TRACK`; `datasets copy` skips host `SIGINT` wiring; `documents query` ignores host `SANITY_CLI_QUERY_API_VERSION`.
- Commands execute via `SanityCommand.runInExecutionContext()` on an already-constructed instance rather than oclif's static runner, avoiding the per-call `Config.load()` re-entry and global config cache mutation, and `settings.enableAutoTranspile` is disabled so only compiled command modules load.

Deliberate scope decisions: the package's own `Config.load()` stays cached at startup (it reads only this package's installed files — process-lifetime initialization, not per-invocation host state), and no subprocess/worker sandbox was introduced; the in-process context boundary plus the command policy set covers the invokable surface.

### What to review

- `packages/@sanity/cli/src/exports/invokeSanityCli/index.ts` — the context boundary now wraps the whole invocation; command instantiation and isolated execution.
- `packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts` — fail-closed token resolution and user-config guards.
- `packages/@sanity/cli-core/src/SanityCommand.ts` — `runInExecutionContext()` and the project-root guard.
- Context guards in spinners, telemetry (`getCliTelemetry`, `services/telemetry`, `resolveConsent`), `datasets copy`, and `documents query`.

Only programmatic invocations are affected: every guard is conditional on an active execution context, so normal terminal CLI usage is unchanged.

### Testing

- Unit tests added/updated alongside each guard, plus a regression test asserting an allowed invocation completes without consulting or mutating representative host state (`process.cwd`, stdout/stderr, `SIGINT` handlers, the global telemetry registry, host env tokens).
- Verified end to end against a locally running MCP server (mellon) linked to this branch: help rendering, an authenticated `projects list` against staging, and the failure modes (usage error, denied command, denied flag) all behave correctly through the real MCP `run_sanity_cli` path.

### Notes for release

Programmatic CLI invocations (`invokeSanityCli`) are now fully isolated from the host process: they never fall back to host credentials, never read or write the host user config or environment, and never mutate host process state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication and isolation for embedded CLI invocations; a bug could leak host tokens or break MCP/programmatic callers, though interactive CLI paths are explicitly unchanged.
> 
> **Overview**
> **Programmatic CLI invocations** (`invokeSanityCli`) are tightened so multi-tenant in-process hosts (e.g. MCP) cannot leak or inherit host credentials and process state.
> 
> The **execution context is established at the start** of `invokeSanityCli`—before help, parsing, module load, or run—so downstream code can fail closed. Commands run via **`SanityCommand.runInExecutionContext()`** on a constructed instance instead of oclif’s static `Command.run()` (avoids repeated `Config.load()` / global config cache writes). **`settings.enableAutoTranspile` is disabled** so command loads don’t probe the filesystem or `process.cwd()`.
> 
> Under an active context: **`getCliToken()` uses only the context token** (no env, cache, or `~/.config` fallback); **host user config access throws**; **`getProjectRoot()` refuses filesystem cwd resolution**; **spinners are silent**; **telemetry/consent skip host globals, CI/`DO_NOT_TRACK`, and disk consent cache**; **`datasets copy` skips `SIGINT` handlers**; **`documents query` ignores `SANITY_CLI_QUERY_API_VERSION`**.
> 
> Terminal CLI behavior is unchanged—guards are gated on the execution context. Tests cover each guard plus a regression that allowed invocations don’t touch host cwd, stdio, signals, telemetry registry, or env tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3db38cc19ea4ec5afa4ac32aebcfa4b3669a8c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->