### PR TITLE
feat(workbench): register asset_source view type

### DIFF
--- a/.changeset/pr-1638.md
+++ b/.changeset/pr-1638.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+'@sanity/workbench-cli': minor
+---
+
+feat(workbench): register asset_source view type

--- a/packages/@sanity/cli/src/exports/runtime.ts
+++ b/packages/@sanity/cli/src/exports/runtime.ts
@@ -8,7 +8,10 @@
 //
 // `unstable_defineApp` is config-time (Node) and stays on the main `@sanity/cli`
 // entry; only the runtime helpers live here.
+export type {AssetSource, AssetSourceComponentProps} from '@sanity/types'
 export type {
+  AssetSourceComponent,
+  AssetSourceViewComponents,
   DefinedService,
   DefinedView,
   InterfaceType,

--- a/packages/@sanity/workbench-cli/package.json
+++ b/packages/@sanity/workbench-cli/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@module-federation/vite": "1.20.1",
     "@sanity/cli-core": "workspace:^",
+    "@sanity/types": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "form-data": "catalog:",
     "tar-fs": "catalog:",

--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -153,6 +153,20 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     expect(result.error?.issues[0]?.message).toBe('View `title` is required')
   })
 
+  test('accepts an asset_source view declaration', () => {
+    const parsed = DefineAppInputSchema.parse(
+      validInput({
+        views: [{name: 'library', src: './src/picker.tsx', title: 'Library', type: 'asset_source'}],
+      }),
+    )
+    expect(parsed.views?.[0]).toEqual({
+      name: 'library',
+      src: './src/picker.tsx',
+      title: 'Library',
+      type: 'asset_source',
+    })
+  })
+
   test('rejects an unknown view type', () => {
     expect(
       DefineAppInputSchema.safeParse(
@@ -276,6 +290,28 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     expect(result.error?.issues.some((issue) => /at most one panel view/.test(issue.message))).toBe(
       true,
     )
+  })
+
+  test('accepts an `entry` alongside an asset_source view', () => {
+    const result = DefineAppInputSchema.safeParse(
+      validInput({
+        entry: './src/App.tsx',
+        views: [{name: 'library', src: './src/picker.tsx', title: 'Library', type: 'asset_source'}],
+      }),
+    )
+    expect(result.success).toBe(true)
+  })
+
+  test('does not count an asset_source view toward the one-panel cap', () => {
+    const result = DefineAppInputSchema.safeParse(
+      validInput({
+        views: [
+          {name: 'feed', src: './src/panel.tsx', title: 'feed', type: 'panel'},
+          {name: 'library', src: './src/picker.tsx', title: 'Library', type: 'asset_source'},
+        ],
+      }),
+    )
+    expect(result.success).toBe(true)
   })
 
   test('rejects `entry` on a studio with a not-yet-implemented error', () => {

--- a/packages/@sanity/workbench-cli/src/__tests__/defineView.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineView.test.ts
@@ -1,3 +1,4 @@
+import {type AssetSourceComponentProps} from '@sanity/types'
 import {describe, expect, expectTypeOf, test} from 'vitest'
 
 import {VIEW_CONTRACT_VERSION} from '../contract.js'
@@ -5,6 +6,7 @@ import {type DefinedView, type PanelViewProps, unstable_defineView} from '../def
 
 const title = ({view}: PanelViewProps) => view.name
 const panel = ({view}: PanelViewProps) => view.name
+const assetSource = (props: AssetSourceComponentProps) => props.assetSource.name
 
 describe('unstable_defineView', () => {
   test('returns the view type, contract version, and the author components', () => {
@@ -49,5 +51,32 @@ describe('type surface', () => {
   test('rejects an unknown view type', () => {
     // @ts-expect-error — "sidebar" is not a known view type.
     unstable_defineView('sidebar', {panel: () => null, title: () => null})
+  })
+})
+
+describe('asset_source view', () => {
+  test('returns the view type, contract version, and the author component', () => {
+    const view = unstable_defineView('asset_source', {asset_source: assetSource})
+
+    expect(view.type).toBe('asset_source')
+    expect(view.version).toBe(VIEW_CONTRACT_VERSION)
+    expect(view.components.asset_source).toBe(assetSource)
+  })
+
+  test('narrows the component record and props from the view type argument', () => {
+    const view = unstable_defineView('asset_source', {
+      asset_source: (props) => {
+        expectTypeOf(props).toEqualTypeOf<AssetSourceComponentProps>()
+        return null
+      },
+    })
+
+    expectTypeOf(view).toEqualTypeOf<DefinedView<'asset_source'>>()
+    expectTypeOf(view.components).toHaveProperty('asset_source')
+  })
+
+  test('rejects a panel component record for an asset_source view', () => {
+    // @ts-expect-error — asset_source exposes only the `asset_source` slot.
+    unstable_defineView('asset_source', {panel: () => null, title: () => null})
   })
 })

--- a/packages/@sanity/workbench-cli/src/_exports/index.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/index.ts
@@ -18,6 +18,8 @@ export type {
 } from '../defineService.js'
 export {unstable_defineView} from '../defineView.js'
 export type {
+  AssetSourceComponent,
+  AssetSourceViewComponents,
   DefinedView,
   PanelComponent,
   PanelViewComponents,

--- a/packages/@sanity/workbench-cli/src/actions/deploy/viewDeployment.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/viewDeployment.ts
@@ -7,7 +7,7 @@ import {z} from 'zod/mini'
 const viewRecordSchema = z.looseObject({
   name: z.string().check(z.regex(/^[a-zA-Z0-9_-]+$/, 'View `name` must match /^[a-zA-Z0-9_-]+$/')),
   src: z.string(),
-  type: z.enum(['panel']),
+  type: z.enum(['panel', 'asset_source']),
 })
 
 /**

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -78,6 +78,7 @@ const devServerInterfaceSchema = z.discriminatedUnion('type', [
     type: z.literal('app'),
   }),
   z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('panel')}),
+  z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('asset_source')}),
   z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('worker')}),
 ])
 

--- a/packages/@sanity/workbench-cli/src/contract.ts
+++ b/packages/@sanity/workbench-cli/src/contract.ts
@@ -31,6 +31,7 @@ export interface ViewComponentBaseProps<TView> {
  * @internal
  */
 export const VIEW_COMPONENTS = {
+  asset_source: ['asset_source'],
   panel: ['title', 'panel'],
 } as const satisfies Record<string, readonly string[]>
 
@@ -83,6 +84,7 @@ export function interfaceModuleId(type: string, name: string): string {
     case 'app': {
       return 'App'
     }
+    case 'asset_source':
     case 'panel': {
       return `views/${name}`
     }
@@ -118,8 +120,16 @@ const PanelViewSchema = z.object({
   ...interfaceDeclarationFields('View'),
 })
 
+const AssetSourceViewSchema = z.object({
+  type: z.literal('asset_source'),
+  ...interfaceDeclarationFields('View'),
+})
+
 /** @internal */
-export const InterfaceDeclarationSchema = z.discriminatedUnion('type', [PanelViewSchema])
+export const InterfaceDeclarationSchema = z.discriminatedUnion('type', [
+  PanelViewSchema,
+  AssetSourceViewSchema,
+])
 
 const WorkerServiceSchema = z.object({
   type: z.literal('worker'),

--- a/packages/@sanity/workbench-cli/src/defineApp.ts
+++ b/packages/@sanity/workbench-cli/src/defineApp.ts
@@ -121,25 +121,38 @@ export const DefineAppInputSchema = z
     }),
   )
   .check(
-    // An app exposes one interface kind: an app view (`entry`) or panels.
+    // A navigable app view (`entry`) and dock panels are the mutually-exclusive
+    // navigable kinds. An `asset_source` view is a separate kind — a picker
+    // brokered to other apps — so it may sit alongside either.
     z.refine(
-      (input) => !(input.entry !== undefined && (input.views?.length ?? 0) > 0),
+      (input) =>
+        !(
+          input.entry !== undefined &&
+          (input.views?.some((view) => view.type === 'panel') ?? false)
+        ),
       'An app cannot expose both an app view (`entry`) and panel views. Declare one or the other.',
     ),
   )
   .check(
     z.refine(
-      (input) => (input.views?.length ?? 0) <= 1,
+      (input) => (input.views?.filter((view) => view.type === 'panel').length ?? 0) <= 1,
       'An app can expose at most one panel view.',
     ),
   )
 
+/** The `asset_source` variant of an app's `views`. @public */
+export type AssetSourceView = Extract<
+  NonNullable<z.output<typeof DefineAppInputSchema>['views']>[number],
+  {type: 'asset_source'}
+>
+
 /**
  * User-facing input for `unstable_defineApp`. Excludes the internal
- * `applicationType`, `isSingleton`, and `config` — validated by the
- * schema but not part of the public surface (Sanity-owned apps set them via
- * `@ts-expect-error`). A union so an app declares an app `entry` or `views`,
- * never both.
+ * `applicationType`, `isSingleton`, and `config` — validated by the schema but
+ * not part of the public surface (Sanity-owned apps set them via
+ * `@ts-expect-error`). A union: an app declares an app `entry` (navigable) or
+ * panel `views`, never both — but an `asset_source` view is a separate kind and
+ * may accompany either.
  * @public
  */
 export type DefineAppInput = Omit<
@@ -148,7 +161,7 @@ export type DefineAppInput = Omit<
 > &
   (
     | {entry?: never; views?: NonNullable<z.output<typeof DefineAppInputSchema>['views']>}
-    | {entry?: string; views?: never}
+    | {entry?: string; views?: AssetSourceView[]}
   )
 
 /**

--- a/packages/@sanity/workbench-cli/src/defineView.ts
+++ b/packages/@sanity/workbench-cli/src/defineView.ts
@@ -1,3 +1,5 @@
+import {type AssetSourceComponentProps} from '@sanity/types'
+
 import {
   type InterfaceType,
   VIEW_CONTRACT_VERSION,
@@ -36,10 +38,29 @@ export interface PanelViewComponents {
 export type PanelComponent = keyof PanelViewComponents
 
 /**
+ * The component slots an `asset_source` view exposes — a single picker island,
+ * typed with the studio asset-source props it renders behind. The props are
+ * `@sanity/types`' `AssetSourceComponentProps` directly, so an authored picker
+ * receives exactly what a studio `AssetSource.component` does.
+ * @public
+ */
+export interface AssetSourceViewComponents {
+  asset_source: ViewComponent<AssetSourceComponentProps>
+}
+
+/**
+ * An asset source's view-component slot — the module-federation expose for its
+ * one island.
+ * @public
+ */
+export type AssetSourceComponent = keyof AssetSourceViewComponents
+
+/**
  * The components each interface type exposes, keyed by type.
  * @public
  */
 export interface ViewComponentsByType {
+  asset_source: AssetSourceViewComponents
   panel: PanelViewComponents
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1274,6 +1274,9 @@ importers:
       '@sanity/cli-core':
         specifier: workspace:^
         version: link:../cli-core
+      '@sanity/types':
+        specifier: 'catalog:'
+        version: 6.7.0(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -4717,9 +4720,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^18.3 || ^19.0.0-0
-
-  '@sanity/media-library-types@1.5.0':
-    resolution: {integrity: sha512-rna9aGwpe4evOtCrGs2qNOmU6b4HmtZql8IF1/phJSK5/U+u4vrrFee0Pxyp3eIjwdsOzL0vH7JAnmo6Affoqg==}
 
   '@sanity/media-library-types@1.6.0':
     resolution: {integrity: sha512-1Nqw8GSUr7E8AFue9luyTOM4Ev0ZlJ35SHcQrHZ6T68G5llfXw99e3GkLXzk6qYFk9r9fJaBTSpW5IyO2mObZQ==}
@@ -13660,8 +13660,6 @@ snapshots:
       '@sanity/color': 3.0.8
       react: 19.2.7
 
-  '@sanity/media-library-types@1.5.0': {}
-
   '@sanity/media-library-types@1.6.0': {}
 
   '@sanity/message-protocol@0.23.0':
@@ -13962,7 +13960,7 @@ snapshots:
       '@sanity/message-protocol': 0.23.0
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
-      '@sanity/types': 6.5.0(@types/react@19.2.17)
+      '@sanity/types': 6.7.0(@types/react@19.2.17)
       groq: 3.88.1-typegen-experimental.0
       groq-js: 1.30.3
       reselect: 5.2.0
@@ -14024,7 +14022,7 @@ snapshots:
   '@sanity/types@6.5.0(@types/react@19.2.17)':
     dependencies:
       '@sanity/client': 7.25.0
-      '@sanity/media-library-types': 1.5.0
+      '@sanity/media-library-types': 1.6.0
       '@types/react': 19.2.17
 
   '@sanity/types@6.7.0(@types/react@19.2.17)':


### PR DESCRIPTION
### Description

Lets an app author contribute a Media-Library-owned asset picker as a federated view: `unstable_defineView('asset_source', …)` is now a real, type-safe view type whose component receives the same props a Studio asset source does.

This covers the authoring surface — the types and identity an author writes against — so apps have a stable prop shape to build an `asset_source` view on.

Resolves [SDK-2206](https://linear.app/sanity/issue/SDK-2206).

### Notes for release

`unstable_defineView('asset_source', …)` is now supported, letting apps contribute a custom asset source as a federated view.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Authoring-surface and validation changes with tests; no auth or runtime behavior beyond registering the new view type in dev/deploy schemas.
> 
> **Overview**
> Registers **`asset_source`** as a first-class workbench view type so app authors can contribute a federated Media Library–style asset picker.
> 
> Authors use **`unstable_defineView('asset_source', { asset_source: … })`** with a single component typed as **`AssetSourceComponentProps`** from `@sanity/types` (same contract as Studio asset sources). **`unstable_defineApp`** can declare `type: 'asset_source'` views in `views`, and **`DefineAppInput`** rules are updated so **`asset_source` is not a navigable panel**: it may sit alongside an **`entry`** or one **`panel`**, without counting toward the one-panel limit.
> 
> The change threads through the extension contract (**`VIEW_COMPONENTS`**, Zod declarations, deploy payload, dev registry) and re-exports **`AssetSource` / asset-source view types** from **`@sanity/cli`** runtime and **`@sanity/workbench-cli`**, with **`@sanity/types`** added as a workbench-cli dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 684b68a6d184bcd732d4e145a3539e9e4eb807dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->