### PR TITLE
feat(workbench): deploy and forward asset_source views

### DIFF
--- a/.changeset/pr-1639.md
+++ b/.changeset/pr-1639.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/workbench-cli': minor
+---
+
+feat(workbench): deploy and forward asset_source views

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-extension-artifacts.node.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-extension-artifacts.node.test.ts
@@ -76,6 +76,30 @@ describe('sanityExtensionArtifacts', () => {
     expect(title).toContain('view.components["title"]')
   })
 
+  it('emits a single render-contract artifact for an asset_source view', () => {
+    const root = makeRoot()
+    runConfigResolved(
+      sanityExtensionArtifacts({
+        artifacts: workbenchArtifacts({
+          views: [
+            {name: 'library', src: './src/picker.tsx', title: 'library', type: 'asset_source'},
+          ],
+        }),
+      }),
+      root,
+    )
+
+    // An asset_source exposes a single `asset_source` island.
+    const libraryDir = path.join(root, '.sanity/federation/views/library')
+    expect(fs.readdirSync(libraryDir).toSorted()).toEqual(['asset_source.js'])
+
+    const picker = fs.readFileSync(path.join(libraryDir, 'asset_source.js'), 'utf8')
+    expect(picker).toContain('import view from "../../../../src/picker.tsx"')
+    expect(picker).toContain('view.components["asset_source"]')
+    expect(picker).toContain('export function render(rootElement, props')
+    expect(picker).toContain('import.meta.hot.accept')
+  })
+
   it('writes nothing when no views are declared', () => {
     const root = makeRoot()
     runConfigResolved(sanityExtensionArtifacts({artifacts: workbenchArtifacts({views: []})}), root)

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -29,6 +29,24 @@ describe('deriveInterfaces', () => {
     ])
   })
 
+  test('maps asset_source views to asset_source interfaces', () => {
+    const app = workbenchApp({
+      views: [{name: 'library', src: './src/Picker.tsx', title: 'library', type: 'asset_source'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {
+        id: 'test-app-asset_source-library',
+        metadata: null,
+        moduleId: 'views/library',
+        name: 'library',
+        src: './src/Picker.tsx',
+        title: 'library',
+        type: 'asset_source',
+        version: '1',
+      },
+    ])
+  })
+
   test('maps services to worker interfaces', () => {
     const app = workbenchApp({
       services: [{name: 'unread', src: './src/service.ts', title: 'unread', type: 'worker'}],

--- a/packages/@sanity/workbench-cli/src/contract.ts
+++ b/packages/@sanity/workbench-cli/src/contract.ts
@@ -61,6 +61,7 @@ export type AppInterfaceMetadata = z.infer<typeof AppInterfaceMetadataSchema>
  */
 const INTERFACE_CONTRACT_VERSIONS = {
   app: undefined,
+  asset_source: VIEW_CONTRACT_VERSION,
   panel: VIEW_CONTRACT_VERSION,
   worker: SERVICE_CONTRACT_VERSION,
 } as const

--- a/packages/@sanity/workbench-cli/src/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/deriveInterfaces.ts
@@ -26,6 +26,7 @@ interface DerivedInterfaceBase {
 /** @internal */
 export type DerivedInterface =
   | (DerivedInterfaceBase & {metadata: AppInterfaceMetadata | null; type: 'app'})
+  | (DerivedInterfaceBase & {metadata: null; type: 'asset_source'})
   | (DerivedInterfaceBase & {metadata: null; type: 'panel'})
   | (DerivedInterfaceBase & {metadata: null; type: 'worker'})
 
@@ -62,7 +63,7 @@ export function deriveInterfaces(
 
   return [
     ...(app.views ?? []).map(
-      (view): DerivedInterface => ({...shared('panel', view), metadata: null}),
+      (view): DerivedInterface => ({...shared(view.type, view), metadata: null}),
     ),
     ...(app.services ?? []).map(
       (service): DerivedInterface => ({...shared('worker', service), metadata: null}),

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -32,6 +32,7 @@ interface BrettInterfaceBase {
  */
 export type BrettInterface =
   | (BrettInterfaceBase & {metadata: AppInterfaceMetadata | null; type: 'app'})
+  | (BrettInterfaceBase & {metadata: null; type: 'asset_source'})
   | (BrettInterfaceBase & {metadata: null; type: 'panel'})
   | (BrettInterfaceBase & {metadata: null; type: 'worker'})
 


### PR DESCRIPTION
### Description

Makes an `asset_source` view deploy and forward in local dev as itself, so it reaches the workbench instead of being treated as a panel. An app declaring `unstable_defineView('asset_source', …)` now builds its render artifact, deploys an `asset_source` interface record, and has that record forwarded to the workbench during `sanity dev`.

Resolves [SDK-2210](https://linear.app/sanity/issue/SDK-2210).

### Notes for release

Workbench `asset_source` views now deploy and forward in local dev.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interface typing and deployment metadata for a new view kind; incorrect forwarding could affect how the workbench loads asset pickers, but scope is limited to workbench-cli federation plumbing.
> 
> **Overview**
> **`asset_source` views are no longer forced through the panel pipeline.** `deriveInterfaces` now preserves each view’s declared `type` instead of always emitting `panel`, so `unstable_defineView('asset_source', …)` registers as an `asset_source` interface in local dev and on deploy.
> 
> The workbench contract and Brett deployment types gain **`asset_source`** alongside existing interface kinds, with the same view contract version and `views/{name}` module id as panels. The Vite artifact plugin emits a single **`asset_source.js`** render bundle (with HMR) for that slot rather than panel/title artifacts.
> 
> Tests cover interface derivation and federation artifact output for `asset_source` views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3139bb8db3df114210fd0ad58fc547f9bc93ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->