### PR TITLE
feat(workbench)!: drop `name` from unstable_defineApp

### DIFF
--- a/.changeset/drop-workbench-app-name.md
+++ b/.changeset/drop-workbench-app-name.md
@@ -1,0 +1,6 @@
+---
+'@sanity/workbench-cli': minor
+'@sanity/cli': minor
+---
+
+`unstable_defineApp` drops `name` — `slug` is the app's only identifier, and has to be a valid DNS label

--- a/fixtures/federated-studio/sanity.cli.ts
+++ b/fixtures/federated-studio/sanity.cli.ts
@@ -8,7 +8,6 @@ export default defineCliConfig({
   // Calling `unstable_defineApp` opts this studio into workbench (a
   // `sanity.config.ts` is present, so it resolves to `applicationType: 'studio'`).
   app: unstable_defineApp({
-    name: 'federated-studio',
     organizationId: 'oSyH1iET5',
     slug: 'federated-studio',
     title: 'Federated Studio',

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -77,7 +77,7 @@ async function runAppDeployment(
   const deployApplication = !workbench || workbench.hasInterfaces
 
   const appTitle = workbench
-    ? flags.title?.trim() || cliConfig.app?.title?.trim() || workbench.name
+    ? flags.title?.trim() || cliConfig.app?.title?.trim() || workbench.slug
     : ''
 
   // A federated app with no entry, view or service would ship a remote with
@@ -284,7 +284,7 @@ async function runAppDeployment(
         applicationId,
         icon: appIcon,
         interfaces: buildExposes(workbench, {
-          appName: workbench.name,
+          appSlug: workbench.slug,
           appTitle,
           exposesAppView: workbench.entry !== undefined,
           version,

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -75,7 +75,7 @@ async function runStudioDeployment(
   }
 
   const appTitle = workbench
-    ? flags.title?.trim() || cliConfig.app?.title?.trim() || workbench.name
+    ? flags.title?.trim() || cliConfig.app?.title?.trim() || workbench.slug
     : ''
 
   const isAutoUpdating = checkAutoUpdates(reporter, {cliConfig, flags})
@@ -196,7 +196,7 @@ async function runStudioDeployment(
         applicationId,
         icon: appIcon,
         interfaces: buildExposes(workbench, {
-          appName: workbench.name,
+          appSlug: workbench.slug,
           appTitle,
           exposesAppView: true,
           version,

--- a/packages/@sanity/cli/src/actions/dev/__tests__/testHelpers.ts
+++ b/packages/@sanity/cli/src/actions/dev/__tests__/testHelpers.ts
@@ -13,7 +13,6 @@ import {type DevActionOptions} from '../types.js'
  */
 export function workbenchApp(overrides: Record<string, unknown> = {}): CliConfig['app'] {
   return unstable_defineApp({
-    name: 'test-app',
     organizationId: 'org-123',
     slug: 'test-app',
     title: 'Test App',

--- a/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapLocalTemplate.ts
@@ -4,6 +4,7 @@ import {styleText} from 'node:util'
 
 import {Output, subdebug} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
+import {toAppSlug} from '@sanity/workbench-cli/init'
 import deburr from 'lodash-es/deburr.js'
 
 import {copy} from '../../util/copy.js'
@@ -126,7 +127,7 @@ export async function bootstrapLocalTemplate(
   // project name. Fall back to a constant when the source slugifies to
   // nothing (e.g. a fully non-latin name): an empty `slug` fails app config
   // validation, which is exactly what pre-filling it is meant to avoid.
-  const slug = (isAppTemplate ? packageJsonName : slugify(title)) || 'sanity-app'
+  const slug = toAppSlug(isAppTemplate ? packageJsonName : title) ?? 'sanity-app'
 
   // Now create a package manifest (`package.json`) with the merged dependencies
   spin = spinner('Creating default project files').start()
@@ -150,7 +151,6 @@ export async function bootstrapLocalTemplate(
     ? createAppCliConfig({
         entry: template.entry!,
         isWorkbenchApp: variables.workbench,
-        name: packageJsonName,
         organizationId: variables.organizationId,
         slug,
         title,
@@ -159,7 +159,6 @@ export async function bootstrapLocalTemplate(
         autoUpdates: variables.autoUpdates,
         dataset: variables.dataset,
         isWorkbenchApp: variables.workbench,
-        name: packageJsonName,
         organizationId: variables.organizationId,
         projectId: variables.projectId,
         slug,

--- a/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createAppCliConfig.ts
@@ -16,7 +16,6 @@ export default defineCliConfig({
 interface GenerateCliConfigOptions {
   entry: string
   isWorkbenchApp: boolean
-  name: string
   slug: string
   title: string
 

--- a/packages/@sanity/cli/src/actions/init/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init/createCliConfig.ts
@@ -24,7 +24,6 @@ interface GenerateCliConfigOptions {
   autoUpdates: boolean
   dataset: string
   isWorkbenchApp: boolean
-  name: string
   projectId: string
   slug: string
   title: string

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -75,7 +75,6 @@ describe('extractCoreAppManifest', () => {
   test('forwards slug from a workbench app', async () => {
     mockGetCliConfig.mockResolvedValue({
       app: unstable_defineApp({
-        name: 'my-app',
         organizationId: 'org-1',
         slug: 'my-slug',
         title: 'My App',

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -605,7 +605,6 @@ describe('#undeploy', () => {
         cliConfig: {
           app: unstable_defineApp({
             entry: './src/App.tsx',
-            name: 'my-app',
             organizationId: 'org-1',
             slug: 'my-app-x1',
             title: 'My App',
@@ -642,7 +641,6 @@ describe('#undeploy', () => {
         cliConfig: {
           app: unstable_defineApp({
             entry: './src/App.tsx',
-            name: 'my-app',
             organizationId: 'org-1',
             slug: 'my-app-x1',
             title: 'My App',

--- a/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
+++ b/packages/@sanity/cli/test/integration/actions/init/bootstrapLocalTemplate.test.ts
@@ -128,9 +128,8 @@ describe('bootstrapLocalTemplate (workbench)', () => {
 
     const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
     expect(cliConfig).toContain(`import {defineCliConfig, unstable_defineApp} from 'sanity/cli'`)
-    expect(cliConfig).toContain(`name: 'my-studio'`)
     expect(cliConfig).toContain(`title: 'My Studio'`)
-    // `slug` defaults from the entered name/title, slugified
+    // `slug` derives from the entered project name, slugified
     expect(cliConfig).toContain(`slug: 'my-studio'`)
     expect(cliConfig).toContain(`organizationId: 'org1'`)
     expect(cliConfig).toContain(`projectId: 'abc123'`)
@@ -159,11 +158,9 @@ describe('bootstrapLocalTemplate (workbench)', () => {
 
     const cliConfig = await readFile(path.join(tmp, 'sanity.cli.ts'), 'utf8')
     expect(cliConfig).toContain(`import {defineCliConfig, unstable_defineApp} from 'sanity/cli'`)
-    // App init derives `name` from the output directory, same as package.json
-    const pkgJson = JSON.parse(await readFile(path.join(tmp, 'package.json'), 'utf8'))
-    expect(cliConfig).toContain(`name: '${pkgJson.name}'`)
     expect(cliConfig).toContain(`title: 'My App'`)
-    // App init derives `slug` from the output directory too, same as `name`
+    // App init derives `slug` from the output directory, same as package.json's name
+    const pkgJson = JSON.parse(await readFile(path.join(tmp, 'package.json'), 'utf8'))
     expect(cliConfig).toContain(`slug: '${pkgJson.name}'`)
     expect(cliConfig).toContain(`organizationId: 'org1'`)
     expect(cliConfig).toContain(`entry: './src/App.tsx'`)

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -308,7 +308,6 @@ describe('#deploy app', () => {
     process.cwd = () => cwd
 
     const app = unstable_defineApp({
-      name: 'workbench-app',
       organizationId,
       slug: 'workbench-app',
       title: 'Workbench App',
@@ -340,7 +339,6 @@ describe('#deploy app', () => {
 
     const app = unstable_defineApp({
       entry: './src/App.tsx',
-      name: 'workbench-app',
       organizationId,
       slug: 'drop-desk-host',
       title: 'Workbench App',
@@ -379,7 +377,6 @@ describe('#deploy app', () => {
 
     const app = unstable_defineApp({
       entry: './src/App.tsx',
-      name: 'workbench-app',
       organizationId,
       slug: 'drop-desk-host',
       title: 'Workbench App',
@@ -401,7 +398,6 @@ describe('#deploy app', () => {
 
     const app = unstable_defineApp({
       entry: './src/App.tsx',
-      name: 'workbench-app',
       organizationId,
       slug: 'drop-desk-host',
       title: 'Workbench App',
@@ -424,7 +420,6 @@ describe('#deploy app', () => {
 
     const app = unstable_defineApp({
       entry: './src/App.tsx',
-      name: 'workbench-app',
       organizationId,
       slug: 'drop-desk-host',
       title: 'Workbench App',
@@ -464,7 +459,6 @@ describe('#deploy app', () => {
 
     const app = unstable_defineApp({
       entry: './src/App.tsx',
-      name: 'workbench-app',
       organizationId,
       slug: 'drop-desk-host',
       title: 'Workbench App',
@@ -492,7 +486,6 @@ describe('#deploy app', () => {
     const app = unstable_defineApp({
       entry: './src/App.tsx',
       icon: './icon.svg',
-      name: 'workbench-app',
       organizationId,
       slug: 'drop-desk-host',
       title: 'Workbench App',
@@ -517,7 +510,6 @@ describe('#deploy app', () => {
     const app = unstable_defineApp({
       entry: './src/App.tsx',
       icon: './missing-icon.svg',
-      name: 'workbench-app',
       organizationId,
       slug: 'drop-desk-host',
       title: 'Workbench App',

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.external.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.external.test.ts
@@ -853,7 +853,6 @@ describe('#deploy studio (external)', () => {
       // Brand the config as a studio so the deploy command routes it through
       // deployStudio (the only path that accepts --external).
       const app = unstable_defineApp({
-        name: 'test-studio',
         organizationId: 'org-1',
         slug: 'test-studio',
         title: 'Test Studio',

--- a/packages/@sanity/workbench-cli/src/__tests__/appId.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/appId.test.ts
@@ -13,7 +13,6 @@ describe('resolveAppId', () => {
 describe('buildAppId', () => {
   const app: ResolvedWorkbenchApp = {
     entry: './src/App.tsx',
-    name: 'drop-desk',
     organizationId: 'org-1',
     services: [{name: 'unread', src: './src/worker.ts', type: 'worker'}],
     slug: 'drop-desk',
@@ -44,7 +43,7 @@ describe('buildAppId', () => {
 
   test('changes when the declared shape changes', async () => {
     const base = await buildAppId(app)
-    expect(base).not.toBe(await buildAppId({...app, name: 'other'}))
+    expect(base).not.toBe(await buildAppId({...app, slug: 'other'}))
     expect(base).not.toBe(await buildAppId({...app, organizationId: 'org-2'}))
     expect(base).not.toBe(await buildAppId({...app, entry: './src/Other.tsx'}))
     expect(base).not.toBe(

--- a/packages/@sanity/workbench-cli/src/__tests__/appSlug.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/appSlug.test.ts
@@ -1,0 +1,22 @@
+import {describe, expect, test} from 'vitest'
+
+import {toAppSlug} from '../appSlug.js'
+
+describe('toAppSlug', () => {
+  test.each([
+    ['Drop Desk', 'drop-desk'],
+    ["Acme's Dashboard (v2)!", 'acme-s-dashboard-v2'],
+    ['Café Roma', 'cafe-roma'],
+    ['Bodø Studio', 'bod-studio'],
+    ['-leading-and-trailing-', 'leading-and-trailing'],
+  ])('coerces %j to %j', (input, expected) => {
+    expect(toAppSlug(input)).toBe(expected)
+  })
+
+  test.each(['', '日本語プロジェクト', '2024-desk', 'x'])(
+    'returns null for %j — nothing lawful survives',
+    (input) => {
+      expect(toAppSlug(input)).toBeNull()
+    },
+  )
+})

--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -21,7 +21,6 @@ const WORKBENCH_APP = Symbol.for('sanity.workbench.defineApp')
  * `delete` one to assert it's required. A new required field only needs adding here.
  */
 const validInput = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
-  name: 'drop-desk',
   organizationId: 'org-1',
   slug: 'drop-desk',
   title: 'Drop',
@@ -30,35 +29,35 @@ const validInput = (overrides: Record<string, unknown> = {}): Record<string, unk
 
 describe('unstable_defineApp', () => {
   test('is identity at runtime — returns the same object reference', () => {
-    const input = {name: 'drop-desk', organizationId: 'org-1', title: 'Drop Desk'}
+    const input = {organizationId: 'org-1', slug: 'drop-desk', title: 'Drop Desk'}
     expect(unstable_defineApp(input)).toBe(input)
   })
 
   test('brands the result so the CLI can discriminate it', () => {
-    const app = unstable_defineApp({name: 'drop-desk', organizationId: 'org-1', title: 'Drop Desk'})
+    const app = unstable_defineApp({organizationId: 'org-1', slug: 'drop-desk', title: 'Drop Desk'})
     expect(Object.getOwnPropertyDescriptor(app, WORKBENCH_APP)?.value).toBe(true)
   })
 
   test('leaves the brand non-enumerable so it does not leak into config spreads', () => {
-    const app = unstable_defineApp({name: 'drop-desk', organizationId: 'org-1', title: 'Drop Desk'})
-    expect(Object.keys(app)).toEqual(['name', 'organizationId', 'title'])
+    const app = unstable_defineApp({organizationId: 'org-1', slug: 'drop-desk', title: 'Drop Desk'})
+    expect(Object.keys(app)).toEqual(['organizationId', 'slug', 'title'])
     expect(Object.getOwnPropertySymbols({...app})).not.toContain(WORKBENCH_APP)
   })
 
   test('preserves declared fields', () => {
     const app = unstable_defineApp({
       icon: './icon.svg',
-      name: 'athlete-desk',
       organizationId: 'org-1',
+      slug: 'athlete-desk',
       title: 'Athlete Desk',
     })
-    expect(app.name).toBe('athlete-desk')
+    expect(app.slug).toBe('athlete-desk')
     expect(app.title).toBe('Athlete Desk')
     expect(app.icon).toBe('./icon.svg')
   })
 
   test('is recognised by `isWorkbenchApp` (Symbol.for brand contract)', () => {
-    const app = unstable_defineApp({name: 'drop-desk', organizationId: 'org-1', title: 'Drop Desk'})
+    const app = unstable_defineApp({organizationId: 'org-1', slug: 'drop-desk', title: 'Drop Desk'})
     expect(isWorkbenchApp(app)).toBe(true)
   })
 
@@ -76,15 +75,18 @@ describe('unstable_defineApp', () => {
 })
 
 describe('DefineAppInputSchema (build-time validation)', () => {
-  test('accepts a valid name', () => {
-    expect(DefineAppInputSchema.parse(validInput({name: 'drop_desk-1'})).name).toBe('drop_desk-1')
+  test('accepts a slug that is a valid DNS label', () => {
+    expect(DefineAppInputSchema.parse(validInput({slug: 'drop-desk-1'})).slug).toBe('drop-desk-1')
   })
 
-  test('rejects a name with illegal characters', () => {
-    const result = DefineAppInputSchema.safeParse(validInput({name: 'drop desk!'}))
-    expect(result.success).toBe(false)
-    expect(result.error?.issues[0]?.message).toMatch(/must match/)
-  })
+  test.each(['Drop-Desk', 'drop_desk', 'drop desk', '-drop-desk', 'drop-desk-'])(
+    'rejects the slug %j — it would not survive as a hostname',
+    (slug) => {
+      const result = DefineAppInputSchema.safeParse(validInput({slug}))
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0]?.message).toMatch(/must be lowercase/)
+    },
+  )
 
   test('requires a title', () => {
     const input = validInput()

--- a/packages/@sanity/workbench-cli/src/__tests__/defineMediaLibrary.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineMediaLibrary.test.ts
@@ -26,11 +26,11 @@ describe('unstable_defineMediaLibrary', () => {
     expect(isWorkbenchApp(app)).toBe(true)
   })
 
-  test('declares a media-library singleton with a stable name', () => {
+  test('declares a media-library singleton with a stable slug', () => {
     const app = mediaLibrary({organizationId: 'org-1'})
     expect(app.applicationType).toBe('media-library')
     expect(app.isSingleton).toBe(true)
-    expect(app.name).toBe('media-library')
+    expect(app.slug).toBe('media-library')
   })
 
   test('collects all fields into one config', () => {

--- a/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/resolveWorkbenchApp.test.ts
@@ -19,7 +19,6 @@ describe('resolveWorkbenchApp', () => {
   test('resolves a branded app with defaulted views/services and no singleton flag', () => {
     const config = asConfig(
       unstable_defineApp({
-        name: 'my-app',
         organizationId: 'org-123',
         slug: 'my-app',
         title: 'My App',
@@ -31,7 +30,6 @@ describe('resolveWorkbenchApp', () => {
       config: undefined,
       entry: undefined,
       isSingleton: undefined,
-      name: 'my-app',
       organizationId: 'org-123',
       services: [],
       slug: 'my-app',
@@ -43,7 +41,6 @@ describe('resolveWorkbenchApp', () => {
     const config = asConfig(
       unstable_defineApp({
         entry: './src/App.tsx',
-        name: 'my-app',
         organizationId: 'org-123',
         services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
         slug: 'my-app-host',
@@ -63,7 +60,6 @@ describe('resolveWorkbenchApp', () => {
   test('passes through declared panel views and services', () => {
     const config = asConfig(
       unstable_defineApp({
-        name: 'my-app',
         organizationId: 'org-123',
         services: [{name: 'worker', src: './src/worker.ts', type: 'worker'}],
         slug: 'my-app-host',
@@ -82,7 +78,6 @@ describe('resolveWorkbenchApp', () => {
     const config = asConfig(
       unstable_defineApp({
         entry: './src/App.tsx',
-        name: 'my-app',
         organizationId: 'org-123',
         slug: 'my-app',
         title: 'My App',
@@ -104,7 +99,7 @@ describe('resolveWorkbenchApp', () => {
     const resolved = resolveWorkbenchApp(config)
     expect(resolved).toMatchObject({
       isSingleton: true,
-      name: 'media-library',
+      slug: 'media-library',
     })
     expect(resolved!.config).toEqual({
       appType: 'media-library',
@@ -117,7 +112,6 @@ describe('resolveWorkbenchApp', () => {
       unstable_defineApp({
         // @ts-expect-error -- config is internal; forcing the invalid combination
         config: {appType: 'media-library', fields: []},
-        name: 'my-app',
         organizationId: 'org-123',
         slug: 'my-app',
         title: 'My App',

--- a/packages/@sanity/workbench-cli/src/__tests__/validateWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/validateWorkbenchApp.test.ts
@@ -4,7 +4,6 @@ import {formatWorkbenchAppErrors, validateWorkbenchApp} from '../validateWorkben
 
 /** A minimal valid app; spread overrides to vary the fields under test. */
 const app = (overrides: Record<string, unknown> = {}) => ({
-  name: 'test-app',
   organizationId: 'org-1',
   slug: 'test-app',
   title: 'Test App',
@@ -19,8 +18,8 @@ describe('validateWorkbenchApp', () => {
   })
 
   test('validates the whole input, not just interfaces', () => {
-    expect(validateWorkbenchApp(app({name: 'bad name!'}))).toContainEqual(
-      expect.stringMatching(/name: App `name` must match/),
+    expect(validateWorkbenchApp(app({slug: 'Bad Slug!'}))).toContainEqual(
+      expect.stringMatching(/slug: App `slug` must be lowercase/),
     )
   })
 
@@ -48,11 +47,11 @@ describe('validateWorkbenchApp', () => {
     const errors = validateWorkbenchApp(
       app({
         entry: './src/App.tsx',
-        name: 'bad!',
+        slug: 'bad!',
         views: [panel, {name: 'inbox', src: './src/Inbox.tsx', type: 'panel'}],
       }),
     )
-    expect(errors).toContainEqual(expect.stringMatching(/name: App `name` must match/))
+    expect(errors).toContainEqual(expect.stringMatching(/slug: App `slug` must be lowercase/))
     expect(errors).toContainEqual(expect.stringContaining('cannot expose both an app view'))
     expect(errors).toContainEqual(expect.stringContaining('at most one panel view'))
   })

--- a/packages/@sanity/workbench-cli/src/_exports/init.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/init.ts
@@ -1,6 +1,7 @@
 // Browser-safe `init` entry: the workbench `sanity.cli.ts` config templates the
-// CLI's init scaffolding fills in. Plain strings — no runtime deps.
+// CLI's init scaffolding fills in, and the coercion that fills `%slug%`. No runtime deps.
 export {
   workbenchAppConfigTemplate,
   workbenchStudioConfigTemplate,
 } from '../actions/init/cliConfig.js'
+export {toAppSlug} from '../appSlug.js'

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/buildExposes.test.ts
@@ -4,7 +4,7 @@ import {type WorkbenchExposes} from '../../../resolveWorkbenchApp.js'
 import {buildExposes, summarizeExposes} from '../buildExposes.js'
 
 const context = {
-  appName: 'drop-desk',
+  appSlug: 'drop-desk',
   appTitle: 'Drop Desk',
   exposesAppView: true,
   version: '1.2.3',

--- a/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/buildExposes.ts
@@ -3,7 +3,7 @@ import {type WorkbenchExposes} from '../../resolveWorkbenchApp.js'
 import {type BrettInterface} from '../../services/applications.js'
 
 interface BuildExposesContext {
-  appName: string
+  appSlug: string
   appTitle: string
   /** Whether the build exposes the app view (`./App`) — apps with an `entry`, and every studio. */
   exposesAppView: boolean
@@ -17,14 +17,14 @@ interface BuildExposesContext {
  */
 export function buildExposes(
   exposes: WorkbenchExposes,
-  {appName, appTitle, exposesAppView, version}: BuildExposesContext,
+  {appSlug, appTitle, exposesAppView, version}: BuildExposesContext,
 ): BrettInterface[] {
   const records: BrettInterface[] = []
   if (exposesAppView) {
     records.push({
       metadata: null,
-      moduleId: interfaceModuleId('app', appName),
-      name: appName,
+      moduleId: interfaceModuleId('app', appSlug),
+      name: appSlug,
       title: appTitle,
       type: 'app',
       version,

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -45,7 +45,7 @@ describe('deriveInterfaces', () => {
   })
 
   test('derives an app interface from entry for an SDK app', () => {
-    const app = workbenchApp({entry: './src/App.tsx', name: 'my-app'})
+    const app = workbenchApp({entry: './src/App.tsx', slug: 'my-app'})
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
       {
         id: 'my-app-app-my-app',
@@ -97,8 +97,8 @@ describe('deriveInterfaces', () => {
 
   test('orders a panel view ahead of services', () => {
     const app = workbenchApp({
-      name: 'my-app',
       services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+      slug: 'my-app',
       views: [{name: 'feed', src: './src/FeedPanel.tsx', type: 'panel'}],
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
@@ -128,8 +128,8 @@ describe('deriveInterfaces', () => {
   test('places the app view after services', () => {
     const app = workbenchApp({
       entry: './src/App.tsx',
-      name: 'my-app',
       services: [{name: 'unread', src: './src/service.ts', type: 'worker'}],
+      slug: 'my-app',
     })
     expect(deriveInterfaces(app, {isApp: true})).toEqual([
       {
@@ -156,8 +156,8 @@ describe('deriveInterfaces', () => {
 
   test('derives a unique id per interface, disambiguating a view and service that share a name', () => {
     const app = workbenchApp({
-      name: 'my-app',
       services: [{name: 'sync', src: './src/sync.ts', type: 'worker'}],
+      slug: 'my-app',
       views: [{name: 'sync', src: './src/SyncPanel.tsx', type: 'panel'}],
     })
     const ids = deriveInterfaces(app, {isApp: true})?.map((iface) => iface.id) ?? []

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
@@ -30,7 +30,6 @@ export class FakeFsWatcher extends EventEmitter {
 /** A CliConfig `app` from a branded `unstable_defineApp(...)` — the workbench opt-in. */
 export function workbenchApp(overrides: Record<string, unknown> = {}): CliConfig['app'] {
   return unstable_defineApp({
-    name: 'test-app',
     organizationId: 'org-123',
     slug: 'test-app',
     title: 'Test App',

--- a/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/deriveInterfaces.ts
@@ -33,7 +33,7 @@ export function deriveInterfaces(
     throw new Error('App views for studios are not implemented yet')
   }
 
-  const interfaceId = (type: string, name: string): string => `${app.name}-${type}-${name}`
+  const interfaceId = (type: string, name: string): string => `${app.slug}-${type}-${name}`
 
   const views = (app.views ?? []).map(
     (view): DevServerInterface => ({
@@ -70,10 +70,10 @@ export function deriveInterfaces(
       ? []
       : [
           {
-            id: interfaceId('app', app.name),
+            id: interfaceId('app', app.slug),
             metadata: null,
-            moduleId: interfaceModuleId('app', app.name),
-            name: app.name,
+            moduleId: interfaceModuleId('app', app.slug),
+            name: app.slug,
             src: appEntry,
             title: app.title,
             type: 'app',
@@ -121,7 +121,7 @@ export async function deriveConfigs(app: CliConfig['app']): Promise<DevServerCon
       src: field.src,
       title: field.title,
     })),
-    moduleName: app.name,
+    moduleName: app.slug,
     version: String(MEDIA_LIBRARY_CONFIG_CONTRACT_VERSION),
   }
   return [{...entry, id: await contentHash(JSON.stringify(entry))}]

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -103,7 +103,7 @@ const devServerManifestSchema = z.object({
         // Content hash of the config — the workbench's change-detection key
         // (see deriveConfigs).
         id: z.string(),
-        // The app's `unstable_defineApp` name — the module-federation alias the
+        // The app's `unstable_defineApp` slug — the module-federation alias the
         // workbench loads this config's live values from.
         moduleName: z.optional(z.string()),
         // The version the workbench federates this config's module under —

--- a/packages/@sanity/workbench-cli/src/actions/init/cliConfig.ts
+++ b/packages/@sanity/workbench-cli/src/actions/init/cliConfig.ts
@@ -2,7 +2,7 @@
 // consumed by the CLI's `init` scaffolding. The branded `unstable_defineApp`
 // result is the sole workbench (module-federation) opt-in, so its config shape
 // is workbench's to own; the CLI keeps the non-workbench templates and the
-// `%placeholder%` substitution. `%name%`/`%title%`/etc. are filled in by the
+// `%placeholder%` substitution. `%slug%`/`%title%`/etc. are filled in by the
 // CLI's template processor.
 
 /** App scaffold — `entry` auto-declares the navigable app view. */
@@ -11,7 +11,6 @@ import {defineCliConfig, unstable_defineApp} from 'sanity/cli'
 
 export default defineCliConfig({
   app: unstable_defineApp({
-    name: '%name%',
     title: '%title%',
     slug: '%slug%',
     organizationId: '%organizationId%',
@@ -21,7 +20,7 @@ export default defineCliConfig({
 `
 
 /**
- * Studio scaffold — brands with name/title only, no `entry` (studio app views
+ * Studio scaffold — brands with slug/title only, no `entry` (studio app views
  * aren't implemented yet).
  */
 export const workbenchStudioConfigTemplate = `
@@ -33,7 +32,6 @@ export default defineCliConfig({
     dataset: '%dataset%'
   },
   app: unstable_defineApp({
-    name: '%name%',
     title: '%title%',
     slug: '%slug%',
     organizationId: '%organizationId%',

--- a/packages/@sanity/workbench-cli/src/actions/undeploy/workbenchUndeployAdapter.ts
+++ b/packages/@sanity/workbench-cli/src/actions/undeploy/workbenchUndeployAdapter.ts
@@ -179,7 +179,7 @@ async function resolveConfigTarget({
         organizationId,
         projectId: null,
         summary: config ? [summarizeConfig(config)] : undefined,
-        title: workbench.name,
+        title: workbench.slug,
         type: 'coreApp',
         url: getWorkbenchUrl(organizationId),
       },

--- a/packages/@sanity/workbench-cli/src/appId.ts
+++ b/packages/@sanity/workbench-cli/src/appId.ts
@@ -32,9 +32,9 @@ export async function buildAppId(app: ResolvedWorkbenchApp): Promise<string> {
   const shape = JSON.stringify({
     config: app.config ?? null,
     entry: app.entry ?? null,
-    name: app.name,
     organizationId: app.organizationId,
     services: canonical(app.services),
+    slug: app.slug,
     views: canonical(app.views),
   })
   // eslint-disable-next-line n/no-unsupported-features/node-builtins -- the Web Crypto global is available on our Node target and in the browser

--- a/packages/@sanity/workbench-cli/src/appSlug.ts
+++ b/packages/@sanity/workbench-cli/src/appSlug.ts
@@ -1,0 +1,12 @@
+/** Mirrors brett's `STUDIO_APP_HOST_PATTERN`, which rejects anything else on create. */
+export const APP_SLUG_PATTERN = /^[a-z][a-z0-9-]*[a-z0-9]$/
+
+export function toAppSlug(value: string): string | null {
+  const slug = value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replaceAll(/\p{M}/gu, '')
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-|-$/g, '')
+  return APP_SLUG_PATTERN.test(slug) ? slug : null
+}

--- a/packages/@sanity/workbench-cli/src/defineApp.ts
+++ b/packages/@sanity/workbench-cli/src/defineApp.ts
@@ -1,9 +1,7 @@
 import {z} from 'zod/mini'
 
+import {APP_SLUG_PATTERN} from './appSlug.js'
 import {ConfigSchema, InterfaceDeclarationSchema, ServiceDeclarationSchema} from './contract.js'
-
-/** Allowed characters for an app `name`. */
-const APP_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/
 
 /**
  * Dashboard visibility values. Mirrors `APP_VISIBILITIES` in `@sanity/cli-core`
@@ -63,8 +61,6 @@ export const DefineAppInputSchema = z
      * @internal
      */
     isSingleton: z.optional(z.boolean()),
-    /** Unique app identifier — must match `APP_NAME_PATTERN`. */
-    name: z.string().check(z.regex(APP_NAME_PATTERN, 'App `name` must match /^[a-zA-Z0-9_-]+$/')),
     /** Organization that owns the app — the workbench runs and deploys against it. */
     organizationId: z.string(
       "App `organizationId` is required — pass the owning organization's ID to `unstable_defineApp`",
@@ -82,7 +78,14 @@ export const DefineAppInputSchema = z
           ),
         ),
     ),
-    slug: z.string('App `slug` is required — the hostname the application is created at on deploy'),
+    slug: z
+      .string('App `slug` is required — the hostname the application is created at on deploy')
+      .check(
+        z.regex(
+          APP_SLUG_PATTERN,
+          'App `slug` must be lowercase alphanumerics and hyphens, starting with a letter and ending with an alphanumeric',
+        ),
+      ),
     /** User-facing app title. Wins over studio.config.ts title on merge. */
     title: z.string(),
     /** Views the app exposes (e.g. dock panels). */
@@ -197,7 +200,7 @@ export function readConfig(app: WorkbenchApp): WorkbenchApp['config'] | undefine
 /**
  * Declare a Sanity Workbench application. Identity at runtime — returns the same
  * object reference, tagged with the workbench brand. Field validation (the
- * `name` pattern etc.) runs at build time in the CLI via `DefineAppInputSchema`;
+ * `slug` pattern etc.) runs at build time in the CLI via `DefineAppInputSchema`;
  * this helper stays a thin, pure identity wrapper.
  * @public
  */
@@ -245,7 +248,6 @@ export function unstable_defineMediaLibrary(input: DefineMediaLibraryInput): Def
     applicationType: 'media-library',
     config: input.fields?.length ? {appType: 'media-library', fields: input.fields} : undefined,
     isSingleton: true,
-    name: 'media-library',
     organizationId: input.organizationId,
     slug: 'media-library',
     title: 'Media Library',

--- a/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/resolveWorkbenchApp.ts
@@ -22,14 +22,11 @@ export interface WorkbenchExposes {
 
 /** @public */
 export interface ResolvedWorkbenchApp {
-  /** The app's unique `name` from `unstable_defineApp`. */
-  readonly name: string
   /** Organization that owns the app — part of its build-id identity. */
   readonly organizationId: string
   /** Background worker services the app declares. */
   readonly services: NonNullable<DefineAppInput['services']>
 
-  /** Hostname the application is created at on first deploy. */
   readonly slug: string
 
   /** Dock panel views the app declares. */
@@ -68,7 +65,6 @@ export function resolveWorkbenchApp(
     entry: app.entry,
     icon: app.icon,
     isSingleton: app.isSingleton,
-    name: app.name,
     organizationId: app.organizationId,
     services: app.services ?? [],
     slug: app.slug,


### PR DESCRIPTION
### Description

Drop `name` in favor of `slug` from `unstable_defineApp`. Name was confusing, a duplicate and didn't really serve a purpose anymore.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking config API for all workbench apps that still pass `name`; deploy and dev identity now follow `slug`, so mismatched or invalid slugs can fail validation or change federation interface IDs versus configs that used a different `name`.
> 
> **Overview**
> **Breaking:** `unstable_defineApp` no longer accepts `name`. **`slug`** is the only stable identifier and must match a valid DNS label (`APP_SLUG_PATTERN`), replacing the looser `name` regex.
> 
> Deploy, dev, and federation paths that used **`workbench.name`** / **`appName`** now use **`slug`** (default deploy title, Brett interface `moduleId`/`name`, dev interface IDs, `buildAppId` hashing, media-library `moduleName`, init templates). **`ResolvedWorkbenchApp`** drops **`name`**.
> 
> **Init** stops emitting `name` in generated `sanity.cli.ts` and derives default slugs via exported **`toAppSlug`** (with `'sanity-app'` fallback when coercion fails). Changeset marks **`@sanity/workbench-cli`** and **`@sanity/cli`** as minor (note: PR title uses `!` for breaking API).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 320724dbd18ea4b771aa30d92645112b46bcae61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->