### PR TITLE
feat(workbench): deploy dock placement as a dock_item interface

### DIFF
--- a/.changeset/wide-pandas-listen.md
+++ b/.changeset/wide-pandas-listen.md
@@ -1,0 +1,6 @@
+---
+'@sanity/workbench-cli': minor
+'@sanity/cli': minor
+---
+
+Deploy an app's dock placement as a `dock_item` interface, overridable with a `dock_item` view

--- a/packages/@sanity/cli/src/actions/dev/servers/getDevServerConfig.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/getDevServerConfig.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import {type CliConfig, getSanityEnvVar, type Output} from '@sanity/cli-core'
 import {logSymbols, spinner} from '@sanity/cli-core/ux'
-import {isWorkbenchApp, resolveAppId} from '@sanity/workbench-cli'
+import {isWorkbenchApp, resolveAppId, resolveViews} from '@sanity/workbench-cli'
 
 import {type DevServerOptions} from '../../../server/devServer.js'
 import {determineIsApp} from '../../../util/determineIsApp.js'
@@ -63,7 +63,7 @@ export function getDevServerConfig({
     // view: the runtime/federation skip the `./App` render path entirely.
     entry: app?.entry,
     exposes: isWorkbenchApp(app)
-      ? {config: app.config, services: app.services, views: app.views}
+      ? {config: app.config, services: app.services, views: resolveViews(app)}
       : undefined,
     // `devAction` passes an explicit port when a running workbench claimed the
     // configured one; otherwise the shared resolution stands.

--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -246,6 +246,32 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     )
   })
 
+  test('accepts a dock_item view alongside an entry — placement is not a surface', () => {
+    expect(
+      DefineAppInputSchema.safeParse(
+        validInput({
+          entry: './src/App.tsx',
+          views: [{name: 'dock', src: './src/dockItem.tsx', type: 'dock_item'}],
+        }),
+      ).success,
+    ).toBe(true)
+  })
+
+  test('rejects more than one dock_item view', () => {
+    const result = DefineAppInputSchema.safeParse(
+      validInput({
+        views: [
+          {name: 'dock', src: './src/a.tsx', type: 'dock_item'},
+          {name: 'dock-2', src: './src/b.tsx', type: 'dock_item'},
+        ],
+      }),
+    )
+    expect(result.success).toBe(false)
+    expect(
+      result.error?.issues.some((issue) => /at most one `dock_item`/.test(issue.message)),
+    ).toBe(true)
+  })
+
   test('rejects more than one panel view', () => {
     const result = DefineAppInputSchema.safeParse(
       validInput({
@@ -305,6 +331,7 @@ describe('type surface', () => {
 describe('interface union (entry vs views)', () => {
   type Base = {name: string; organizationId: string; slug: string; title: string}
   type PanelView = {name: string; src: string; type: 'panel'}
+  type DockItemView = {name: string; src: string; type: 'dock_item'}
 
   test('allows an app entry without panel views', () => {
     expectTypeOf<Base & {entry: string}>().toExtend<DefineAppInput>()
@@ -316,6 +343,10 @@ describe('interface union (entry vs views)', () => {
 
   test('rejects declaring an app entry and panel views together', () => {
     expectTypeOf<Base & {entry: string; views: PanelView[]}>().not.toExtend<DefineAppInput>()
+  })
+
+  test('allows a dock item next to an app entry', () => {
+    expectTypeOf<Base & {entry: string; views: DockItemView[]}>().toExtend<DefineAppInput>()
   })
 })
 

--- a/packages/@sanity/workbench-cli/src/__tests__/defineView.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineView.test.ts
@@ -1,7 +1,12 @@
 import {describe, expect, expectTypeOf, test} from 'vitest'
 
 import {VIEW_CONTRACT_VERSION} from '../contract.js'
-import {type DefinedView, type PanelViewProps, unstable_defineView} from '../defineView.js'
+import {
+  type DefinedView,
+  type DockItemViewProps,
+  type PanelViewProps,
+  unstable_defineView,
+} from '../defineView.js'
 
 const title = ({view}: PanelViewProps) => view.name
 const panel = ({view}: PanelViewProps) => view.name
@@ -44,6 +49,18 @@ describe('type surface', () => {
         return null
       },
     })
+  })
+
+  test('takes a bare component for a single-slot view type', () => {
+    const dockItem = unstable_defineView('dock_item', ({icon, view}) => {
+      expectTypeOf(view.title).toEqualTypeOf<string>()
+      expectTypeOf(view.priority).toEqualTypeOf<number | undefined>()
+      expectTypeOf(icon.variant).toEqualTypeOf<'avatar' | 'image'>()
+      return null
+    })
+
+    expectTypeOf(dockItem.components).toBeFunction()
+    expectTypeOf(dockItem.components).parameter(0).toEqualTypeOf<DockItemViewProps>()
   })
 
   test('rejects an unknown view type', () => {

--- a/packages/@sanity/workbench-cli/src/__tests__/resolveViews.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/resolveViews.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, test} from 'vitest'
+
+import {resolveViews} from '../resolveViews.js'
+
+const app = {name: 'drop-desk', title: 'Drop Desk'}
+const dockItem = {name: 'dock', src: './src/dockItem.tsx', type: 'dock_item'} as const
+const panel = {name: 'feed', src: './src/Feed.tsx', type: 'panel'} as const
+
+describe('resolveViews', () => {
+  test('leaves an app that says nothing about the dock without a dock item', () => {
+    expect(resolveViews(app)).toEqual([])
+    expect(resolveViews({...app, views: [panel]})).toEqual([panel])
+  })
+
+  test('generates a dock item from the declared placement', () => {
+    expect(resolveViews({...app, group: 'dock.system', priority: 20})).toEqual([
+      {
+        generated: true,
+        metadata: {group: 'dock.system', priority: 20},
+        name: 'drop-desk',
+        src: './.sanity/federation/interfaces/dock-item.js',
+        type: 'dock_item',
+      },
+    ])
+  })
+
+  test('generates one from either half of the placement on its own', () => {
+    expect(resolveViews({...app, group: 'dock.user'})[0]?.metadata).toEqual({group: 'dock.user'})
+    // 0 is a real priority, not an absent one.
+    expect(resolveViews({...app, priority: 0})[0]?.metadata).toEqual({priority: 0})
+  })
+
+  test('carries the placement on a declared dock item instead of generating one', () => {
+    expect(resolveViews({...app, priority: 5, views: [panel, dockItem]})).toEqual([
+      panel,
+      {...dockItem, metadata: {priority: 5}},
+    ])
+  })
+
+  test('a declared dock item needs no placement', () => {
+    expect(resolveViews({...app, views: [{...dockItem, title: 'Inbox'}]})).toEqual([
+      {...dockItem, metadata: {}, title: 'Inbox'},
+    ])
+  })
+})

--- a/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
@@ -78,6 +78,46 @@ describe('resolveWorkbenchApp', () => {
     })
   })
 
+  test('lifts the declared placement onto a generated dock item', () => {
+    const config = asConfig(
+      unstable_defineApp({
+        group: 'dock.system',
+        name: 'my-app',
+        organizationId: 'org-123',
+        priority: 20,
+        slug: 'my-app',
+        title: 'My App',
+      }),
+    )
+
+    expect(resolveWorkbenchApp(config)?.views).toEqual([
+      {
+        generated: true,
+        metadata: {group: 'dock.system', priority: 20},
+        name: 'my-app',
+        src: './.sanity/federation/interfaces/dock-item.js',
+        type: 'dock_item',
+      },
+    ])
+  })
+
+  test('keeps a declared dock item as the app view it is', () => {
+    const config = asConfig(
+      unstable_defineApp({
+        entry: './src/App.tsx',
+        name: 'my-app',
+        organizationId: 'org-123',
+        slug: 'my-app',
+        title: 'My App',
+        views: [{name: 'dock', src: './src/dockItem.tsx', type: 'dock_item'}],
+      }),
+    )
+
+    expect(resolveWorkbenchApp(config)?.views).toEqual([
+      {metadata: {}, name: 'dock', src: './src/dockItem.tsx', type: 'dock_item'},
+    ])
+  })
+
   test('throws when an app declares both an entry and panel views', () => {
     const config = asConfig(
       unstable_defineApp({

--- a/packages/@sanity/workbench-cli/src/_exports/index.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/index.ts
@@ -19,8 +19,11 @@ export type {
 export {unstable_defineView} from '../defineView.js'
 export type {
   DefinedView,
+  DockItemViewProps,
+  IconDescriptor,
   PanelComponent,
   PanelViewComponents,
   PanelViewProps,
   ViewComponentsByType,
 } from '../defineView.js'
+export {type ResolvedView, resolveViews} from '../resolveViews.js'

--- a/packages/@sanity/workbench-cli/src/actions/build/views/__tests__/artifact.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/views/__tests__/artifact.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, test} from 'vitest'
+
+import {viewArtifacts} from '../artifact.js'
+
+const context = {resolveImport: (src: string) => `../../${src}`}
+
+describe('viewArtifacts', () => {
+  test('expands a panel into one exposed artifact per component slot', () => {
+    const artifacts = viewArtifacts([{name: 'feed', src: './src/Feed.tsx', type: 'panel'}])
+
+    expect(artifacts.map((artifact) => [artifact.expose, artifact.path])).toEqual([
+      ['./views/feed/title', 'views/feed/title.js'],
+      ['./views/feed/panel', 'views/feed/panel.js'],
+    ])
+    expect(artifacts[0]?.source(context)).toContain('import view from "../.././src/Feed.tsx"')
+  })
+
+  test('renders a declared dock item from its source, generating nothing', () => {
+    const artifacts = viewArtifacts([{name: 'dock', src: './src/dockItem.tsx', type: 'dock_item'}])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]?.expose).toBe('./views/dock/item')
+    expect(artifacts[0]?.source(context)).toContain('import view from "../.././src/dockItem.tsx"')
+  })
+
+  test('writes the source of a generated dock item, so it loads like any other view', () => {
+    const [source, render] = viewArtifacts([
+      {
+        generated: true,
+        name: 'drop-desk',
+        src: './.sanity/federation/interfaces/dock-item.js',
+        type: 'dock_item',
+      },
+    ])
+
+    // The module the render artifact imports renders nothing, so the workbench
+    // falls back to its default dock rendering.
+    expect(source?.path).toBe('interfaces/dock-item.js')
+    expect(source?.expose).toBeUndefined()
+    expect(source?.source(context)).toContain(
+      "export default {components: () => null, type: 'dock_item', version: 1}",
+    )
+    expect(render?.source(context)).toContain(
+      'import view from "../.././.sanity/federation/interfaces/dock-item.js"',
+    )
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/build/views/artifact.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/views/artifact.ts
@@ -1,4 +1,5 @@
-import {type InterfaceType, VIEW_COMPONENTS} from '../../../contract.js'
+import {type InterfaceType, VIEW_COMPONENTS, VIEW_CONTRACT_VERSION} from '../../../contract.js'
+import {GENERATED_DOCK_ITEM_FILE} from '../../../resolveViews.js'
 import {type GeneratedArtifact} from '../artifact.js'
 import {renderRemote} from '../render-remote.js'
 
@@ -18,6 +19,22 @@ export interface InterfaceArtifact {
   src: string
   /** Interface type — selects which components the build expands. */
   type: InterfaceType
+
+  /** The build writes this view's `src` too — see {@link GENERATED_DOCK_ITEM}. */
+  generated?: boolean
+}
+
+/**
+ * The `src` of a dock item the app placed but didn't author: an inlined
+ * `unstable_defineView('dock_item', ...)` that renders nothing, so the workbench
+ * keeps its own dock rendering.
+ */
+const GENERATED_DOCK_ITEM: GeneratedArtifact = {
+  path: GENERATED_DOCK_ITEM_FILE,
+  source: () => `// This file is auto-generated on 'sanity build' / 'sanity dev'
+// Modifications to this file are automatically discarded
+export default {components: () => null, type: 'dock_item', version: ${VIEW_CONTRACT_VERSION}}
+`,
 }
 
 /**
@@ -32,6 +49,7 @@ export interface InterfaceArtifact {
 export function viewArtifacts(views: readonly InterfaceArtifact[]): GeneratedArtifact[] {
   const artifacts: GeneratedArtifact[] = []
   for (const view of views) {
+    if (view.generated) artifacts.push(GENERATED_DOCK_ITEM)
     for (const component of VIEW_COMPONENTS[view.type]) {
       artifacts.push({
         expose: `./${VIEWS_DIR_NAME}/${view.name}/${component}`,

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-extension-artifacts.node.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-extension-artifacts.node.test.ts
@@ -76,6 +76,38 @@ describe('sanityExtensionArtifacts', () => {
     expect(title).toContain('view.components["title"]')
   })
 
+  it('writes both halves of a generated dock item: its source and its render artifact', () => {
+    const root = makeRoot()
+    runConfigResolved(
+      sanityExtensionArtifacts({
+        artifacts: workbenchArtifacts({
+          views: [
+            {
+              generated: true,
+              metadata: {group: 'dock.user'},
+              name: 'drop-desk',
+              src: './.sanity/federation/interfaces/dock-item.js',
+              type: 'dock_item',
+            },
+          ],
+        }),
+      }),
+      root,
+    )
+
+    const source = fs.readFileSync(
+      path.join(root, '.sanity/federation/interfaces/dock-item.js'),
+      'utf8',
+    )
+    expect(source).toContain('components: () => null')
+
+    const item = fs.readFileSync(
+      path.join(root, '.sanity/federation/views/drop-desk/item.js'),
+      'utf8',
+    )
+    expect(item).toContain('import view from "../../interfaces/dock-item.js"')
+  })
+
   it('writes nothing when no views are declared', () => {
     const root = makeRoot()
     runConfigResolved(sanityExtensionArtifacts({artifacts: workbenchArtifacts({views: []})}), root)

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
@@ -72,6 +72,39 @@ describe('buildExposes', () => {
     })
   })
 
+  test("sends a dock item's placement as its metadata, under the app's deployed title", () => {
+    const exposes: WorkbenchExposes = {
+      views: [
+        {
+          generated: true,
+          metadata: {group: 'dock.system', priority: 20},
+          name: 'drop-desk',
+          src: './.sanity/federation/interfaces/dock-item.js',
+          type: 'dock_item',
+        },
+      ],
+    }
+    expect(buildExposes(exposes, {...context, exposesAppView: false})).toEqual([
+      {
+        metadata: {group: 'dock.system', priority: 20},
+        moduleId: 'views/drop-desk',
+        name: 'drop-desk',
+        title: 'Drop Desk',
+        type: 'dock_item',
+        version: '1.2.3',
+      },
+    ])
+  })
+
+  test('keeps a declared dock item title over the app title', () => {
+    const exposes: WorkbenchExposes = {
+      views: [
+        {metadata: {}, name: 'dock', src: './src/dockItem.tsx', title: 'Inbox', type: 'dock_item'},
+      ],
+    }
+    expect(buildExposes(exposes, {...context, exposesAppView: false})[0]?.title).toBe('Inbox')
+  })
+
   test('forwards the declared type unchanged for the server to validate', () => {
     const exposes: WorkbenchExposes = {
       views: [{name: 'feed', src: './src/feed.tsx', type: 'panel'}],
@@ -99,5 +132,25 @@ describe('summarizeExposes', () => {
 
   test('is empty when nothing is exposed', () => {
     expect(summarizeExposes({})).toEqual({exposes: [], lines: []})
+  })
+
+  test('reports a declared dock item, but not a generated one', () => {
+    const declared = summarizeExposes({
+      views: [{metadata: {}, name: 'dock', src: './src/dockItem.tsx', type: 'dock_item'}],
+    })
+    expect(declared.lines).toEqual(['Views:\n  dock: ./src/dockItem.tsx'])
+
+    const generated = summarizeExposes({
+      views: [
+        {
+          generated: true,
+          metadata: {group: 'dock.user'},
+          name: 'drop-desk',
+          src: './.sanity/federation/interfaces/dock-item.js',
+          type: 'dock_item',
+        },
+      ],
+    })
+    expect(generated).toEqual({exposes: [], lines: []})
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/getWorkbench.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/getWorkbench.test.ts
@@ -102,6 +102,20 @@ describe('assertDeployable', () => {
     ).not.toThrow()
   })
 
+  test('passes when the app declares a dock item to render', () => {
+    expect(() =>
+      workbench({
+        views: [{name: 'dock', src: './src/dockItem.tsx', type: 'dock_item'}],
+      }).assertDeployable(),
+    ).not.toThrow()
+  })
+
+  test('throws when placement is all the app declares — a generated item renders nothing', () => {
+    expect(() => workbench({group: 'dock.user', priority: 20}).assertDeployable()).toThrow(
+      'declares no entry, views, services or config',
+    )
+  })
+
   test('passes when a media library declares a field', () => {
     expect(() =>
       mediaLibrary({

--- a/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
@@ -31,14 +31,18 @@ export function buildExposes(
     })
   }
   for (const view of exposes.views ?? []) {
-    records.push({
-      metadata: null,
-      moduleId: interfaceModuleId('panel', view.name),
+    const record = {
+      moduleId: interfaceModuleId(view.type, view.name),
       name: view.name,
-      title: view.title ?? view.name,
-      type: 'panel',
+      // A dock item stands in for the app in the dock, so it borrows its title.
+      title: view.title ?? (view.type === 'dock_item' ? appTitle : view.name),
       version,
-    })
+    }
+    records.push(
+      view.type === 'dock_item'
+        ? {...record, metadata: view.metadata, type: view.type}
+        : {...record, metadata: null, type: view.type},
+    )
   }
   for (const service of exposes.services ?? []) {
     records.push({
@@ -95,7 +99,8 @@ export function summarizeExposes({services, views}: WorkbenchExposes): {
     title: decl.title ?? decl.name,
     type: decl.type,
   })
-  const viewExposes = (views ?? []).map((view) => toExpose(view))
+  // A generated dock item is no entry point the app authored.
+  const viewExposes = (views ?? []).filter((view) => !view.generated).map((view) => toExpose(view))
   const serviceExposes = (services ?? []).map((service) => toExpose(service))
 
   const lines: string[] = []

--- a/packages/@sanity/workbench-cli/src/actions/deploy/getWorkbench.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/getWorkbench.ts
@@ -36,15 +36,17 @@ export function getWorkbench(
   if (!app) return null
 
   const {config, entry, isSingleton, services, views} = app
+  // A generated dock item renders nothing, so it alone isn't worth hosting.
+  const hasInterfaces = !!entry || views.some((view) => !view.generated) || services.length > 0
 
   return {
     ...app,
 
     deploySingletonConfig: !!isSingleton && !!config,
-    hasInterfaces: !!entry || views.length > 0 || services.length > 0,
+    hasInterfaces,
 
     assertDeployable() {
-      if (!entry && views.length === 0 && services.length === 0 && !config) {
+      if (!hasInterfaces && !config) {
         throw new Error(
           'Nothing to deploy: the app declares no entry, views, services or config. ' +
             'Add at least one to the app config.',

--- a/packages/@sanity/workbench-cli/src/actions/deploy/viewDeployment.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/viewDeployment.ts
@@ -7,7 +7,7 @@ import {z} from 'zod/mini'
 const viewRecordSchema = z.looseObject({
   name: z.string().check(z.regex(/^[a-zA-Z0-9_-]+$/, 'View `name` must match /^[a-zA-Z0-9_-]+$/')),
   src: z.string(),
-  type: z.enum(['panel']),
+  type: z.enum(['dock_item', 'panel']),
 })
 
 /**
@@ -30,7 +30,7 @@ export type ViewDeploymentPayload = z.infer<typeof viewDeploymentPayloadSchema>
  */
 export function buildViewDeploymentPayload(input: {
   applicationId: string
-  views?: ReadonlyArray<Record<string, unknown>>
+  views?: readonly object[]
 }): ViewDeploymentPayload {
   return viewDeploymentPayloadSchema.parse({
     applicationId: input.applicationId,

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -79,14 +79,49 @@ describe('deriveInterfaces', () => {
     ])
   })
 
-  test('carries null metadata on every interface (not yet populated)', () => {
+  test('leaves metadata null on every interface but the dock item', () => {
     const app = workbenchApp({
       entry: './src/App.tsx',
+      group: 'dock.user',
       services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
     })
-    expect(deriveInterfaces(app, {isApp: true})?.every((iface) => iface.metadata === null)).toBe(
-      true,
+    const metadataByType = Object.fromEntries(
+      (deriveInterfaces(app, {isApp: true}) ?? []).map((iface) => [iface.type, iface.metadata]),
     )
+    expect(metadataByType).toEqual({app: null, dock_item: {group: 'dock.user'}, worker: null})
+  })
+
+  test('forwards the placement as a dock item, so dev and deploy read one source', () => {
+    const app = workbenchApp({entry: './src/App.tsx', group: 'dock.user', priority: 20})
+    expect(deriveInterfaces(app, {isApp: true})?.[0]).toEqual({
+      id: 'test-app-dock_item-test-app',
+      metadata: {group: 'dock.user', priority: 20},
+      moduleId: 'views/test-app',
+      name: 'test-app',
+      src: './.sanity/federation/interfaces/dock-item.js',
+      title: 'Test App',
+      type: 'dock_item',
+      version: '1',
+    })
+  })
+
+  test('serves a declared dock item from its own source file', () => {
+    const app = workbenchApp({
+      priority: 5,
+      views: [{name: 'dock', src: './src/DockItem.tsx', title: 'Inbox', type: 'dock_item'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {
+        id: 'test-app-dock_item-dock',
+        metadata: {priority: 5},
+        moduleId: 'views/dock',
+        name: 'dock',
+        src: './src/DockItem.tsx',
+        title: 'Inbox',
+        type: 'dock_item',
+        version: '1',
+      },
+    ])
   })
 
   test('omits the app interface for a dock-only app (no entry)', () => {

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/registry.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/registry.test.ts
@@ -151,6 +151,29 @@ describe('registerDevServer', () => {
     expect(getRegisteredServers()[0]).toMatchObject({id: 'app-abc', projectId: 'x1g7jygt'})
   })
 
+  test('keeps a dock item and its placement on re-read', () => {
+    const dockItem = {
+      id: 'app-abc-dock_item-drop-desk',
+      metadata: {group: 'dock.user', priority: 20},
+      moduleId: 'views/drop-desk',
+      name: 'drop-desk',
+      src: './.sanity/federation/interfaces/dock-item.js',
+      title: 'Drop Desk',
+      type: 'dock_item',
+      version: '1',
+    } as const
+
+    registerDevServer({
+      host: 'localhost',
+      interfaces: [dockItem],
+      port: 3334,
+      type: 'coreApp',
+      workDir: '/tmp/project',
+    })
+
+    expect(getRegisteredServers()[0]?.interfaces).toEqual([dockItem])
+  })
+
   test('omits optional metadata when not provided', () => {
     registerDevServer({host: 'localhost', port: 3334, type: 'studio', workDir: '/tmp/project'})
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -7,6 +7,7 @@ import {
   VIEW_CONTRACT_VERSION,
 } from '../../contract.js'
 import {isWorkbenchApp, readConfig} from '../../defineApp.js'
+import {resolveViews} from '../../resolveViews.js'
 import {FEDERATION_FILE_NAME, RUNTIME_DIR} from '../build/vite/constants.js'
 import {type DevServerManifest} from './registry.js'
 
@@ -35,18 +36,19 @@ export function deriveInterfaces(
 
   const interfaceId = (type: string, name: string): string => `${app.name}-${type}-${name}`
 
-  const views = (app.views ?? []).map(
-    (view): DevServerInterface => ({
-      id: interfaceId('panel', view.name),
-      metadata: null,
-      moduleId: interfaceModuleId('panel', view.name),
+  const views = resolveViews(app).map((view): DevServerInterface => {
+    const record = {
+      id: interfaceId(view.type, view.name),
+      moduleId: interfaceModuleId(view.type, view.name),
       name: view.name,
       src: view.src,
-      title: view.title ?? view.name,
-      type: 'panel',
+      title: view.title ?? (view.type === 'dock_item' ? app.title : view.name),
       version: String(VIEW_CONTRACT_VERSION),
-    }),
-  )
+    }
+    return view.type === 'dock_item'
+      ? {...record, metadata: view.metadata, type: view.type}
+      : {...record, metadata: null, type: view.type}
+  })
 
   const services = (app.services ?? []).map(
     (service): DevServerInterface => ({

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -17,7 +17,7 @@ import {
 } from '@sanity/cli-core'
 import {z} from 'zod/mini'
 
-import {AppInterfaceMetadataSchema} from '../../contract.js'
+import {DockItemMetadataSchema} from '../../contract.js'
 import {canonicalizeWatchDir} from './canonicalizeWatchDir.js'
 import {getProcessStartTime, isOurProcess} from './processLiveness.js'
 
@@ -74,9 +74,10 @@ const interfaceBaseFields = {
 const devServerInterfaceSchema = z.discriminatedUnion('type', [
   z.object({
     ...interfaceBaseFields,
-    metadata: z.nullable(AppInterfaceMetadataSchema),
-    type: z.literal('app'),
+    metadata: z.nullable(DockItemMetadataSchema),
+    type: z.literal('dock_item'),
   }),
+  z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('app')}),
   z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('panel')}),
   z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('worker')}),
 ])

--- a/packages/@sanity/workbench-cli/src/contract.ts
+++ b/packages/@sanity/workbench-cli/src/contract.ts
@@ -31,6 +31,7 @@ export interface ViewComponentBaseProps<TView> {
  * @internal
  */
 export const VIEW_COMPONENTS = {
+  dock_item: ['item'],
   panel: ['title', 'panel'],
 } as const satisfies Record<string, readonly string[]>
 
@@ -41,17 +42,17 @@ export type InterfaceType = keyof typeof VIEW_COMPONENTS
 export type ServiceType = 'worker'
 
 /**
- * The `app` interface's dock-placement metadata. Interface metadata is
- * discriminated on `type`; `app` is the only type with a shape so far.
+ * Where an app renders in the dock. `group` stays a loose string — the
+ * workbench, not the CLI, decides which groups exist.
  * @internal
  */
-export const AppInterfaceMetadataSchema = z.object({
+export const DockItemMetadataSchema = z.object({
   group: z.optional(z.string()),
   priority: z.optional(z.number()),
 })
 
 /** @internal */
-export type AppInterfaceMetadata = z.infer<typeof AppInterfaceMetadataSchema>
+export type DockItemMetadata = z.infer<typeof DockItemMetadataSchema>
 
 /**
  * The module-federation id a build exposes an interface at. Dev stamps the same
@@ -63,6 +64,7 @@ export function interfaceModuleId(type: string, name: string): string {
     case 'app': {
       return 'App'
     }
+    case 'dock_item':
     case 'panel': {
       return `views/${name}`
     }
@@ -95,8 +97,19 @@ const PanelViewSchema = z.object({
   ...interfaceDeclarationFields('View'),
 })
 
+const DockItemViewSchema = z.object({
+  type: z.literal('dock_item'),
+  ...interfaceDeclarationFields('View'),
+})
+
 /** @internal */
-export const InterfaceDeclarationSchema = z.discriminatedUnion('type', [PanelViewSchema])
+export const InterfaceDeclarationSchema = z.discriminatedUnion('type', [
+  DockItemViewSchema,
+  PanelViewSchema,
+])
+
+/** @internal */
+export type InterfaceDeclaration = z.infer<typeof InterfaceDeclarationSchema>
 
 const WorkerServiceSchema = z.object({
   type: z.literal('worker'),

--- a/packages/@sanity/workbench-cli/src/defineApp.ts
+++ b/packages/@sanity/workbench-cli/src/defineApp.ts
@@ -29,6 +29,9 @@ const DockGroupSchema = z.enum(['dock.system', 'dock.applications', 'dock.user']
  */
 export type DockGroup = z.output<typeof DockGroupSchema>
 
+const countViews = (views: readonly {type: string}[] | undefined, type: string) =>
+  (views ?? []).filter((view) => view.type === type).length
+
 /**
  * Runtime-validation schema for `unstable_defineApp`.
  * @internal
@@ -118,25 +121,34 @@ export const DefineAppInputSchema = z
     }),
   )
   .check(
-    // An app exposes one interface kind: an app view (`entry`) or panels.
+    // A dock item is placement, not a surface, so it rides with an entry or a panel.
     z.refine(
-      (input) => !(input.entry !== undefined && (input.views?.length ?? 0) > 0),
+      (input) => !(input.entry !== undefined && countViews(input.views, 'panel') > 0),
       'An app cannot expose both an app view (`entry`) and panel views. Declare one or the other.',
     ),
   )
   .check(
     z.refine(
-      (input) => (input.views?.length ?? 0) <= 1,
+      (input) => countViews(input.views, 'panel') <= 1,
       'An app can expose at most one panel view.',
     ),
   )
+  .check(
+    // Only one item renders in the dock, so a second declaration would be dropped.
+    z.refine(
+      (input) => countViews(input.views, 'dock_item') <= 1,
+      'An app can declare at most one `dock_item` view.',
+    ),
+  )
+
+type ViewDeclaration = NonNullable<z.output<typeof DefineAppInputSchema>['views']>[number]
 
 /**
  * User-facing input for `unstable_defineApp`. Excludes the internal
  * `applicationType`, `isSingleton`, and `config` — validated by the
  * schema but not part of the public surface (Sanity-owned apps set them via
- * `@ts-expect-error`). A union so an app declares an app `entry` or `views`,
- * never both.
+ * `@ts-expect-error`). A union so an app declares an app `entry` or panel
+ * `views`, never both; a `dock_item` view goes with either.
  * @public
  */
 export type DefineAppInput = Omit<
@@ -144,8 +156,8 @@ export type DefineAppInput = Omit<
   'applicationType' | 'config' | 'entry' | 'isSingleton' | 'views'
 > &
   (
-    | {entry?: never; views?: NonNullable<z.output<typeof DefineAppInputSchema>['views']>}
-    | {entry?: string; views?: never}
+    | {entry?: never; views?: ViewDeclaration[]}
+    | {entry?: string; views?: Extract<ViewDeclaration, {type: 'dock_item'}>[]}
   )
 
 /**

--- a/packages/@sanity/workbench-cli/src/defineView.ts
+++ b/packages/@sanity/workbench-cli/src/defineView.ts
@@ -4,6 +4,7 @@ import {
   type ViewComponent,
   type ViewComponentBaseProps,
 } from './contract.js'
+import {type DockGroup} from './defineApp.js'
 
 /**
  * Props a panel component receives: its interface record, minus the
@@ -36,10 +37,34 @@ export interface PanelViewComponents {
 export type PanelComponent = keyof PanelViewComponents
 
 /**
- * The components each interface type exposes, keyed by type.
+ * The icon the host resolved for the app: the declared SVG, or the avatar it
+ * falls back to. `color` names a design-system avatar color.
+ * @public
+ */
+export type IconDescriptor =
+  | {color: string; initials: string; variant: 'avatar'}
+  | {svg: string; variant: 'image'}
+
+/**
+ * Props a dock-item component receives: its dock record, with the placement
+ * metadata flattened in, plus the icon the host would render by default.
+ * @public
+ */
+export type DockItemViewProps = ViewComponentBaseProps<{
+  group?: DockGroup
+  name: string
+  priority?: number
+  title: string
+  type: 'dock_item'
+}> & {icon: IconDescriptor}
+
+/**
+ * The components each interface type exposes, keyed by type. A type with a
+ * single slot takes the component itself, not a record.
  * @public
  */
 export interface ViewComponentsByType {
+  dock_item: ViewComponent<DockItemViewProps>
   panel: PanelViewComponents
 }
 

--- a/packages/@sanity/workbench-cli/src/resolveViews.ts
+++ b/packages/@sanity/workbench-cli/src/resolveViews.ts
@@ -1,0 +1,52 @@
+import {RUNTIME_DIR} from './actions/build/vite/constants.js'
+import {type DockItemMetadata, type InterfaceDeclaration, type InterfaceType} from './contract.js'
+
+/** Path relative to {@link RUNTIME_DIR}, so the build writes it where it belongs. @internal */
+export const GENERATED_DOCK_ITEM_FILE = 'interfaces/dock-item.js'
+
+const GENERATED_DOCK_ITEM_SRC = `./${RUNTIME_DIR}/${GENERATED_DOCK_ITEM_FILE}`
+
+interface ResolvedViewBase {
+  name: string
+  src: string
+
+  /** The build writes this view's `src`; the app authored no module for it. */
+  generated?: boolean
+  title?: string
+}
+
+/**
+ * A view after normalization, discriminated like the interface record it deploys
+ * as: only a `dock_item` carries placement metadata.
+ * @internal
+ */
+export type ResolvedView =
+  | (ResolvedViewBase & {metadata: DockItemMetadata; type: 'dock_item'})
+  | (ResolvedViewBase & {type: Exclude<InterfaceType, 'dock_item'>})
+
+interface ViewSource {
+  name: string
+
+  group?: string
+  priority?: number
+  views?: readonly InterfaceDeclaration[]
+}
+
+/**
+ * The app's views, plus the dock item its placement implies. A declared
+ * `dock_item` overrides the generated one and carries the placement instead.
+ * @internal
+ */
+export function resolveViews(app: ViewSource): ResolvedView[] {
+  const metadata: DockItemMetadata = {group: app.group, priority: app.priority}
+  const views = (app.views ?? []).map(
+    (view): ResolvedView => (view.type === 'dock_item' ? {...view, metadata} : view),
+  )
+
+  const declaresPlacement = app.group !== undefined || app.priority !== undefined
+  if (!declaresPlacement || views.some((view) => view.type === 'dock_item')) return views
+  return [
+    ...views,
+    {generated: true, metadata, name: app.name, src: GENERATED_DOCK_ITEM_SRC, type: 'dock_item'},
+  ]
+}

--- a/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
@@ -7,6 +7,7 @@
 import {type AppVisibility, type CliConfig} from '@sanity/cli-core'
 
 import {type DefineAppInput, isWorkbenchApp, readConfig, type WorkbenchApp} from './defineApp.js'
+import {type ResolvedView, resolveViews} from './resolveViews.js'
 import {formatWorkbenchAppErrors, validateWorkbenchApp} from './validateWorkbenchApp.js'
 
 /**
@@ -17,7 +18,7 @@ import {formatWorkbenchAppErrors, validateWorkbenchApp} from './validateWorkbenc
 export interface WorkbenchExposes {
   config?: WorkbenchApp['config']
   services?: DefineAppInput['services']
-  views?: DefineAppInput['views']
+  views?: readonly ResolvedView[]
 }
 
 /** @public */
@@ -32,8 +33,8 @@ export interface ResolvedWorkbenchApp {
   /** Hostname the application is created at on first deploy. */
   readonly slug: string
 
-  /** Dock panel views the app declares. */
-  readonly views: NonNullable<DefineAppInput['views']>
+  /** The views the app exposes, including the dock item its placement implies. */
+  readonly views: readonly ResolvedView[]
 
   /** Resolved app kind — `studio` or one of the SDK app types. */
   readonly applicationType?: string
@@ -72,7 +73,7 @@ export function resolveWorkbenchApp(
     organizationId: app.organizationId,
     services: app.services ?? [],
     slug: app.slug,
-    views: app.views ?? [],
+    views: resolveViews(app),
     visibility: app.visibility,
   }
 }

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -5,7 +5,7 @@ import {type AppVisibility, getGlobalCliClient} from '@sanity/cli-core'
 import {isStaging} from '@sanity/cli-core/util'
 import FormData from 'form-data'
 
-import {type AppInterfaceMetadata} from '../contract.js'
+import {type DockItemMetadata} from '../contract.js'
 import {APP_WORKBENCH_API_VERSION} from './apiVersion.js'
 
 export type ApplicationType = 'coreApp' | 'studio'
@@ -31,7 +31,8 @@ interface BrettInterfaceBase {
  * @internal
  */
 export type BrettInterface =
-  | (BrettInterfaceBase & {metadata: AppInterfaceMetadata | null; type: 'app'})
+  | (BrettInterfaceBase & {metadata: DockItemMetadata | null; type: 'dock_item'})
+  | (BrettInterfaceBase & {metadata: null; type: 'app'})
   | (BrettInterfaceBase & {metadata: null; type: 'panel'})
   | (BrettInterfaceBase & {metadata: null; type: 'worker'})
 


### PR DESCRIPTION
### Description

With the Brett migration there's no manifest left to carry an app's `group`/`priority`, and not every application has an app interface to hang them on. Both now deploy as the `metadata` of a new `dock_item` interface.

`group`/`priority` stay top-level on `unstable_defineApp` — they're normalized into a `dock_item` view at the resolve boundary (`resolveViews`), so build, deploy and dev all see one kind of view. An app that only declares placement gets a generated dock item whose source the build writes to `.sanity/federation/interfaces/dock-item.js`; it renders `null`, so the workbench keeps rendering its own dock item.

Declaring the interface explicitly takes over the rendering:

```ts
app: unstable_defineApp({
  name: 'notifications',
  title: 'Notifications',
  group: 'dock.system',
  views: [{type: 'dock_item', name: 'item', src: './src/dockItem.tsx'}],
})
```

That's the point of the null fallback: the next step is to have the generated module call `props.renderDefault()` against a component federated in from the workbench remote, so the default rendering can change without redeploying every app. This PR is what that gets measured against — whether crossing the island boundary creates React version conflicts.

Blocked on the server side before release: Brett's `INTERFACE_TYPES` is `['app', 'worker', 'asset_source', 'panel']` (a varchar enum in the DB), so it rejects `dock_item` today. The workbench's `InterfaceSchema` needs it too — an unknown interface type fails `LocalApplication.safeParse` and drops the whole local app from the dock in dev.

Brett requires `title` on every interface (`NOT NULL`, `min(1)`), so a dock item can't omit it: it sends the app's deployed title (so `--title` still wins) and a declared `title` overrides that. `metadata` is a shared nullable column there rather than per-type — the CLI's union is deliberately stricter.

Closes SDK-1921.

### What to review

- `resolveViews.ts` — the normalization, and that a dock item is only generated when the app declares no `dock_item` view
- `views/artifact.ts` — the generated source, and that it's written only for a generated item
- `buildExposes.ts` / `deriveInterfaces.ts` — a dock item borrows the app's title (the deployed one, so `--title` still wins) and is the only record carrying metadata
- `defineApp.ts` — the `entry`-vs-panels rules now count panels, so a dock item rides with either

### Testing

Unit tests across `resolveViews`, `viewArtifacts`, `buildExposes`, `deriveInterfaces`, `getWorkbench`, `defineApp`, `defineView` and the registry schema. Verified on a real `sanity build` of `fixtures/federated-studio`: both modules land under `.sanity/federation/` and the built manifest exposes `./views/federated-studio/item`.

