### PR TITLE
feat(workbench): render the host's dock item from a generated dock_item

### DIFF
--- a/.changeset/mighty-lions-render.md
+++ b/.changeset/mighty-lions-render.md
@@ -1,0 +1,5 @@
+---
+'@sanity/workbench-cli': minor
+---
+
+Render the workbench's own dock item from a generated `dock_item`, via `props.renderDefault()`

--- a/packages/@sanity/workbench-cli/src/actions/build/views/__tests__/artifact.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/views/__tests__/artifact.test.ts
@@ -33,13 +33,11 @@ describe('viewArtifacts', () => {
       },
     ])
 
-    // The module the render artifact imports renders nothing, so the workbench
-    // falls back to its default dock rendering.
+    // The module the render artifact imports renders the host's own dock item,
+    // and nothing at all against a host that offers none.
     expect(source?.path).toBe('interfaces/dock-item.js')
     expect(source?.expose).toBeUndefined()
-    expect(source?.source(context)).toContain(
-      "export default {components: () => null, type: 'dock_item', version: 1}",
-    )
+    expect(source?.source(context)).toContain('(props) => props.renderDefault?.() ?? null')
     expect(render?.source(context)).toContain(
       'import view from "../.././.sanity/federation/interfaces/dock-item.js"',
     )

--- a/packages/@sanity/workbench-cli/src/actions/build/views/artifact.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/views/artifact.ts
@@ -26,14 +26,19 @@ export interface InterfaceArtifact {
 
 /**
  * The `src` of a dock item the app placed but didn't author: an inlined
- * `unstable_defineView('dock_item', ...)` that renders nothing, so the workbench
- * keeps its own dock rendering.
+ * `unstable_defineView('dock_item', ...)` that renders the host's default, so the
+ * dock item stays the workbench's to change and never enters the app's bundle.
+ * Renders nothing against a host that offers no default.
  */
 const GENERATED_DOCK_ITEM: GeneratedArtifact = {
   path: GENERATED_DOCK_ITEM_FILE,
   source: () => `// This file is auto-generated on 'sanity build' / 'sanity dev'
 // Modifications to this file are automatically discarded
-export default {components: () => null, type: 'dock_item', version: ${VIEW_CONTRACT_VERSION}}
+export default {
+  components: (props) => props.renderDefault?.() ?? null,
+  type: 'dock_item',
+  version: ${VIEW_CONTRACT_VERSION},
+}
 `,
 }
 

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-extension-artifacts.node.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-extension-artifacts.node.test.ts
@@ -99,7 +99,7 @@ describe('sanityExtensionArtifacts', () => {
       path.join(root, '.sanity/federation/interfaces/dock-item.js'),
       'utf8',
     )
-    expect(source).toContain('components: () => null')
+    expect(source).toContain('props.renderDefault?.()')
 
     const item = fs.readFileSync(
       path.join(root, '.sanity/federation/views/drop-desk/item.js'),

--- a/packages/@sanity/workbench-cli/src/defineView.ts
+++ b/packages/@sanity/workbench-cli/src/defineView.ts
@@ -48,6 +48,10 @@ export type IconDescriptor =
 /**
  * Props a dock-item component receives: its dock record, with the placement
  * metadata flattened in, plus the icon the host would render by default.
+ *
+ * `renderDefault` returns the workbench's own dock item, so an override can wrap
+ * it (a badge, a counter) instead of rebuilding it. It comes from the host, not
+ * the app's bundle: absent against a host that offers no default.
  * @public
  */
 export type DockItemViewProps = ViewComponentBaseProps<{
@@ -56,7 +60,7 @@ export type DockItemViewProps = ViewComponentBaseProps<{
   priority?: number
   title: string
   type: 'dock_item'
-}> & {icon: IconDescriptor}
+}> & {icon: IconDescriptor; renderDefault?: () => unknown}
 
 /**
  * The components each interface type exposes, keyed by type. A type with a


### PR DESCRIPTION
### Description

A dock item an app only *placed* has nothing of its own to draw. The generated module now calls `props.renderDefault()` and returns that, so the default dock item stays the workbench's: never bundled into an app, and it changes when the remote updates rather than on every app's next deploy.

```js
// .sanity/federation/interfaces/dock-item.js
export default {
  components: (props) => props.renderDefault?.() ?? null,
  type: 'dock_item',
  version: 1,
}
```

`renderDefault` is typed as optional on `DockItemViewProps`, so an app deployed against a host that passes no default renders nothing — the behaviour this stacks on. An explicit `dock_item` view gets the same prop, which is what makes a badge-around-the-default override possible without rebuilding the item.

This is the CLI half only. Nothing passes `renderDefault` yet, so what it can't answer on its own is the question behind the experiment: whether a host-created element rendered inside the island's React root keeps its hooks and the workbench's context, or breaks on React identity. That needs the workbench to pass the prop.

### What to review

Whether the optional call is the right default (`props.renderDefault?.() ?? null` vs. requiring the prop and bumping `VIEW_CONTRACT_VERSION`). Optional keeps older hosts rendering, at the cost of failing silently if the host forgets to pass it.

### Testing

Updated the generated-source assertions in `viewArtifacts` and the extension-artifacts node test.
