### PR TITLE
test: drop `name` from the remaining fixtures

### DIFF
--- a/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
+++ b/packages/@sanity/cli/src/actions/manifest/__tests__/extractCoreAppManifest.test.ts
@@ -56,7 +56,6 @@ describe('extractCoreAppManifest', () => {
     mockGetCliConfig.mockResolvedValue({
       app: unstable_defineApp({
         group: 'dock.system',
-        name: 'my-app',
         organizationId: 'org-1',
         priority: 20,
         slug: 'my-slug',
@@ -78,7 +77,6 @@ describe('extractCoreAppManifest', () => {
   test('keeps priority 0 (not dropped as a falsy value)', async () => {
     mockGetCliConfig.mockResolvedValue({
       app: unstable_defineApp({
-        name: 'my-app',
         organizationId: 'org-1',
         priority: 0,
         slug: 'my-slug',

--- a/packages/@sanity/cli/src/config/__tests__/defineCliConfig.test.ts
+++ b/packages/@sanity/cli/src/config/__tests__/defineCliConfig.test.ts
@@ -36,7 +36,6 @@ describe('the `app` config slot', () => {
     defineCliConfig({
       app: unstable_defineApp({
         group: 'dock.system',
-        name: 'my-app',
         organizationId: 'org-1',
         priority: 20,
         slug: 'my-app',

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/getWorkbench.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/getWorkbench.test.ts
@@ -14,7 +14,6 @@ import {getWorkbench} from '../getWorkbench.js'
 // than a hand-rolled stand-in.
 function workbench(overrides: Partial<DefineAppInput> = {}) {
   const app = unstable_defineApp({
-    name: 'test-app',
     organizationId: 'org-id',
     slug: 'test-app',
     title: 'Test App',

--- a/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
@@ -20,7 +20,6 @@ vi.mock('@sanity/cli-core', async (importOriginal) => ({
 function workbenchApp(): DeployableWorkbenchApp {
   const app = getWorkbench({
     app: unstable_defineApp({
-      name: 'my-app',
       organizationId: 'org-1',
       slug: 'my-app',
       title: 'My App',


### PR DESCRIPTION
### Description

Typecheck is broken on main due to #1631: removed `name` from the `unstable_defineApp` input; #1632 merged 14 seconds later carrying test fixtures still written against the old shape. Missed a rebase.

### Testing

`pnpm check:types` is clean and the unit suite passes (3420).

### Notes for release

N/A: test-only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture updates with no production code or runtime behavior changes.
> 
> **Overview**
> Fixes **red typecheck on `main`** by aligning test fixtures with the current `unstable_defineApp` input shape ( **`name` was removed** in a prior change; some tests still passed it).
> 
> **`name` is deleted** from `unstable_defineApp({...})` literals in manifest extraction tests, `defineCliConfig` type tests, and workbench deploy/undeploy helper fixtures. Assertions and behavior under test are unchanged—`slug` and `title` still identify the app where needed.
> 
> No production or runtime code changes; plain `app: {}` config tests are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 672a984d4059d9b3434e2b283cde9baab9c1ba9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->