### PR TITLE
fix(cli-core): explain missing project membership in Content Lake 401 errors

### DIFF
--- a/.changeset/pr-1644.md
+++ b/.changeset/pr-1644.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': patch
+---
+
+fix(cli-core): explain missing project membership in Content Lake 401 errors

--- a/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
@@ -384,9 +384,11 @@ describe('authErrors middleware', () => {
     const result = onErrorHandler!(error)
 
     expect(result).toBe(error)
-    expect(result?.message).toBe(
-      'Unauthorized. This account is not a member of the project. Organization-level roles do not grant access to project content. Add this account as a project member: https://www.sanity.io/manage/project/test-project/members.',
+    expect(result?.message).toContain('This account is not a member of the project')
+    expect(result?.message).toContain(
+      'sanity users invite <email> --project-id test-project --role <role>',
     )
+    expect(result?.message).toContain('https://www.sanity.io/manage/project/test-project/members')
     expect(result?.message).not.toContain('sanity login')
   })
 
@@ -424,9 +426,13 @@ describe('authErrors middleware', () => {
     const result = onErrorHandler!(error)
 
     expect(result).toBe(error)
-    expect(result?.message).toBe(
-      'project user not found for user ID "gZmyPK60G" in project "test-project". This account is not a member of the project. Organization-level roles do not grant access to project content. Add this account as a project member: https://www.sanity.io/manage/project/test-project/members.',
+    expect(result?.message).toContain(
+      'project user not found for user ID "gZmyPK60G" in project "test-project". This account is not a member of the project',
     )
+    expect(result?.message).toContain(
+      'sanity users invite <email> --project-id test-project --role <role>',
+    )
+    expect(result?.message).toContain('https://www.sanity.io/manage/project/test-project/members')
     expect(result?.message).not.toContain('sanity login')
   })
 
@@ -462,8 +468,9 @@ describe('authErrors middleware', () => {
 
     expect(result).toBe(error)
     expect(result?.message).toContain(
-      'Add this account as a project member: https://www.sanity.io/manage.',
+      'sanity users invite <email> --project-id <project-id> --role <role>',
     )
+    expect(result?.message).toContain('add it as a project member at https://www.sanity.io/manage.')
     expect(result?.message).not.toContain('sanity login')
   })
 
@@ -503,8 +510,9 @@ describe('authErrors middleware', () => {
 
     expect(result).toBe(error)
     expect(result?.message).toContain(
-      'Add this account as a project member: https://www.sanity.io/manage.',
+      'sanity users invite <email> --project-id <project-id> --role <role>',
     )
+    expect(result?.message).toContain('add it as a project member at https://www.sanity.io/manage.')
     expect(result?.message).not.toContain('/members')
     expect(result?.message).not.toContain('sanity login')
   })

--- a/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
@@ -484,11 +484,17 @@ describe('authErrors middleware', () => {
 
     expect(onErrorHandler).toBeDefined()
 
-    const error = new Error('Project user not found') as Error & {
-      response: {body: Record<string, never>}
+    const error = new Error('Unauthorized') as Error & {
+      response: {
+        body: {error: {type: string}}
+      }
       statusCode: number
     }
-    error.response = {body: {}}
+    error.response = {
+      body: {
+        error: {type: 'projectUserNotFoundError'},
+      },
+    }
     error.statusCode = 401
 
     mockIsHttpError.mockReturnValue(true)
@@ -501,6 +507,38 @@ describe('authErrors middleware', () => {
     )
     expect(result?.message).not.toContain('/members')
     expect(result?.message).not.toContain('sanity login')
+  })
+
+  test('does not treat other 401 prose as a membership error', async () => {
+    let onErrorHandler: ((err: Error | null) => Error | null) | undefined
+    const mockRequester = {
+      use: mockRequesterUse.mockImplementation((middleware: {onError?: typeof onErrorHandler}) => {
+        onErrorHandler = middleware.onError
+      }),
+    }
+    mockRequesterClone.mockReturnValue(mockRequester)
+    mockCreateClient.mockResolvedValue({})
+    mockGetCliToken.mockResolvedValue('stored-token')
+    mockGenerateHelpUrl.mockReturnValue('https://help.sanity.io/cli-errors')
+
+    await getGlobalCliClient({apiVersion: '2021-06-07'})
+
+    expect(onErrorHandler).toBeDefined()
+
+    const error = new Error('Session user not found in project "0zvlb7pj"') as Error & {
+      response: {body: Record<string, never>}
+      statusCode: number
+    }
+    error.response = {body: {}}
+    error.statusCode = 401
+
+    mockIsHttpError.mockReturnValue(true)
+
+    const result = onErrorHandler!(error)
+
+    expect(result).toBe(error)
+    expect(result?.message).toContain('sanity login')
+    expect(result?.message).not.toContain('project member')
   })
 
   test('returns non-401 HTTP errors unchanged', async () => {

--- a/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
@@ -430,7 +430,7 @@ describe('authErrors middleware', () => {
     expect(result?.message).not.toContain('sanity login')
   })
 
-  test('derives the members link from the request URL on the global client', async () => {
+  test('explains missing project membership on the global client', async () => {
     vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
 
     let onErrorHandler: ((err: Error | null) => Error | null) | undefined
@@ -450,13 +450,10 @@ describe('authErrors middleware', () => {
     const error = new Error(
       'project user not found for user ID "gZmyPK60G" in project "0zvlb7pj"',
     ) as Error & {
-      response: {body: Record<string, never>; url: string}
+      response: {body: Record<string, never>}
       statusCode: number
     }
-    error.response = {
-      body: {},
-      url: 'https://0zvlb7pj.api.sanity.io/v2021-06-07/data/query/production?query=*',
-    }
+    error.response = {body: {}}
     error.statusCode = 401
 
     mockIsHttpError.mockReturnValue(true)
@@ -465,7 +462,7 @@ describe('authErrors middleware', () => {
 
     expect(result).toBe(error)
     expect(result?.message).toContain(
-      'Add this account as a project member: https://www.sanity.io/manage/project/0zvlb7pj/members.',
+      'Add this account as a project member: https://www.sanity.io/manage.',
     )
     expect(result?.message).not.toContain('sanity login')
   })
@@ -490,7 +487,6 @@ describe('authErrors middleware', () => {
     const error = new Error('Unauthorized') as Error & {
       response: {
         body: {error: {type: string}}
-        url: string
       }
       statusCode: number
     }
@@ -498,7 +494,6 @@ describe('authErrors middleware', () => {
       body: {
         error: {type: 'projectUserNotFoundError'},
       },
-      url: 'https://api.sanity.io/v2021-06-07/some/endpoint',
     }
     error.statusCode = 401
 

--- a/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
@@ -366,7 +366,7 @@ describe('authErrors middleware', () => {
 
     expect(onErrorHandler).toBeDefined()
 
-    const error = new Error('Project user not found') as Error & {
+    const error = new Error('Unauthorized') as Error & {
       response: {
         body: {error: {type: string}}
       }
@@ -385,8 +385,121 @@ describe('authErrors middleware', () => {
 
     expect(result).toBe(error)
     expect(result?.message).toBe(
-      'Project user not found. Add this account as a project member: https://www.sanity.io/manage/project/test-project/members.',
+      'Unauthorized. This account is not a member of the project. Organization-level roles do not grant access to project content. Add this account as a project member: https://www.sanity.io/manage/project/test-project/members.',
     )
+    expect(result?.message).not.toContain('sanity login')
+  })
+
+  test('explains missing project membership for Content Lake "project user not found" 401s', async () => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+
+    let onErrorHandler: ((err: Error | null) => Error | null) | undefined
+    const mockRequester = {
+      use: mockRequesterUse.mockImplementation((middleware: {onError?: typeof onErrorHandler}) => {
+        onErrorHandler = middleware.onError
+      }),
+    }
+    mockRequesterClone.mockReturnValue(mockRequester)
+    mockCreateClient.mockResolvedValue({})
+    mockGetCliToken.mockResolvedValue('stored-token')
+
+    await getProjectCliClient({
+      apiVersion: '2021-06-07',
+      projectId: 'test-project',
+    })
+
+    expect(onErrorHandler).toBeDefined()
+
+    const error = new Error(
+      'project user not found for user ID "gZmyPK60G" in project "test-project"',
+    ) as Error & {
+      response: {body: Record<string, never>}
+      statusCode: number
+    }
+    error.response = {body: {}}
+    error.statusCode = 401
+
+    mockIsHttpError.mockReturnValue(true)
+
+    const result = onErrorHandler!(error)
+
+    expect(result).toBe(error)
+    expect(result?.message).toBe(
+      'project user not found for user ID "gZmyPK60G" in project "test-project". This account is not a member of the project. Organization-level roles do not grant access to project content. Add this account as a project member: https://www.sanity.io/manage/project/test-project/members.',
+    )
+    expect(result?.message).not.toContain('sanity login')
+  })
+
+  test('derives the members link from the error message on the global client', async () => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+
+    let onErrorHandler: ((err: Error | null) => Error | null) | undefined
+    const mockRequester = {
+      use: mockRequesterUse.mockImplementation((middleware: {onError?: typeof onErrorHandler}) => {
+        onErrorHandler = middleware.onError
+      }),
+    }
+    mockRequesterClone.mockReturnValue(mockRequester)
+    mockCreateClient.mockResolvedValue({})
+    mockGetCliToken.mockResolvedValue('stored-token')
+
+    await getGlobalCliClient({apiVersion: '2021-06-07'})
+
+    expect(onErrorHandler).toBeDefined()
+
+    const error = new Error(
+      'project user not found for user ID "gZmyPK60G" in project "0zvlb7pj"',
+    ) as Error & {
+      response: {body: Record<string, never>}
+      statusCode: number
+    }
+    error.response = {body: {}}
+    error.statusCode = 401
+
+    mockIsHttpError.mockReturnValue(true)
+
+    const result = onErrorHandler!(error)
+
+    expect(result).toBe(error)
+    expect(result?.message).toContain(
+      'Add this account as a project member: https://www.sanity.io/manage/project/0zvlb7pj/members.',
+    )
+    expect(result?.message).not.toContain('sanity login')
+  })
+
+  test('falls back to the manage URL when no project id is known', async () => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+
+    let onErrorHandler: ((err: Error | null) => Error | null) | undefined
+    const mockRequester = {
+      use: mockRequesterUse.mockImplementation((middleware: {onError?: typeof onErrorHandler}) => {
+        onErrorHandler = middleware.onError
+      }),
+    }
+    mockRequesterClone.mockReturnValue(mockRequester)
+    mockCreateClient.mockResolvedValue({})
+    mockGetCliToken.mockResolvedValue('stored-token')
+
+    await getGlobalCliClient({apiVersion: '2021-06-07'})
+
+    expect(onErrorHandler).toBeDefined()
+
+    const error = new Error('Project user not found') as Error & {
+      response: {body: Record<string, never>}
+      statusCode: number
+    }
+    error.response = {body: {}}
+    error.statusCode = 401
+
+    mockIsHttpError.mockReturnValue(true)
+
+    const result = onErrorHandler!(error)
+
+    expect(result).toBe(error)
+    expect(result?.message).toContain(
+      'Add this account as a project member: https://www.sanity.io/manage.',
+    )
+    expect(result?.message).not.toContain('/members')
     expect(result?.message).not.toContain('sanity login')
   })
 

--- a/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
@@ -430,7 +430,7 @@ describe('authErrors middleware', () => {
     expect(result?.message).not.toContain('sanity login')
   })
 
-  test('derives the members link from the error message on the global client', async () => {
+  test('derives the members link from the request URL on the global client', async () => {
     vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
 
     let onErrorHandler: ((err: Error | null) => Error | null) | undefined
@@ -450,10 +450,13 @@ describe('authErrors middleware', () => {
     const error = new Error(
       'project user not found for user ID "gZmyPK60G" in project "0zvlb7pj"',
     ) as Error & {
-      response: {body: Record<string, never>}
+      response: {body: Record<string, never>; url: string}
       statusCode: number
     }
-    error.response = {body: {}}
+    error.response = {
+      body: {},
+      url: 'https://0zvlb7pj.api.sanity.io/v2021-06-07/data/query/production?query=*',
+    }
     error.statusCode = 401
 
     mockIsHttpError.mockReturnValue(true)
@@ -487,6 +490,7 @@ describe('authErrors middleware', () => {
     const error = new Error('Unauthorized') as Error & {
       response: {
         body: {error: {type: string}}
+        url: string
       }
       statusCode: number
     }
@@ -494,6 +498,7 @@ describe('authErrors middleware', () => {
       body: {
         error: {type: 'projectUserNotFoundError'},
       },
+      url: 'https://api.sanity.io/v2021-06-07/some/endpoint',
     }
     error.statusCode = 401
 

--- a/packages/@sanity/cli-core/src/apiClient.ts
+++ b/packages/@sanity/cli-core/src/apiClient.ts
@@ -165,8 +165,9 @@ function authErrors(projectId?: string) {
 
       const statusCode = isHttpError(err) && err.statusCode
       if (statusCode === 401) {
-        if (isProjectUserNotFoundError(err.response.body, err.message)) {
-          const membersProjectId = projectId ?? getProjectIdFromMessage(err.message)
+        const membership = detectMissingProjectMembership(err)
+        if (membership) {
+          const membersProjectId = projectId ?? membership.projectId
           const membersUrl = membersProjectId
             ? getSanityUrl(`/manage/project/${encodeURIComponent(membersProjectId)}/members`)
             : getSanityUrl('/manage')
@@ -182,14 +183,27 @@ function authErrors(projectId?: string) {
   }
 }
 
-// The Content Lake reports the missing-membership case as plain text, e.g.
-// `project user not found for user ID "abc" in project "xyz"`, while other
-// APIs use a structured error type. Match both.
-const PROJECT_USER_NOT_FOUND_MESSAGE = /project user not found/i
+// The Content Lake's missing-membership 401 is prose (surfaced verbatim as
+// the client error message), and that sentence is also the only place the
+// project id appears. Match the full sentence so unrelated 401s can't
+// trigger; if the wording ever changes, detection degrades to the generic
+// 401 guidance below rather than misfiring.
+const PROJECT_USER_NOT_FOUND_MESSAGE =
+  /\bproject user not found for user ID "[^"]*" in project "([a-zA-Z0-9-]+)"/
 
-function isProjectUserNotFoundError(body: unknown, message: string): boolean {
-  if (PROJECT_USER_NOT_FOUND_MESSAGE.test(message)) return true
+function detectMissingProjectMembership(
+  err: ClientError | ServerError,
+): {projectId?: string} | undefined {
+  // Structured error type, where the API provides one
+  if (isProjectUserNotFoundErrorBody(err.response.body)) {
+    return {projectId: PROJECT_USER_NOT_FOUND_MESSAGE.exec(err.message)?.[1]}
+  }
 
+  const match = PROJECT_USER_NOT_FOUND_MESSAGE.exec(err.message)
+  return match ? {projectId: match[1]} : undefined
+}
+
+function isProjectUserNotFoundErrorBody(body: unknown): boolean {
   if (typeof body !== 'object' || body === null || !('error' in body)) return false
 
   const {error} = body
@@ -199,10 +213,6 @@ function isProjectUserNotFoundError(body: unknown, message: string): boolean {
     'type' in error &&
     error.type === 'projectUserNotFoundError'
   )
-}
-
-function getProjectIdFromMessage(message: string): string | undefined {
-  return /in project "([a-z0-9-]+)"/i.exec(message)?.[1]
 }
 
 function isReqResError(err: Error): err is ClientError | ServerError {

--- a/packages/@sanity/cli-core/src/apiClient.ts
+++ b/packages/@sanity/cli-core/src/apiClient.ts
@@ -183,24 +183,37 @@ function authErrors(projectId?: string) {
   }
 }
 
-// The Content Lake's missing-membership 401 is prose (surfaced verbatim as
-// the client error message), and that sentence is also the only place the
-// project id appears. Match the full sentence so unrelated 401s can't
-// trigger; if the wording ever changes, detection degrades to the generic
-// 401 guidance below rather than misfiring.
+// Detection fallback for Content Lake responses that carry the
+// missing-membership 401 only as prose. Anchored to the full sentence so
+// unrelated 401s can't trigger; if the wording ever changes, detection
+// degrades to the generic 401 guidance below rather than misfiring.
 const PROJECT_USER_NOT_FOUND_MESSAGE =
-  /\bproject user not found for user ID "[^"]*" in project "([a-zA-Z0-9-]+)"/
+  /\bproject user not found for user ID "[^"]*" in project "[a-zA-Z0-9-]+"/
 
 function detectMissingProjectMembership(
   err: ClientError | ServerError,
 ): {projectId?: string} | undefined {
-  // Structured error type, where the API provides one
-  if (isProjectUserNotFoundErrorBody(err.response.body)) {
-    return {projectId: PROJECT_USER_NOT_FOUND_MESSAGE.exec(err.message)?.[1]}
+  const isMembershipError =
+    isProjectUserNotFoundErrorBody(err.response.body) ||
+    PROJECT_USER_NOT_FOUND_MESSAGE.test(err.message)
+
+  return isMembershipError ? {projectId: getProjectIdFromRequestUrl(err.response.url)} : undefined
+}
+
+// Data-plane requests address the project through the hostname
+// (`{projectId}.api.sanity.io`), so the failing request's URL identifies the
+// project without depending on error prose.
+function getProjectIdFromRequestUrl(url: unknown): string | undefined {
+  if (typeof url !== 'string') return undefined
+
+  let hostname: string
+  try {
+    hostname = new URL(url).hostname
+  } catch {
+    return undefined
   }
 
-  const match = PROJECT_USER_NOT_FOUND_MESSAGE.exec(err.message)
-  return match ? {projectId: match[1]} : undefined
+  return /^([a-z0-9-]+)\.api\.sanity\.(?:io|work)$/.exec(hostname)?.[1]
 }
 
 function isProjectUserNotFoundErrorBody(body: unknown): boolean {

--- a/packages/@sanity/cli-core/src/apiClient.ts
+++ b/packages/@sanity/cli-core/src/apiClient.ts
@@ -165,11 +165,9 @@ function authErrors(projectId?: string) {
 
       const statusCode = isHttpError(err) && err.statusCode
       if (statusCode === 401) {
-        const membership = detectMissingProjectMembership(err)
-        if (membership) {
-          const membersProjectId = projectId ?? membership.projectId
-          const membersUrl = membersProjectId
-            ? getSanityUrl(`/manage/project/${encodeURIComponent(membersProjectId)}/members`)
+        if (isProjectUserNotFoundError(err)) {
+          const membersUrl = projectId
+            ? getSanityUrl(`/manage/project/${encodeURIComponent(projectId)}/members`)
             : getSanityUrl('/manage')
           err.message = `${err.message}. This account is not a member of the project. Organization-level roles do not grant access to project content. Add this account as a project member: ${membersUrl}.`
           return err
@@ -186,34 +184,15 @@ function authErrors(projectId?: string) {
 // Detection fallback for Content Lake responses that carry the
 // missing-membership 401 only as prose. Anchored to the full sentence so
 // unrelated 401s can't trigger; if the wording ever changes, detection
-// degrades to the generic 401 guidance below rather than misfiring.
+// degrades to the generic 401 guidance above rather than misfiring.
 const PROJECT_USER_NOT_FOUND_MESSAGE =
   /\bproject user not found for user ID "[^"]*" in project "[a-zA-Z0-9-]+"/
 
-function detectMissingProjectMembership(
-  err: ClientError | ServerError,
-): {projectId?: string} | undefined {
-  const isMembershipError =
+function isProjectUserNotFoundError(err: ClientError | ServerError): boolean {
+  return (
     isProjectUserNotFoundErrorBody(err.response.body) ||
     PROJECT_USER_NOT_FOUND_MESSAGE.test(err.message)
-
-  return isMembershipError ? {projectId: getProjectIdFromRequestUrl(err.response.url)} : undefined
-}
-
-// Data-plane requests address the project through the hostname
-// (`{projectId}.api.sanity.io`), so the failing request's URL identifies the
-// project without depending on error prose.
-function getProjectIdFromRequestUrl(url: unknown): string | undefined {
-  if (typeof url !== 'string') return undefined
-
-  let hostname: string
-  try {
-    hostname = new URL(url).hostname
-  } catch {
-    return undefined
-  }
-
-  return /^([a-z0-9-]+)\.api\.sanity\.(?:io|work)$/.exec(hostname)?.[1]
+  )
 }
 
 function isProjectUserNotFoundErrorBody(body: unknown): boolean {

--- a/packages/@sanity/cli-core/src/apiClient.ts
+++ b/packages/@sanity/cli-core/src/apiClient.ts
@@ -166,10 +166,14 @@ function authErrors(projectId?: string) {
       const statusCode = isHttpError(err) && err.statusCode
       if (statusCode === 401) {
         if (isProjectUserNotFoundError(err)) {
+          const inviteCommand = styleText(
+            'cyan',
+            `sanity users invite <email> --project-id ${projectId ?? '<project-id>'} --role <role>`,
+          )
           const membersUrl = projectId
             ? getSanityUrl(`/manage/project/${encodeURIComponent(projectId)}/members`)
             : getSanityUrl('/manage')
-          err.message = `${err.message}. This account is not a member of the project. Organization-level roles do not grant access to project content. Add this account as a project member: ${membersUrl}.`
+          err.message = `${err.message}. This account is not a member of the project. Organization-level roles do not grant access to project content. Invite this account with ${inviteCommand} or add it as a project member at ${membersUrl}.`
           return err
         }
 

--- a/packages/@sanity/cli-core/src/apiClient.ts
+++ b/packages/@sanity/cli-core/src/apiClient.ts
@@ -165,8 +165,12 @@ function authErrors(projectId?: string) {
 
       const statusCode = isHttpError(err) && err.statusCode
       if (statusCode === 401) {
-        if (projectId && isProjectUserNotFoundError(err.response.body)) {
-          err.message = `${err.message}. Add this account as a project member: ${getSanityUrl(`/manage/project/${encodeURIComponent(projectId)}/members`)}.`
+        if (isProjectUserNotFoundError(err.response.body, err.message)) {
+          const membersProjectId = projectId ?? getProjectIdFromMessage(err.message)
+          const membersUrl = membersProjectId
+            ? getSanityUrl(`/manage/project/${encodeURIComponent(membersProjectId)}/members`)
+            : getSanityUrl('/manage')
+          err.message = `${err.message}. This account is not a member of the project. Organization-level roles do not grant access to project content. Add this account as a project member: ${membersUrl}.`
           return err
         }
 
@@ -178,9 +182,14 @@ function authErrors(projectId?: string) {
   }
 }
 
-function isProjectUserNotFoundError(
-  body: unknown,
-): body is {error: {type: 'projectUserNotFoundError'}} {
+// The Content Lake reports the missing-membership case as plain text, e.g.
+// `project user not found for user ID "abc" in project "xyz"`, while other
+// APIs use a structured error type. Match both.
+const PROJECT_USER_NOT_FOUND_MESSAGE = /project user not found/i
+
+function isProjectUserNotFoundError(body: unknown, message: string): boolean {
+  if (PROJECT_USER_NOT_FOUND_MESSAGE.test(message)) return true
+
   if (typeof body !== 'object' || body === null || !('error' in body)) return false
 
   const {error} = body
@@ -190,6 +199,10 @@ function isProjectUserNotFoundError(
     'type' in error &&
     error.type === 'projectUserNotFoundError'
   )
+}
+
+function getProjectIdFromMessage(message: string): string | undefined {
+  return /in project "([a-z0-9-]+)"/i.exec(message)?.[1]
 }
 
 function isReqResError(err: Error): err is ClientError | ServerError {


### PR DESCRIPTION
### Description

Solves [AIGRO-5281](https://linear.app/sanity/issue/AIGRO-5281/project-creators-user-id-mapping-never-reached-redis-content-lake-401s).

The Content Lake rejects requests from authenticated users who are not explicit project members with a bare 401: `project user not found for user ID "..." in project "..."`. As the discovery on the ticket showed, this is a legitimate (and confusing) situation: the management API honors organization-level roles (e.g. org administrator), while the data plane requires explicit project membership — so a user can list projects, manage CORS, and deploy schemas, yet be denied on every content request with no hint of why or what to do.

PR #1567 added a members-page link for this case, but it only matched the structured `{error: {type: 'projectUserNotFoundError'}}` body, and only on project-scoped clients. This PR extends the `authErrors` middleware in `@sanity/cli-core` to:

- Detect the membership case on all clients: the structured `projectUserNotFoundError` body type first, with the Content Lake's plain-text sentence as an anchored fallback (`project user not found for user ID "..." in project "..."`). Unrelated 401 prose cannot trigger it; if the wording ever changes, detection degrades to the existing generic 401 guidance rather than misfiring. If the platform confirms the structured type is always present on this error, the sentence fallback can be deleted and detection is purely contract-based.
- Explain the actual situation and give a CLI-native fix first: `sanity users invite` goes through the management plane, which honors org-level roles, so the affected persona can self-serve without a browser (important for agents). The members-page link remains as the second path. All real occurrences arrive on project-scoped clients, which know the project id; the hypothetical no-id case uses placeholders and the Manage root.

Resulting message:

```
project user not found for user ID "gZmyPK60G" in project "0zvlb7pj". This account is not a member of the project. Organization-level roles do not grant access to project content. Invite this account with sanity users invite <email> --project-id 0zvlb7pj --role <role> or add it as a project member at https://www.sanity.io/manage/project/0zvlb7pj/members.
```

This also reaches MCP-driven invocations via `invokeSanityCli`, which relays the enriched error message. Note the MCP command policy currently denies `users:invite`, so MCP-hosted agents can read the guidance but not execute it in-process — whether to allow it there is a separate product/security decision.

An active-probe design (on 401: check session validity, then project membership via the management API) was considered and rejected: the typed 401 from the data plane already states both facts, the probes themselves require grants/session types the affected personas may lack, and asking populus to confirm membership reintroduces the exact management-plane/data-plane divergence this incident is about. A follow-up worth its own ticket: detecting the member-but-not-yet-propagated case (the original sync-lag theory) genuinely requires comparing planes.

### What to review

- `packages/@sanity/cli-core/src/apiClient.ts` — the `authErrors` middleware: `isProjectUserNotFoundError` (structured type or anchored sentence) and the new copy.
- Whether the anchored sentence fallback is acceptable until the data plane's typed contract is confirmed.
- Whether pointing at `sanity users invite` is the right first remediation (it sends an email invitation; direct member addition is only available in Manage).

### Testing

Unit tests in `packages/@sanity/cli-core/src/__tests__/apiClient.test.ts` cover: the structured error type without the message text, the plain-text Content Lake sentence on project-scoped and global clients, the Manage-root fallback when no project id is known, and a negative case proving unrelated 401 prose still gets the login guidance. Full `@sanity/cli-core` unit suite passes (353/353); `pnpm test:unit --changed` passes apart from three pre-existing sandbox-environment failures in network-error simulation tests, which fail identically on `main`.

### Notes for release

`sanity` CLI errors from the Content Lake now explain when access was denied because the account is not a project member (for example, when it only has organization-level roles), suggest `sanity users invite` to fix it from the terminal, and link to the project's members page in Manage.