### PR TITLE
feat(cli): add claim url to studio url hash fragment

### DIFF
--- a/.changeset/pr-1645.md
+++ b/.changeset/pr-1645.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+---
+
+feat(cli): add claim url to studio url hash fragment

--- a/packages/@sanity/cli/src/commands/__tests__/new.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/new.test.ts
@@ -69,6 +69,10 @@ const INSTRUCTIONS_MARKDOWN = [
   '```',
 ].join('\n')
 
+const studioUrl =
+  'http://localhost:3333/#token=sk-robot-token' +
+  '&claim=https%3A%2F%2Fwww.sanity.io%2Fclaim%2Fclaim-token'
+
 const {NewCommand} = await import('../new.js')
 const {InstructionsUnavailableError} = await import('../../services/newInstructions.js')
 
@@ -142,12 +146,10 @@ describe('#new', () => {
       '│  To use the Sanity CLI before claiming use your token by setting',
       `│  SANITY_AUTH_TOKEN="${project.token}" sanity "command"`,
     ])
-    expect(output).toContain('http://localhost:3333/#token=sk-robot-token')
-    const studioLinkIndex = lines.indexOf(
-      '│  Then open this link: http://localhost:3333/#token=sk-robot-token',
-    )
+    expect(output).toContain(studioUrl)
+    const studioLinkIndex = lines.indexOf(`│  Then open this link: ${studioUrl}`)
     expect(lines.slice(studioLinkIndex, studioLinkIndex + 3)).toEqual([
-      '│  Then open this link: http://localhost:3333/#token=sk-robot-token',
+      `│  Then open this link: ${studioUrl}`,
       '│',
       '│  The token signs you in: there is no account yet.',
     ])
@@ -217,7 +219,7 @@ describe('#new', () => {
       '│  No folders or env files were created. Use the project ID and dataset above',
       '│  in your own setup.',
       '│',
-      '│  Once a Studio is running on http://localhost:3333, sign in with: http://localhost:3333/#token=sk-robot-token',
+      `│  Once a Studio is running on http://localhost:3333, sign in with: ${studioUrl}`,
       '│',
       '│  The token signs you in: there is no account yet.',
     ])

--- a/packages/@sanity/cli/src/commands/new.ts
+++ b/packages/@sanity/cli/src/commands/new.ts
@@ -295,14 +295,16 @@ export class NewCommand extends SanityCommand<typeof NewCommand> {
       flow.gap()
     }
 
+    const studioUrl =
+      `http://localhost:3333/#token=${encodeURIComponent(project.token)}` +
+      `&claim=${encodeURIComponent(project.claimUrl)}`
+
     const printStudioInstructions = () => {
       flow.highlight('Start your Studio:')
       flow.gap()
       flow.command(`cd ${STUDIO_DIR} && npx sanity dev`)
       flow.gap()
-      flow.link(`http://localhost:3333/#token=${encodeURIComponent(project.token)}`, {
-        label: 'Then open this link:',
-      })
+      flow.link(studioUrl, {label: 'Then open this link:'})
       flow.gap()
       flow.line('The token signs you in: there is no account yet.')
     }
@@ -401,7 +403,7 @@ export class NewCommand extends SanityCommand<typeof NewCommand> {
           'No folders or env files were created. Use the project ID and dataset above in your own setup.',
         )
         flow.gap()
-        flow.link(`http://localhost:3333/#token=${encodeURIComponent(project.token)}`, {
+        flow.link(studioUrl, {
           label: 'Once a Studio is running on http://localhost:3333, sign in with:',
         })
         flow.gap()


### PR DESCRIPTION
### Description

Adds the URL-encoded project claim URL to the local Studio sign-in hash fragment alongside the temporary token. Both the scaffolded-Studio instructions and the bring-your-own-Studio instructions now use the same constructed URL, allowing the Studio flow to retain the claim destination after sign-in.

Updates the `sanity new` unit tests to cover the complete token-and-claim URL.

### What to review

- The hash-fragment construction and encoding in `packages/@sanity/cli/src/commands/new.ts`
- The two instruction paths that print the Studio URL
- The updated URL assertions in `new.test.ts`

### Testing

- `pnpm test:coverage packages/@sanity/cli/src/commands/__tests__/new.test.ts --bail=1` — 20/20 passed
- `pnpm build:cli`
- `pnpm check:types`
- `pnpm check:lint`
- `pnpm check:deps`
- `pnpm check:format`

### UAT

the new url supplied here spins up a studio with expected banners/notifs

<img width="960" height="621" alt="shapiro persistent-login-banner-post-claim" src="https://github.com/user-attachments/assets/4b0e013f-341b-451f-9b91-ce261bd2167f" />
