### PR TITLE
fix(init): use @sanity/icons v5 de-barrelled imports in templates

### DIFF
--- a/.changeset/pr-1623.md
+++ b/.changeset/pr-1623.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(init): use @sanity/icons v5 de-barrelled imports in templates

--- a/packages/@sanity/cli/src/actions/init/initNextJs.ts
+++ b/packages/@sanity/cli/src/actions/init/initNextJs.ts
@@ -291,7 +291,7 @@ export async function initNextJs({
   trace.log({selectedOption: chosen, step: 'selectPackageManager'})
   const packages = ['@sanity/vision@5', 'sanity@5', '@sanity/image-url@2', 'styled-components@6']
   if (templateToUse === 'blog') {
-    packages.push('@sanity/icons')
+    packages.push('@sanity/icons@5')
   }
   await installNewPackages(
     {

--- a/packages/@sanity/cli/src/actions/init/templates/__tests__/icons.test.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/__tests__/icons.test.ts
@@ -1,0 +1,73 @@
+import {readdir, readFile} from 'node:fs/promises'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+import {describe, expect, test} from 'vitest'
+
+import getStarted from '../getStarted.js'
+import {blogSchemaFolder} from '../nextjs/schemaTypes/blog.js'
+import shopify from '../shopify.js'
+import shopifyOnline from '../shopifyOnline.js'
+
+const templatesRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../../templates',
+)
+
+const barrelImportRe = /from\s+['"]@sanity\/icons['"]/
+const debarrelledImportRe = /from\s+['"]@sanity\/icons\/[A-Za-z0-9]+['"]/
+
+async function collectSourceFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, {withFileTypes: true})
+  const files: string[] = []
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await collectSourceFiles(fullPath)))
+      continue
+    }
+    if (/\.(?:[cm]?[jt]sx?)$/.test(entry.name)) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+describe('init template @sanity/icons usage', () => {
+  test('nextjs blog schema types use de-barrelled icon imports', () => {
+    for (const [fileName, source] of Object.entries(blogSchemaFolder)) {
+      expect(source, fileName).not.toMatch(barrelImportRe)
+      if (source.includes('@sanity/icons')) {
+        expect(source, fileName).toMatch(debarrelledImportRe)
+      }
+    }
+
+    expect(blogSchemaFolder['authorType.']).toContain("from '@sanity/icons/User'")
+    expect(blogSchemaFolder['blockContentType.']).toContain("from '@sanity/icons/Image'")
+    expect(blogSchemaFolder['categoryType.']).toContain("from '@sanity/icons/Tag'")
+    expect(blogSchemaFolder['postType.']).toContain("from '@sanity/icons/DocumentText'")
+  })
+
+  test.each([
+    ['getStarted', getStarted],
+    ['shopify', shopify],
+    ['shopifyOnline', shopifyOnline],
+  ] as const)('%s depends on @sanity/icons v5', (_name, template) => {
+    expect(template.dependencies?.['@sanity/icons']).toMatch(/^\^5\./)
+  })
+
+  test('filesystem templates do not use barrelled @sanity/icons imports', async () => {
+    const sourceFiles = await collectSourceFiles(templatesRoot)
+    expect(sourceFiles.length).toBeGreaterThan(0)
+
+    const offenders: string[] = []
+    for (const file of sourceFiles) {
+      const source = await readFile(file, 'utf8')
+      if (barrelImportRe.test(source)) {
+        offenders.push(path.relative(templatesRoot, file))
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/@sanity/cli/src/actions/init/templates/__tests__/icons.test.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/__tests__/icons.test.ts
@@ -4,6 +4,7 @@ import {fileURLToPath} from 'node:url'
 
 import {describe, expect, test} from 'vitest'
 
+import appSanityUi from '../appSanityUi.js'
 import getStarted from '../getStarted.js'
 import {blogSchemaFolder} from '../nextjs/schemaTypes/blog.js'
 import shopify from '../shopify.js'
@@ -54,6 +55,15 @@ describe('init template @sanity/icons usage', () => {
     ['shopifyOnline', shopifyOnline],
   ] as const)('%s depends on @sanity/icons v5', (_name, template) => {
     expect(template.dependencies?.['@sanity/icons']).toMatch(/^\^5\./)
+  })
+
+  test.each([
+    ['getStarted', getStarted],
+    ['shopify', shopify],
+    ['shopifyOnline', shopifyOnline],
+    ['appSanityUi', appSanityUi],
+  ] as const)('%s depends on @sanity/ui v3', (_name, template) => {
+    expect(template.dependencies?.['@sanity/ui']).toMatch(/^\^3\./)
   })
 
   test('filesystem templates do not use barrelled @sanity/icons imports', async () => {

--- a/packages/@sanity/cli/src/actions/init/templates/appSanityUi.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/appSanityUi.ts
@@ -2,7 +2,7 @@ import {type ProjectTemplate} from '../types.js'
 
 const appSanityUiTemplate: ProjectTemplate = {
   dependencies: {
-    '@sanity/ui': '^3',
+    '@sanity/ui': '^3.5.0',
     'styled-components': '^6.1.18',
   },
   entry: './src/App.tsx',

--- a/packages/@sanity/cli/src/actions/init/templates/getStarted.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/getStarted.ts
@@ -29,7 +29,7 @@ const getStartedTemplate: ProjectTemplate = {
   configTemplate,
   dependencies: {
     '@sanity/icons': '^5.0.0',
-    '@sanity/ui': '^2.0.0',
+    '@sanity/ui': '^3.5.0',
   },
   typescriptOnly: true,
 }

--- a/packages/@sanity/cli/src/actions/init/templates/getStarted.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/getStarted.ts
@@ -28,7 +28,7 @@ export default defineConfig({
 const getStartedTemplate: ProjectTemplate = {
   configTemplate,
   dependencies: {
-    '@sanity/icons': '^2.11.0',
+    '@sanity/icons': '^5.0.0',
     '@sanity/ui': '^2.0.0',
   },
   typescriptOnly: true,

--- a/packages/@sanity/cli/src/actions/init/templates/nextjs/schemaTypes/blog.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/nextjs/schemaTypes/blog.ts
@@ -1,6 +1,6 @@
 // Types
 
-const authorType = `import {UserIcon} from '@sanity/icons'
+const authorType = `import {UserIcon} from '@sanity/icons/User'
 import {defineArrayMember, defineField, defineType} from 'sanity'
 
 export const authorType = defineType({
@@ -49,7 +49,7 @@ export const authorType = defineType({
 `
 
 const blockContentType = `import {defineType, defineArrayMember} from 'sanity'
-import {ImageIcon} from '@sanity/icons'
+import {ImageIcon} from '@sanity/icons/Image'
 
 /**
  * This is the schema type for block content used in the post document type
@@ -126,7 +126,7 @@ export const blockContentType = defineType({
 })
 `
 
-const categoryType = `import {TagIcon} from '@sanity/icons'
+const categoryType = `import {TagIcon} from '@sanity/icons/Tag'
 import {defineField, defineType} from 'sanity'
 
 export const categoryType = defineType({
@@ -154,7 +154,7 @@ export const categoryType = defineType({
 })
 `
 
-const postType = `import {DocumentTextIcon} from '@sanity/icons'
+const postType = `import {DocumentTextIcon} from '@sanity/icons/DocumentText'
 import {defineArrayMember, defineField, defineType} from 'sanity'
 
 export const postType = defineType({

--- a/packages/@sanity/cli/src/actions/init/templates/shopify.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/shopify.ts
@@ -61,7 +61,7 @@ const shopifyTemplate: ProjectTemplate = {
   dependencies: {
     '@sanity/asset-utils': '^2.3.0',
     '@sanity/color-input': '^6.0.4',
-    '@sanity/icons': '^3.7.4',
+    '@sanity/icons': '^5.0.0',
     '@sanity/ui': '^3.1.14',
     'lodash.get': '^4.4.2',
     'pluralize-esm': '^9.0.2',

--- a/packages/@sanity/cli/src/actions/init/templates/shopify.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/shopify.ts
@@ -62,7 +62,7 @@ const shopifyTemplate: ProjectTemplate = {
     '@sanity/asset-utils': '^2.3.0',
     '@sanity/color-input': '^6.0.4',
     '@sanity/icons': '^5.0.0',
-    '@sanity/ui': '^3.1.14',
+    '@sanity/ui': '^3.5.0',
     'lodash.get': '^4.4.2',
     'pluralize-esm': '^9.0.2',
     'sanity-plugin-hotspot-array': '^3.0.2',

--- a/packages/@sanity/cli/src/actions/init/templates/shopifyOnline.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/shopifyOnline.ts
@@ -39,7 +39,7 @@ const shopifyTemplate: ProjectTemplate = {
   dependencies: {
     '@portabletext/toolkit': '^2.0.1',
     '@sanity/icons': '^5.0.0',
-    '@sanity/ui': '^3.1.14',
+    '@sanity/ui': '^3.5.0',
     '@types/lodash.get': '^4.4.7',
     'lodash.get': '^4.4.2',
     'pluralize-esm': '^9.0.4',

--- a/packages/@sanity/cli/src/actions/init/templates/shopifyOnline.ts
+++ b/packages/@sanity/cli/src/actions/init/templates/shopifyOnline.ts
@@ -38,7 +38,7 @@ const shopifyTemplate: ProjectTemplate = {
   configTemplate,
   dependencies: {
     '@portabletext/toolkit': '^2.0.1',
-    '@sanity/icons': '^3.7.4',
+    '@sanity/icons': '^5.0.0',
     '@sanity/ui': '^3.1.14',
     '@types/lodash.get': '^4.4.7',
     'lodash.get': '^4.4.2',

--- a/packages/@sanity/cli/templates/get-started/plugins/sanity-plugin-tutorial/GetStartedTutorial.tsx
+++ b/packages/@sanity/cli/templates/get-started/plugins/sanity-plugin-tutorial/GetStartedTutorial.tsx
@@ -11,7 +11,7 @@ import {
   useElementSize,
   useTheme,
 } from '@sanity/ui'
-import {CloseIcon} from '@sanity/icons'
+import {CloseIcon} from '@sanity/icons/Close'
 import {css, styled} from 'styled-components'
 
 const BlueColor = css`

--- a/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/CollectionHidden.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/CollectionHidden.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {WarningOutlineIcon} from '@sanity/icons'
+import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 
 export default function CollectionHiddenInput() {

--- a/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/ProductHidden.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/ProductHidden.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {WarningOutlineIcon} from '@sanity/icons'
+import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {type StringFieldProps, useFormValue} from 'sanity'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 

--- a/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/ProductVariantHidden.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/ProductVariantHidden.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {WarningOutlineIcon} from '@sanity/icons'
+import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 
 export default function ProductVariantHiddenInput() {

--- a/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/ProxyString.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/components/inputs/ProxyString.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {LockIcon} from '@sanity/icons'
+import {LockIcon} from '@sanity/icons/Lock'
 import {Box, Text, TextInput, Tooltip} from '@sanity/ui'
 import {
   type SanityDocument,

--- a/packages/@sanity/cli/templates/shopify-online-storefront/components/media/ShopifyDocumentStatus.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/components/media/ShopifyDocumentStatus.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
-import {CloseIcon, ImageIcon, LinkRemovedIcon} from '@sanity/icons'
+import {CloseIcon} from '@sanity/icons/Close'
+import {ImageIcon} from '@sanity/icons/Image'
+import {LinkRemovedIcon} from '@sanity/icons/LinkRemoved'
 import {forwardRef, useState} from 'react'
 
 type Props = {

--- a/packages/@sanity/cli/templates/shopify-online-storefront/plugins/shopifyDocumentActions/shopifyDelete.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/plugins/shopifyDocumentActions/shopifyDelete.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react'
-import {TrashIcon} from '@sanity/icons'
+import {TrashIcon} from '@sanity/icons/Trash'
 import {Stack, Text, useToast} from '@sanity/ui'
 import {
   type DocumentActionDescription,

--- a/packages/@sanity/cli/templates/shopify-online-storefront/plugins/shopifyDocumentActions/shopifyLink.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/plugins/shopifyDocumentActions/shopifyLink.ts
@@ -1,4 +1,4 @@
-import {EarthGlobeIcon} from '@sanity/icons'
+import {EarthGlobeIcon} from '@sanity/icons/EarthGlobe'
 import {type DocumentActionDescription} from 'sanity'
 import {collectionUrl, productUrl, productVariantUrl} from '../../utils/shopifyUrls'
 import type {ShopifyDocument, ShopifyDocumentActionProps} from './types'

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/documents/collection.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/documents/collection.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {defineField, defineType} from 'sanity'
-import {PackageIcon} from '@sanity/icons'
+import {PackageIcon} from '@sanity/icons/Package'
 import pluralize from 'pluralize-esm'
 import CollectionHiddenInput from '../../components/inputs/CollectionHidden'
 import ShopifyIcon from '../../components/icons/Shopify'

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/documents/product.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/documents/product.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {TagIcon} from '@sanity/icons'
+import {TagIcon} from '@sanity/icons/Tag'
 import {defineField, defineType} from 'sanity'
 import pluralize from 'pluralize-esm'
 import ShopifyIcon from '../../components/icons/Shopify'

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/documents/productVariant.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/documents/productVariant.tsx
@@ -1,4 +1,4 @@
-import {CopyIcon} from '@sanity/icons'
+import {CopyIcon} from '@sanity/icons/Copy'
 import {defineField, defineType} from 'sanity'
 import ShopifyIcon from '../../components/icons/Shopify'
 import ProductVariantHiddenInput from '../../components/inputs/ProductVariantHidden'

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/accordion.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/accordion.ts
@@ -1,4 +1,4 @@
-import {StackCompactIcon} from '@sanity/icons'
+import {StackCompactIcon} from '@sanity/icons/StackCompact'
 import pluralize from 'pluralize-esm'
 import {defineField, defineType} from 'sanity'
 

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/callout.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/callout.ts
@@ -1,4 +1,4 @@
-import {BulbOutlineIcon} from '@sanity/icons'
+import {BulbOutlineIcon} from '@sanity/icons/BulbOutline'
 import {defineField, defineType} from 'sanity'
 
 export default defineType({

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/option.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/option.ts
@@ -1,4 +1,4 @@
-import {SunIcon} from '@sanity/icons'
+import {SunIcon} from '@sanity/icons/Sun'
 import {defineField, defineType} from 'sanity'
 
 export default defineType({

--- a/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/shopifyCollectionRule.tsx
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/schemaTypes/objects/shopifyCollectionRule.tsx
@@ -1,4 +1,4 @@
-import {FilterIcon} from '@sanity/icons'
+import {FilterIcon} from '@sanity/icons/Filter'
 import {defineField, defineType} from 'sanity'
 
 export default defineType({

--- a/packages/@sanity/cli/templates/shopify-online-storefront/structure/productStructure.ts
+++ b/packages/@sanity/cli/templates/shopify-online-storefront/structure/productStructure.ts
@@ -1,4 +1,4 @@
-import {InfoOutlineIcon} from '@sanity/icons'
+import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {ListItemBuilder} from 'sanity/structure'
 import defineStructure from '../utils/defineStructure'
 

--- a/packages/@sanity/cli/templates/shopify/components/inputs/CollectionHidden.tsx
+++ b/packages/@sanity/cli/templates/shopify/components/inputs/CollectionHidden.tsx
@@ -1,4 +1,4 @@
-import {WarningOutlineIcon} from '@sanity/icons'
+import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {StringFieldProps} from 'sanity'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 

--- a/packages/@sanity/cli/templates/shopify/components/inputs/ProductHidden.tsx
+++ b/packages/@sanity/cli/templates/shopify/components/inputs/ProductHidden.tsx
@@ -1,4 +1,4 @@
-import {WarningOutlineIcon} from '@sanity/icons'
+import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {StringFieldProps, useFormValue} from 'sanity'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 import {productUrl} from '../../utils/shopifyUrls'

--- a/packages/@sanity/cli/templates/shopify/components/inputs/ProductVariantHidden.tsx
+++ b/packages/@sanity/cli/templates/shopify/components/inputs/ProductVariantHidden.tsx
@@ -1,4 +1,4 @@
-import {WarningOutlineIcon} from '@sanity/icons'
+import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 
 export default function ProductVariantHiddenInput() {

--- a/packages/@sanity/cli/templates/shopify/components/inputs/ProxyString.tsx
+++ b/packages/@sanity/cli/templates/shopify/components/inputs/ProxyString.tsx
@@ -1,4 +1,4 @@
-import {LockIcon} from '@sanity/icons'
+import {LockIcon} from '@sanity/icons/Lock'
 import {Box, Text, TextInput, Tooltip} from '@sanity/ui'
 import {StringInputProps, useFormValue, SanityDocument, StringSchemaType} from 'sanity'
 import get from 'lodash.get'

--- a/packages/@sanity/cli/templates/shopify/components/media/ShopifyDocumentStatus.tsx
+++ b/packages/@sanity/cli/templates/shopify/components/media/ShopifyDocumentStatus.tsx
@@ -1,4 +1,6 @@
-import {CloseIcon, ImageIcon, LinkRemovedIcon} from '@sanity/icons'
+import {CloseIcon} from '@sanity/icons/Close'
+import {ImageIcon} from '@sanity/icons/Image'
+import {LinkRemovedIcon} from '@sanity/icons/LinkRemoved'
 import React, {forwardRef, useState} from 'react'
 
 type Props = {

--- a/packages/@sanity/cli/templates/shopify/constants.ts
+++ b/packages/@sanity/cli/templates/shopify/constants.ts
@@ -1,7 +1,9 @@
 // Currency code (ISO 4217) to use when displaying prices in the studio
 
 import ShopifyIcon from './components/icons/Shopify'
-import {ColorWheelIcon, ComposeIcon, SearchIcon} from '@sanity/icons'
+import {ColorWheelIcon} from '@sanity/icons/ColorWheel'
+import {ComposeIcon} from '@sanity/icons/Compose'
+import {SearchIcon} from '@sanity/icons/Search'
 
 // https://en.wikipedia.org/wiki/ISO_4217
 export const DEFAULT_CURRENCY_CODE = 'USD'

--- a/packages/@sanity/cli/templates/shopify/plugins/customDocumentActions/shopifyDelete.tsx
+++ b/packages/@sanity/cli/templates/shopify/plugins/customDocumentActions/shopifyDelete.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react'
-import {TrashIcon} from '@sanity/icons'
+import {TrashIcon} from '@sanity/icons/Trash'
 import {Stack, Text, useToast} from '@sanity/ui'
 import {
   type DocumentActionDescription,

--- a/packages/@sanity/cli/templates/shopify/plugins/customDocumentActions/shopifyLink.ts
+++ b/packages/@sanity/cli/templates/shopify/plugins/customDocumentActions/shopifyLink.ts
@@ -1,4 +1,4 @@
-import {EarthGlobeIcon} from '@sanity/icons'
+import {EarthGlobeIcon} from '@sanity/icons/EarthGlobe'
 import {collectionUrl, productUrl, productVariantUrl} from '../../utils/shopifyUrls'
 import {type DocumentActionDescription} from 'sanity'
 import type {ShopifyDocument, ShopifyDocumentActionProps} from './types'

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/documents/collection.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/documents/collection.tsx
@@ -1,5 +1,5 @@
 import {defineArrayMember, defineField, defineType} from 'sanity'
-import {PackageIcon} from '@sanity/icons'
+import {PackageIcon} from '@sanity/icons/Package'
 import {getExtension} from '@sanity/asset-utils'
 import pluralize from 'pluralize-esm'
 import CollectionHiddenInput from '../../components/inputs/CollectionHidden'

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/documents/colorTheme.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/documents/colorTheme.tsx
@@ -1,4 +1,4 @@
-import {IceCreamIcon} from '@sanity/icons'
+import {IceCreamIcon} from '@sanity/icons/IceCream'
 import {defineField, defineType} from 'sanity'
 
 import ColorTheme from '../../components/media/ColorTheme'

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/documents/page.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/documents/page.ts
@@ -1,4 +1,4 @@
-import {DocumentIcon} from '@sanity/icons'
+import {DocumentIcon} from '@sanity/icons/Document'
 import {defineField} from 'sanity'
 
 import {validateSlug} from '../../utils/validateSlug'

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/documents/product.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/documents/product.tsx
@@ -1,4 +1,4 @@
-import {TagIcon} from '@sanity/icons'
+import {TagIcon} from '@sanity/icons/Tag'
 import pluralize from 'pluralize-esm'
 import ProductHiddenInput from '../../components/inputs/ProductHidden'
 import ShopifyDocumentStatus from '../../components/media/ShopifyDocumentStatus'

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/documents/productVariant.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/documents/productVariant.tsx
@@ -1,4 +1,4 @@
-import {CopyIcon} from '@sanity/icons'
+import {CopyIcon} from '@sanity/icons/Copy'
 import {defineField, defineType} from 'sanity'
 
 import ProductVariantHiddenInput from '../../components/inputs/ProductVariantHidden'

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/collection/collectionGroupType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/collection/collectionGroupType.ts
@@ -1,4 +1,4 @@
-import {PackageIcon} from '@sanity/icons'
+import {PackageIcon} from '@sanity/icons/Package'
 import {defineField} from 'sanity'
 
 export const collectionGroupType = defineField({

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/hotspot/imageWithProductHotspotsType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/hotspot/imageWithProductHotspotsType.ts
@@ -1,4 +1,4 @@
-import {ImageIcon} from '@sanity/icons'
+import {ImageIcon} from '@sanity/icons/Image'
 import pluralize from 'pluralize-esm'
 import {defineField} from 'sanity'
 

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/link/linkEmailType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/link/linkEmailType.tsx
@@ -1,4 +1,4 @@
-import {EnvelopeIcon} from '@sanity/icons'
+import {EnvelopeIcon} from '@sanity/icons/Envelope'
 import {defineField} from 'sanity'
 
 export const linkEmailType = defineField({

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/link/linkExternalType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/link/linkExternalType.tsx
@@ -1,4 +1,4 @@
-import {EarthGlobeIcon} from '@sanity/icons'
+import {EarthGlobeIcon} from '@sanity/icons/EarthGlobe'
 import {defineField} from 'sanity'
 
 export const linkExternalType = defineField({

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/link/linkInternalType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/link/linkInternalType.tsx
@@ -1,4 +1,4 @@
-import {LinkIcon} from '@sanity/icons'
+import {LinkIcon} from '@sanity/icons/Link'
 import {defineField} from 'sanity'
 import {PAGE_REFERENCES} from '../../../constants'
 

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/link/linkProductType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/link/linkProductType.tsx
@@ -1,4 +1,4 @@
-import {TagIcon} from '@sanity/icons'
+import {TagIcon} from '@sanity/icons/Tag'
 import {defineField} from 'sanity'
 
 export const linkProductType = defineField({

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/accordionType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/accordionType.ts
@@ -1,4 +1,4 @@
-import {StackCompactIcon} from '@sanity/icons'
+import {StackCompactIcon} from '@sanity/icons/StackCompact'
 import pluralize from 'pluralize-esm'
 import {defineField} from 'sanity'
 

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/callToActionType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/callToActionType.tsx
@@ -1,4 +1,5 @@
-import {BlockElementIcon, ImageIcon} from '@sanity/icons'
+import {BlockElementIcon} from '@sanity/icons/BlockElement'
+import {ImageIcon} from '@sanity/icons/Image'
 import {defineArrayMember, defineField} from 'sanity'
 
 export const callToActionType = defineField({

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/calloutType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/calloutType.ts
@@ -1,4 +1,4 @@
-import {BulbOutlineIcon} from '@sanity/icons'
+import {BulbOutlineIcon} from '@sanity/icons/BulbOutline'
 import {defineField} from 'sanity'
 
 export const calloutType = defineField({

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/collectionReferenceType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/collectionReferenceType.tsx
@@ -1,4 +1,4 @@
-import {PackageIcon} from '@sanity/icons'
+import {PackageIcon} from '@sanity/icons/Package'
 import {defineField} from 'sanity'
 
 import ShopifyDocumentStatus from '../../../components/media/ShopifyDocumentStatus'

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/gridType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/gridType.ts
@@ -1,4 +1,4 @@
-import {ThLargeIcon} from '@sanity/icons'
+import {ThLargeIcon} from '@sanity/icons/ThLarge'
 import pluralize from 'pluralize-esm'
 import {defineArrayMember, defineField} from 'sanity'
 

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/imageFeatureType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/imageFeatureType.ts
@@ -1,4 +1,4 @@
-import {ImageIcon} from '@sanity/icons'
+import {ImageIcon} from '@sanity/icons/Image'
 import {defineField} from 'sanity'
 
 const VARIANTS = [

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/imageFeaturesType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/imageFeaturesType.tsx
@@ -1,4 +1,4 @@
-import {ImageIcon} from '@sanity/icons'
+import {ImageIcon} from '@sanity/icons/Image'
 import pluralize from 'pluralize-esm'
 import {defineField} from 'sanity'
 

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/instagramType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/instagramType.ts
@@ -1,4 +1,4 @@
-import {UserIcon} from '@sanity/icons'
+import {UserIcon} from '@sanity/icons/User'
 import {defineField} from 'sanity'
 
 export const instagramType = defineField({

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/productFeaturesType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/productFeaturesType.tsx
@@ -1,4 +1,4 @@
-import {TagIcon} from '@sanity/icons'
+import {TagIcon} from '@sanity/icons/Tag'
 import pluralize from 'pluralize-esm'
 import {defineField} from 'sanity'
 

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/productReferenceType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/module/productReferenceType.tsx
@@ -1,4 +1,4 @@
-import {TagIcon} from '@sanity/icons'
+import {TagIcon} from '@sanity/icons/Tag'
 
 import {defineField} from 'sanity'
 

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/collectionRuleType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/collectionRuleType.tsx
@@ -1,4 +1,4 @@
-import {FilterIcon} from '@sanity/icons'
+import {FilterIcon} from '@sanity/icons/Filter'
 import {defineField} from 'sanity'
 
 export const collectionRuleType = defineField({

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/optionType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/optionType.tsx
@@ -1,4 +1,4 @@
-import {SunIcon} from '@sanity/icons'
+import {SunIcon} from '@sanity/icons/Sun'
 import {defineField} from 'sanity'
 
 export const optionType = defineField({

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/productWithVariantType.tsx
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/objects/shopify/productWithVariantType.tsx
@@ -1,4 +1,4 @@
-import {TagIcon} from '@sanity/icons'
+import {TagIcon} from '@sanity/icons/Tag'
 import pluralize from 'pluralize-esm'
 
 import {defineField} from 'sanity'

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/singletons/homeType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/singletons/homeType.ts
@@ -1,4 +1,4 @@
-import {HomeIcon} from '@sanity/icons'
+import {HomeIcon} from '@sanity/icons/Home'
 import {defineArrayMember, defineField} from 'sanity'
 import {GROUPS} from '../../constants'
 

--- a/packages/@sanity/cli/templates/shopify/schemaTypes/singletons/settingsType.ts
+++ b/packages/@sanity/cli/templates/shopify/schemaTypes/singletons/settingsType.ts
@@ -1,4 +1,8 @@
-import {CogIcon, ControlsIcon, ErrorOutlineIcon, MenuIcon, SearchIcon} from '@sanity/icons'
+import {CogIcon} from '@sanity/icons/Cog'
+import {ControlsIcon} from '@sanity/icons/Controls'
+import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
+import {MenuIcon} from '@sanity/icons/Menu'
+import {SearchIcon} from '@sanity/icons/Search'
 import {defineType, defineField} from 'sanity'
 
 const TITLE = 'Settings'

--- a/packages/@sanity/cli/templates/shopify/structure/pageStructure.ts
+++ b/packages/@sanity/cli/templates/shopify/structure/pageStructure.ts
@@ -1,4 +1,4 @@
-import {DocumentsIcon} from '@sanity/icons'
+import {DocumentsIcon} from '@sanity/icons/Documents'
 import {ListItemBuilder} from 'sanity/structure'
 import defineStructure from '../utils/defineStructure'
 

--- a/packages/@sanity/cli/templates/shopify/structure/productStructure.ts
+++ b/packages/@sanity/cli/templates/shopify/structure/productStructure.ts
@@ -1,4 +1,4 @@
-import {InfoOutlineIcon} from '@sanity/icons'
+import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {ListItemBuilder} from 'sanity/structure'
 import defineStructure from '../utils/defineStructure'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`sanity init` templates (especially Next.js blog schema) still barrel-imported from `@sanity/icons` and pinned v2/v3. With `@sanity/icons` v5, icons should be imported via de-barrelled paths like `import {UserIcon} from '@sanity/icons/User'`.

This updates:
- Next.js blog schema template strings
- Shopify / Shopify Online Storefront / get-started filesystem templates
- Template dependency pins to `@sanity/icons` `^5.0.0`
- Next.js blog package install to `@sanity/icons@5`
- Template `@sanity/ui` pins to `^3.5.0` (get-started was still on `^2.0.0`; shopify/app templates aligned)

`app-quickstart` does not use `@sanity/icons` / needs no icon changes.

### What to review

- Icon import path convention: `@sanity/icons/<Name>` (strip trailing `Icon`)
- Dependency version bumps in `getStarted` / `shopify` / `shopifyOnline` / `appSanityUi` templates
- Next.js init installs `@sanity/icons@5` for the blog template

### Testing

- Added unit tests in `packages/@sanity/cli/src/actions/init/templates/__tests__/icons.test.ts` covering Next blog schema sources, `@sanity/icons` v5 / `@sanity/ui` v3 template dependency versions, and a scan of filesystem templates for barrel imports
- `pnpm test:unit icons.test` passed
- Format / ESLint / `pnpm check:types` / `pnpm check:deps` passed for the change set

### Notes for release

Update init templates to use `@sanity/icons` v5 with de-barrelled import paths, and bump template `@sanity/ui` to v3.5

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sanity-io.slack.com/archives/C3Q637VGW/p1785356866485649?thread_ts=1785356866.485649&cid=C3Q637VGW)

<div><a href="https://cursor.com/agents/bc-9d95db7a-d3be-5993-91e9-672d9906f987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d95db7a-d3be-5993-91e9-672d9906f987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

