### PR TITLE
fix(config): stop workbench types from leaking into app config

### DIFF
--- a/.changeset/pr-1632.md
+++ b/.changeset/pr-1632.md
@@ -4,4 +4,4 @@
 '@sanity/cli': patch
 ---
 
-fix(config): drop workbench-only fields from the app config type
+fix(config): stop workbench types from leaking into app config

--- a/.changeset/pr-1632.md
+++ b/.changeset/pr-1632.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': patch
+'@sanity/cli': patch
+---
+
+fix(config): drop workbench-only fields from the app config type

--- a/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/types/cliConfig.ts
@@ -33,8 +33,6 @@ export interface CliConfig {
   app?: {
     /** The entrypoint for your custom app. By default, `src/App.tsx` */
     entry?: string
-    /** Dock group the app renders in. Defaults to `dock.applications`. */
-    group?: 'dock.applications' | 'dock.system' | 'dock.user'
     /**
      * Path to an icon file relative to project root.
      * The file must be an SVG.
@@ -44,8 +42,6 @@ export interface CliConfig {
     id?: string
     /** The ID for the Sanity organization that manages this application */
     organizationId?: string
-    /** Sort position within the dock group, ascending. Defaults to `100`. */
-    priority?: number
     /** The title of the custom app, as it is seen in Dashboard UI */
     title?: string
     /** Dashboard visibility of the application. Defaults to `default`. */

--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -54,17 +54,36 @@ describe('extractCoreAppManifest', () => {
 
   test('merges group and priority into the manifest', async () => {
     mockGetCliConfig.mockResolvedValue({
-      app: {group: 'dock.system', organizationId: 'org-1', priority: 20, title: 'My App'},
+      app: unstable_defineApp({
+        group: 'dock.system',
+        name: 'my-app',
+        organizationId: 'org-1',
+        priority: 20,
+        slug: 'my-slug',
+        title: 'My App',
+      }),
     } as never)
 
     const result = await extractCoreAppManifest({workDir: '/project'})
 
-    expect(result).toEqual({group: 'dock.system', priority: 20, title: 'My App', version: '1'})
+    expect(result).toEqual({
+      group: 'dock.system',
+      priority: 20,
+      slug: 'my-slug',
+      title: 'My App',
+      version: '1',
+    })
   })
 
   test('keeps priority 0 (not dropped as a falsy value)', async () => {
     mockGetCliConfig.mockResolvedValue({
-      app: {organizationId: 'org-1', priority: 0, title: 'My App'},
+      app: unstable_defineApp({
+        name: 'my-app',
+        organizationId: 'org-1',
+        priority: 0,
+        slug: 'my-slug',
+        title: 'My App',
+      }),
     } as never)
 
     const result = await extractCoreAppManifest({workDir: '/project'})
@@ -87,9 +106,15 @@ describe('extractCoreAppManifest', () => {
     expect(result).toEqual({slug: 'my-slug', title: 'My App', version: '1'})
   })
 
-  test('does not forward slug for a non-workbench app', async () => {
+  test('drops slug and dock placement for a non-workbench app', async () => {
     mockGetCliConfig.mockResolvedValue({
-      app: {organizationId: 'org-1', slug: 'my-slug', title: 'My App'},
+      app: {
+        group: 'dock.system',
+        organizationId: 'org-1',
+        priority: 20,
+        slug: 'my-slug',
+        title: 'My App',
+      },
     } as never)
 
     const result = await extractCoreAppManifest({workDir: '/project'})

--- a/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
+++ b/packages/@sanity/cli/src/actions/manifest/extractCoreAppManifest.ts
@@ -110,15 +110,15 @@ export async function extractCoreAppManifest(
       return undefined
     }
 
-    const slug = isWorkbenchApp(app) ? app.slug : undefined
+    const workbench = isWorkbenchApp(app) ? app : undefined
 
     const manifest: CoreAppManifest = coreAppManifestSchema.parse({
       version: '1',
       ...(icon ? {icon} : {}),
       ...(app.title ? {title: app.title} : {}),
-      ...(app.group ? {group: app.group} : {}),
-      ...(app.priority === undefined ? {} : {priority: app.priority}),
-      ...(slug ? {slug} : {}),
+      ...(workbench?.group ? {group: workbench.group} : {}),
+      ...(workbench?.priority === undefined ? {} : {priority: workbench.priority}),
+      ...(workbench?.slug ? {slug: workbench.slug} : {}),
     })
 
     spin.succeed(`Extracted manifest`)

--- a/packages/@sanity/cli/src/config/__tests__/defineCliConfig.test.ts
+++ b/packages/@sanity/cli/src/config/__tests__/defineCliConfig.test.ts
@@ -1,4 +1,5 @@
 import {type CliConfig} from '@sanity/cli-core'
+import {type DefineAppResult, unstable_defineApp} from '@sanity/workbench-cli'
 import {describe, expect, expectTypeOf, test} from 'vitest'
 
 import {defineCliConfig} from '../defineCliConfig.js'
@@ -18,12 +19,48 @@ describe('#defineCliConfig', () => {
 
     const result = defineCliConfig(config)
 
-    // Returns the exact same object reference (no transformation)
     expect(result).toBe(config)
-    expect(result).toEqual(config)
   })
 
   test('defineCliConfig type is CliConfig', () => {
     expectTypeOf<ReturnType<typeof defineCliConfig>>().toEqualTypeOf<CliConfig>()
+  })
+})
+
+// An `unstable_defineApp(...)` result fits `CliConfig['app']` only because every
+// field declared there is optional; nothing in the type states the relationship.
+describe('the `app` config slot', () => {
+  test('accepts an `unstable_defineApp` result, workbench fields and all', () => {
+    expectTypeOf<DefineAppResult>().toExtend<CliConfig['app']>()
+
+    defineCliConfig({
+      app: unstable_defineApp({
+        group: 'dock.system',
+        name: 'my-app',
+        organizationId: 'org-1',
+        priority: 20,
+        slug: 'my-app',
+        title: 'My App',
+      }),
+    })
+  })
+
+  // One literal only ever reports its first excess property, so one call each.
+  test('rejects workbench fields written by hand', () => {
+    defineCliConfig({
+      app: {
+        // @ts-expect-error `group` comes from `unstable_defineApp`
+        group: 'dock.system',
+        organizationId: 'org-1',
+      },
+    })
+
+    defineCliConfig({
+      app: {
+        organizationId: 'org-1',
+        // @ts-expect-error `priority` comes from `unstable_defineApp`
+        priority: 20,
+      },
+    })
   })
 })


### PR DESCRIPTION
### Description

At some point the types for workbench (`group` and `priority`) started leaking into the sanity CLI app config, but they can only be set through the new workbench APIs. This PR makes sure `app` only displays the existing properties and everything else that's experimental is hidden from users unless they start using `unstable_defineApp`:

| Before | After |
|-|-|
|<img width="669" height="335" alt="Screenshot 2026-07-30 at 18 17 57" src="https://github.com/user-attachments/assets/b2cabc49-bf87-4369-9803-88e4255736f0" />|<img width="669" height="335" alt="Screenshot 2026-07-30 at 18 01 52" src="https://github.com/user-attachments/assets/fb8989aa-4067-4d82-b493-f37145181cf0" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type and manifest-shaping changes with tests; behavior for workbench apps using `unstable_defineApp` is preserved.
> 
> **Overview**
> Removes **workbench-only** fields (`group`, `priority`) from the public `CliConfig['app']` type so IDE hints and config docs only show stable app options (`entry`, `icon`, `title`, `visibility`, etc.). Workbench placement still works when `app` is set via `unstable_defineApp` from `@sanity/workbench-cli`.
> 
> **Manifest extraction** now copies `group`, `priority`, and `slug` into the core app manifest only when `isWorkbenchApp(app)` is true, so plain `app` objects cannot accidentally publish dock metadata even if extra keys exist at runtime.
> 
> Adds **type-level tests** that `DefineAppResult` still extends `CliConfig['app']` while hand-written `group` / `priority` on `app` are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9b1dcf78456076dfe0f5c0c43c50c4a34ac11a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->