### PR TITLE
feat(tokens): add expiry option and migrate token management to the Access API

### DIFF
--- a/.changeset/pr-1633.md
+++ b/.changeset/pr-1633.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(tokens): add expiry option and migrate token management to the Access API

--- a/packages/@sanity/cli/src/actions/tokens/__tests__/expiry.test.ts
+++ b/packages/@sanity/cli/src/actions/tokens/__tests__/expiry.test.ts
@@ -1,0 +1,69 @@
+import {describe, expect, test} from 'vitest'
+
+import {
+  formatExpiryChoiceDate,
+  formatTokenExpiry,
+  getPresetExpiryDate,
+  TOKEN_EXPIRY_PRESET_DAYS,
+  validateExpiryDate,
+} from '../expiry.js'
+
+describe('tokens expiry helpers', () => {
+  test('exposes the same preset choices as the Manage token creation flow', () => {
+    expect(TOKEN_EXPIRY_PRESET_DAYS).toEqual([30, 60, 90])
+  })
+
+  test('getPresetExpiryDate resolves days from now to a yyyy-MM-dd date', () => {
+    const now = new Date('2026-07-30T12:00:00Z')
+    expect(getPresetExpiryDate(30, now)).toBe('2026-08-29')
+    expect(getPresetExpiryDate(60, now)).toBe('2026-09-28')
+    expect(getPresetExpiryDate(90, now)).toBe('2026-10-28')
+  })
+
+  test('formatExpiryChoiceDate formats dates for prompt choices', () => {
+    expect(formatExpiryChoiceDate('2026-08-29')).toBe('29 Aug 2026')
+  })
+
+  describe('validateExpiryDate', () => {
+    const now = new Date('2026-07-30T12:00:00Z')
+
+    test('accepts today and future dates', () => {
+      expect(validateExpiryDate('2026-07-30', now)).toBe(true)
+      expect(validateExpiryDate('2026-08-01', now)).toBe(true)
+      expect(validateExpiryDate('2030-01-01', now)).toBe(true)
+    })
+
+    test('rejects malformed values', () => {
+      expect(validateExpiryDate('soon', now)).toBe('Use the date format YYYY-MM-DD')
+      expect(validateExpiryDate('30-07-2026', now)).toBe('Use the date format YYYY-MM-DD')
+      expect(validateExpiryDate('2026-7-30', now)).toBe('Use the date format YYYY-MM-DD')
+      expect(validateExpiryDate('', now)).toBe('Use the date format YYYY-MM-DD')
+    })
+
+    test('rejects impossible dates', () => {
+      expect(validateExpiryDate('2026-13-01', now)).toBe('Invalid date')
+      expect(validateExpiryDate('2026-02-30', now)).toBe('Invalid date')
+    })
+
+    test('rejects past dates', () => {
+      expect(validateExpiryDate('2026-07-29', now)).toBe('Date must be today or later')
+      expect(validateExpiryDate('2020-01-01', now)).toBe('Date must be today or later')
+    })
+  })
+
+  describe('formatTokenExpiry', () => {
+    test('formats timestamps as dates', () => {
+      expect(formatTokenExpiry('2026-12-31T00:00:00.000Z')).toBe('2026-12-31')
+    })
+
+    test('shows Never when unset', () => {
+      expect(formatTokenExpiry(null)).toBe('Never')
+      expect(formatTokenExpiry(undefined)).toBe('Never')
+      expect(formatTokenExpiry('')).toBe('Never')
+    })
+
+    test('falls back to the raw value for unparseable dates', () => {
+      expect(formatTokenExpiry('not-a-date')).toBe('not-a-date')
+    })
+  })
+})

--- a/packages/@sanity/cli/src/actions/tokens/expiry.ts
+++ b/packages/@sanity/cli/src/actions/tokens/expiry.ts
@@ -1,0 +1,60 @@
+import {addDays} from 'date-fns/addDays'
+import {format} from 'date-fns/format'
+import {isValid} from 'date-fns/isValid'
+import {parseISO} from 'date-fns/parseISO'
+
+/**
+ * Preset expiry choices offered when creating a token, mirroring the options
+ * in the Sanity Manage token creation flow.
+ */
+export const TOKEN_EXPIRY_PRESET_DAYS = [30, 60, 90] as const
+
+/**
+ * Resolve a preset "days from now" choice to a `yyyy-MM-dd` date string
+ *
+ * @internal
+ */
+export function getPresetExpiryDate(days: number, now: Date = new Date()): string {
+  return format(addDays(now, days), 'yyyy-MM-dd')
+}
+
+/**
+ * Format a `yyyy-MM-dd` date for display in prompt choices, eg `29 Aug 2026`
+ *
+ * @internal
+ */
+export function formatExpiryChoiceDate(date: string): string {
+  return format(parseISO(date), 'dd MMM yyyy')
+}
+
+/**
+ * Validate a user-supplied expiry date. Must be `yyyy-MM-dd` and today or later.
+ *
+ * @internal
+ */
+export function validateExpiryDate(value: string, now: Date = new Date()): string | true {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return 'Use the date format YYYY-MM-DD'
+  }
+  const parsed = parseISO(value)
+  if (!isValid(parsed)) {
+    return 'Invalid date'
+  }
+  if (value < format(now, 'yyyy-MM-dd')) {
+    return 'Date must be today or later'
+  }
+  return true
+}
+
+/**
+ * Format a token's expiry timestamp for display, or `Never` when unset
+ *
+ * @internal
+ */
+export function formatTokenExpiry(expiresAt: string | null | undefined): string {
+  if (!expiresAt) {
+    return 'Never'
+  }
+  const parsed = new Date(expiresAt)
+  return isValid(parsed) ? format(parsed, 'yyyy-MM-dd') : expiresAt
+}

--- a/packages/@sanity/cli/src/actions/tokens/types.ts
+++ b/packages/@sanity/cli/src/actions/tokens/types.ts
@@ -3,24 +3,56 @@ interface TokenRole {
   title: string
 }
 
-export interface Token {
+/**
+ * A robot as returned by the Access API
+ * (`/access/project/{projectId}/robots`)
+ *
+ * @internal
+ */
+export interface Robot {
   createdAt: string
-  createdBy: string
+  expiresAt: string | null
   id: string
   label: string
-  lastUsedAt: string | null
-  permissions: string[]
-  projectId: string
-  projectUserId: string
-  roles: TokenRole[]
+  memberships: RobotMembership[]
+  tokenId: string
+
+  managedBy?: {
+    resourceId: string
+    resourceType: string
+  } | null
 }
 
-export interface TokenResponse {
+interface RobotMembership {
+  resourceId: string
+  resourceType: string
+  roleNames: string[]
+
+  addedAt?: string
+  lastSeenAt?: string | null
+  resourceUserId?: string | null
+}
+
+/**
+ * A project API token, mapped from an Access API robot.
+ *
+ * `id` is the robot ID used by the Access API for delete/update operations,
+ * while `tokenId` is the identifier of the current token credential (the ID
+ * previously exposed by the deprecated Projects API tokens endpoints).
+ *
+ * @internal
+ */
+export interface Token {
+  createdAt: string
+  expiresAt: string | null
   id: string
-  key: string
   label: string
-  projectUserId: string
   roles: TokenRole[]
+  tokenId: string
+}
+
+export interface TokenResponse extends Token {
+  key: string
 }
 
 export interface ProjectRole {
@@ -29,6 +61,5 @@ export interface ProjectRole {
   description: string
   isCustom: boolean
   name: string
-  projectId: string
   title: string
 }

--- a/packages/@sanity/cli/src/actions/tokens/validateRole.ts
+++ b/packages/@sanity/cli/src/actions/tokens/validateRole.ts
@@ -1,13 +1,14 @@
 import {exitCodes, type Output} from '@sanity/cli-core'
 
 import {getTokenRoles} from '../../services/tokens.js'
+import {type ProjectRole} from './types.js'
 
 /**
  * Validate a role name
  * @param roleName - The role name to validate
  * @param projectId - The project ID
  * @param output - Output to raise the error through the calling command
- * @returns A promise that resolves to the validated role name
+ * @returns A promise that resolves to the validated role
  *
  * @internal
  */
@@ -15,13 +16,13 @@ export async function validateRole(
   roleName: string,
   projectId: string,
   output: Output,
-): Promise<string> {
+): Promise<ProjectRole> {
   const roles = await getTokenRoles(projectId)
   const robotRoles = roles.filter((role) => role.appliesToRobots)
 
   const role = robotRoles.find((r) => r.name === roleName)
   if (role) {
-    return roleName
+    return role
   }
 
   const availableRoles = robotRoles.map((r) => r.name).join(', ')

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/create.test.ts
@@ -5,6 +5,7 @@ import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {TOKENS_API_VERSION} from '../../../actions/tokens/constants.js'
+import {getPresetExpiryDate} from '../../../actions/tokens/expiry.js'
 import {CreateTokenCommand} from '../create.js'
 
 vi.mock('@sanity/cli-core/ux', async () => {
@@ -32,6 +33,57 @@ const defaultMocks = {
   token: 'test-token',
 }
 
+const viewerRole = {
+  appliesToRobots: true,
+  appliesToUsers: true,
+  description: 'Can read documents',
+  isCustom: false,
+  name: 'viewer',
+  title: 'Viewer',
+}
+
+const editorRole = {
+  appliesToRobots: true,
+  appliesToUsers: true,
+  description: 'Can read and write documents',
+  isCustom: false,
+  name: 'editor',
+  title: 'Editor',
+}
+
+const createRobot = (overrides: Record<string, unknown> = {}) => ({
+  createdAt: '2026-01-01T00:00:00.000Z',
+  expiresAt: null,
+  id: 'g-robot-123',
+  label: 'My Test Token',
+  managedBy: {resourceId: testProjectId, resourceType: 'project'},
+  memberships: [
+    {
+      addedAt: '2026-01-01T00:00:00.000Z',
+      resourceId: testProjectId,
+      resourceType: 'project',
+      roleNames: ['viewer'],
+    },
+  ],
+  token: 'sk_test_abcd1234',
+  tokenId: 'si-token-123',
+  ...overrides,
+})
+
+const mockRolesApi = (roles: unknown[] = [viewerRole, editorRole]) =>
+  mockApi({
+    apiVersion: TOKENS_API_VERSION,
+    query: {includeChildren: 'false', limit: '500'},
+    uri: `/access/project/${testProjectId}/roles`,
+  }).reply(200, {data: roles, nextCursor: null})
+
+const mockCreateRobotApi = () =>
+  mockApi({
+    apiVersion: TOKENS_API_VERSION,
+    method: 'post',
+    uri: `/access/project/${testProjectId}/robots`,
+  })
+
 describe('#tokens:create', () => {
   beforeEach(() => {
     vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
@@ -45,51 +97,12 @@ describe('#tokens:create', () => {
     expect(pending, 'pending mocks').toEqual([])
   })
 
-  test('creates token with label argument and default role', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read and write documents',
-        isCustom: false,
-        name: 'editor',
-        projectId: 'test-project',
-        title: 'Editor',
-      },
-    ]
+  test('creates token with label argument and prompted role and expiry', async () => {
+    mockedSelect.mockResolvedValueOnce('viewer') // role
+    mockedSelect.mockResolvedValueOnce('none') // expiry
 
-    const mockToken = {
-      id: 'token-123',
-      key: 'sk_test_abcd1234',
-      label: 'My Test Token',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'viewer',
-          title: 'Viewer',
-        },
-      ],
-    }
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+    mockRolesApi()
+    mockCreateRobotApi().reply(201, createRobot())
 
     const {error, stdout} = await testCommand(CreateTokenCommand, ['My Test Token'], {
       mocks: defaultMocks,
@@ -98,57 +111,148 @@ describe('#tokens:create', () => {
     expect(error).toBeUndefined()
     expect(stdout).toContain('API token created')
     expect(stdout).toContain('Label: My Test Token')
-    expect(stdout).toContain('ID: token-123')
+    expect(stdout).toContain('ID: g-robot-123')
     expect(stdout).toContain('Role: Viewer')
+    expect(stdout).toContain('Expires: Never')
     expect(stdout).toContain('Token: sk_test_abcd1234')
     expect(stdout).toContain("Copy the token now. It won't be shown again.")
   })
 
+  test('offers expiry choices matching the Manage token creation flow', async () => {
+    mockedSelect.mockResolvedValueOnce('viewer')
+    mockedSelect.mockResolvedValueOnce('none')
+
+    mockRolesApi()
+    mockCreateRobotApi().reply(201, createRobot())
+
+    await testCommand(CreateTokenCommand, ['My Test Token'], {mocks: defaultMocks})
+
+    const expiryCall = mockedSelect.mock.calls[1][0]
+    expect(expiryCall.message).toBe('Token expiration:')
+    expect(expiryCall.default).toBe('none')
+    expect(expiryCall.choices.map((choice) => (choice as {value: string}).value)).toEqual([
+      'none',
+      '30',
+      '60',
+      '90',
+      'custom',
+    ])
+    expect((expiryCall.choices[0] as {name: string}).name).toBe('No expiration')
+    expect((expiryCall.choices[1] as {name: string}).name).toMatch(
+      /^30 days \(\d{2} \w{3} \d{4}\)$/,
+    )
+  })
+
+  test('creates token with a preset expiry', async () => {
+    mockedSelect.mockResolvedValueOnce('viewer')
+    mockedSelect.mockResolvedValueOnce('30')
+
+    const expectedDate = getPresetExpiryDate(30)
+    let requestBody: Record<string, unknown> = {}
+
+    mockRolesApi()
+    mockCreateRobotApi().reply(201, (uri, body) => {
+      requestBody = body as Record<string, unknown>
+      return createRobot({expiresAt: `${expectedDate}T00:00:00.000Z`})
+    })
+
+    const {stdout} = await testCommand(CreateTokenCommand, ['My Test Token'], {
+      mocks: defaultMocks,
+    })
+
+    expect(requestBody.expiresAt).toBe(expectedDate)
+    expect(requestBody.memberships).toEqual([
+      {resourceId: testProjectId, resourceType: 'project', roleNames: ['viewer']},
+    ])
+    expect(stdout).toContain(`Expires: ${expectedDate}`)
+  })
+
+  test('creates token with a custom expiry date', async () => {
+    mockedSelect.mockResolvedValueOnce('viewer')
+    mockedSelect.mockResolvedValueOnce('custom')
+    mockedInput.mockResolvedValueOnce('2099-12-31')
+
+    let requestBody: Record<string, unknown> = {}
+
+    mockRolesApi()
+    mockCreateRobotApi().reply(201, (uri, body) => {
+      requestBody = body as Record<string, unknown>
+      return createRobot({expiresAt: '2099-12-31T00:00:00.000Z'})
+    })
+
+    const {stdout} = await testCommand(CreateTokenCommand, ['My Test Token'], {
+      mocks: defaultMocks,
+    })
+
+    expect(mockedInput).toHaveBeenCalledWith({
+      message: 'Expiration date (YYYY-MM-DD):',
+      validate: expect.any(Function),
+    })
+    expect(requestBody.expiresAt).toBe('2099-12-31')
+    expect(stdout).toContain('Expires: 2099-12-31')
+  })
+
+  test('creates token with --expires-at flag without prompting for expiry', async () => {
+    mockedSelect.mockResolvedValueOnce('viewer')
+
+    let requestBody: Record<string, unknown> = {}
+
+    mockRolesApi()
+    mockCreateRobotApi().reply(201, (uri, body) => {
+      requestBody = body as Record<string, unknown>
+      return createRobot({expiresAt: '2099-06-15T00:00:00.000Z'})
+    })
+
+    const {stdout} = await testCommand(
+      CreateTokenCommand,
+      ['My Test Token', '--expires-at=2099-06-15'],
+      {mocks: defaultMocks},
+    )
+
+    expect(mockedSelect).toHaveBeenCalledTimes(1) // only the role prompt
+    expect(requestBody.expiresAt).toBe('2099-06-15')
+    expect(stdout).toContain('Expires: 2099-06-15')
+  })
+
+  test.each([
+    {reason: 'not a date', value: 'soon'},
+    {reason: 'wrong format', value: '15-06-2099'},
+    {reason: 'invalid date', value: '2099-13-45'},
+    {reason: 'in the past', value: '2020-01-01'},
+  ])('rejects --expires-at value that is $reason', async ({value}) => {
+    mockedSelect.mockResolvedValueOnce('viewer')
+    mockRolesApi()
+
+    const {error} = await testCommand(
+      CreateTokenCommand,
+      ['My Test Token', `--expires-at=${value}`],
+      {mocks: defaultMocks},
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Invalid `--expires-at` value')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+  })
+
   test('creates token with specific role', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read and write documents',
-        isCustom: false,
-        name: 'editor',
-        projectId: 'test-project',
-        title: 'Editor',
-      },
-    ]
+    mockedSelect.mockResolvedValueOnce('none') // expiry
 
-    const mockToken = {
-      id: 'token-456',
-      key: 'sk_test_editor1234',
-      label: 'Editor Token',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'editor',
-          title: 'Editor',
-        },
-      ],
-    }
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+    mockRolesApi()
+    mockCreateRobotApi().reply(
+      201,
+      createRobot({
+        label: 'Editor Token',
+        memberships: [
+          {
+            addedAt: '2026-01-01T00:00:00.000Z',
+            resourceId: testProjectId,
+            resourceType: 'project',
+            roleNames: ['editor'],
+          },
+        ],
+        token: 'sk_test_editor1234',
+      }),
+    )
 
     const {stdout} = await testCommand(CreateTokenCommand, ['Editor Token', '--role=editor'], {
       mocks: defaultMocks,
@@ -161,56 +265,35 @@ describe('#tokens:create', () => {
   })
 
   test('outputs JSON when --json flag is used', async () => {
-    const mockToken = {
-      id: 'token-json',
-      key: 'sk_test_json1234',
-      label: 'JSON Token',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'viewer',
-          title: 'Viewer',
-        },
-      ],
-    }
-
-    // --json is unattended, so the role defaults to viewer without a roles prompt
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+    // --json is unattended, so the role defaults to viewer without any prompts
+    mockCreateRobotApi().reply(201, createRobot({label: 'JSON Token', token: 'sk_test_json1234'}))
 
     const {stdout} = await testCommand(CreateTokenCommand, ['JSON Token', '--json'], {
       mocks: defaultMocks,
     })
 
     const parsedOutput = JSON.parse(stdout)
-    expect(parsedOutput).toEqual(mockToken)
+    expect(parsedOutput).toEqual({
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: null,
+      id: 'g-robot-123',
+      key: 'sk_test_json1234',
+      label: 'JSON Token',
+      roles: [{name: 'viewer', title: 'Viewer'}],
+      tokenId: 'si-token-123',
+    })
     expect(mockedSelect).not.toHaveBeenCalled()
     expect(mockedInput).not.toHaveBeenCalled()
   })
 
   test('works in unattended mode with --yes flag', async () => {
-    const mockToken = {
-      id: 'token-unattended',
-      key: 'sk_test_unattended1234',
-      label: 'Unattended Token',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'viewer',
-          title: 'Viewer',
-        },
-      ],
-    }
-
-    // Only mock the token creation API, not the roles API since unattended mode uses default role
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+    // Only mock the robot creation API; unattended mode uses the default role
+    // and no expiry without prompting
+    let requestBody: Record<string, unknown> = {}
+    mockCreateRobotApi().reply(201, (uri, body) => {
+      requestBody = body as Record<string, unknown>
+      return createRobot({label: 'Unattended Token'})
+    })
 
     const {stdout} = await testCommand(CreateTokenCommand, ['Unattended Token', '--yes'], {
       mocks: defaultMocks,
@@ -218,27 +301,32 @@ describe('#tokens:create', () => {
 
     expect(stdout).toContain('API token created')
     expect(stdout).toContain('Label: Unattended Token')
+    expect(stdout).toContain('Expires: Never')
+    expect(requestBody.expiresAt).toBeUndefined()
     expect(mockedSelect).not.toHaveBeenCalled()
     expect(mockedInput).not.toHaveBeenCalled()
   })
 
-  test('handles invalid role error', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-    ]
+  test('accepts --expires-at in unattended mode', async () => {
+    let requestBody: Record<string, unknown> = {}
+    mockCreateRobotApi().reply(201, (uri, body) => {
+      requestBody = body as Record<string, unknown>
+      return createRobot({expiresAt: '2099-06-15T00:00:00.000Z', label: 'CI Token'})
+    })
 
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
+    const {stdout} = await testCommand(
+      CreateTokenCommand,
+      ['CI Token', '--yes', '--expires-at=2099-06-15'],
+      {mocks: defaultMocks},
+    )
+
+    expect(requestBody.expiresAt).toBe('2099-06-15')
+    expect(stdout).toContain('Expires: 2099-06-15')
+    expect(mockedSelect).not.toHaveBeenCalled()
+  })
+
+  test('handles invalid role error', async () => {
+    mockRolesApi([viewerRole])
 
     const {error} = await testCommand(CreateTokenCommand, ['Test Token', '--role=invalid'], {
       mocks: defaultMocks,
@@ -251,28 +339,11 @@ describe('#tokens:create', () => {
   })
 
   test('handles API error during token creation', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-    ]
+    mockedSelect.mockResolvedValueOnce('viewer')
+    mockedSelect.mockResolvedValueOnce('none')
 
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(500, {message: 'Internal Server Error'})
+    mockRolesApi([viewerRole])
+    mockCreateRobotApi().reply(500, {message: 'Internal Server Error'})
 
     const {error} = await testCommand(CreateTokenCommand, ['Failed Token'], {mocks: defaultMocks})
 
@@ -296,22 +367,16 @@ describe('#tokens:create', () => {
   })
 
   test('handles no roles available for tokens', async () => {
-    const mockRoles = [
+    mockRolesApi([
       {
         appliesToRobots: false, // Not applicable to robots
         appliesToUsers: true,
         description: 'Full access',
         isCustom: false,
         name: 'admin',
-        projectId: 'test-project',
         title: 'Admin',
       },
-    ]
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
+    ])
 
     const {error} = await testCommand(CreateTokenCommand, ['Test Token'], {mocks: defaultMocks})
 
@@ -321,44 +386,12 @@ describe('#tokens:create', () => {
   })
 
   test('prompts for label when not provided in interactive mode', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-    ]
-
-    const mockToken = {
-      id: 'token-prompted',
-      key: 'sk_test_prompted1234',
-      label: 'Prompted Label',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'viewer',
-          title: 'Viewer',
-        },
-      ],
-    }
-
     mockedInput.mockResolvedValueOnce('Prompted Label')
     mockedSelect.mockResolvedValueOnce('viewer')
+    mockedSelect.mockResolvedValueOnce('none')
 
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+    mockRolesApi([viewerRole])
+    mockCreateRobotApi().reply(201, createRobot({label: 'Prompted Label'}))
 
     const {stdout} = await testCommand(CreateTokenCommand, [], {mocks: defaultMocks})
 
@@ -374,42 +407,10 @@ describe('#tokens:create', () => {
     // Mock input to capture the validation function and return a valid label
     mockedInput.mockResolvedValueOnce('Valid Label')
     mockedSelect.mockResolvedValueOnce('viewer')
+    mockedSelect.mockResolvedValueOnce('none')
 
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-    ]
-
-    const mockToken = {
-      id: 'token-validated',
-      key: 'sk_test_validated1234',
-      label: 'Valid Label',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'viewer',
-          title: 'Viewer',
-        },
-      ],
-    }
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+    mockRolesApi([viewerRole])
+    mockCreateRobotApi().reply(201, createRobot({label: 'Valid Label'}))
 
     await testCommand(CreateTokenCommand, [], {mocks: defaultMocks})
 

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
@@ -4,41 +4,66 @@ import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {TOKENS_API_VERSION} from '../../../actions/tokens/constants.js'
-import {type Token} from '../../../actions/tokens/types.js'
+import {type Robot} from '../../../actions/tokens/types.js'
 import {DeleteTokensCommand} from '../delete.js'
 
+const testProjectId = 'test-project'
+
 // Test fixtures
-const createToken = (overrides: Partial<Token> & {id: string}): Token => ({
-  createdAt: '2023-01-01T00:00:00Z',
-  createdBy: 'user-creator',
+const createRobot = (overrides: Partial<Robot> & {id: string}): Robot => ({
+  createdAt: '2023-01-01T00:00:00.000Z',
+  expiresAt: null,
   label: 'Test Token',
-  lastUsedAt: null,
-  permissions: ['read', 'write'],
-  projectId: 'test-project',
-  projectUserId: 'user-123',
-  roles: [{name: 'editor', title: 'Editor'}],
+  managedBy: {resourceId: testProjectId, resourceType: 'project'},
+  memberships: [
+    {
+      addedAt: '2023-01-01T00:00:00.000Z',
+      resourceId: testProjectId,
+      resourceType: 'project',
+      roleNames: ['editor'],
+    },
+  ],
+  tokenId: `si-${overrides.id}`,
   ...overrides,
 })
 
-const TEST_TOKENS = {
-  API_TOKEN: createToken({
-    id: 'token-api-123',
+const TEST_ROBOTS = {
+  API_TOKEN: createRobot({
+    id: 'g-robot-api-123',
     label: 'API Token',
-    roles: [{name: 'editor', title: 'Editor'}],
   }),
-  READ_TOKEN: createToken({
-    id: 'token-read-456',
+  READ_TOKEN: createRobot({
+    id: 'g-robot-read-456',
     label: 'Read Token',
-    roles: [{name: 'viewer', title: 'Viewer'}],
-  }),
-  WRITE_TOKEN: createToken({
-    id: 'token-write-789',
-    label: 'Write Token',
-    roles: [{name: 'administrator', title: 'Administrator'}],
+    memberships: [
+      {
+        addedAt: '2023-01-01T00:00:00.000Z',
+        resourceId: testProjectId,
+        resourceType: 'project',
+        roleNames: ['viewer'],
+      },
+    ],
   }),
 } as const
 
-const testProjectId = 'test-project'
+const mockRoles = [
+  {
+    appliesToRobots: true,
+    appliesToUsers: true,
+    description: 'Can read and write documents',
+    isCustom: false,
+    name: 'editor',
+    title: 'Editor',
+  },
+  {
+    appliesToRobots: true,
+    appliesToUsers: true,
+    description: 'Can read documents',
+    isCustom: false,
+    name: 'viewer',
+    title: 'Viewer',
+  },
+]
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
@@ -50,6 +75,27 @@ const defaultMocks = {
   },
   token: 'test-token',
 }
+
+const mockRobotsApi = () =>
+  mockApi({
+    apiVersion: TOKENS_API_VERSION,
+    query: {includeChildren: 'false'},
+    uri: `/access/project/${testProjectId}/robots`,
+  })
+
+const mockRolesApi = () =>
+  mockApi({
+    apiVersion: TOKENS_API_VERSION,
+    query: {includeChildren: 'false', limit: '500'},
+    uri: `/access/project/${testProjectId}/roles`,
+  })
+
+const mockDeleteRobotApi = (robotId: string) =>
+  mockApi({
+    apiVersion: TOKENS_API_VERSION,
+    method: 'delete',
+    uri: `/access/project/${testProjectId}/robots/${robotId}`,
+  })
 
 vi.mock('@sanity/cli-core/ux', async () => {
   const actual = await vi.importActual<typeof import('@sanity/cli-core/ux')>('@sanity/cli-core/ux')
@@ -72,31 +118,23 @@ describe('#tokens:delete', () => {
     const {confirm} = await import('@sanity/cli-core/ux')
     vi.mocked(confirm).mockResolvedValue(true)
 
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'delete',
-      uri: '/projects/test-project/tokens/token-api-123',
-    }).reply(204)
+    mockDeleteRobotApi('g-robot-api-123').reply(204)
 
-    const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123'], {
+    const {stdout} = await testCommand(DeleteTokensCommand, ['g-robot-api-123'], {
       mocks: defaultMocks,
     })
     expect(stdout).toBe('API token deleted\n')
     expect(confirm).toHaveBeenCalledWith({
       default: false,
-      message: 'Delete API token "token-api-123"?',
+      message: 'Delete API token "g-robot-api-123"?',
     })
   })
 
   test('deletes a specific token by ID with --yes flag (skips confirmation)', async () => {
     const {confirm} = await import('@sanity/cli-core/ux')
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'delete',
-      uri: '/projects/test-project/tokens/token-api-123',
-    }).reply(204)
+    mockDeleteRobotApi('g-robot-api-123').reply(204)
 
-    const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {
+    const {stdout} = await testCommand(DeleteTokensCommand, ['g-robot-api-123', '--yes'], {
       mocks: defaultMocks,
     })
     expect(stdout).toBe('API token deleted\n')
@@ -104,23 +142,59 @@ describe('#tokens:delete', () => {
   })
 
   test('deletes a specific token by ID with -y flag (skips confirmation)', async () => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'delete',
-      uri: '/projects/test-project/tokens/token-api-123',
-    }).reply(204)
+    mockDeleteRobotApi('g-robot-api-123').reply(204)
 
-    const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123', '-y'], {
+    const {stdout} = await testCommand(DeleteTokensCommand, ['g-robot-api-123', '-y'], {
       mocks: defaultMocks,
     })
     expect(stdout).toBe('API token deleted\n')
+  })
+
+  test('deletes a token by its legacy token ID', async () => {
+    // A legacy token ID (from the deprecated Projects API) is not a robot ID,
+    // so the first delete attempt 404s and the ID is resolved via the robot list
+    mockDeleteRobotApi('si-g-robot-api-123').reply(404, {message: 'Robot not found'})
+    mockRobotsApi().reply(200, {
+      data: [TEST_ROBOTS.API_TOKEN, TEST_ROBOTS.READ_TOKEN],
+      nextCursor: null,
+    })
+    mockDeleteRobotApi('g-robot-api-123').reply(204)
+
+    const {stdout} = await testCommand(DeleteTokensCommand, ['si-g-robot-api-123', '--yes'], {
+      mocks: defaultMocks,
+    })
+    expect(stdout).toBe('API token deleted\n')
+  })
+
+  test('throws not found when the ID matches no robot or legacy token ID', async () => {
+    mockDeleteRobotApi('nonexistent-token').reply(404, {message: 'Robot not found'})
+    mockRobotsApi().reply(200, {data: [TEST_ROBOTS.API_TOKEN], nextCursor: null})
+
+    const {error} = await testCommand(DeleteTokensCommand, ['nonexistent-token', '--yes'], {
+      mocks: defaultMocks,
+    })
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Token with ID "nonexistent-token" not found')
+    expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test('surfaces the original not found error when the robot list cannot be fetched', async () => {
+    mockDeleteRobotApi('nonexistent-token').reply(404, {message: 'Robot not found'})
+    mockRobotsApi().reply(403, {message: 'Forbidden'})
+
+    const {error} = await testCommand(DeleteTokensCommand, ['nonexistent-token', '--yes'], {
+      mocks: defaultMocks,
+    })
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Token with ID "nonexistent-token" not found')
+    expect(error?.oclif?.exit).toBe(1)
   })
 
   test('cancels deletion when user declines confirmation', async () => {
     const {confirm} = await import('@sanity/cli-core/ux')
     vi.mocked(confirm).mockResolvedValue(false)
 
-    const {error, stdout} = await testCommand(DeleteTokensCommand, ['token-api-123'], {
+    const {error, stdout} = await testCommand(DeleteTokensCommand, ['g-robot-api-123'], {
       mocks: defaultMocks,
     })
     expect(error).toBeInstanceOf(Error)
@@ -143,7 +217,7 @@ describe('#tokens:delete', () => {
     )
     expect(missingId.error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
 
-    const missingConfirmation = await testCommand(DeleteTokensCommand, ['token-api-123'], {
+    const missingConfirmation = await testCommand(DeleteTokensCommand, ['g-robot-api-123'], {
       mocks: {...defaultMocks, isInteractive: false},
     })
     expect(missingConfirmation.error?.message).toContain('--yes')
@@ -154,26 +228,22 @@ describe('#tokens:delete', () => {
 
   test('prompts user to select token when none specified', async () => {
     const {confirm, select} = await import('@sanity/cli-core/ux')
-    vi.mocked(select).mockResolvedValue('token-read-456')
+    vi.mocked(select).mockResolvedValue('g-robot-read-456')
     vi.mocked(confirm).mockResolvedValue(true)
 
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
-    }).reply(200, [TEST_TOKENS.API_TOKEN, TEST_TOKENS.READ_TOKEN])
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'delete',
-      uri: '/projects/test-project/tokens/token-read-456',
-    }).reply(204)
+    mockRobotsApi().reply(200, {
+      data: [TEST_ROBOTS.API_TOKEN, TEST_ROBOTS.READ_TOKEN],
+      nextCursor: null,
+    })
+    mockRolesApi().reply(200, {data: mockRoles, nextCursor: null})
+    mockDeleteRobotApi('g-robot-read-456').reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(stdout).toBe('API token deleted\n')
     expect(select).toHaveBeenCalledWith({
       choices: [
-        {name: 'API Token (Editor)', value: 'token-api-123'},
-        {name: 'Read Token (Viewer)', value: 'token-read-456'},
+        {name: 'API Token (Editor)', value: 'g-robot-api-123'},
+        {name: 'Read Token (Viewer)', value: 'g-robot-read-456'},
       ],
       message: 'Select token to delete:',
     })
@@ -181,85 +251,64 @@ describe('#tokens:delete', () => {
 
   test('handles tokens with multiple roles', async () => {
     const {confirm, select} = await import('@sanity/cli-core/ux')
-    const multiRoleToken = createToken({
-      id: 'token-multi-123',
+    const multiRoleRobot = createRobot({
+      id: 'g-robot-multi-123',
       label: 'Multi Role Token',
-      roles: [
-        {name: 'editor', title: 'Editor'},
-        {name: 'viewer', title: 'Viewer'},
+      memberships: [
+        {
+          addedAt: '2023-01-01T00:00:00.000Z',
+          resourceId: testProjectId,
+          resourceType: 'project',
+          roleNames: ['editor', 'viewer'],
+        },
       ],
     })
-    vi.mocked(select).mockResolvedValue('token-multi-123')
+    vi.mocked(select).mockResolvedValue('g-robot-multi-123')
     vi.mocked(confirm).mockResolvedValue(true)
 
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
-    }).reply(200, [multiRoleToken])
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'delete',
-      uri: '/projects/test-project/tokens/token-multi-123',
-    }).reply(204)
+    mockRobotsApi().reply(200, {data: [multiRoleRobot], nextCursor: null})
+    mockRolesApi().reply(200, {data: mockRoles, nextCursor: null})
+    mockDeleteRobotApi('g-robot-multi-123').reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(stdout).toBe('API token deleted\n')
     expect(select).toHaveBeenCalledWith({
-      choices: [{name: 'Multi Role Token (Editor, Viewer)', value: 'token-multi-123'}],
+      choices: [{name: 'Multi Role Token (Editor, Viewer)', value: 'g-robot-multi-123'}],
       message: 'Select token to delete:',
     })
   })
 
   test('handles tokens with no roles', async () => {
     const {confirm, select} = await import('@sanity/cli-core/ux')
-    const noRoleToken = createToken({
-      id: 'token-no-role-123',
+    const noRoleRobot = createRobot({
+      id: 'g-robot-no-role-123',
       label: 'No Role Token',
-      roles: [],
+      memberships: [
+        {
+          addedAt: '2023-01-01T00:00:00.000Z',
+          resourceId: testProjectId,
+          resourceType: 'project',
+          roleNames: [],
+        },
+      ],
     })
-    vi.mocked(select).mockResolvedValue('token-no-role-123')
+    vi.mocked(select).mockResolvedValue('g-robot-no-role-123')
     vi.mocked(confirm).mockResolvedValue(true)
 
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
-    }).reply(200, [noRoleToken])
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'delete',
-      uri: '/projects/test-project/tokens/token-no-role-123',
-    }).reply(204)
+    mockRobotsApi().reply(200, {data: [noRoleRobot], nextCursor: null})
+    mockRolesApi().reply(200, {data: mockRoles, nextCursor: null})
+    mockDeleteRobotApi('g-robot-no-role-123').reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(stdout).toBe('API token deleted\n')
     expect(select).toHaveBeenCalledWith({
-      choices: [{name: 'No Role Token ()', value: 'token-no-role-123'}],
+      choices: [{name: 'No Role Token ()', value: 'g-robot-no-role-123'}],
       message: 'Select token to delete:',
     })
   })
 
-  test('throws error when token not found (404)', async () => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'delete',
-      uri: '/projects/test-project/tokens/nonexistent-token',
-    }).reply(404, {message: 'Token not found'})
-
-    const {error} = await testCommand(DeleteTokensCommand, ['nonexistent-token', '--yes'], {
-      mocks: defaultMocks,
-    })
-    expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toContain('Token with ID "nonexistent-token" not found')
-    expect(error?.oclif?.exit).toBe(1)
-  })
-
   test('throws error when no tokens exist in project', async () => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
-    }).reply(200, [])
+    mockRobotsApi().reply(200, {data: [], nextCursor: null})
 
     const {error} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
@@ -271,13 +320,9 @@ describe('#tokens:delete', () => {
     {desc: 'when deleting token', message: 'Internal Server Error', statusCode: 500},
     {desc: 'with forbidden error when deleting token', message: 'Forbidden', statusCode: 403},
   ])('handles API error $desc', async ({message, statusCode}) => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      method: 'delete',
-      uri: '/projects/test-project/tokens/token-api-123',
-    }).reply(statusCode, {message})
+    mockDeleteRobotApi('g-robot-api-123').reply(statusCode, {message})
 
-    const {error} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {
+    const {error} = await testCommand(DeleteTokensCommand, ['g-robot-api-123', '--yes'], {
       mocks: defaultMocks,
     })
     expect(error).toBeInstanceOf(Error)
@@ -287,10 +332,7 @@ describe('#tokens:delete', () => {
   })
 
   test('handles API error when fetching tokens', async () => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
-    }).reply(404, {message: 'Project not found'})
+    mockRobotsApi().reply(404, {message: 'Project not found'})
 
     const {error} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
@@ -301,10 +343,7 @@ describe('#tokens:delete', () => {
   })
 
   test('handles API error with server error when fetching tokens', async () => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
-    }).reply(500, {message: 'Internal Server Error'})
+    mockRobotsApi().reply(500, {message: 'Internal Server Error'})
 
     const {error} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
@@ -317,7 +356,7 @@ describe('#tokens:delete', () => {
     {desc: 'no project ID is found', projectId: undefined},
     {desc: 'project ID is empty string', projectId: ''},
   ])('throws error when $desc', async ({projectId}) => {
-    const {error} = await testCommand(DeleteTokensCommand, ['token-api-123'], {
+    const {error} = await testCommand(DeleteTokensCommand, ['g-robot-api-123'], {
       mocks: {
         ...defaultMocks,
         cliConfig: {api: {projectId}},
@@ -338,7 +377,7 @@ describe('#tokens:delete', () => {
 
   test('handles network errors when deleting token', async () => {
     // Don't set up any mock to simulate network failure
-    const {error} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {
+    const {error} = await testCommand(DeleteTokensCommand, ['g-robot-api-123', '--yes'], {
       mocks: defaultMocks,
     })
     expect(error).toBeInstanceOf(Error)

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/list.test.ts
@@ -17,44 +17,107 @@ const defaultMocks = {
   token: 'test-token',
 }
 
-const mockTokens = [
+const mockRoles = [
   {
-    createdAt: '2023-01-01T00:00:00Z',
-    createdBy: 'user@example.com',
-    id: 'token-1',
-    label: 'Production API',
-    lastUsedAt: '2023-12-01T00:00:00Z',
-    permissions: ['read', 'write'],
-    projectId: testProjectId,
-    projectUserId: 'user-1',
-    roles: [
-      {name: 'admin', title: 'Administrator'},
-      {name: 'editor', title: 'Editor'},
-    ],
+    appliesToRobots: true,
+    appliesToUsers: true,
+    description: 'Administer the project',
+    isCustom: false,
+    name: 'administrator',
+    title: 'Administrator',
   },
   {
-    createdAt: '2023-02-01T00:00:00Z',
-    createdBy: 'dev@example.com',
-    id: 'token-2',
-    label: 'Development API',
-    lastUsedAt: null,
-    permissions: ['read'],
-    projectId: testProjectId,
-    projectUserId: 'user-2',
-    roles: [{name: 'viewer', title: 'Viewer'}],
+    appliesToRobots: true,
+    appliesToUsers: true,
+    description: 'Can read and write documents',
+    isCustom: false,
+    name: 'editor',
+    title: 'Editor',
   },
   {
-    createdAt: '2023-03-01T00:00:00Z',
-    createdBy: 'analytics@example.com',
-    id: 'token-3',
-    label: 'Analytics Token',
-    lastUsedAt: '2023-11-15T00:00:00Z',
-    permissions: ['read'],
-    projectId: testProjectId,
-    projectUserId: 'user-3',
-    roles: [],
+    appliesToRobots: true,
+    appliesToUsers: true,
+    description: 'Can read documents',
+    isCustom: false,
+    name: 'viewer',
+    title: 'Viewer',
   },
 ]
+
+const createRobot = (overrides: Record<string, unknown> = {}) => ({
+  createdAt: '2023-01-01T00:00:00.000Z',
+  expiresAt: null,
+  id: 'g-robot-1',
+  label: 'Test Robot',
+  managedBy: {resourceId: testProjectId, resourceType: 'project'},
+  memberships: [
+    {
+      addedAt: '2023-01-01T00:00:00.000Z',
+      resourceId: testProjectId,
+      resourceType: 'project',
+      roleNames: ['viewer'],
+    },
+  ],
+  tokenId: 'si-token-1',
+  ...overrides,
+})
+
+const mockRobots = [
+  createRobot({
+    createdAt: '2023-01-01T00:00:00.000Z',
+    expiresAt: '2099-12-31T00:00:00.000Z',
+    id: 'g-robot-1',
+    label: 'Production API',
+    memberships: [
+      {
+        addedAt: '2023-01-01T00:00:00.000Z',
+        resourceId: testProjectId,
+        resourceType: 'project',
+        roleNames: ['administrator', 'editor'],
+      },
+    ],
+    tokenId: 'si-token-1',
+  }),
+  createRobot({
+    createdAt: '2023-02-01T00:00:00.000Z',
+    id: 'g-robot-2',
+    label: 'Development API',
+    tokenId: 'si-token-2',
+  }),
+  createRobot({
+    createdAt: '2023-03-01T00:00:00.000Z',
+    id: 'g-robot-3',
+    label: 'Analytics Token',
+    memberships: [
+      {
+        addedAt: '2023-03-01T00:00:00.000Z',
+        resourceId: testProjectId,
+        resourceType: 'project',
+        roleNames: [],
+      },
+    ],
+    tokenId: 'si-token-3',
+  }),
+]
+
+const mockRobotsApi = () =>
+  mockApi({
+    apiVersion: TOKENS_API_VERSION,
+    query: {includeChildren: 'false'},
+    uri: `/access/project/${testProjectId}/robots`,
+  })
+
+const mockRolesApi = () =>
+  mockApi({
+    apiVersion: TOKENS_API_VERSION,
+    query: {includeChildren: 'false', limit: '500'},
+    uri: `/access/project/${testProjectId}/roles`,
+  })
+
+const mockListApis = (robots: unknown[] = mockRobots, roles: unknown[] = mockRoles) => {
+  mockRobotsApi().reply(200, {data: robots, nextCursor: null})
+  mockRolesApi().reply(200, {data: roles, nextCursor: null})
+}
 
 describe('#tokens:list', () => {
   afterEach(() => {
@@ -65,10 +128,7 @@ describe('#tokens:list', () => {
   })
 
   test('displays tokens in table format by default', async () => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, mockTokens)
+    mockListApis()
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
@@ -76,43 +136,75 @@ describe('#tokens:list', () => {
     expect(stdout).toContain('Label')
     expect(stdout).toContain('Token ID')
     expect(stdout).toContain('Roles')
+    expect(stdout).toContain('Expires')
     expect(stdout).toContain('Production API')
-    expect(stdout).toContain('token-1')
+    expect(stdout).toContain('g-robot-1')
     expect(stdout).toContain('Administrator, Editor')
+    expect(stdout).toContain('2099-12-31')
     expect(stdout).toContain('Development API')
-    expect(stdout).toContain('token-2')
+    expect(stdout).toContain('g-robot-2')
     expect(stdout).toContain('Viewer')
+    expect(stdout).toContain('Never')
     expect(stdout).toContain('Analytics Token')
-    expect(stdout).toContain('token-3')
+    expect(stdout).toContain('g-robot-3')
     expect(stdout).toContain('No roles')
   })
 
-  test('displays tokens in JSON format when requested', async () => {
+  test('excludes robots managed by other resources', async () => {
+    const orgManagedRobot = createRobot({
+      id: 'g-org-robot',
+      label: 'Org Managed Robot',
+      managedBy: {resourceId: 'some-org', resourceType: 'organization'},
+    })
+
+    mockListApis([mockRobots[0], orgManagedRobot])
+
+    const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
+
+    expect(stdout).toContain('Found 1 API tokens')
+    expect(stdout).toContain('Production API')
+    expect(stdout).not.toContain('Org Managed Robot')
+  })
+
+  test('follows pagination cursors when listing robots', async () => {
+    mockRobotsApi().reply(200, {data: [mockRobots[0]], nextCursor: 'cursor-1'})
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, mockTokens)
+      query: {includeChildren: 'false', nextCursor: 'cursor-1'},
+      uri: `/access/project/${testProjectId}/robots`,
+    }).reply(200, {data: [mockRobots[1]], nextCursor: null})
+    mockRolesApi().reply(200, {data: mockRoles, nextCursor: null})
+
+    const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
+
+    expect(stdout).toContain('Found 2 API tokens')
+    expect(stdout).toContain('Production API')
+    expect(stdout).toContain('Development API')
+  })
+
+  test('displays tokens in JSON format when requested', async () => {
+    mockListApis()
 
     const {stdout} = await testCommand(TokensListCommand, ['--json'], {mocks: defaultMocks})
 
     const parsed = JSON.parse(stdout)
     expect(parsed).toHaveLength(3)
-    expect(parsed[0]).toMatchObject({
-      createdBy: 'user@example.com',
-      id: 'token-1',
+    expect(parsed[0]).toEqual({
+      createdAt: '2023-01-01T00:00:00.000Z',
+      expiresAt: '2099-12-31T00:00:00.000Z',
+      id: 'g-robot-1',
       label: 'Production API',
       roles: [
-        {name: 'admin', title: 'Administrator'},
+        {name: 'administrator', title: 'Administrator'},
         {name: 'editor', title: 'Editor'},
       ],
+      tokenId: 'si-token-1',
     })
   })
 
   test('handles empty tokens list', async () => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, [])
+    // The roles endpoint is not queried when there are no tokens to resolve
+    mockRobotsApi().reply(200, {data: [], nextCursor: null})
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
@@ -120,10 +212,7 @@ describe('#tokens:list', () => {
   })
 
   test('displays an error if the API request fails', async () => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(500, {message: 'Internal Server Error'})
+    mockRobotsApi().reply(500, {message: 'Internal Server Error'})
 
     const {error} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
@@ -154,19 +243,6 @@ describe('#tokens:list', () => {
     expect(error?.oclif?.exit).toBe(1)
   })
 
-  test('throws error when project ID is null', async () => {
-    const {error} = await testCommand(TokensListCommand, [], {
-      mocks: {
-        ...defaultMocks,
-        cliConfig: {api: {projectId: undefined}},
-      },
-    })
-
-    expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toContain('Unable to determine project ID')
-    expect(error?.oclif?.exit).toBe(1)
-  })
-
   test('throws error when project ID is empty string', async () => {
     const {error} = await testCommand(TokensListCommand, [], {
       mocks: {
@@ -180,10 +256,7 @@ describe('#tokens:list', () => {
   })
 
   test('handles 404 error gracefully', async () => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(404, {message: 'Project not found'})
+    mockRobotsApi().reply(404, {message: 'Project not found'})
 
     const {error} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
@@ -194,10 +267,7 @@ describe('#tokens:list', () => {
   })
 
   test('handles 403 forbidden error', async () => {
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(403, {message: 'Forbidden'})
+    mockRobotsApi().reply(403, {message: 'Forbidden'})
 
     const {error} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
@@ -208,68 +278,72 @@ describe('#tokens:list', () => {
   })
 
   test('displays single token correctly', async () => {
-    const singleToken = [mockTokens[0]]
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, singleToken)
+    mockListApis([mockRobots[0]])
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
     expect(stdout).toContain('Found 1 API tokens')
     expect(stdout).toContain('Production API')
-    expect(stdout).toContain('token-1')
+    expect(stdout).toContain('g-robot-1')
     expect(stdout).toContain('Administrator, Editor')
   })
 
-  test('handles tokens with special characters in labels', async () => {
-    const specialTokens = [
-      {
-        createdAt: '2023-01-01T00:00:00Z',
-        createdBy: 'user@café.com',
-        id: 'token-special',
-        label: 'API Token (Test & Dev)',
-        lastUsedAt: null,
-        permissions: ['read'],
-        projectId: testProjectId,
-        projectUserId: 'user-special',
-        roles: [{name: 'viewer', title: 'Viewer'}],
-      },
-    ]
+  test('falls back to role names when a role title is unknown', async () => {
+    const customRoleRobot = createRobot({
+      id: 'g-robot-custom',
+      label: 'Custom Role Token',
+      memberships: [
+        {
+          addedAt: '2023-01-01T00:00:00.000Z',
+          resourceId: testProjectId,
+          resourceType: 'project',
+          roleNames: ['my-custom-role'],
+        },
+      ],
+    })
 
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, specialTokens)
+    mockListApis([customRoleRobot], [])
+
+    const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
+
+    expect(stdout).toContain('Custom Role Token')
+    expect(stdout).toContain('my-custom-role')
+  })
+
+  test('lists tokens with role names when the roles cannot be fetched', async () => {
+    mockRobotsApi().reply(200, {data: [mockRobots[1]], nextCursor: null})
+    mockRolesApi().reply(403, {message: 'Forbidden'})
+
+    const {error, stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
+
+    expect(error).toBeUndefined()
+    expect(stdout).toContain('Development API')
+    expect(stdout).toContain('viewer')
+  })
+
+  test('handles tokens with special characters in labels', async () => {
+    mockListApis([
+      createRobot({
+        id: 'g-robot-special',
+        label: 'API Token (Test & Dev)',
+      }),
+    ])
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
     expect(stdout).toContain('API Token (Test & Dev)')
-    expect(stdout).toContain('token-special')
+    expect(stdout).toContain('g-robot-special')
     expect(stdout).toContain('Viewer')
   })
 
   test('truncates long labels correctly', async () => {
-    const longLabelTokens = [
-      {
-        createdAt: '2023-01-01T00:00:00Z',
-        createdBy: 'user@example.com',
-        id: 'token-long',
+    mockListApis([
+      createRobot({
+        id: 'g-robot-long',
         label:
           'This is a very long token label that should be truncated because it exceeds the maximum length',
-        lastUsedAt: null,
-        permissions: ['read'],
-        projectId: testProjectId,
-        projectUserId: 'user-long',
-        roles: [{name: 'viewer', title: 'Viewer'}],
-      },
-    ]
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, longLabelTokens)
+      }),
+    ])
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
@@ -278,29 +352,20 @@ describe('#tokens:list', () => {
   })
 
   test('truncates long roles correctly', async () => {
-    const longRolesTokens = [
-      {
-        createdAt: '2023-01-01T00:00:00Z',
-        createdBy: 'user@example.com',
-        id: 'token-roles',
+    mockListApis([
+      createRobot({
+        id: 'g-robot-roles',
         label: 'Multi Role Token',
-        lastUsedAt: null,
-        permissions: ['read'],
-        projectId: testProjectId,
-        projectUserId: 'user-roles',
-        roles: [
-          {name: 'administrator', title: 'Administrator'},
-          {name: 'editor', title: 'Editor'},
-          {name: 'viewer', title: 'Viewer'},
-          {name: 'contributor', title: 'Contributor'},
+        memberships: [
+          {
+            addedAt: '2023-01-01T00:00:00.000Z',
+            resourceId: testProjectId,
+            resourceType: 'project',
+            roleNames: ['administrator', 'editor', 'viewer', 'contributor'],
+          },
         ],
-      },
-    ]
-
-    mockApi({
-      apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, longRolesTokens)
+      }),
+    ])
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 

--- a/packages/@sanity/cli/src/commands/tokens/create.ts
+++ b/packages/@sanity/cli/src/commands/tokens/create.ts
@@ -2,12 +2,27 @@ import {Args, Flags} from '@oclif/core'
 import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 
+import {
+  formatExpiryChoiceDate,
+  formatTokenExpiry,
+  getPresetExpiryDate,
+  TOKEN_EXPIRY_PRESET_DAYS,
+  validateExpiryDate,
+} from '../../actions/tokens/expiry.js'
 import {validateRole} from '../../actions/tokens/validateRole.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {createToken, getTokenRoles} from '../../services/tokens.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
 
 const tokensCreateDebug = subdebug('tokens:create')
+
+// Default role for unattended mode; `viewer` is a built-in role present on every project
+const DEFAULT_ROLE = {name: 'viewer', title: 'Viewer'}
+
+interface SelectedRole {
+  name: string
+  title: string
+}
 
 export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand> {
   static override args = {
@@ -40,12 +55,21 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       command: '<%= config.bin %> <%= command.id %> "My Token" --project-id abc123 --role=editor',
       description: 'Create a token for a specific project',
     },
+    {
+      command: '<%= config.bin %> <%= command.id %> "My Token" --expires-at 2026-12-31',
+      description: 'Create a token that expires on a given date',
+    },
   ]
 
   static override flags = {
     ...getProjectIdFlag({
       description: 'Project ID to create token in',
       semantics: 'override',
+    }),
+    'expires-at': Flags.string({
+      description:
+        'Expiration date for the token (YYYY-MM-DD). Omit for a token that never expires.',
+      helpValue: 'YYYY-MM-DD',
     }),
     json: Flags.boolean({
       default: false,
@@ -86,19 +110,24 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
         }),
     })
 
-    const roleName = await (role
+    const selectedRole: SelectedRole = await (role
       ? validateRole(role, projectId, this.output)
       : this.promptForRole(projectId))
 
+    const expiresAt = await this.resolveExpiry(flags['expires-at'])
+
     try {
       tokensCreateDebug(`Creating token for project ${projectId}`, {
+        expiresAt,
         label,
-        roleName,
+        roleName: selectedRole.name,
       })
       const token = await createToken({
+        expiresAt,
         label,
         projectId,
-        roleName,
+        roleName: selectedRole.name,
+        roleTitle: selectedRole.title,
       })
 
       if (json) {
@@ -110,6 +139,7 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       this.log(`Label: ${token.label}`)
       this.log(`ID: ${token.id}`)
       this.log(`Role: ${token.roles.map((r) => r.title).join(', ')}`)
+      this.log(`Expires: ${formatTokenExpiry(token.expiresAt)}`)
       this.log(`Token: ${token.key}`)
       this.log('')
       this.log("Copy the token now. It won't be shown again.")
@@ -141,9 +171,9 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
     return label.trim()
   }
 
-  private async promptForRole(projectId: string): Promise<string> {
+  private async promptForRole(projectId: string): Promise<SelectedRole> {
     if (this.isUnattended()) {
-      return 'viewer' // Default role for unattended mode
+      return DEFAULT_ROLE
     }
 
     const roles = await getTokenRoles(projectId)
@@ -165,6 +195,56 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       message: 'Select role for the token:',
     })
 
-    return selectedRoleName
+    const selectedRole = robotRoles.find((r) => r.name === selectedRoleName)
+    return selectedRole ?? {name: selectedRoleName, title: selectedRoleName}
+  }
+
+  private async resolveExpiry(expiresAtFlag: string | undefined): Promise<string | undefined> {
+    if (expiresAtFlag !== undefined) {
+      const validation = validateExpiryDate(expiresAtFlag)
+      if (validation !== true) {
+        this.error(`Invalid \`--expires-at\` value "${expiresAtFlag}": ${validation}`, {
+          exit: exitCodes.USAGE_ERROR,
+        })
+      }
+      return expiresAtFlag
+    }
+
+    // No expiration by default, matching the Manage token creation flow
+    if (this.isUnattended()) {
+      return undefined
+    }
+
+    const now = new Date()
+    const choice = await select({
+      choices: [
+        {name: 'No expiration', short: 'No expiration', value: 'none'},
+        ...TOKEN_EXPIRY_PRESET_DAYS.map((days) => {
+          const date = getPresetExpiryDate(days, now)
+          return {
+            name: `${days} days (${formatExpiryChoiceDate(date)})`,
+            short: `${days} days`,
+            value: String(days),
+          }
+        }),
+        {name: 'Custom date', short: 'Custom date', value: 'custom'},
+      ],
+      default: 'none',
+      message: 'Token expiration:',
+    })
+
+    if (choice === 'none') {
+      return undefined
+    }
+
+    if (choice === 'custom') {
+      const customDate = await input({
+        message: 'Expiration date (YYYY-MM-DD):',
+        validate: (value) => validateExpiryDate(value.trim()),
+      })
+      return customDate.trim()
+    }
+
+    return getPresetExpiryDate(Number(choice), now)
   }
 }

--- a/packages/@sanity/cli/src/commands/tokens/delete.ts
+++ b/packages/@sanity/cli/src/commands/tokens/delete.ts
@@ -13,7 +13,8 @@ const deleteTokenDebug = subdebug('tokens:delete')
 export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensCommand> {
   static override args = {
     tokenId: Args.string({
-      description: 'Token ID to delete (will prompt if not provided)',
+      description:
+        'ID of the token to delete, as shown by `tokens list` (will prompt if not provided)',
       required: false,
     }),
   }

--- a/packages/@sanity/cli/src/commands/tokens/list.ts
+++ b/packages/@sanity/cli/src/commands/tokens/list.ts
@@ -3,6 +3,7 @@ import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {Table} from 'console-table-printer'
 
+import {formatTokenExpiry} from '../../actions/tokens/expiry.js'
 import {type Token} from '../../actions/tokens/types.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {getTokens} from '../../services/tokens.js'
@@ -76,6 +77,7 @@ export class TokensListCommand extends SanityCommand<typeof TokensListCommand> {
         {alignment: 'left', maxLen: 40, name: 'label', title: 'Label'},
         {alignment: 'left', maxLen: 20, name: 'id', title: 'Token ID'},
         {alignment: 'left', maxLen: 30, name: 'roles', title: 'Roles'},
+        {alignment: 'left', maxLen: 12, name: 'expires', title: 'Expires'},
       ],
       title: `Found ${tokens.length} API tokens`,
     })
@@ -87,6 +89,7 @@ export class TokensListCommand extends SanityCommand<typeof TokensListCommand> {
       const truncatedRoles = roles.length > 27 ? `${roles.slice(0, 27)}...` : roles
 
       table.addRow({
+        expires: formatTokenExpiry(token.expiresAt),
         id: token.id,
         label: truncatedLabel,
         roles: truncatedRoles,

--- a/packages/@sanity/cli/src/services/tokens.ts
+++ b/packages/@sanity/cli/src/services/tokens.ts
@@ -1,13 +1,90 @@
 import {getGlobalCliClient} from '@sanity/cli-core'
+import {ClientError, type SanityClient} from '@sanity/client'
 
-import {type ProjectRole, type Token, type TokenResponse} from '../actions/tokens/types.js'
+import {TOKENS_API_VERSION} from '../actions/tokens/constants.js'
+import {
+  type ProjectRole,
+  type Robot,
+  type Token,
+  type TokenResponse,
+} from '../actions/tokens/types.js'
 
-const TOKENS_API_VERSION = 'v2025-08-18'
+interface AccessApiPage<T> {
+  data: T[]
+  nextCursor: string | null
+}
+
+async function getClient(): Promise<SanityClient> {
+  return getGlobalCliClient({
+    apiVersion: TOKENS_API_VERSION,
+    requireUser: true,
+  })
+}
+
+async function fetchAllPages<T>(
+  client: SanityClient,
+  uri: string,
+  query: Record<string, string> = {},
+): Promise<T[]> {
+  const results: T[] = []
+  let cursor: string | undefined
+
+  do {
+    const page = await client.request<AccessApiPage<T>>({
+      query: {...query, ...(cursor ? {nextCursor: cursor} : {})},
+      uri,
+    })
+    results.push(...(page.data ?? []))
+    cursor = page.nextCursor ?? undefined
+  } while (cursor)
+
+  return results
+}
+
+function getProjectRoleNames(robot: Robot, projectId: string): string[] {
+  return (robot.memberships ?? [])
+    .filter(
+      (membership) => membership.resourceType === 'project' && membership.resourceId === projectId,
+    )
+    .flatMap((membership) => membership.roleNames ?? [])
+}
+
+function robotToToken(robot: Robot, projectId: string, roleTitles: Map<string, string>): Token {
+  return {
+    createdAt: robot.createdAt,
+    expiresAt: robot.expiresAt ?? null,
+    id: robot.id,
+    label: robot.label,
+    roles: getProjectRoleNames(robot, projectId).map((name) => ({
+      name,
+      title: roleTitles.get(name) ?? name,
+    })),
+    tokenId: robot.tokenId,
+  }
+}
+
+function getRobots(client: SanityClient, projectId: string): Promise<Robot[]> {
+  return fetchAllPages<Robot>(client, `/access/project/${projectId}/robots`, {
+    includeChildren: 'false',
+  })
+}
+
+/**
+ * Robots can hold a membership on a project while being managed elsewhere
+ * (eg by an organization). Only robots managed by the project itself are
+ * project API tokens.
+ */
+function isManagedByProject(robot: Robot, projectId: string): boolean {
+  return robot.managedBy?.resourceType === 'project' && robot.managedBy.resourceId === projectId
+}
 
 interface CreateTokenOptions {
   label: string
   projectId: string
   roleName: string
+
+  expiresAt?: string
+  roleTitle?: string
 }
 
 /**
@@ -18,18 +95,24 @@ interface CreateTokenOptions {
  * @internal
  */
 export async function createToken(options: CreateTokenOptions): Promise<TokenResponse> {
-  const {label, projectId, roleName} = options
+  const {expiresAt, label, projectId, roleName, roleTitle} = options
 
-  const client = await getGlobalCliClient({
-    apiVersion: TOKENS_API_VERSION,
-    requireUser: true,
-  })
+  const client = await getClient()
 
-  return client.request<TokenResponse>({
-    body: {label, roleName},
+  const robot = await client.request<Robot & {token: string}>({
+    body: {
+      label,
+      memberships: [{resourceId: projectId, resourceType: 'project', roleNames: [roleName]}],
+      ...(expiresAt ? {expiresAt} : {}),
+    },
     method: 'POST',
-    uri: `/projects/${projectId}/tokens`,
+    uri: `/access/project/${projectId}/robots`,
   })
+
+  return {
+    ...robotToToken(robot, projectId, new Map(roleTitle ? [[roleName, roleTitle]] : [])),
+    key: robot.token,
+  }
 }
 
 interface DeleteTokenOptions {
@@ -38,7 +121,10 @@ interface DeleteTokenOptions {
 }
 
 /**
- * Delete a token from a project
+ * Delete a token from a project. Accepts either the robot ID (as shown by
+ * `tokens list`) or the legacy token ID previously exposed by the Projects
+ * API, which maps to the robot's `tokenId`.
+ *
  * @param options - The options for deleting a token from a project
  * @returns A promise that resolves when the token is deleted
  *
@@ -47,15 +133,37 @@ interface DeleteTokenOptions {
 export async function deleteToken(options: DeleteTokenOptions): Promise<void> {
   const {projectId, tokenId} = options
 
-  const client = await getGlobalCliClient({
-    apiVersion: TOKENS_API_VERSION,
-    requireUser: true,
-  })
+  const client = await getClient()
 
-  return client.request({
-    method: 'DELETE',
-    uri: `/projects/${projectId}/tokens/${tokenId}`,
-  })
+  const deleteRobot = (robotId: string) =>
+    client.request<void>({
+      method: 'DELETE',
+      uri: `/access/project/${projectId}/robots/${robotId}`,
+    })
+
+  try {
+    return await deleteRobot(tokenId)
+  } catch (error) {
+    if (!(error instanceof ClientError && error.response.statusCode === 404)) {
+      throw error
+    }
+
+    // The given ID may be a legacy token ID (as exposed by the deprecated
+    // Projects API), which maps to a robot's `tokenId` rather than its `id`
+    let robots: Robot[]
+    try {
+      robots = await getRobots(client, projectId)
+    } catch {
+      throw error
+    }
+
+    const match = robots.find((robot) => robot.tokenId === tokenId)
+    if (!match) {
+      throw error
+    }
+
+    return await deleteRobot(match.id)
+  }
 }
 
 /**
@@ -66,13 +174,31 @@ export async function deleteToken(options: DeleteTokenOptions): Promise<void> {
  * @internal
  */
 export async function getTokens(projectId: string): Promise<Token[]> {
-  const client = await getGlobalCliClient({
-    apiVersion: TOKENS_API_VERSION,
-    requireUser: true,
-  })
+  const client = await getClient()
 
-  return client.request<Token[]>({
-    uri: `/projects/${projectId}/tokens`,
+  const robots = await getRobots(client, projectId)
+  const projectRobots = robots.filter((robot) => isManagedByProject(robot, projectId))
+  if (projectRobots.length === 0) {
+    return []
+  }
+
+  // Robot memberships only carry role names; fetch the project roles to
+  // resolve display titles, falling back to the names if that fails
+  let roleTitles = new Map<string, string>()
+  try {
+    const roles = await fetchProjectRoles(client, projectId)
+    roleTitles = new Map(roles.map((role) => [role.name, role.title]))
+  } catch {
+    // Listing tokens should not require permission to read roles
+  }
+
+  return projectRobots.map((robot) => robotToToken(robot, projectId, roleTitles))
+}
+
+function fetchProjectRoles(client: SanityClient, projectId: string): Promise<ProjectRole[]> {
+  return fetchAllPages<ProjectRole>(client, `/access/project/${projectId}/roles`, {
+    includeChildren: 'false',
+    limit: '500',
   })
 }
 
@@ -84,10 +210,7 @@ export async function getTokens(projectId: string): Promise<Token[]> {
  * @internal
  */
 export async function getTokenRoles(projectId: string): Promise<ProjectRole[]> {
-  const client = await getGlobalCliClient({
-    apiVersion: TOKENS_API_VERSION,
-    requireUser: true,
-  })
+  const client = await getClient()
 
-  return client.request<ProjectRole[]>({uri: `/projects/${projectId}/roles`})
+  return fetchProjectRoles(client, projectId)
 }


### PR DESCRIPTION
### Description

`sanity tokens create` previously prompted for a label and role but offered no way to set an expiration, and `tokens list` gave no visibility into whether a token expires. This PR adds expiry support to the token commands and, to enable it, migrates all token management from the deprecated Projects API tokens endpoints to the Access API robots endpoints.

**Expiry**

- `tokens create` now includes an expiration step in the interactive flow, with the same choices and default as the Manage token creation flow: No expiration (default), 30/60/90 days (labeled with the resolved date), or a custom date
- A new `--expires-at YYYY-MM-DD` flag sets the expiry non-interactively (validated as today or later); unattended mode defaults to no expiration
- `tokens create` output includes `Expires: <date>` (or `Never`), and `tokens list` gains an `Expires` column

**Access API migration**

- `services/tokens.ts` now uses `access/project/{id}/robots` and `access/project/{id}/roles` (with cursor pagination) instead of `projects/{id}/tokens` and `projects/{id}/roles`
- Listing filters robots to those managed by the project, matching what the old endpoint returned (robots managed by other resources can hold project memberships but are not project tokens)
- The Access API identifies robots by a robot ID, while the old Projects API exposed what is now the robot's `tokenId`. Tokens carry both: `id` (robot ID, displayed and used for operations) and `tokenId` (legacy ID) in `--json` output
- `tokens delete` accepts either form: it tries the given ID as a robot ID first, and on 404 resolves it as a legacy token ID against the robot list — so IDs saved from earlier CLI versions keep working
- If the project roles cannot be fetched (used only to resolve role display titles), `tokens list` degrades to showing role names instead of failing

Note: `--json` output shape changed accordingly — it now includes `id`, `tokenId`, `expiresAt`, and `roles`, and no longer includes Projects-API-only fields such as `projectUserId` and `permissions`.

### What to review

- `packages/@sanity/cli/src/services/tokens.ts` — the endpoint migration, pagination, `managedBy` filtering, and the delete ID-resolution fallback
- `packages/@sanity/cli/src/actions/tokens/expiry.ts` — expiry choice/validation/formatting helpers
- `packages/@sanity/cli/src/commands/tokens/{create,list,delete}.ts` — prompt flow, flag handling, and output changes
- Manual check: run `sanity tokens create`, `tokens list`, and `tokens delete` against a project; try deleting by both the listed ID and a legacy token ID from an older CLI version

### Testing

- Rewrote the three command test suites against the Access API endpoints, including new coverage for the expiry prompt choices, preset/custom/flag expiry paths, `--expires-at` validation, pagination, `managedBy` filtering, legacy-ID delete resolution, and the roles-fetch fallback
- Added unit tests for the expiry helpers
- Full `@sanity/cli` unit suite passes (the only failures are network-simulation tests that also fail on `main` in the sandbox environment used for development)

### Notes for release

`sanity tokens create` now offers an expiration setting for new tokens — interactively or via the `--expires-at YYYY-MM-DD` flag — and `sanity tokens list` shows when each token expires.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UvuCLVE5Rw17DfrRQhyVH