### PR TITLE
feat(cli): show terms of service in sanity new

### DIFF
--- a/.changeset/pr-1642.md
+++ b/.changeset/pr-1642.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): show terms of service in sanity new

--- a/packages/@sanity/cli/src/commands/__tests__/new.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/new.test.ts
@@ -37,6 +37,8 @@ const project = {
   datasetName: 'production',
   expiresAt: '2026-08-01T00:00:00.000Z',
   resourceId: 'abc123',
+  termsNotice: 'By continuing to use this project you accept the Sanity Terms of Service.',
+  termsUrl: 'https://www.sanity.io/legal/tos',
   token: 'sk-robot-token',
 }
 
@@ -48,6 +50,7 @@ const result = {
   dataset: project.datasetName,
   expiresAt: project.expiresAt,
   projectId: project.resourceId,
+  terms: {notice: project.termsNotice, url: project.termsUrl},
   token: project.token,
 }
 
@@ -279,6 +282,23 @@ describe('#new', () => {
     expect(outputText().indexOf('cd web && pnpm add --save-prod next-sanity')).toBeLessThan(
       outputText().indexOf('In a separate terminal, start your website:'),
     )
+  })
+
+  test('prints the terms of service notice from the provision response', async () => {
+    await NewCommand.run(['My New Project'])
+
+    const lines = outputLines()
+    expect(lines).toContain(`│  ${project.termsNotice}`)
+    expect(lines).toContain(`│  Terms of Service: ${project.termsUrl}`)
+    expect(lines.indexOf(`│  Terms of Service: ${project.termsUrl}`)).toBeLessThan(
+      lines.indexOf('└  visit https://sanity.new'),
+    )
+  })
+
+  test('prints the terms of service notice when the project is created without scaffolding', async () => {
+    await NewCommand.run(['My New Project', '--no-scaffold'])
+
+    expect(outputLines()).toContain(`│  Terms of Service: ${project.termsUrl}`)
   })
 
   test('exits without additional recovery output when setup is cancelled', async () => {

--- a/packages/@sanity/cli/src/commands/new.ts
+++ b/packages/@sanity/cli/src/commands/new.ts
@@ -85,6 +85,10 @@ export interface NewProjectResult {
   dataset: string
   expiresAt: string
   projectId: string
+  terms: {
+    notice: string
+    url: string
+  }
   token: string
 }
 
@@ -97,6 +101,7 @@ function toResult(project: MintedProject): NewProjectResult {
     dataset: project.datasetName,
     expiresAt: project.expiresAt,
     projectId: project.resourceId,
+    terms: {notice: project.termsNotice, url: project.termsUrl},
     token: project.token,
   }
 }
@@ -369,6 +374,9 @@ export class NewCommand extends SanityCommand<typeof NewCommand> {
         'The claim link and token are printed above but you can recover them ' +
           `with ${styleText('cyan', 'sanity projects unclaimed')} before the timer runs out on ${formatClaimDeadline(project.expiresAt)}.`,
       )
+      flow.gap()
+      flow.line(project.termsNotice)
+      flow.link(project.termsUrl, {label: 'Terms of Service:'})
       flow.gap()
       flow.line('For more information on how claiming works or how to build your app')
       flow.link(SANITY_NEW_URL, {label: 'visit', outro: true})

--- a/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/mintProject.test.ts
@@ -19,6 +19,10 @@ const provisionResponse = {
   },
   resourceId: 'abc123',
   resourceType: 'project',
+  terms: {
+    notice: 'By continuing to use this project you accept the Sanity Terms of Service.',
+    url: 'https://www.sanity.io/legal/tos',
+  },
   token: 'sk-robot-token',
 }
 
@@ -49,6 +53,8 @@ describe('mintUnclaimedProject', () => {
       datasetName: provisionResponse.datasetName,
       expiresAt: provisionResponse.expiresAt,
       resourceId: provisionResponse.resourceId,
+      termsNotice: provisionResponse.terms.notice,
+      termsUrl: provisionResponse.terms.url,
       token: provisionResponse.token,
     })
 
@@ -110,6 +116,23 @@ describe('mintUnclaimedProject', () => {
 
     await expect(mintUnclaimedProject({displayName: 'My Project'})).resolves.toMatchObject({
       resourceId: provisionResponse.resourceId,
+    })
+  })
+
+  // The terms notice has to reach the user even when the API predates it, so it falls back to
+  // the bundled copy rather than joining the required-field check.
+  test.each([
+    ['omits terms', {}],
+    ['sends terms that are not an object', {terms: 'nope'}],
+    ['sends empty terms strings', {terms: {notice: '', url: ''}}],
+  ])('falls back to the bundled terms of service when the response %s', async (_, overrides) => {
+    mockRequest.mockResolvedValue(
+      jsonResponse({...provisionResponse, terms: undefined, ...overrides}),
+    )
+
+    await expect(mintUnclaimedProject({displayName: 'My Project'})).resolves.toMatchObject({
+      termsNotice: 'By continuing to use this project you accept the Sanity Terms of Service.',
+      termsUrl: 'https://www.sanity.io/legal/tos',
     })
   })
 

--- a/packages/@sanity/cli/src/services/mintProject.ts
+++ b/packages/@sanity/cli/src/services/mintProject.ts
@@ -2,6 +2,11 @@ import {subdebug} from '@sanity/cli-core/debug'
 import {createRequester} from '@sanity/cli-core/request'
 import {isStaging} from '@sanity/cli-core/util'
 
+import {
+  TERMS_OF_SERVICE_FALLBACK_NOTICE,
+  TERMS_OF_SERVICE_FALLBACK_URL,
+} from '../util/mintProjectConstants.js'
+
 const debug = subdebug('new:provision')
 
 /** Provision API version for minting unclaimed projects. */
@@ -17,6 +22,9 @@ export interface MintedProject {
   datasetName: string
   expiresAt: string
   resourceId: string
+  /** Terms of Service accepted by using the project. Falls back to the bundled constants. */
+  termsNotice: string
+  termsUrl: string
   token: string
 }
 
@@ -50,6 +58,10 @@ function parseProvisionResponse(body: unknown): MintedProject {
     response.links && typeof response.links === 'object' && !Array.isArray(response.links)
       ? (response.links as Record<string, unknown>)
       : {}
+  const terms =
+    response.terms && typeof response.terms === 'object' && !Array.isArray(response.terms)
+      ? (response.terms as Record<string, unknown>)
+      : {}
 
   const minted = {
     apiHost: getString(response.apiHost),
@@ -72,7 +84,11 @@ function parseProvisionResponse(body: unknown): MintedProject {
     throw new Error(`Project creation response is missing or invalid: ${missing.join(', ')}`)
   }
 
-  return minted as MintedProject
+  return {
+    ...(minted as Omit<MintedProject, 'termsNotice' | 'termsUrl'>),
+    termsNotice: getString(terms.notice) ?? TERMS_OF_SERVICE_FALLBACK_NOTICE,
+    termsUrl: getString(terms.url) ?? TERMS_OF_SERVICE_FALLBACK_URL,
+  }
 }
 
 /**

--- a/packages/@sanity/cli/src/util/__tests__/unclaimedProjects.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/unclaimedProjects.test.ts
@@ -29,6 +29,8 @@ const minted: MintedProject = {
   datasetName: 'production',
   expiresAt: '2026-08-01T00:00:00.000Z',
   resourceId: 'abc123',
+  termsNotice: 'By continuing to use this project you accept the Sanity Terms of Service.',
+  termsUrl: 'https://www.sanity.io/legal/tos',
   token: 'sk-robot-token',
 }
 

--- a/packages/@sanity/cli/src/util/mintProjectConstants.ts
+++ b/packages/@sanity/cli/src/util/mintProjectConstants.ts
@@ -2,3 +2,8 @@
 export const CLAIM_WINDOW_HOURS = 72
 
 export const SANITY_NEW_URL = 'https://sanity.new'
+
+export const TERMS_OF_SERVICE_FALLBACK_URL = 'https://www.sanity.io/legal/tos'
+
+export const TERMS_OF_SERVICE_FALLBACK_NOTICE =
+  'By continuing to use this project you accept the Sanity Terms of Service.'


### PR DESCRIPTION
### Description

`sanity new` creates a real, working project without an account, so there's no signup step where anyone accepts our terms. Consent is implicit in using the project, which only holds up if we actually say so in the output.

The provisioning API now returns a terms of service notice and URL alongside a new project, and `sanity new` prints both just above the closing link. `--json` carries the same thing under a new `terms` key, since that path prints nothing else and is what agents read.

The CLI treats the field as optional rather than required. If the API doesn't send it, the notice falls back to a bundled copy, so it can't silently vanish from the output and a CLI release doesn't have to line up with an API deploy.

### What to review

- Placement in `new.ts`: the notice sits after the token and claim caveats, above the `visit sanity.new` outro.
- `parseProvisionResponse` in `services/mintProject.ts`: `terms` is deliberately outside the required-field check, so a response without it still mints.
- `terms` is a new field on the `NewProjectResult` that `--json` prints, so anything consuming that output sees a new key.

### Testing

Unit tests cover the printed lines for the scaffolded and `--no-scaffold` paths, the `--json` shape, and the fallback when the response omits `terms`.

To see it by hand without minting a real project, point the CLI at a local stub of the provision endpoint with `SANITY_API_HOST` and set `SANITY_CLI_CONFIG_PATH` to a throwaway file, then run `sanity new "Test" --no-scaffold --yes` and again with `--json`. I ran all four combinations that way (terms present and absent, both flags).

### Notes for release

`sanity new` now prints the terms of service you accept by using an unclaimed project, and includes them in `--json` output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI output and an optional JSON field with safe API fallbacks; no changes to auth, provisioning requirements, or stored recovery records.
> 
> **Overview**
> **`sanity new`** now surfaces Terms of Service after the token/claim guidance and before the `sanity.new` outro: the notice text plus a labeled link, for both scaffolded and `--no-scaffold` flows.
> 
> Provisioning responses can supply `terms.notice` and `terms.url`; the mint layer maps these onto **`MintedProject`** and uses **bundled fallbacks** when the API omits or sends invalid/empty terms, without blocking project creation. **`--json`** adds a **`terms`** object (`notice`, `url`) on **`NewProjectResult`** for the same data agents and scripts consume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e92351c202973c4e201d9db28d50c24c87654a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->