### PR TITLE
refactor: adopt typegen CLI integration

### DIFF
--- a/.changeset/move-typegen-into-cli.md
+++ b/.changeset/move-typegen-into-cli.md
@@ -2,4 +2,4 @@
 '@sanity/cli': minor
 ---
 
-Move the `typegen generate` command into the CLI instead of loading `@sanity/codegen` as an oclif plugin. Requires `@sanity/codegen` v8.
+The `sanity typegen generate` command now ships directly in the CLI. There is no change to how you run it.

--- a/.changeset/move-typegen-into-cli.md
+++ b/.changeset/move-typegen-into-cli.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': minor
+---
+
+Move the `typegen generate` command into the CLI instead of loading `@sanity/codegen` as an oclif plugin. Requires `@sanity/codegen` v8.

--- a/.changeset/spinner-non-interactive-output.md
+++ b/.changeset/spinner-non-interactive-output.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli-core': patch
+---
+
+Spinners now forward the lines they persist (success, failure, warning, info) to the sinks of an active CLI execution context, instead of dropping them. Frame animation and transient progress text are still discarded.

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
       "node-pty"
     ],
     "overrides": {
-      "@sanity/cli": "workspace:*"
+      "@sanity/cli": "workspace:*",
+      "@sanity/codegen": "link:../codegen"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,8 +87,7 @@
       "node-pty"
     ],
     "overrides": {
-      "@sanity/cli": "workspace:*",
-      "@sanity/codegen": "link:../codegen"
+      "@sanity/cli": "workspace:*"
     }
   }
 }

--- a/packages/@sanity/cli-core/src/ux/__tests__/spinner.test.ts
+++ b/packages/@sanity/cli-core/src/ux/__tests__/spinner.test.ts
@@ -20,6 +20,63 @@ describe('spinner', () => {
     }
   })
 
+  test('forwards persisted lines to the context stderr sink', () => {
+    const lines: string[] = []
+
+    runWithCliExecutionContext({stderr: (line) => lines.push(line)}, () => {
+      const instance = spinner('Loading schema…').start()
+      instance.text = 'Generating query types…'
+      instance.succeed('Schema loaded from ./schema.json')
+      instance.warn('Encountered errors in 2 files while generating types')
+      instance.info('Nothing to do')
+      instance.fail('Generation failed')
+      instance.stopAndPersist({symbol: '→', text: 'Persisted'})
+    })
+
+    expect(lines).toEqual([
+      '✔ Schema loaded from ./schema.json',
+      '⚠ Encountered errors in 2 files while generating types',
+      'ℹ Nothing to do',
+      '✖ Generation failed',
+      '→ Persisted',
+    ])
+  })
+
+  test('persists the current text when no text is given, and skips empty lines', () => {
+    const lines: string[] = []
+
+    runWithCliExecutionContext({stderr: (line) => lines.push(line)}, () => {
+      const instance = spinner({text: 'Loading schema…'}).start()
+      instance.fail()
+      instance.text = ''
+      instance.succeed()
+      instance.stopAndPersist()
+    })
+
+    expect(lines).toEqual(['✖ Loading schema…', '✔'])
+  })
+
+  test('renders prefix and suffix text around persisted lines', () => {
+    const lines: string[] = []
+
+    runWithCliExecutionContext({stderr: (line) => lines.push(line)}, () => {
+      spinner({prefixText: () => '[typegen]', suffixText: '(1/2)', text: 'Working'}).succeed()
+    })
+
+    expect(lines).toEqual(['[typegen] ✔ Working (1/2)'])
+  })
+
+  test('falls back to the stdout sink and honors isSilent', () => {
+    const stdout: string[] = []
+
+    runWithCliExecutionContext({stdout: (line) => stdout.push(line)}, () => {
+      spinner({text: 'Working'}).succeed('Done')
+      spinner({isSilent: true, text: 'Quiet'}).succeed('Also done')
+    })
+
+    expect(stdout).toEqual(['✔ Done'])
+  })
+
   test('runs spinner promise actions without process output under a context', async () => {
     const write = vi.spyOn(process.stderr, 'write')
 

--- a/packages/@sanity/cli-core/src/ux/spinner.ts
+++ b/packages/@sanity/cli-core/src/ux/spinner.ts
@@ -3,27 +3,98 @@ import ora, {
   type Ora,
   oraPromise,
   type Spinner as OraSpinner,
+  type PersistOptions,
   type PromiseOptions,
 } from 'ora'
 
 import {getCliExecutionContext} from '../executionContext.js'
 
+/**
+ * Uncolored counterparts of the `log-symbols` glyphs a real spinner persists
+ * with. Lines forwarded to an execution context are handed to the embedding
+ * host verbatim, so they should not carry ANSI codes the host has to strip.
+ */
+const persistSymbols = {
+  error: '✖',
+  info: 'ℹ',
+  success: '✔',
+  warning: '⚠',
+}
+
+function resolveAffix(value: Options['prefixText'] | Options['suffixText']): string {
+  const resolved = typeof value === 'function' ? value() : value
+  return typeof resolved === 'string' ? resolved : ''
+}
+
+/**
+ * Stand-in for a real spinner, used when a CLI execution context is active.
+ *
+ * Frame animation and transient text updates have nowhere useful to go, so they
+ * are dropped. The lines a spinner *persists* (`succeed`, `fail`, `warn`,
+ * `info`, `stopAndPersist`) are the command's actual output rather than
+ * progress, so they are forwarded to the context's sink instead of being
+ * swallowed. Ora writes to `process.stderr` by default, so the `stderr` sink is
+ * preferred, falling back to `stdout`.
+ */
 function silentSpinner(options?: Options | string): Ora {
+  const resolved = typeof options === 'string' ? {text: options} : (options ?? {})
+  const context = getCliExecutionContext()
+  const emit = resolved.isSilent ? undefined : (context?.stderr ?? context?.stdout)
+
+  const prefixText = resolveAffix(resolved.prefixText)
+  const suffixText = resolveAffix(resolved.suffixText)
+  const state = {text: resolved.text ?? ''}
+
+  const persist = (symbol: string, text?: string): void => {
+    if (!emit) return
+
+    // Mirrors ora's own line layout, minus the trailing whitespace it leaves
+    // behind when only one of the symbol and the text is present.
+    const body = text ?? state.text
+    const line =
+      (prefixText ? `${prefixText} ` : '') +
+      symbol +
+      (symbol && body ? ` ${body}` : body) +
+      (suffixText ? ` ${suffixText}` : '')
+
+    if (line.trim() !== '') emit(line)
+  }
+
   const instance = {
     clear: () => instance,
-    fail: () => instance,
+    fail: (text?: string) => {
+      persist(persistSymbols.error, text)
+      return instance
+    },
     frame: () => '',
-    info: () => instance,
+    info: (text?: string) => {
+      persist(persistSymbols.info, text)
+      return instance
+    },
     isSpinning: false,
-    prefixText: typeof options === 'object' ? (options.prefixText ?? '') : '',
+    prefixText,
     render: () => instance,
     start: () => instance,
     stop: () => instance,
-    stopAndPersist: () => instance,
-    succeed: () => instance,
-    suffixText: typeof options === 'object' ? (options.suffixText ?? '') : '',
-    text: typeof options === 'string' ? options : (options?.text ?? ''),
-    warn: () => instance,
+    stopAndPersist: (persistOptions: PersistOptions = {}) => {
+      persist(persistOptions.symbol ?? '', persistOptions.text)
+      return instance
+    },
+    succeed: (text?: string) => {
+      persist(persistSymbols.success, text)
+      return instance
+    },
+    suffixText,
+    get text(): string {
+      return state.text
+    },
+    set text(value: string) {
+      state.text = value
+    },
+    warn: (text?: string) => {
+      persist(persistSymbols.warning, text)
+      return instance
+    },
   }
   return instance as unknown as Ora
 }

--- a/packages/@sanity/cli/oclif.config.js
+++ b/packages/@sanity/cli/oclif.config.js
@@ -12,10 +12,10 @@ export default {
       './dist/hooks/prerun/warnings.js',
     ],
   },
-  // Note: do not add '@sanity/migrate' here. The `migrations` commands now ship
-  // natively (see commands/migrations/); re-adding the plugin would register
-  // duplicate command ids.
-  plugins: ['@oclif/plugin-help', '@sanity/runtime-cli', '@sanity/codegen'],
+  // Note: do not add '@sanity/migrate' or '@sanity/codegen' here. Their
+  // `migrations` and `typegen` commands now ship natively (see commands/); re-adding
+  // either plugin would register duplicate command ids.
+  plugins: ['@oclif/plugin-help', '@sanity/runtime-cli'],
   topics: {
     backups: {description: 'Manage dataset backups'},
     cors: {description: 'Manage CORS origins for your project'},
@@ -35,6 +35,7 @@ export default {
     skills: {description: 'Install Sanity agent skills for AI agents'},
     telemetry: {description: 'Manage telemetry consent'},
     tokens: {description: 'Manage API tokens for your project'},
+    typegen: {description: 'Generate TypeScript types for schema and GROQ'},
     users: {description: 'Manage project users and invitations'},
   },
   topicSeparator: ' ',

--- a/packages/@sanity/cli/oclif.config.js
+++ b/packages/@sanity/cli/oclif.config.js
@@ -12,9 +12,6 @@ export default {
       './dist/hooks/prerun/warnings.js',
     ],
   },
-  // Note: do not add '@sanity/migrate' or '@sanity/codegen' here. Their
-  // `migrations` and `typegen` commands now ship natively (see commands/); re-adding
-  // either plugin would register duplicate command ids.
   plugins: ['@oclif/plugin-help', '@sanity/runtime-cli'],
   topics: {
     backups: {description: 'Manage dataset backups'},

--- a/packages/@sanity/cli/scripts/check-topic-aliases.ts
+++ b/packages/@sanity/cli/scripts/check-topic-aliases.ts
@@ -37,6 +37,7 @@ const knownTopicsWithoutAliases: Set<string> = new Set([
   'openapi',
   'skills',
   'telemetry',
+  'typegen',
 ])
 
 // Topics provided by oclif plugins (not in our manifest, but resolved at runtime).

--- a/packages/@sanity/cli/src/actions/typegen/__tests__/renderTypegenProgress.test.ts
+++ b/packages/@sanity/cli/src/actions/typegen/__tests__/renderTypegenProgress.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, test, vi} from 'vitest'
+
+import {createTypegenProgressRenderer} from '../renderTypegenProgress.js'
+
+function createFakeSpinner() {
+  const calls: {method: string; text?: string}[] = []
+  const spin = {
+    fail: vi.fn((text?: string) => {
+      calls.push({method: 'fail', text})
+      return spin
+    }),
+    isSpinning: true,
+    start: vi.fn((text?: string) => {
+      calls.push({method: 'start', text})
+      return spin
+    }),
+    succeed: vi.fn((text?: string) => {
+      calls.push({method: 'succeed', text})
+      return spin
+    }),
+    text: '',
+    warn: vi.fn((text?: string) => {
+      calls.push({method: 'warn', text})
+      return spin
+    }),
+  }
+  return {calls, spin}
+}
+
+const result = {
+  code: 'x',
+  duration: 12,
+  emptyUnionTypeNodesGenerated: 0,
+  filesWithErrors: 0,
+  outputSize: 1,
+  queriesCount: 3,
+  queryFilesCount: 2,
+  schemaTypesCount: 4,
+  typeNodesGenerated: 5,
+  unknownTypeNodesGenerated: 0,
+  unknownTypeNodesRatio: 0,
+}
+
+describe('createTypegenProgressRenderer', () => {
+  test('succeeds spinner on schemaLoaded and on complete', () => {
+    const {calls, spin} = createFakeSpinner()
+    const render = createTypegenProgressRenderer(spin, {
+      formatGeneratedCode: false,
+      generates: 'sanity.types.ts',
+      schema: 'schema.json',
+    })
+
+    render({type: 'schemaLoaded'})
+    render({expectedFileCount: 2, type: 'typegenStarted'})
+    render({schemaTypesCount: 4, type: 'schemaTypesGenerated'})
+    render({
+      errors: [],
+      evaluatedFiles: 2,
+      expectedFileCount: 2,
+      queriesCount: 3,
+      queryFilesCount: 2,
+      type: 'moduleEvaluated',
+    })
+    render({result, type: 'complete'})
+
+    expect(spin.succeed).toHaveBeenCalledWith(expect.stringContaining('Schema loaded from schema.json'))
+    const success = calls.find((c) => c.method === 'succeed' && c.text?.includes('Successfully generated'))
+    expect(success?.text).toContain('sanity.types.ts')
+  })
+
+  test('fails spinner for each module error', () => {
+    const {spin} = createFakeSpinner()
+    const render = createTypegenProgressRenderer(spin, {
+      formatGeneratedCode: false,
+      generates: 'sanity.types.ts',
+      schema: 'schema.json',
+    })
+
+    render({
+      errors: ['boom'],
+      evaluatedFiles: 1,
+      expectedFileCount: 1,
+      queriesCount: 0,
+      queryFilesCount: 0,
+      type: 'moduleEvaluated',
+    })
+
+    expect(spin.fail).toHaveBeenCalledWith('boom')
+  })
+})

--- a/packages/@sanity/cli/src/actions/typegen/__tests__/renderTypegenProgress.test.ts
+++ b/packages/@sanity/cli/src/actions/typegen/__tests__/renderTypegenProgress.test.ts
@@ -87,4 +87,82 @@ describe('createTypegenProgressRenderer', () => {
 
     expect(spin.fail).toHaveBeenCalledWith('boom')
   })
+
+  test('sets spinner text on formatting', () => {
+    const {spin} = createFakeSpinner()
+    const render = createTypegenProgressRenderer(spin, {
+      formatGeneratedCode: true,
+      generates: 'sanity.types.ts',
+      schema: 'schema.json',
+    })
+
+    render({formatterName: 'prettier', type: 'formatting'})
+
+    expect(spin.text).toBe('Formatting generated types with prettier…')
+  })
+
+  test('warns on formatFailed', () => {
+    const {spin} = createFakeSpinner()
+    const render = createTypegenProgressRenderer(spin, {
+      formatGeneratedCode: true,
+      generates: 'sanity.types.ts',
+      schema: 'schema.json',
+    })
+
+    render({formatterName: 'prettier', message: 'unexpected token', type: 'formatFailed'})
+
+    expect(spin.warn).toHaveBeenCalledWith(
+      'Failed to format generated types with prettier: unexpected token',
+    )
+  })
+
+  test('warns about files with errors before succeeding on complete', () => {
+    const {calls, spin} = createFakeSpinner()
+    const render = createTypegenProgressRenderer(spin, {
+      formatGeneratedCode: false,
+      generates: 'sanity.types.ts',
+      schema: 'schema.json',
+    })
+
+    render({result: {...result, filesWithErrors: 2}, type: 'complete'})
+
+    expect(spin.warn).toHaveBeenCalledWith('Encountered errors in 2 files while generating types')
+
+    const warnIndex = calls.findIndex((c) => c.method === 'warn')
+    const succeedIndex = calls.findIndex((c) => c.method === 'succeed')
+    expect(warnIndex).toBeGreaterThanOrEqual(0)
+    expect(succeedIndex).toBeGreaterThan(warnIndex)
+  })
+
+  test('success text mentions the formatter used when formatting succeeded', () => {
+    const {spin} = createFakeSpinner()
+    const render = createTypegenProgressRenderer(spin, {
+      formatGeneratedCode: true,
+      generates: 'sanity.types.ts',
+      schema: 'schema.json',
+    })
+
+    render({formatterName: 'prettier', type: 'formatting'})
+    render({result, type: 'complete'})
+
+    expect(spin.succeed).toHaveBeenCalledWith(
+      expect.stringContaining('formatted the generated code with prettier'),
+    )
+  })
+
+  test('success text mentions a formatting error when formatting failed', () => {
+    const {spin} = createFakeSpinner()
+    const render = createTypegenProgressRenderer(spin, {
+      formatGeneratedCode: true,
+      generates: 'sanity.types.ts',
+      schema: 'schema.json',
+    })
+
+    render({formatterName: 'prettier', message: 'unexpected token', type: 'formatFailed'})
+    render({result, type: 'complete'})
+
+    expect(spin.succeed).toHaveBeenCalledWith(
+      expect.stringContaining('an error occurred during formatting'),
+    )
+  })
 })

--- a/packages/@sanity/cli/src/actions/typegen/__tests__/renderTypegenProgress.test.ts
+++ b/packages/@sanity/cli/src/actions/typegen/__tests__/renderTypegenProgress.test.ts
@@ -1,3 +1,5 @@
+import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
+import {spinner} from '@sanity/cli-core/ux'
 import {describe, expect, test, vi} from 'vitest'
 
 import {createTypegenProgressRenderer} from '../renderTypegenProgress.js'
@@ -9,7 +11,6 @@ function createFakeSpinner() {
       calls.push({method: 'fail', text})
       return spin
     }),
-    isSpinning: true,
     start: vi.fn((text?: string) => {
       calls.push({method: 'start', text})
       return spin
@@ -72,8 +73,8 @@ describe('createTypegenProgressRenderer', () => {
     expect(success?.text).toContain('sanity.types.ts')
   })
 
-  test('fails spinner for each module error', () => {
-    const {spin} = createFakeSpinner()
+  test('fails spinner for each module error, then restarts it', () => {
+    const {calls, spin} = createFakeSpinner()
     const render = createTypegenProgressRenderer(spin, {
       formatGeneratedCode: false,
       generates: 'sanity.types.ts',
@@ -81,7 +82,7 @@ describe('createTypegenProgressRenderer', () => {
     })
 
     render({
-      errors: ['boom'],
+      errors: ['boom', 'bang'],
       evaluatedFiles: 1,
       expectedFileCount: 1,
       queriesCount: 0,
@@ -90,6 +91,35 @@ describe('createTypegenProgressRenderer', () => {
     })
 
     expect(spin.fail).toHaveBeenCalledWith('boom')
+    expect(spin.fail).toHaveBeenCalledWith('bang')
+    expect(calls.map((c) => c.method)).toEqual(['fail', 'fail', 'start'])
+  })
+
+  test('does not restart the spinner for error-free modules', () => {
+    const {calls, spin} = createFakeSpinner()
+    const render = createTypegenProgressRenderer(spin, {
+      formatGeneratedCode: false,
+      generates: 'sanity.types.ts',
+      schema: 'schema.json',
+    })
+
+    for (let evaluatedFiles = 1; evaluatedFiles <= 3; evaluatedFiles++) {
+      render({
+        errors: [],
+        evaluatedFiles,
+        expectedFileCount: 3,
+        queriesCount: evaluatedFiles,
+        queryFilesCount: evaluatedFiles,
+        type: 'moduleEvaluated',
+      })
+    }
+
+    // A disabled (non-interactive) spinner writes a line on every `start`, so
+    // progress must be reported through `text` alone while nothing fails.
+    expect(calls).toEqual([])
+    expect(spin.text).toBe(
+      'Generating query types… (100.0%)\n  └─ Processed 3 of 3 files. Found 3 queries from 3 files.',
+    )
   })
 
   test('sets spinner text on formatting', () => {
@@ -152,6 +182,41 @@ describe('createTypegenProgressRenderer', () => {
     expect(spin.succeed).toHaveBeenCalledWith(
       expect.stringContaining('formatted the generated code with prettier'),
     )
+  })
+
+  test('reports the summary, but not progress, through an execution context sink', () => {
+    const lines: string[] = []
+
+    runWithCliExecutionContext({stderr: (line) => lines.push(line)}, () => {
+      const spin = spinner({}).start('Loading schema…')
+      const render = createTypegenProgressRenderer(spin, {
+        formatGeneratedCode: false,
+        generates: 'sanity.types.ts',
+        schema: 'schema.json',
+      })
+
+      render({type: 'schemaLoaded'})
+      render({expectedFileCount: 2, type: 'typegenStarted'})
+      render({schemaTypesCount: 4, type: 'schemaTypesGenerated'})
+      for (let evaluatedFiles = 1; evaluatedFiles <= 2; evaluatedFiles++) {
+        render({
+          errors: [],
+          evaluatedFiles,
+          expectedFileCount: 2,
+          queriesCount: evaluatedFiles,
+          queryFilesCount: evaluatedFiles,
+          type: 'moduleEvaluated',
+        })
+      }
+      render({result, type: 'complete'})
+    })
+
+    expect(lines).toEqual([
+      '✔ Schema loaded from schema.json',
+      '✔ Successfully generated types to sanity.types.ts in 12ms' +
+        '\n  └─ 2 queries and 4 schema types' +
+        '\n  └─ found queries in 2 files after evaluating 2 files',
+    ])
   })
 
   test('success text mentions a formatting error when formatting failed', () => {

--- a/packages/@sanity/cli/src/actions/typegen/__tests__/renderTypegenProgress.test.ts
+++ b/packages/@sanity/cli/src/actions/typegen/__tests__/renderTypegenProgress.test.ts
@@ -63,8 +63,12 @@ describe('createTypegenProgressRenderer', () => {
     })
     render({result, type: 'complete'})
 
-    expect(spin.succeed).toHaveBeenCalledWith(expect.stringContaining('Schema loaded from schema.json'))
-    const success = calls.find((c) => c.method === 'succeed' && c.text?.includes('Successfully generated'))
+    expect(spin.succeed).toHaveBeenCalledWith(
+      expect.stringContaining('Schema loaded from schema.json'),
+    )
+    const success = calls.find(
+      (c) => c.method === 'succeed' && c.text?.includes('Successfully generated'),
+    )
     expect(success?.text).toContain('sanity.types.ts')
   })
 

--- a/packages/@sanity/cli/src/actions/typegen/count.ts
+++ b/packages/@sanity/cli/src/actions/typegen/count.ts
@@ -1,0 +1,6 @@
+export const count = (
+  amount: number,
+  plural: string = '',
+  singular: string = plural.slice(0, Math.max(0, plural.length - 1)),
+): string =>
+  [amount.toLocaleString('en-US'), amount === 1 ? singular : plural].filter(Boolean).join(' ')

--- a/packages/@sanity/cli/src/actions/typegen/formatPath.ts
+++ b/packages/@sanity/cli/src/actions/typegen/formatPath.ts
@@ -1,0 +1,4 @@
+/** Formats a path so it is the same in Windows and Unix. */
+export function formatPath(path: string): string {
+  return path.replaceAll('\\', '/')
+}

--- a/packages/@sanity/cli/src/actions/typegen/percent.ts
+++ b/packages/@sanity/cli/src/actions/typegen/percent.ts
@@ -1,0 +1,7 @@
+const formatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 1,
+  style: 'percent',
+})
+
+export const percent = (value: number): string => formatter.format(Math.min(value, 1))

--- a/packages/@sanity/cli/src/actions/typegen/renderTypegenProgress.ts
+++ b/packages/@sanity/cli/src/actions/typegen/renderTypegenProgress.ts
@@ -15,7 +15,6 @@ import {percent} from './percent.js'
  */
 export interface TypegenSpinner {
   fail(text?: string): void
-  isSpinning: boolean
   start(text?: string): void
   succeed(text?: string): void
   text: string
@@ -86,10 +85,15 @@ export function createTypegenProgressRenderer(
         queriesCount = event.queriesCount
         queryFilesCount = event.queryFilesCount
 
+        // `fail` stops the spinner, so it has to be restarted to keep rendering
+        // progress. Restarting only after a failure (rather than whenever the
+        // spinner reports it is not spinning) keeps non-interactive output
+        // quiet: a disabled spinner never reports itself as spinning, and each
+        // `start` writes a line, which would emit progress once per source file.
         for (const message of event.errors) {
           spin.fail(message)
         }
-        if (!spin.isSpinning) {
+        if (event.errors.length > 0) {
           spin.start()
         }
 

--- a/packages/@sanity/cli/src/actions/typegen/renderTypegenProgress.ts
+++ b/packages/@sanity/cli/src/actions/typegen/renderTypegenProgress.ts
@@ -52,7 +52,9 @@ export function createTypegenProgressRenderer(
       case 'complete': {
         const {result} = event
         if (result.filesWithErrors > 0) {
-          spin.warn(`Encountered errors in ${count(result.filesWithErrors, 'files')} while generating types`)
+          spin.warn(
+            `Encountered errors in ${count(result.filesWithErrors, 'files')} while generating types`,
+          )
         }
 
         let successText =

--- a/packages/@sanity/cli/src/actions/typegen/renderTypegenProgress.ts
+++ b/packages/@sanity/cli/src/actions/typegen/renderTypegenProgress.ts
@@ -1,0 +1,118 @@
+import {type TypeGenConfig, type TypegenProgressEvent} from '@sanity/codegen'
+
+import {count} from './count.js'
+import {formatPath} from './formatPath.js'
+import {percent} from './percent.js'
+
+/**
+ * Minimal structural shape of the spinner the renderer depends on.
+ *
+ * The `@sanity/cli-core/ux` `spinner` factory returns an instance whose
+ * methods return `this` (for chaining), which is assignable to this
+ * `void`-returning interface. This is deliberately narrower than the real
+ * spinner type so that test doubles (plain object literals) can satisfy it
+ * structurally without a type assertion.
+ */
+export interface TypegenSpinner {
+  fail(text?: string): void
+  isSpinning: boolean
+  start(text?: string): void
+  succeed(text?: string): void
+  text: string
+  warn(text?: string): void
+}
+
+interface RendererContext {
+  // Indexed access avoids needing a dedicated FormatGeneratedCode export from @sanity/codegen.
+  formatGeneratedCode: TypeGenConfig['formatGeneratedCode']
+  generates: string
+  schema: string
+}
+
+/**
+ * Builds an onProgress handler that renders typegen progress to a spinner,
+ * matching the output the command produced before the library was decoupled.
+ */
+export function createTypegenProgressRenderer(
+  spin: TypegenSpinner,
+  context: RendererContext,
+): (event: TypegenProgressEvent) => void {
+  const {formatGeneratedCode, generates, schema} = context
+
+  // Track cross-event data needed for the final success message.
+  let evaluatedFiles = 0
+  let queriesCount = 0
+  let queryFilesCount = 0
+  let schemaTypesCount = 0
+  let formatterName: string | undefined
+  let formattingError = false
+
+  return (event) => {
+    switch (event.type) {
+      case 'complete': {
+        const {result} = event
+        if (result.filesWithErrors > 0) {
+          spin.warn(`Encountered errors in ${count(result.filesWithErrors, 'files')} while generating types`)
+        }
+
+        let successText =
+          `Successfully generated types to ${formatPath(generates)} in ${Number(result.duration).toFixed(0)}ms` +
+          `\n  └─ ${count(queriesCount, 'queries', 'query')} and ${count(schemaTypesCount, 'schema types', 'schema type')}` +
+          `\n  └─ found queries in ${count(queryFilesCount, 'files', 'file')} after evaluating ${count(evaluatedFiles, 'files', 'file')}`
+
+        // formatGeneratedCode !== false means a formatter was attempted.
+        if (formatGeneratedCode !== false && formatterName) {
+          successText += `\n  └─ ${formattingError ? 'an error occurred during formatting' : `formatted the generated code with ${formatterName}`}`
+        }
+
+        spin.succeed(successText)
+        return
+      }
+      case 'formatFailed': {
+        formatterName = event.formatterName
+        formattingError = true
+        spin.warn(`Failed to format generated types with ${event.formatterName}: ${event.message}`)
+        return
+      }
+      case 'formatting': {
+        formatterName = event.formatterName
+        spin.text = `Formatting generated types with ${event.formatterName}…`
+        return
+      }
+      case 'moduleEvaluated': {
+        evaluatedFiles = event.evaluatedFiles
+        queriesCount = event.queriesCount
+        queryFilesCount = event.queryFilesCount
+
+        for (const message of event.errors) {
+          spin.fail(message)
+        }
+        if (!spin.isSpinning) {
+          spin.start()
+        }
+
+        spin.text =
+          `Generating query types… (${percent(event.evaluatedFiles / event.expectedFileCount)})\n` +
+          `  └─ Processed ${count(event.evaluatedFiles)} of ${count(event.expectedFileCount, 'files')}. ` +
+          `Found ${count(event.queriesCount, 'queries', 'query')} from ${count(event.queryFilesCount, 'files')}.`
+        return
+      }
+      case 'schemaLoaded': {
+        spin.succeed(`Schema loaded from ${formatPath(schema)}`)
+        spin.start('Generating schema types…')
+        return
+      }
+      case 'schemaTypesGenerated': {
+        schemaTypesCount = event.schemaTypesCount
+        spin.text = 'Generating query types…'
+        return
+      }
+      case 'typegenStarted': {
+        return
+      }
+      default: {
+        return
+      }
+    }
+  }
+}

--- a/packages/@sanity/cli/src/commands/typegen/__tests__/generate.test.ts
+++ b/packages/@sanity/cli/src/commands/typegen/__tests__/generate.test.ts
@@ -128,6 +128,8 @@ describe('#typegen:generate', () => {
 
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Typegen config file not found: ./does-not-exist.json')
+    // The specific config error must not be re-wrapped by the outer catch.
+    expect(error?.message).not.toContain('An error occurred during config loading')
     expect(error?.oclif?.exit).toBe(1)
     expect(runTypegenGenerate).not.toHaveBeenCalled()
   })
@@ -162,6 +164,35 @@ describe('#typegen:generate', () => {
     const [options] = runTypegenWatcher.mock.calls[0]
     expect(options.workDir).toBe(convertToSystemPath('/test/path'))
     expect(typeof options.onProgress).toBe('function')
+    expect(stop).toHaveBeenCalledOnce()
+    expect(process.listenerCount('SIGINT')).toBe(0)
+    expect(process.listenerCount('SIGTERM')).toBe(0)
+  })
+
+  test('still completes on SIGINT when the watcher fails to stop', async () => {
+    const stop = vi.fn().mockRejectedValue(new Error('watcher close failed'))
+    runTypegenWatcher.mockReturnValue({
+      getStats: () => ({
+        averageGenerationDuration: 0,
+        generationFailedCount: 0,
+        generationSuccessfulCount: 0,
+        watcherDuration: 0,
+      }),
+      stop,
+      watcher: {},
+    })
+
+    const promise = testCommand(TypegenGenerateCommand, ['--watch'], {mocks: defaultMocks})
+
+    await waitForSigintListener()
+    const sigintListener = process.listeners('SIGINT').at(-1)
+    if (!sigintListener) throw new Error('Expected a SIGINT listener to be registered')
+    sigintListener('SIGINT')
+
+    // A rejecting stop() must not hang the command or leak the rejection.
+    const {error} = await promise
+    if (error) throw error
+
     expect(stop).toHaveBeenCalledOnce()
     expect(process.listenerCount('SIGINT')).toBe(0)
     expect(process.listenerCount('SIGTERM')).toBe(0)

--- a/packages/@sanity/cli/src/commands/typegen/__tests__/generate.test.ts
+++ b/packages/@sanity/cli/src/commands/typegen/__tests__/generate.test.ts
@@ -4,13 +4,32 @@ import {afterEach, describe, expect, test, vi} from 'vitest'
 const runTypegenGenerate = vi.hoisted(() =>
   vi.fn<typeof import('@sanity/codegen').runTypegenGenerate>(),
 )
-// Not strictly typed against `typeof runTypegenWatcher`: its return type includes
-// a chokidar `FSWatcher`, but two different chokidar major versions are present in
-// this workspace's dependency graph (see pnpm-lock.yaml), so a literal `FSWatcher`
-// instance built here doesn't structurally match the one in @sanity/codegen's
-// compiled types. The command under test never reads `.watcher` (only `getStats()`
-// and `stop()`), so a loosely-typed mock is a deliberate, contained trade-off.
-const runTypegenWatcher = vi.hoisted(() => vi.fn())
+
+/**
+ * Minimal structural shape of `runTypegenWatcher`'s return value, covering only
+ * what `TypegenGenerateCommand` actually reads (`getStats()` and `stop()`).
+ *
+ * Not typed against `typeof runTypegenWatcher`: its real return type includes a
+ * chokidar `FSWatcher`, but two different chokidar major versions are present in
+ * this workspace's dependency graph (see pnpm-lock.yaml), so a literal `FSWatcher`
+ * instance built here doesn't structurally match the one in \@sanity/codegen's
+ * compiled types. `watcher: unknown` keeps this mock honest without needing that
+ * type or a type assertion.
+ */
+interface FakeTypegenWatcher {
+  getStats: () => {
+    averageGenerationDuration: number
+    generationFailedCount: number
+    generationSuccessfulCount: number
+    watcherDuration: number
+  }
+  stop: () => Promise<void>
+  watcher: unknown
+}
+
+const runTypegenWatcher = vi.hoisted(() =>
+  vi.fn<(options: import('@sanity/codegen').RunTypegenOptions) => FakeTypegenWatcher>(),
+)
 
 vi.mock('@sanity/codegen', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/codegen')>()

--- a/packages/@sanity/cli/src/commands/typegen/__tests__/generate.test.ts
+++ b/packages/@sanity/cli/src/commands/typegen/__tests__/generate.test.ts
@@ -1,0 +1,151 @@
+import {testCommand} from '@sanity/cli-test'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+const runTypegenGenerate = vi.hoisted(() => vi.fn())
+const runTypegenWatcher = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/codegen', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/codegen')>()
+  return {...actual, runTypegenGenerate, runTypegenWatcher}
+})
+
+const {TypegenGenerateCommand} = await import('../generate.js')
+
+const baseResult = {
+  code: 'export type X = 1',
+  duration: 5,
+  emptyUnionTypeNodesGenerated: 0,
+  filesWithErrors: 0,
+  outputSize: 10,
+  queriesCount: 1,
+  queryFilesCount: 1,
+  schemaTypesCount: 1,
+  typeNodesGenerated: 1,
+  unknownTypeNodesGenerated: 0,
+  unknownTypeNodesRatio: 0,
+}
+
+const defaultMocks = {
+  cliConfig: {typegen: {generates: './sanity.types.ts'}},
+  projectRoot: {
+    directory: '/test/path',
+    path: '/test/path/sanity.config.ts',
+    type: 'studio' as const,
+  },
+}
+
+/**
+ * Polls until the command under test has registered a `SIGINT` listener, so the
+ * watch-mode test can trigger it deterministically instead of relying on a fixed
+ * sleep or emitting a real OS signal (which risks tripping other process-wide
+ * signal handling in the test runner).
+ */
+async function waitForSigintListener(): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (process.listenerCount('SIGINT') > 0) return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  throw new Error('Timed out waiting for the command to register a SIGINT listener')
+}
+
+describe('#typegen:generate', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('runs a single generation using CLI config and wires up onProgress', async () => {
+    runTypegenGenerate.mockResolvedValue(baseResult)
+
+    const {error} = await testCommand(TypegenGenerateCommand, [], {mocks: defaultMocks})
+    if (error) throw error
+
+    expect(runTypegenGenerate).toHaveBeenCalledOnce()
+    const [options] = runTypegenGenerate.mock.calls[0]
+    expect(options.workDir).toBe('/test/path')
+    expect(typeof options.onProgress).toBe('function')
+    expect(options.config.generates).toBe('./sanity.types.ts')
+  })
+
+  test('falls back to CLI config defaults when no typegen config is set', async () => {
+    runTypegenGenerate.mockResolvedValue(baseResult)
+
+    const {error} = await testCommand(TypegenGenerateCommand, [], {
+      mocks: {...defaultMocks, cliConfig: {}},
+    })
+    if (error) throw error
+
+    expect(runTypegenGenerate).toHaveBeenCalledOnce()
+    const [options] = runTypegenGenerate.mock.calls[0]
+    expect(options.config.generates).toBe('./sanity.types.ts')
+    expect(options.config.schema).toBe('./schema.json')
+  })
+
+  test('surfaces generation errors as a command error with exit 1', async () => {
+    runTypegenGenerate.mockRejectedValue(new Error('schema.json not found'))
+
+    const {error} = await testCommand(TypegenGenerateCommand, [], {mocks: defaultMocks})
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('schema.json not found')
+    expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test('fails fast when --config-path is provided but the file does not exist', async () => {
+    const {error} = await testCommand(
+      TypegenGenerateCommand,
+      ['--config-path', './does-not-exist.json'],
+      {mocks: defaultMocks},
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Typegen config file not found: ./does-not-exist.json')
+    expect(error?.oclif?.exit).toBe(1)
+    expect(runTypegenGenerate).not.toHaveBeenCalled()
+  })
+
+  test('uses the watcher when --watch is passed and stops once on SIGINT', async () => {
+    const stop = vi.fn().mockResolvedValue(undefined)
+    runTypegenWatcher.mockReturnValue({
+      getStats: () => ({
+        averageGenerationDuration: 5,
+        generationFailedCount: 0,
+        generationSuccessfulCount: 1,
+        watcherDuration: 10,
+      }),
+      stop,
+      watcher: {},
+    })
+
+    const promise = testCommand(TypegenGenerateCommand, ['--watch'], {mocks: defaultMocks})
+
+    await waitForSigintListener()
+    const sigintListener = process.listeners('SIGINT').at(-1)
+    if (!sigintListener) throw new Error('Expected a SIGINT listener to be registered')
+    // Trigger the command's own registered handler directly, deterministically,
+    // rather than emitting a real SIGINT (which could interact with other
+    // process-wide signal handling in the test runner).
+    sigintListener('SIGINT')
+
+    const {error} = await promise
+    if (error) throw error
+
+    expect(runTypegenWatcher).toHaveBeenCalledOnce()
+    const [options] = runTypegenWatcher.mock.calls[0]
+    expect(options.workDir).toBe('/test/path')
+    expect(stop).toHaveBeenCalledOnce()
+    expect(process.listenerCount('SIGINT')).toBe(0)
+    expect(process.listenerCount('SIGTERM')).toBe(0)
+  })
+
+  test('surfaces watcher setup errors as a command error with exit 1', async () => {
+    runTypegenWatcher.mockImplementation(() => {
+      throw new Error('failed to start watcher')
+    })
+
+    const {error} = await testCommand(TypegenGenerateCommand, ['--watch'], {mocks: defaultMocks})
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('failed to start watcher')
+    expect(error?.oclif?.exit).toBe(1)
+  })
+})

--- a/packages/@sanity/cli/src/commands/typegen/__tests__/generate.test.ts
+++ b/packages/@sanity/cli/src/commands/typegen/__tests__/generate.test.ts
@@ -1,7 +1,15 @@
 import {testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-const runTypegenGenerate = vi.hoisted(() => vi.fn())
+const runTypegenGenerate = vi.hoisted(() =>
+  vi.fn<typeof import('@sanity/codegen').runTypegenGenerate>(),
+)
+// Not strictly typed against `typeof runTypegenWatcher`: its return type includes
+// a chokidar `FSWatcher`, but two different chokidar major versions are present in
+// this workspace's dependency graph (see pnpm-lock.yaml), so a literal `FSWatcher`
+// instance built here doesn't structurally match the one in @sanity/codegen's
+// compiled types. The command under test never reads `.watcher` (only `getStats()`
+// and `stop()`), so a loosely-typed mock is a deliberate, contained trade-off.
 const runTypegenWatcher = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/codegen', async (importOriginal) => {
@@ -61,6 +69,7 @@ describe('#typegen:generate', () => {
 
     expect(runTypegenGenerate).toHaveBeenCalledOnce()
     const [options] = runTypegenGenerate.mock.calls[0]
+    if (!options.config) throw new Error('Expected a config to be passed to runTypegenGenerate')
     expect(options.workDir).toBe('/test/path')
     expect(typeof options.onProgress).toBe('function')
     expect(options.config.generates).toBe('./sanity.types.ts')
@@ -76,6 +85,7 @@ describe('#typegen:generate', () => {
 
     expect(runTypegenGenerate).toHaveBeenCalledOnce()
     const [options] = runTypegenGenerate.mock.calls[0]
+    if (!options.config) throw new Error('Expected a config to be passed to runTypegenGenerate')
     expect(options.config.generates).toBe('./sanity.types.ts')
     expect(options.config.schema).toBe('./schema.json')
   })

--- a/packages/@sanity/cli/src/commands/typegen/__tests__/generate.test.ts
+++ b/packages/@sanity/cli/src/commands/typegen/__tests__/generate.test.ts
@@ -1,4 +1,4 @@
-import {testCommand} from '@sanity/cli-test'
+import {convertToSystemPath, testCommand} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 const runTypegenGenerate = vi.hoisted(() =>
@@ -89,7 +89,7 @@ describe('#typegen:generate', () => {
     expect(runTypegenGenerate).toHaveBeenCalledOnce()
     const [options] = runTypegenGenerate.mock.calls[0]
     if (!options.config) throw new Error('Expected a config to be passed to runTypegenGenerate')
-    expect(options.workDir).toBe('/test/path')
+    expect(options.workDir).toBe(convertToSystemPath('/test/path'))
     expect(typeof options.onProgress).toBe('function')
     expect(options.config.generates).toBe('./sanity.types.ts')
   })
@@ -160,7 +160,8 @@ describe('#typegen:generate', () => {
 
     expect(runTypegenWatcher).toHaveBeenCalledOnce()
     const [options] = runTypegenWatcher.mock.calls[0]
-    expect(options.workDir).toBe('/test/path')
+    expect(options.workDir).toBe(convertToSystemPath('/test/path'))
+    expect(typeof options.onProgress).toBe('function')
     expect(stop).toHaveBeenCalledOnce()
     expect(process.listenerCount('SIGINT')).toBe(0)
     expect(process.listenerCount('SIGTERM')).toBe(0)

--- a/packages/@sanity/cli/src/commands/typegen/generate.ts
+++ b/packages/@sanity/cli/src/commands/typegen/generate.ts
@@ -2,6 +2,7 @@ import {stat} from 'node:fs/promises'
 import {styleText} from 'node:util'
 
 import {Flags} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
 import {SanityCommand} from '@sanity/cli-core'
 import {spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
 import {
@@ -152,8 +153,12 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
         workDir,
       }
     } catch (err) {
+      // The config-file checks above already reported a user-facing error via
+      // `this.error()` (an oclif CLIError). Re-throw those as-is instead of
+      // wrapping them a second time and failing the spinner twice.
+      if (err instanceof CLIError) throw err
       spin.fail()
-      this.error(`An error occured during config loading ${err}`, {exit: 1})
+      this.error(`An error occurred during config loading: ${err}`, {exit: 1})
     }
   }
 
@@ -242,7 +247,12 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
         })
         trace.complete()
 
-        await typegenWatcher.stop()
+        try {
+          await typegenWatcher.stop()
+        } catch {
+          // We're shutting down; a failure to close the watcher shouldn't hang
+          // the process or surface as an unhandled rejection.
+        }
         resolve()
       })
 

--- a/packages/@sanity/cli/src/commands/typegen/generate.ts
+++ b/packages/@sanity/cli/src/commands/typegen/generate.ts
@@ -3,7 +3,7 @@ import {styleText} from 'node:util'
 
 import {Flags} from '@oclif/core'
 import {SanityCommand} from '@sanity/cli-core'
-import {spinner} from '@sanity/cli-core/ux'
+import {spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
 import {
   configDefinition,
   readConfig,
@@ -159,12 +159,13 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
 
   private async runSingle(): Promise<void> {
     const trace = this.telemetry.trace(TypesGeneratedTrace)
+    let spin: SpinnerInstance | undefined
 
     try {
       const {config: typegenConfig, type: typegenConfigMethod, workDir} = await this.getConfig()
       trace.start()
 
-      const spin = spinner({}).start('Loading schema…')
+      spin = spinner({}).start('Loading schema…')
       const result = await runTypegenGenerate({
         config: typegenConfig,
         onProgress: createTypegenProgressRenderer(spin, {
@@ -184,6 +185,9 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
       })
       trace.complete()
     } catch (error) {
+      if (spin?.isSpinning) {
+        spin.fail()
+      }
       trace.error(error instanceof Error ? error : new Error(String(error)))
       this.error(`${error instanceof Error ? error.message : 'Unknown error'}`, {exit: 1})
     }

--- a/packages/@sanity/cli/src/commands/typegen/generate.ts
+++ b/packages/@sanity/cli/src/commands/typegen/generate.ts
@@ -1,0 +1,232 @@
+import {stat} from 'node:fs/promises'
+import {styleText} from 'node:util'
+
+import {Flags} from '@oclif/core'
+import {SanityCommand} from '@sanity/cli-core'
+import {spinner} from '@sanity/cli-core/ux'
+import {
+  configDefinition,
+  readConfig,
+  runTypegenGenerate,
+  runTypegenWatcher,
+  type TypeGenConfig,
+  TypegenWatchModeTrace,
+  TypesGeneratedTrace,
+} from '@sanity/codegen'
+import omit from 'lodash-es/omit.js'
+import once from 'lodash-es/once.js'
+
+import {createTypegenProgressRenderer} from '../../actions/typegen/renderTypegenProgress.js'
+
+const description = `Sanity TypeGen
+
+${styleText('bold', 'Configuration:')}
+This command can utilize configuration settings defined in a \`sanity-typegen.json\` file. These settings include:
+
+- "path": Specifies a glob pattern to locate your TypeScript or JavaScript files.
+  Default: "./src/**/*.{ts,tsx,js,jsx}"
+
+- "schema": Defines the path to your Sanity schema file. This file should be generated using the \`sanity schema extract\` command.
+  Default: "schema.json"
+
+- "generates": Indicates the path where the generated TypeScript type definitions will be saved.
+  Default: "./sanity.types.ts"
+
+The default configuration values listed above are used if not overridden in your \`sanity-typegen.json\` configuration file. To customize the behavior of the type generation, adjust these properties in the configuration file according to your project's needs.
+
+${styleText('bold', 'Note:')}
+- The \`sanity schema extract\` command is a prerequisite for extracting your Sanity Studio schema into a \`schema.json\` file, which is then used by the \`sanity typegen generate\` command to generate type definitions.`.trim()
+
+export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerateCommand> {
+  static override description = description
+
+  static override examples = [
+    {
+      command: '<%= config.bin %> <%= command.id %>',
+      description: `Generate TypeScript type definitions from a Sanity Studio schema extracted using the \`sanity schema extract\` command.`,
+    },
+  ]
+
+  static override flags = {
+    'config-path': Flags.string({
+      description:
+        '[Default: sanity-typegen.json] Specifies the path to the typegen configuration file. This file should be a JSON file that contains settings for the type generation process.',
+    }),
+    watch: Flags.boolean({
+      default: false,
+      description: '[Default: false] Run the typegen in watch mode',
+    }),
+  }
+
+  static override hiddenAliases: string[] = ['typegen:generate']
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(TypegenGenerateCommand)
+
+    if (flags.watch) {
+      await this.runWatcher()
+      return
+    }
+
+    await this.runSingle()
+  }
+
+  private async getConfig(): Promise<{
+    config: TypeGenConfig
+    path?: string
+    type: 'cli' | 'legacy'
+    workDir: string
+  }> {
+    const spin = spinner({}).start('Loading config…')
+
+    try {
+      const {flags} = await this.parse(TypegenGenerateCommand)
+      const rootDir = await this.getProjectRoot()
+      const config = await this.getCliConfig()
+
+      const configPath = flags['config-path']
+      const workDir = rootDir.directory
+
+      const legacyConfigPath = configPath || 'sanity-typegen.json'
+      let hasLegacyConfig = false
+
+      try {
+        const file = await stat(legacyConfigPath)
+        hasLegacyConfig = file.isFile()
+      } catch (err) {
+        if (err instanceof Error && 'code' in err && err.code === 'ENOENT' && configPath) {
+          spin.fail()
+          this.error(`Typegen config file not found: ${configPath}`, {exit: 1})
+        }
+
+        if (err instanceof Error && 'code' in err && err.code !== 'ENOENT') {
+          spin.fail()
+          this.error(`Error when checking if typegen config file exists: ${legacyConfigPath}`, {
+            exit: 1,
+          })
+        }
+      }
+
+      if (config?.typegen && hasLegacyConfig) {
+        spin.warn(
+          styleText(
+            'yellow',
+            `You've specified typegen in your Sanity CLI config, but also have a typegen config.
+
+    The config from the Sanity CLI config is used.
+    `,
+          ),
+        )
+
+        return {
+          config: configDefinition.parse(config.typegen || {}),
+          path: rootDir.path,
+          type: 'cli',
+          workDir,
+        }
+      }
+
+      if (hasLegacyConfig) {
+        spin.warn(
+          styleText(
+            'yellow',
+            `The separate typegen config has been deprecated. Use \`typegen\` in the sanity CLI config instead.
+
+    See: https://www.sanity.io/docs/help/configuring-typegen-in-sanity-cli-config`,
+          ),
+        )
+        return {
+          config: await readConfig(legacyConfigPath),
+          path: legacyConfigPath,
+          type: 'legacy',
+          workDir,
+        }
+      }
+
+      spin.succeed(`Config loaded from sanity.cli.ts`)
+
+      return {
+        config: configDefinition.parse(config.typegen || {}),
+        path: rootDir.path,
+        type: 'cli',
+        workDir,
+      }
+    } catch (err) {
+      spin.fail()
+      this.error(`An error occured during config loading ${err}`, {exit: 1})
+    }
+  }
+
+  private async runSingle(): Promise<void> {
+    const trace = this.telemetry.trace(TypesGeneratedTrace)
+
+    try {
+      const {config: typegenConfig, type: typegenConfigMethod, workDir} = await this.getConfig()
+      trace.start()
+
+      const spin = spinner({}).start('Loading schema…')
+      const result = await runTypegenGenerate({
+        config: typegenConfig,
+        onProgress: createTypegenProgressRenderer(spin, {
+          formatGeneratedCode: typegenConfig.formatGeneratedCode,
+          generates: typegenConfig.generates,
+          schema: typegenConfig.schema,
+        }),
+        workDir,
+      })
+
+      const traceStats = omit(result, 'code', 'duration')
+
+      trace.log({
+        configMethod: typegenConfigMethod,
+        configOverloadClientMethods: typegenConfig.overloadClientMethods,
+        ...traceStats,
+      })
+      trace.complete()
+    } catch (error) {
+      trace.error(error instanceof Error ? error : new Error(String(error)))
+      this.error(`${error instanceof Error ? error.message : 'Unknown error'}`, {exit: 1})
+    }
+  }
+
+  private async runWatcher(): Promise<void> {
+    const trace = this.telemetry.trace(TypegenWatchModeTrace)
+
+    try {
+      const {config: typegenConfig, workDir} = await this.getConfig()
+      trace.start()
+
+      // @ts-expect-error `Promise.withResolvers` is available at runtime (Node 22.12+) but
+      // not in this monorepo's `ES2023` lib typings; see `codegen/src/utils/promiseWithResolvers.ts`
+      // for the same workaround.
+      const {promise, resolve} = Promise.withResolvers<void>()
+
+      const typegenWatcher = runTypegenWatcher({
+        config: typegenConfig,
+        workDir,
+      })
+
+      const stop = once(async () => {
+        process.off('SIGINT', stop)
+        process.off('SIGTERM', stop)
+
+        trace.log({
+          step: 'stopped',
+          ...typegenWatcher.getStats(),
+        })
+        trace.complete()
+
+        await typegenWatcher.stop()
+        resolve()
+      })
+
+      process.on('SIGINT', stop)
+      process.on('SIGTERM', stop)
+
+      await promise
+    } catch (error) {
+      trace.error(error instanceof Error ? error : new Error(String(error)))
+      this.error(`${error instanceof Error ? error.message : 'Unknown error'}`, {exit: 1})
+    }
+  }
+}

--- a/packages/@sanity/cli/src/commands/typegen/generate.ts
+++ b/packages/@sanity/cli/src/commands/typegen/generate.ts
@@ -196,10 +196,10 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
       const {config: typegenConfig, workDir} = await this.getConfig()
       trace.start()
 
-      // @ts-expect-error `Promise.withResolvers` is available at runtime (Node 22.12+) but
-      // not in this monorepo's `ES2023` lib typings; see `codegen/src/utils/promiseWithResolvers.ts`
-      // for the same workaround.
-      const {promise, resolve} = Promise.withResolvers<void>()
+      let resolve: () => void = () => {}
+      const promise = new Promise<void>((res) => {
+        resolve = res
+      })
 
       const typegenWatcher = runTypegenWatcher({
         config: typegenConfig,

--- a/packages/@sanity/cli/src/commands/typegen/generate.ts
+++ b/packages/@sanity/cli/src/commands/typegen/generate.ts
@@ -195,6 +195,7 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
 
   private async runWatcher(): Promise<void> {
     const trace = this.telemetry.trace(TypegenWatchModeTrace)
+    let spin: SpinnerInstance | undefined
 
     try {
       const {config: typegenConfig, workDir} = await this.getConfig()
@@ -205,14 +206,35 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
         resolve = res
       })
 
+      const watchSpin = spinner({}).start('Loading schema…')
+      spin = watchSpin
+      const rendererContext = {
+        formatGeneratedCode: typegenConfig.formatGeneratedCode,
+        generates: typegenConfig.generates,
+        schema: typegenConfig.schema,
+      }
+      let renderProgress = createTypegenProgressRenderer(watchSpin, rendererContext)
+
       const typegenWatcher = runTypegenWatcher({
         config: typegenConfig,
+        onProgress: (event) => {
+          // 'schemaLoaded' is the first event of every generation cycle; the
+          // renderer accumulates per-run state, so start each cycle fresh.
+          if (event.type === 'schemaLoaded') {
+            renderProgress = createTypegenProgressRenderer(watchSpin, rendererContext)
+          }
+          renderProgress(event)
+        },
         workDir,
       })
 
       const stop = once(async () => {
         process.off('SIGINT', stop)
         process.off('SIGTERM', stop)
+
+        if (watchSpin.isSpinning) {
+          watchSpin.stop()
+        }
 
         trace.log({
           step: 'stopped',
@@ -229,6 +251,9 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
 
       await promise
     } catch (error) {
+      if (spin?.isSpinning) {
+        spin.fail()
+      }
       trace.error(error instanceof Error ? error : new Error(String(error)))
       this.error(`${error instanceof Error ? error.message : 'Unknown error'}`, {exit: 1})
     }

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -58,8 +58,8 @@ describe('invokeSanityCli', () => {
     // policy entry for a removed command fails too. Command ids come from the
     // loaded oclif config — the same source invokeSanityCli resolves against —
     // scoped to this package's own visible commands: hidden entries are alias
-    // redirects, and commands contributed by other plugins (blueprints,
-    // typegen, help) are uncategorized by design, so they fail closed.
+    // redirects, and commands contributed by other plugins (blueprints, help)
+    // are uncategorized by design, so they fail closed.
     const commandIds = config.commands
       .filter((command) => command.pluginName === config.pjson.name && !command.hidden)
       .map((command) => command.id)

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -209,6 +209,9 @@ export const mcpPolicy: CommandPolicySet = {
   // Exposes authentication credential metadata.
   'tokens:list': deny,
 
+  // Reads the local schema and source files and writes generated types to the project.
+  'typegen:generate': deny,
+
   // Loads local CLI and workbench configuration to identify the deployed Studio or application.
   undeploy: deny,
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^3.2.88
       version: 3.2.88
     '@sanity/codegen':
-      specifier: ^7.0.3
-      version: 7.0.3
+      specifier: ^8.0.0
+      version: 8.0.0
     '@sanity/pkg-utils':
       specifier: ^11.0.17
       version: 11.0.17
@@ -566,7 +566,7 @@ importers:
         version: 7.25.0
       '@sanity/codegen':
         specifier: 'catalog:'
-        version: 7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@packages+@sanity+cli-core)(oxfmt@0.59.0)(react@19.2.7)
+        version: 8.0.0(oxfmt@0.59.0)(react@19.2.7)
       '@sanity/descriptors':
         specifier: ^1.3.0
         version: 1.3.0
@@ -4579,12 +4579,10 @@ packages:
       sanity: ^5 || ^6.0.0-0
       styled-components: ^6.1
 
-  '@sanity/codegen@7.0.3':
-    resolution: {integrity: sha512-t3Svo28RWX7OOvj4DkNX0fSWpzt+94pslKwvkKhSs4Lw24Ta1hYkE1a+OgwUjKBbw2Za54V7NpMwNlXjPEr2Fw==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
+  '@sanity/codegen@8.0.0':
+    resolution: {integrity: sha512-TE1yn1j52l7sNkDul0vnDKV1UHHaRvFq+G9iNYGybYvMXmZI/eVDbc2ti4cOK2RXRrO59oQMa9u4+8RlBlqs/Q==}
+    engines: {node: '>=22.12'}
     peerDependencies:
-      '@oclif/core': ^4.8.0
-      '@sanity/cli-core': ^2
       oxfmt: '*'
     peerDependenciesMeta:
       oxfmt:
@@ -8471,11 +8469,6 @@ packages:
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  prettier@3.9.5:
-    resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
-    engines: {node: '>=14'}
     hasBin: true
 
   prettier@3.9.6:
@@ -13436,7 +13429,7 @@ snapshots:
       - react-dom
       - react-is
 
-  '@sanity/codegen@7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@packages+@sanity+cli-core)(oxfmt@0.59.0)(react@19.2.7)':
+  '@sanity/codegen@8.0.0(oxfmt@0.59.0)(react@19.2.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
@@ -13446,18 +13439,16 @@ snapshots:
       '@babel/register': 7.29.7(@babel/core@7.29.7)
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-      '@oclif/core': 4.11.14
-      '@sanity/cli-core': link:packages/@sanity/cli-core
       '@sanity/telemetry': 1.1.0(react@19.2.7)
       '@sanity/worker-channels': 2.0.0
       chokidar: 3.6.0
       debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       groq: 6.1.0
-      groq-js: 1.30.3
+      groq-js: 2.0.0
       json5: 2.2.3
       lodash-es: 4.18.1
-      prettier: 3.9.5
+      prettier: 3.9.6
       reselect: 5.2.0
       tsconfig-paths: 4.2.0
       zod: 4.4.3
@@ -17746,8 +17737,6 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
-
-  prettier@3.9.5: {}
 
   prettier@3.9.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ catalog:
   '@sanity/types': ^6.7.0
   '@sanity/schema': ^6.7.0
   '@sanity/client': ^7.25.0
-  '@sanity/codegen': ^7.0.3
+  '@sanity/codegen': ^8.0.0
   '@sanity/telemetry': ^1.1.0
 
   # Build & Development Tools


### PR DESCRIPTION
### Description

Moves the `sanity typegen generate` command out of the `@sanity/codegen` oclif plugin and into `@sanity/cli` as a native command. This follows the same approach as the earlier `migrations` move (#1322).

Background: `@sanity/codegen` used to register its command as an oclif plugin, so it depended on `@sanity/cli-core` and `@oclif/core` as peers. Every `@sanity/cli-core` major then forced a coordinated codegen release to keep those peer ranges from conflicting. `@sanity/codegen` v8 drops those dependencies and exposes the generation engine directly, reporting progress through an `onProgress` callback instead of driving a spinner itself. This PR moves the command, and all of its terminal output, into the CLI and depends on the published `@sanity/codegen@^8`.

What changed:

- Adds a native `typegen generate` command (`--config-path`, `--watch`) with the same config resolution as before: a `sanity-typegen.json` file, the `typegen` block in the CLI config, and the deprecation warning when both are present.
- Adds `renderTypegenProgress`, which turns codegen's progress events into the same spinner output the command produced previously.
- Drops `@sanity/codegen` from the oclif `plugins` list and registers `typegen` as a topic. `@sanity/codegen` stays a runtime dependency, bumped to `^8`.
- Categorizes `typegen:generate` as `deny` in the MCP command policy, since it reads the local schema and source files and writes generated types to disk (the same category as `schema:extract` and `manifest:extract`).

The Vite typegen plugin is untouched: `onProgress` is optional, so `runTypegenGenerate` still returns a `Promise<GenerationResult>`.

Requires `@sanity/codegen` v8, which is published.

### What to review

- `commands/typegen/generate.ts`: config resolution and the deprecation warning match the previous codegen command; telemetry traces and the `--watch` path.
- `actions/typegen/renderTypegenProgress.ts`: the spinner output matches what `@sanity/codegen` printed before, line for line.
- `oclif.config.js`: `typegen` is sourced natively now rather than from a plugin, so there is no duplicate command id.
- `commandPolicies/mcpPolicy.ts`: the `deny` entry for `typegen:generate`.
- To try it locally: `pnpm build:cli`, then run `sanity typegen generate` (and `--watch`) from a studio that has a `schema.json`.

### Testing

- Unit tests for the command (config resolution, telemetry, error handling, and the `--watch` wiring) and for `renderTypegenProgress` (every event branch, including the formatting and error paths).
- The full `@sanity/cli` unit suite passes against the published `@sanity/codegen@8.0.0`.
- Ran `sanity typegen generate` end to end against a studio fixture: same spinner output and the same generated `sanity.types.ts` as before the move.

### Notes for release

N/A: a changeset is already committed in the branch (`@sanity/cli`, minor).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a widely used CLI command and file-writing behavior, but aims for parity with the prior plugin; spinner sink changes mainly affect embedded/non-TTY hosts.
> 
> **Overview**
> **`sanity typegen generate`** is now a first-party `@sanity/cli` command instead of the `@sanity/codegen` oclif plugin. Invocation and flags stay the same (`--config-path`, `--watch`); the CLI calls **`@sanity/codegen@^8`** (`runTypegenGenerate` / `runTypegenWatcher`) and owns config resolution plus terminal UX.
> 
> The new **`TypegenGenerateCommand`** keeps prior behavior: `sanity-typegen.json` vs `typegen` in the CLI config (with deprecation when both exist), telemetry, and watch mode with SIGINT/SIGTERM shutdown. **`createTypegenProgressRenderer`** maps codegen **`onProgress`** events back to the old spinner messages; it avoids extra **`start`** calls on the silent spinner so embedded/non-interactive runs do not spam per-file lines.
> 
> **`@sanity/cli-core`** spinners under an execution context now **emit persisted** `succeed` / `fail` / `warn` / `info` / `stopAndPersist` lines to context sinks (stderr, else stdout) instead of dropping them; animation and transient `text` updates are still ignored.
> 
> Oclif drops the codegen plugin, adds a **`typegen`** topic, and MCP policy **`deny`**s **`typegen:generate`** (local read/write). Lockfile/catalog bump **`@sanity/codegen`** to **8.0.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa24f922bffd9fa8ba300db913d47730c050f80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->