### PR TITLE
fix(workbench): stop stranding the module-federation dts worker

### DIFF
--- a/.changeset/quiet-pumas-listen.md
+++ b/.changeset/quiet-pumas-listen.md
@@ -1,0 +1,5 @@
+---
+'@sanity/workbench-cli': patch
+---
+
+Stop `sanity dev` from stranding a module-federation type worker that keeps the terminal from quitting

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-module-federation.node.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-module-federation.node.test.ts
@@ -31,14 +31,18 @@ describe('sanityModuleFederation', () => {
   // project with a tsconfig.json, but it compiles the generated .js/.jsx
   // expose shims with the user's compiler options — tsc rejects them without
   // allowJs (TS6504), and declaration emit of the user's noEmit app code fails
-  // on its own (TS2742/TS4082). Type generation must stay explicitly off.
-  it('disables dts type generation so the user tsconfig never compiles the generated exposes', () => {
+  // on its own (TS2742/TS4082).
+  //
+  // Must be `false`, not `{generateTypes: false}`: an object keeps type
+  // consumption on, and that forks a dts dev worker which survives a hard exit
+  // holding our stdout pipe, leaving `sanity dev` unquittable under a wrapper.
+  it('disables dts entirely so no expose shims compile and no dts dev worker is forked', () => {
     mockFederation.mockReturnValue([])
 
     runPlugin()
 
     expect(mockFederation).toHaveBeenCalledTimes(1)
-    expect(mockFederation.mock.calls[0][0].dts).toEqual({generateTypes: false})
+    expect(mockFederation.mock.calls[0][0].dts).toBe(false)
   })
 
   it('scopes plugins to the dev server and the federation build environment', () => {

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-module-federation.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-module-federation.ts
@@ -21,7 +21,7 @@ export function sanityModuleFederation({exposes, name}: FederationOptions): Plug
       disableDynamicRemoteTypeHints: true,
       remoteHmr: true,
     },
-    // Remote type generation stays off: it compiles the exposes with the
+    // Remote types stay off entirely: generation compiles the exposes with the
     // project's tsconfig, and that breaks twice over on real projects.
     // The exposes are generated .js/.jsx shims, which tsc refuses without
     // allowJs (TYPE-001/TS6504) — no app template sets it. And with allowJs
@@ -29,7 +29,13 @@ export function sanityModuleFederation({exposes, name}: FederationOptions): Plug
     // are noEmit projects never written to be declaration-emittable: TS2742
     // (non-portable inferred types, endemic under pnpm) and TS4082 (private
     // names in default exports) then fail the compile just the same.
-    dts: {generateTypes: false},
+    //
+    // `false` rather than `{generateTypes: false}`: an object still leaves type
+    // *consumption* on, which forks a dts dev worker that inherits our stdio and
+    // is only asked to exit over IPC when vite closes cleanly. Any hard exit
+    // strands it, and a stranded worker holds the stdout pipe open, so a wrapper
+    // like turbo waits for EOF forever and `sanity dev` can't be quit.
+    dts: false,
     exposes,
     filename: `${FEDERATION_FILE_NAME}.js`,
     manifest: true,


### PR DESCRIPTION
### Description

`sanity dev` for a workbench app often can't be quit: Ctrl-C appears to do nothing and the terminal has to be killed from elsewhere.

The app's federation remote passed `dts: {generateTypes: false}`. Upstream only skips its dts plugins when `dts === false` - an object leaves type *consumption* on, which forks `@module-federation/dts-plugin`'s `fork-dev-worker.js` with `stdio: ['inherit', 'inherit', 'inherit', 'ipc']`. That worker is only cleaned up on vite's `httpServer` `close` event, and `exit()` merely sends an IPC message: no kill, no wait.

So any exit that skips graceful teardown - Ctrl-C during startup, the 5s teardown grace expiring, a signal that reaches the CLI but not the process group - strands the worker holding our stdout. A stranded worker means the pipe never reaches EOF, so a wrapper like `turbo run dev --ui=tui` waits for output to close forever. Measured before the fix: hard-exit the CLI and the pipes stayed open indefinitely. The same leak also accumulates orphans - I had four on this machine, the oldest eight days old.

Workbench neither generates nor consumes remote types, so `dts: false` is the honest setting and there is no worker to strand.

### What to review

Whether dropping the dts plugins entirely is safe for the federation surface. With `generateTypes` already off, the remaining plugin only consumed remote types, which workbench never does - types come from the `sanity/workbench` package.

Verified against `fixtures/federated-studio`: no worker forked while dev runs (was one per dev server), `SIGKILL` on the CLI now closes the pipes in ~900ms so a wrapper exits, Ctrl-C quits in 17-75ms across plain, startup-window, live-HMR-client and mid-rebuild states with nothing left listening. Dev still serves the shell, `remote-entry.js` and `mf-manifest.json`; `sanity build` output is unchanged.

### Testing

The TYPE-001 regression test now asserts `dts` is `false` rather than `{generateTypes: false}`, which covers the forked worker as well as the original tsconfig failure.