### PR TITLE
feat(tokens)!: migrate token management to the Access API, add expiry and rotate

### DIFF
--- a/.changeset/pr-1646.md
+++ b/.changeset/pr-1646.md
@@ -1,6 +1,0 @@
-<!-- auto-generated -->
----
-'@sanity/cli': major
----
-
-feat(tokens)!: migrate token management to the Access API, add expiry and rotate

--- a/.changeset/pr-1646.md
+++ b/.changeset/pr-1646.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': major
+---
+
+feat(tokens)!: migrate token management to the Access API, add expiry and rotate

--- a/.changeset/tokens-access-api.md
+++ b/.changeset/tokens-access-api.md
@@ -1,0 +1,12 @@
+---
+'@sanity/cli': major
+---
+
+feat(tokens)!: migrate token management to the Access API
+
+The `tokens create`, `tokens list` and `tokens delete` commands are now backed by the Access API, and `--json` output returns its token shape verbatim. To migrate:
+
+- `tokens create --json`: read the secret from `.token` instead of `.key`
+- `tokens list --json`: roles now live in `.memberships[].roleNames` instead of `.roles[].name`; `createdBy`, `permissions`, `projectUserId` and `lastUsedAt` are no longer returned
+- `.id` is still the identifier to pass to `tokens delete`, but existing ids change with the backing API
+- `tokens list` shows role names instead of display titles, and no longer includes organization-managed tokens, which cannot be managed at project scope

--- a/.changeset/tokens-expiry.md
+++ b/.changeset/tokens-expiry.md
@@ -1,0 +1,7 @@
+---
+'@sanity/cli': minor
+---
+
+feat(tokens): support token expiry on create and in list output
+
+`tokens create --expires-at <date>` sets an expiry (ISO 8601 date or timestamp); interactive runs offer the same presets as sanity.io/manage. `tokens list` shows expiry in a new Expires column.

--- a/.changeset/tokens-rotate.md
+++ b/.changeset/tokens-rotate.md
@@ -1,0 +1,7 @@
+---
+'@sanity/cli': minor
+---
+
+feat(tokens): add tokens rotate command
+
+`echo "$SANITY_TOKEN" | sanity tokens rotate` replaces a token's secret while preserving its roles and expiry. The token is read from standard input to keep secrets out of shell history (`-t, --token` is also accepted); the previous secret is revoked immediately.

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapRemoteTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapRemoteTemplate.test.ts
@@ -202,7 +202,9 @@ describe('bootstrapRemoteTemplate', () => {
       await bootstrapRemoteTemplate(baseOpts)
 
       expect(mocks.createToken).toHaveBeenCalledOnce()
-      expect(mocks.createToken).toHaveBeenCalledWith(expect.objectContaining({roleName: 'viewer'}))
+      expect(mocks.createToken).toHaveBeenCalledWith(
+        expect.objectContaining({role: {name: 'viewer', title: 'Viewer'}}),
+      )
     })
 
     test('creates a write token when the template requires one', async () => {
@@ -213,7 +215,9 @@ describe('bootstrapRemoteTemplate', () => {
       await bootstrapRemoteTemplate(baseOpts)
 
       expect(mocks.createToken).toHaveBeenCalledOnce()
-      expect(mocks.createToken).toHaveBeenCalledWith(expect.objectContaining({roleName: 'editor'}))
+      expect(mocks.createToken).toHaveBeenCalledWith(
+        expect.objectContaining({role: {name: 'editor', title: 'Editor'}}),
+      )
     })
 
     test('does not create any tokens when the template requires none', async () => {

--- a/packages/@sanity/cli/src/actions/init/__tests__/bootstrapRemoteTemplate.test.ts
+++ b/packages/@sanity/cli/src/actions/init/__tests__/bootstrapRemoteTemplate.test.ts
@@ -202,9 +202,7 @@ describe('bootstrapRemoteTemplate', () => {
       await bootstrapRemoteTemplate(baseOpts)
 
       expect(mocks.createToken).toHaveBeenCalledOnce()
-      expect(mocks.createToken).toHaveBeenCalledWith(
-        expect.objectContaining({role: {name: 'viewer', title: 'Viewer'}}),
-      )
+      expect(mocks.createToken).toHaveBeenCalledWith(expect.objectContaining({roleName: 'viewer'}))
     })
 
     test('creates a write token when the template requires one', async () => {
@@ -215,9 +213,7 @@ describe('bootstrapRemoteTemplate', () => {
       await bootstrapRemoteTemplate(baseOpts)
 
       expect(mocks.createToken).toHaveBeenCalledOnce()
-      expect(mocks.createToken).toHaveBeenCalledWith(
-        expect.objectContaining({role: {name: 'editor', title: 'Editor'}}),
-      )
+      expect(mocks.createToken).toHaveBeenCalledWith(expect.objectContaining({roleName: 'editor'}))
     })
 
     test('does not create any tokens when the template requires none', async () => {

--- a/packages/@sanity/cli/src/actions/init/bootstrapRemoteTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapRemoteTemplate.ts
@@ -38,8 +38,8 @@ const SANITY_DEFAULT_PORT = 3333
 const READ_TOKEN_LABEL = 'Live Preview API'
 const WRITE_TOKEN_LABEL = 'App Write Token'
 const INITIAL_COMMIT_MESSAGE = 'Initial commit from Sanity CLI'
-const API_READ_TOKEN_ROLE = {name: 'viewer', title: 'Viewer'}
-const API_WRITE_TOKEN_ROLE = {name: 'editor', title: 'Editor'}
+const API_READ_TOKEN_ROLE = 'viewer'
+const API_WRITE_TOKEN_ROLE = 'editor'
 
 export async function bootstrapRemoteTemplate(opts: BootstrapRemoteOptions): Promise<void> {
   const {bearerToken, output, outputPath, packageName, repoInfo, variables} = opts
@@ -80,7 +80,7 @@ export async function bootstrapRemoteTemplate(opts: BootstrapRemoteOptions): Pro
         await createToken({
           label: READ_TOKEN_LABEL,
           projectId: variables.projectId,
-          role: API_READ_TOKEN_ROLE,
+          roleName: API_READ_TOKEN_ROLE,
         })
       ).token
     : undefined
@@ -89,7 +89,7 @@ export async function bootstrapRemoteTemplate(opts: BootstrapRemoteOptions): Pro
         await createToken({
           label: WRITE_TOKEN_LABEL,
           projectId: variables.projectId,
-          role: API_WRITE_TOKEN_ROLE,
+          roleName: API_WRITE_TOKEN_ROLE,
         })
       ).token
     : undefined

--- a/packages/@sanity/cli/src/actions/init/bootstrapRemoteTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init/bootstrapRemoteTemplate.ts
@@ -38,8 +38,8 @@ const SANITY_DEFAULT_PORT = 3333
 const READ_TOKEN_LABEL = 'Live Preview API'
 const WRITE_TOKEN_LABEL = 'App Write Token'
 const INITIAL_COMMIT_MESSAGE = 'Initial commit from Sanity CLI'
-const API_READ_TOKEN_ROLE = 'viewer'
-const API_WRITE_TOKEN_ROLE = 'editor'
+const API_READ_TOKEN_ROLE = {name: 'viewer', title: 'Viewer'}
+const API_WRITE_TOKEN_ROLE = {name: 'editor', title: 'Editor'}
 
 export async function bootstrapRemoteTemplate(opts: BootstrapRemoteOptions): Promise<void> {
   const {bearerToken, output, outputPath, packageName, repoInfo, variables} = opts
@@ -80,18 +80,18 @@ export async function bootstrapRemoteTemplate(opts: BootstrapRemoteOptions): Pro
         await createToken({
           label: READ_TOKEN_LABEL,
           projectId: variables.projectId,
-          roleName: API_READ_TOKEN_ROLE,
+          role: API_READ_TOKEN_ROLE,
         })
-      ).key
+      ).token
     : undefined
   const writeToken = needsWriteToken
     ? (
         await createToken({
           label: WRITE_TOKEN_LABEL,
           projectId: variables.projectId,
-          roleName: API_WRITE_TOKEN_ROLE,
+          role: API_WRITE_TOKEN_ROLE,
         })
-      ).key
+      ).token
     : undefined
 
   for (const pkg of packages ?? ['']) {

--- a/packages/@sanity/cli/src/actions/tokens/__tests__/expiry.test.ts
+++ b/packages/@sanity/cli/src/actions/tokens/__tests__/expiry.test.ts
@@ -1,0 +1,50 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {expiryInDays, parseExpiryDate} from '../expiry.js'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('parseExpiryDate', () => {
+  test('normalizes a date to an ISO 8601 timestamp', () => {
+    expect(parseExpiryDate('2030-01-01')).toEqual({expiresAt: '2030-01-01T00:00:00.000Z'})
+  })
+
+  test('accepts a full timestamp', () => {
+    expect(parseExpiryDate('2030-01-01T12:30:00Z')).toEqual({
+      expiresAt: '2030-01-01T12:30:00.000Z',
+    })
+  })
+
+  test('rejects an unparseable value', () => {
+    expect(parseExpiryDate('not-a-date')).toEqual({
+      error:
+        'Invalid expiry date "not-a-date". Pass an ISO 8601 date or timestamp, for example 2027-01-01 or 2027-01-01T12:00:00Z.',
+    })
+  })
+
+  test('rejects a date in the past', () => {
+    expect(parseExpiryDate('2020-01-01')).toEqual({
+      error: 'Expiry date "2020-01-01" must be in the future.',
+    })
+  })
+
+  test('rejects the current instant', () => {
+    expect(parseExpiryDate('2026-01-01T00:00:00.000Z')).toEqual({
+      error: 'Expiry date "2026-01-01T00:00:00.000Z" must be in the future.',
+    })
+  })
+})
+
+describe('expiryInDays', () => {
+  test('returns the timestamp the given number of days from now', () => {
+    expect(expiryInDays(30)).toBe('2026-01-31T00:00:00.000Z')
+    expect(expiryInDays(90)).toBe('2026-04-01T00:00:00.000Z')
+  })
+})

--- a/packages/@sanity/cli/src/actions/tokens/constants.ts
+++ b/packages/@sanity/cli/src/actions/tokens/constants.ts
@@ -1,4 +1,4 @@
 /**
- * API version for tokens endpoints
+ * API version for the Access API endpoints backing the tokens commands
  */
-export const TOKENS_API_VERSION = 'v2025-08-18'
+export const TOKENS_API_VERSION = 'v2025-07-11'

--- a/packages/@sanity/cli/src/actions/tokens/expiry.ts
+++ b/packages/@sanity/cli/src/actions/tokens/expiry.ts
@@ -1,0 +1,33 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Parse a user-supplied expiry date or timestamp into an ISO 8601 timestamp
+ * @param value - The raw flag or prompt input
+ * @returns The normalized timestamp, or an error message describing why the
+ * input was rejected
+ *
+ * @internal
+ */
+export function parseExpiryDate(value: string): {error: string} | {expiresAt: string} {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return {
+      error: `Invalid expiry date "${value}". Pass an ISO 8601 date or timestamp, for example 2027-01-01 or 2027-01-01T12:00:00Z.`,
+    }
+  }
+  if (date.getTime() <= Date.now()) {
+    return {error: `Expiry date "${value}" must be in the future.`}
+  }
+  return {expiresAt: date.toISOString()}
+}
+
+/**
+ * Get the expiry timestamp a number of days from now
+ * @param days - The number of days until expiry
+ * @returns An ISO 8601 timestamp
+ *
+ * @internal
+ */
+export function expiryInDays(days: number): string {
+  return new Date(Date.now() + days * MS_PER_DAY).toISOString()
+}

--- a/packages/@sanity/cli/src/actions/tokens/types.ts
+++ b/packages/@sanity/cli/src/actions/tokens/types.ts
@@ -1,34 +1,40 @@
-interface TokenRole {
-  name: string
-  title: string
-}
-
-export interface Token {
-  createdAt: string
-  createdBy: string
-  id: string
-  label: string
-  lastUsedAt: string | null
-  permissions: string[]
-  projectId: string
-  projectUserId: string
-  roles: TokenRole[]
-}
-
-export interface TokenResponse {
-  id: string
-  key: string
-  label: string
-  projectUserId: string
-  roles: TokenRole[]
-}
-
-export interface ProjectRole {
+export interface Role {
   appliesToRobots: boolean
   appliesToUsers: boolean
   description: string
   isCustom: boolean
   name: string
-  projectId: string
+  resourceId: string
+  resourceType: string
   title: string
+}
+
+export type SelectedTokenRole = Pick<Role, 'name' | 'title'>
+
+export interface Membership {
+  resourceId: string
+  resourceType: string
+  roleNames: string[]
+
+  addedAt?: string
+  lastSeenAt?: string | null
+  resourceUserId?: string | null
+}
+
+export interface Robot {
+  createdAt: string
+  id: string
+  label: string
+  memberships: Membership[]
+
+  expiresAt?: string | null
+  managedBy?: {
+    resourceId: string
+    resourceType: string
+  }
+  tokenId?: string
+}
+
+export interface RobotWithToken extends Robot {
+  token: string
 }

--- a/packages/@sanity/cli/src/actions/tokens/validateRole.ts
+++ b/packages/@sanity/cli/src/actions/tokens/validateRole.ts
@@ -1,13 +1,14 @@
 import {exitCodes, type Output} from '@sanity/cli-core'
 
 import {getTokenRoles} from '../../services/tokens.js'
+import {type SelectedTokenRole} from './types.js'
 
 /**
  * Validate a role name
  * @param roleName - The role name to validate
  * @param projectId - The project ID
  * @param output - Output to raise the error through the calling command
- * @returns A promise that resolves to the validated role name
+ * @returns A promise that resolves to the validated role
  *
  * @internal
  */
@@ -15,13 +16,13 @@ export async function validateRole(
   roleName: string,
   projectId: string,
   output: Output,
-): Promise<string> {
+): Promise<SelectedTokenRole> {
   const roles = await getTokenRoles(projectId)
   const robotRoles = roles.filter((role) => role.appliesToRobots)
 
   const role = robotRoles.find((r) => r.name === roleName)
   if (role) {
-    return roleName
+    return {name: role.name, title: role.title}
   }
 
   const availableRoles = robotRoles.map((r) => r.name).join(', ')

--- a/packages/@sanity/cli/src/commands/login.ts
+++ b/packages/@sanity/cli/src/commands/login.ts
@@ -1,11 +1,10 @@
-import {text} from 'node:stream/consumers'
-
 import {Command, Flags} from '@oclif/core'
 import {type FlagInput} from '@oclif/core/interfaces'
 import {exitCodes, SanityCommand} from '@sanity/cli-core'
 
 import {login} from '../actions/auth/login/login.js'
 import {LOGIN_PROVIDER_IDS} from '../actions/auth/login/loginInstructions.js'
+import {readTokenFromStdin} from '../util/readTokenFromStdin.js'
 
 export class LoginCommand extends SanityCommand<typeof LoginCommand> {
   static override description = 'Log in to your Sanity account'
@@ -69,7 +68,11 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
     const {'sso-provider': ssoProvider, 'with-token': withToken, ...loginFlags} = flags
 
     try {
-      const token = withToken ? await readTokenFromStdin() : undefined
+      const token = withToken
+        ? await readTokenFromStdin(
+            'Token is required on standard input. Run `sanity login --with-token < token.txt`.',
+          )
+        : undefined
 
       await login({
         ...loginFlags,
@@ -84,14 +87,4 @@ export class LoginCommand extends SanityCommand<typeof LoginCommand> {
       this.error(`Login failed: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
   }
-}
-
-async function readTokenFromStdin(): Promise<string> {
-  if (process.stdin.isTTY) {
-    throw new Error(
-      'Token is required on standard input. Run `sanity login --with-token < token.txt`.',
-    )
-  }
-
-  return text(process.stdin)
 }

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/create.test.ts
@@ -32,6 +32,52 @@ const defaultMocks = {
   token: 'test-token',
 }
 
+const viewerRole = {
+  appliesToRobots: true,
+  appliesToUsers: true,
+  description: 'Can read documents',
+  isCustom: false,
+  name: 'viewer',
+  resourceId: testProjectId,
+  resourceType: 'project',
+  title: 'Viewer',
+}
+
+const editorRole = {
+  appliesToRobots: true,
+  appliesToUsers: true,
+  description: 'Can read and write documents',
+  isCustom: false,
+  name: 'editor',
+  resourceId: testProjectId,
+  resourceType: 'project',
+  title: 'Editor',
+}
+
+function mockRobotWithToken(options: {
+  id: string
+  label: string
+  roleNames: string[]
+  token: string
+}) {
+  return {
+    createdAt: '2026-07-01T00:00:00.000Z',
+    id: options.id,
+    label: options.label,
+    memberships: [
+      {
+        resourceId: testProjectId,
+        resourceType: 'project',
+        resourceUserId: 'user-123',
+        roleNames: options.roleNames,
+      },
+    ],
+    token: options.token,
+    // Distinct from `id` on purpose: the robot id is the public identifier
+    tokenId: `${options.id}-active-token`,
+  }
+}
+
 describe('#tokens:create', () => {
   beforeEach(() => {
     vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
@@ -46,50 +92,26 @@ describe('#tokens:create', () => {
   })
 
   test('creates token with label argument and default role', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read and write documents',
-        isCustom: false,
-        name: 'editor',
-        projectId: 'test-project',
-        title: 'Editor',
-      },
-    ]
-
-    const mockToken = {
-      id: 'token-123',
-      key: 'sk_test_abcd1234',
-      label: 'My Test Token',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'viewer',
-          title: 'Viewer',
-        },
-      ],
-    }
-
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
+      uri: '/access/project/test-project/roles',
+    }).reply(200, {data: [viewerRole, editorRole], nextCursor: null})
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+      uri: '/access/project/test-project/robots',
+    }).reply(
+      201,
+      mockRobotWithToken({
+        id: 'robot-123',
+        label: 'My Test Token',
+        roleNames: ['viewer'],
+        token: 'sk_test_abcd1234',
+      }),
+    )
+
+    mockedSelect.mockResolvedValueOnce('viewer')
 
     const {error, stdout} = await testCommand(CreateTokenCommand, ['My Test Token'], {
       mocks: defaultMocks,
@@ -98,57 +120,31 @@ describe('#tokens:create', () => {
     expect(error).toBeUndefined()
     expect(stdout).toContain('API token created')
     expect(stdout).toContain('Label: My Test Token')
-    expect(stdout).toContain('ID: token-123')
+    expect(stdout).toContain('ID: robot-123')
     expect(stdout).toContain('Role: Viewer')
     expect(stdout).toContain('Token: sk_test_abcd1234')
     expect(stdout).toContain("Copy the token now. It won't be shown again.")
   })
 
   test('creates token with specific role', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read and write documents',
-        isCustom: false,
-        name: 'editor',
-        projectId: 'test-project',
-        title: 'Editor',
-      },
-    ]
-
-    const mockToken = {
-      id: 'token-456',
-      key: 'sk_test_editor1234',
-      label: 'Editor Token',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'editor',
-          title: 'Editor',
-        },
-      ],
-    }
-
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
+      uri: '/access/project/test-project/roles',
+    }).reply(200, {data: [viewerRole, editorRole], nextCursor: null})
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+      uri: '/access/project/test-project/robots',
+    }).reply(
+      201,
+      mockRobotWithToken({
+        id: 'robot-456',
+        label: 'Editor Token',
+        roleNames: ['editor'],
+        token: 'sk_test_editor1234',
+      }),
+    )
 
     const {stdout} = await testCommand(CreateTokenCommand, ['Editor Token', '--role=editor'], {
       mocks: defaultMocks,
@@ -160,57 +156,46 @@ describe('#tokens:create', () => {
     expect(stdout).toContain('Token: sk_test_editor1234')
   })
 
-  test('outputs JSON when --json flag is used', async () => {
-    const mockToken = {
-      id: 'token-json',
-      key: 'sk_test_json1234',
+  test('outputs the created robot as JSON when --json flag is used', async () => {
+    const robotWithToken = mockRobotWithToken({
+      id: 'robot-json',
       label: 'JSON Token',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'viewer',
-          title: 'Viewer',
-        },
-      ],
-    }
+      roleNames: ['viewer'],
+      token: 'sk_test_json1234',
+    })
 
     // --json is unattended, so the role defaults to viewer without a roles prompt
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+      uri: '/access/project/test-project/robots',
+    }).reply(201, robotWithToken)
 
     const {stdout} = await testCommand(CreateTokenCommand, ['JSON Token', '--json'], {
       mocks: defaultMocks,
     })
 
     const parsedOutput = JSON.parse(stdout)
-    expect(parsedOutput).toEqual(mockToken)
+    expect(parsedOutput).toEqual(robotWithToken)
     expect(mockedSelect).not.toHaveBeenCalled()
     expect(mockedInput).not.toHaveBeenCalled()
   })
 
   test('works in unattended mode with --yes flag', async () => {
-    const mockToken = {
-      id: 'token-unattended',
-      key: 'sk_test_unattended1234',
-      label: 'Unattended Token',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'viewer',
-          title: 'Viewer',
-        },
-      ],
-    }
-
-    // Only mock the token creation API, not the roles API since unattended mode uses default role
+    // Only mock the robot creation API, not the roles API since unattended mode uses default role
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+      uri: '/access/project/test-project/robots',
+    }).reply(
+      201,
+      mockRobotWithToken({
+        id: 'robot-unattended',
+        label: 'Unattended Token',
+        roleNames: ['viewer'],
+        token: 'sk_test_unattended1234',
+      }),
+    )
 
     const {stdout} = await testCommand(CreateTokenCommand, ['Unattended Token', '--yes'], {
       mocks: defaultMocks,
@@ -223,22 +208,10 @@ describe('#tokens:create', () => {
   })
 
   test('handles invalid role error', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-    ]
-
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
+      uri: '/access/project/test-project/roles',
+    }).reply(200, {data: [viewerRole], nextCursor: null})
 
     const {error} = await testCommand(CreateTokenCommand, ['Test Token', '--role=invalid'], {
       mocks: defaultMocks,
@@ -251,28 +224,18 @@ describe('#tokens:create', () => {
   })
 
   test('handles API error during token creation', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-    ]
-
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
+      uri: '/access/project/test-project/roles',
+    }).reply(200, {data: [viewerRole], nextCursor: null})
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'post',
-      uri: '/projects/test-project/tokens',
+      uri: '/access/project/test-project/robots',
     }).reply(500, {message: 'Internal Server Error'})
+
+    mockedSelect.mockResolvedValueOnce('viewer')
 
     const {error} = await testCommand(CreateTokenCommand, ['Failed Token'], {mocks: defaultMocks})
 
@@ -296,22 +259,18 @@ describe('#tokens:create', () => {
   })
 
   test('handles no roles available for tokens', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: false, // Not applicable to robots
-        appliesToUsers: true,
-        description: 'Full access',
-        isCustom: false,
-        name: 'admin',
-        projectId: 'test-project',
-        title: 'Admin',
-      },
-    ]
+    const adminRole = {
+      ...viewerRole,
+      appliesToRobots: false, // Not applicable to robots
+      description: 'Full access',
+      name: 'admin',
+      title: 'Admin',
+    }
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
+      uri: '/access/project/test-project/roles',
+    }).reply(200, {data: [adminRole], nextCursor: null})
 
     const {error} = await testCommand(CreateTokenCommand, ['Test Token'], {mocks: defaultMocks})
 
@@ -321,44 +280,27 @@ describe('#tokens:create', () => {
   })
 
   test('prompts for label when not provided in interactive mode', async () => {
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-    ]
-
-    const mockToken = {
-      id: 'token-prompted',
-      key: 'sk_test_prompted1234',
-      label: 'Prompted Label',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'viewer',
-          title: 'Viewer',
-        },
-      ],
-    }
-
     mockedInput.mockResolvedValueOnce('Prompted Label')
     mockedSelect.mockResolvedValueOnce('viewer')
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
+      uri: '/access/project/test-project/roles',
+    }).reply(200, {data: [viewerRole], nextCursor: null})
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+      uri: '/access/project/test-project/robots',
+    }).reply(
+      201,
+      mockRobotWithToken({
+        id: 'robot-prompted',
+        label: 'Prompted Label',
+        roleNames: ['viewer'],
+        token: 'sk_test_prompted1234',
+      }),
+    )
 
     const {stdout} = await testCommand(CreateTokenCommand, [], {mocks: defaultMocks})
 
@@ -375,41 +317,24 @@ describe('#tokens:create', () => {
     mockedInput.mockResolvedValueOnce('Valid Label')
     mockedSelect.mockResolvedValueOnce('viewer')
 
-    const mockRoles = [
-      {
-        appliesToRobots: true,
-        appliesToUsers: true,
-        description: 'Can read documents',
-        isCustom: false,
-        name: 'viewer',
-        projectId: 'test-project',
-        title: 'Viewer',
-      },
-    ]
-
-    const mockToken = {
-      id: 'token-validated',
-      key: 'sk_test_validated1234',
-      label: 'Valid Label',
-      projectUserId: 'user-123',
-      roles: [
-        {
-          name: 'viewer',
-          title: 'Viewer',
-        },
-      ],
-    }
-
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/roles',
-    }).reply(200, mockRoles)
+      uri: '/access/project/test-project/roles',
+    }).reply(200, {data: [viewerRole], nextCursor: null})
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'post',
-      uri: '/projects/test-project/tokens',
-    }).reply(200, mockToken)
+      uri: '/access/project/test-project/robots',
+    }).reply(
+      201,
+      mockRobotWithToken({
+        id: 'robot-validated',
+        label: 'Valid Label',
+        roleNames: ['viewer'],
+        token: 'sk_test_validated1234',
+      }),
+    )
 
     await testCommand(CreateTokenCommand, [], {mocks: defaultMocks})
 

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/create.test.ts
@@ -55,6 +55,7 @@ const editorRole = {
 }
 
 function mockRobotWithToken(options: {
+  expiresAt?: string
   id: string
   label: string
   roleNames: string[]
@@ -62,6 +63,7 @@ function mockRobotWithToken(options: {
 }) {
   return {
     createdAt: '2026-07-01T00:00:00.000Z',
+    expiresAt: options.expiresAt ?? null,
     id: options.id,
     label: options.label,
     memberships: [
@@ -111,7 +113,7 @@ describe('#tokens:create', () => {
       }),
     )
 
-    mockedSelect.mockResolvedValueOnce('viewer')
+    mockedSelect.mockResolvedValueOnce('viewer').mockResolvedValueOnce('never')
 
     const {error, stdout} = await testCommand(CreateTokenCommand, ['My Test Token'], {
       mocks: defaultMocks,
@@ -145,6 +147,8 @@ describe('#tokens:create', () => {
         token: 'sk_test_editor1234',
       }),
     )
+
+    mockedSelect.mockResolvedValueOnce('never')
 
     const {stdout} = await testCommand(CreateTokenCommand, ['Editor Token', '--role=editor'], {
       mocks: defaultMocks,
@@ -207,6 +211,130 @@ describe('#tokens:create', () => {
     expect(mockedInput).not.toHaveBeenCalled()
   })
 
+  test('creates token with an expiry date', async () => {
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'post',
+      uri: '/access/project/test-project/robots',
+    }).reply(
+      201,
+      mockRobotWithToken({
+        expiresAt: '2030-01-01T00:00:00.000Z',
+        id: 'robot-expiring',
+        label: 'Expiring Token',
+        roleNames: ['viewer'],
+        token: 'sk_test_expiring1234',
+      }),
+    )
+
+    const {stdout} = await testCommand(
+      CreateTokenCommand,
+      ['Expiring Token', '--expires-at', '2030-01-01', '--yes'],
+      {mocks: defaultMocks},
+    )
+
+    expect(stdout).toContain('API token created')
+    expect(stdout).toContain('Expires: 2030-01-01T00:00:00.000Z')
+  })
+
+  test('prompts for expiry in interactive mode and applies a preset', async () => {
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      uri: '/access/project/test-project/roles',
+    }).reply(200, {data: [viewerRole], nextCursor: null})
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'post',
+      uri: '/access/project/test-project/robots',
+    }).reply(
+      201,
+      mockRobotWithToken({
+        expiresAt: '2026-08-30T00:00:00.000Z',
+        id: 'robot-preset',
+        label: 'Preset Token',
+        roleNames: ['viewer'],
+        token: 'sk_test_preset1234',
+      }),
+    )
+
+    mockedSelect.mockResolvedValueOnce('viewer').mockResolvedValueOnce('30')
+
+    const {stdout} = await testCommand(CreateTokenCommand, ['Preset Token'], {mocks: defaultMocks})
+
+    expect(mockedSelect).toHaveBeenLastCalledWith({
+      choices: [
+        {name: 'Never', value: 'never'},
+        {name: expect.stringMatching(/^30 days \(\d{4}-\d{2}-\d{2}\)$/), value: '30'},
+        {name: expect.stringMatching(/^60 days \(\d{4}-\d{2}-\d{2}\)$/), value: '60'},
+        {name: expect.stringMatching(/^90 days \(\d{4}-\d{2}-\d{2}\)$/), value: '90'},
+        {name: 'Custom date', value: 'custom'},
+      ],
+      default: 'never',
+      message: 'Token expiry:',
+    })
+    expect(stdout).toContain('API token created')
+    expect(stdout).toContain('Expires: 2026-08-30T00:00:00.000Z')
+  })
+
+  test('prompts for a custom expiry date', async () => {
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      uri: '/access/project/test-project/roles',
+    }).reply(200, {data: [viewerRole], nextCursor: null})
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'post',
+      uri: '/access/project/test-project/robots',
+    }).reply(
+      201,
+      mockRobotWithToken({
+        expiresAt: '2030-01-01T00:00:00.000Z',
+        id: 'robot-custom',
+        label: 'Custom Token',
+        roleNames: ['viewer'],
+        token: 'sk_test_custom1234',
+      }),
+    )
+
+    mockedSelect.mockResolvedValueOnce('viewer').mockResolvedValueOnce('custom')
+    mockedInput.mockResolvedValueOnce('2030-01-01')
+
+    const {stdout} = await testCommand(CreateTokenCommand, ['Custom Token'], {mocks: defaultMocks})
+
+    expect(mockedInput).toHaveBeenCalledWith({
+      message: 'Expiry date (ISO 8601, e.g. 2027-01-01):',
+      validate: expect.any(Function),
+    })
+    expect(stdout).toContain('API token created')
+    expect(stdout).toContain('Expires: 2030-01-01T00:00:00.000Z')
+  })
+
+  test('rejects an invalid expiry date', async () => {
+    const {error} = await testCommand(
+      CreateTokenCommand,
+      ['Test Token', '--expires-at', 'not-a-date', '--yes'],
+      {mocks: defaultMocks},
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Invalid expiry date "not-a-date"')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+  })
+
+  test('rejects an expiry date in the past', async () => {
+    const {error} = await testCommand(
+      CreateTokenCommand,
+      ['Test Token', '--expires-at', '2020-01-01', '--yes'],
+      {mocks: defaultMocks},
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Expiry date "2020-01-01" must be in the future')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+  })
+
   test('handles invalid role error', async () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
@@ -235,7 +363,7 @@ describe('#tokens:create', () => {
       uri: '/access/project/test-project/robots',
     }).reply(500, {message: 'Internal Server Error'})
 
-    mockedSelect.mockResolvedValueOnce('viewer')
+    mockedSelect.mockResolvedValueOnce('viewer').mockResolvedValueOnce('never')
 
     const {error} = await testCommand(CreateTokenCommand, ['Failed Token'], {mocks: defaultMocks})
 
@@ -281,7 +409,7 @@ describe('#tokens:create', () => {
 
   test('prompts for label when not provided in interactive mode', async () => {
     mockedInput.mockResolvedValueOnce('Prompted Label')
-    mockedSelect.mockResolvedValueOnce('viewer')
+    mockedSelect.mockResolvedValueOnce('viewer').mockResolvedValueOnce('never')
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
@@ -315,7 +443,7 @@ describe('#tokens:create', () => {
   test('validates label input - rejects empty label', async () => {
     // Mock input to capture the validation function and return a valid label
     mockedInput.mockResolvedValueOnce('Valid Label')
-    mockedSelect.mockResolvedValueOnce('viewer')
+    mockedSelect.mockResolvedValueOnce('viewer').mockResolvedValueOnce('never')
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
@@ -4,41 +4,44 @@ import {cleanAll, pendingMocks} from 'nock'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {TOKENS_API_VERSION} from '../../../actions/tokens/constants.js'
-import {type Token} from '../../../actions/tokens/types.js'
+import {type Robot} from '../../../actions/tokens/types.js'
 import {DeleteTokensCommand} from '../delete.js'
 
+const testProjectId = 'test-project'
+
 // Test fixtures
-const createToken = (overrides: Partial<Token> & {id: string}): Token => ({
+const createRobot = (overrides: {id: string; label?: string; roleNames?: string[]}): Robot => ({
   createdAt: '2023-01-01T00:00:00Z',
-  createdBy: 'user-creator',
-  label: 'Test Token',
-  lastUsedAt: null,
-  permissions: ['read', 'write'],
-  projectId: 'test-project',
-  projectUserId: 'user-123',
-  roles: [{name: 'editor', title: 'Editor'}],
-  ...overrides,
+  id: overrides.id,
+  label: overrides.label ?? 'Test Token',
+  memberships: [
+    {
+      lastSeenAt: null,
+      resourceId: testProjectId,
+      resourceType: 'project',
+      resourceUserId: 'user-123',
+      roleNames: overrides.roleNames ?? ['editor'],
+    },
+  ],
+  tokenId: `${overrides.id}-active-token`,
 })
 
-const TEST_TOKENS = {
-  API_TOKEN: createToken({
+const TEST_ROBOTS = {
+  API_TOKEN: createRobot({
     id: 'token-api-123',
     label: 'API Token',
-    roles: [{name: 'editor', title: 'Editor'}],
+    roleNames: ['editor'],
   }),
-  READ_TOKEN: createToken({
+  READ_TOKEN: createRobot({
     id: 'token-read-456',
     label: 'Read Token',
-    roles: [{name: 'viewer', title: 'Viewer'}],
-  }),
-  WRITE_TOKEN: createToken({
-    id: 'token-write-789',
-    label: 'Write Token',
-    roles: [{name: 'administrator', title: 'Administrator'}],
+    roleNames: ['viewer'],
   }),
 } as const
 
-const testProjectId = 'test-project'
+function robotsPage(robots: Robot[]) {
+  return {data: robots, nextCursor: null}
+}
 
 const defaultMocks = {
   cliConfig: {api: {projectId: testProjectId}},
@@ -75,7 +78,7 @@ describe('#tokens:delete', () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'delete',
-      uri: '/projects/test-project/tokens/token-api-123',
+      uri: '/access/project/test-project/robots/token-api-123',
     }).reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123'], {
@@ -93,7 +96,7 @@ describe('#tokens:delete', () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'delete',
-      uri: '/projects/test-project/tokens/token-api-123',
+      uri: '/access/project/test-project/robots/token-api-123',
     }).reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {
@@ -107,7 +110,7 @@ describe('#tokens:delete', () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'delete',
-      uri: '/projects/test-project/tokens/token-api-123',
+      uri: '/access/project/test-project/robots/token-api-123',
     }).reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, ['token-api-123', '-y'], {
@@ -159,21 +162,21 @@ describe('#tokens:delete', () => {
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
-    }).reply(200, [TEST_TOKENS.API_TOKEN, TEST_TOKENS.READ_TOKEN])
+      uri: '/access/project/test-project/robots',
+    }).reply(200, robotsPage([TEST_ROBOTS.API_TOKEN, TEST_ROBOTS.READ_TOKEN]))
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'delete',
-      uri: '/projects/test-project/tokens/token-read-456',
+      uri: '/access/project/test-project/robots/token-read-456',
     }).reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(stdout).toBe('API token deleted\n')
     expect(select).toHaveBeenCalledWith({
       choices: [
-        {name: 'API Token (Editor)', value: 'token-api-123'},
-        {name: 'Read Token (Viewer)', value: 'token-read-456'},
+        {name: 'API Token (editor)', value: 'token-api-123'},
+        {name: 'Read Token (viewer)', value: 'token-read-456'},
       ],
       message: 'Select token to delete:',
     })
@@ -181,55 +184,52 @@ describe('#tokens:delete', () => {
 
   test('handles tokens with multiple roles', async () => {
     const {confirm, select} = await import('@sanity/cli-core/ux')
-    const multiRoleToken = createToken({
+    const multiRoleRobot = createRobot({
       id: 'token-multi-123',
       label: 'Multi Role Token',
-      roles: [
-        {name: 'editor', title: 'Editor'},
-        {name: 'viewer', title: 'Viewer'},
-      ],
+      roleNames: ['editor', 'viewer'],
     })
     vi.mocked(select).mockResolvedValue('token-multi-123')
     vi.mocked(confirm).mockResolvedValue(true)
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
-    }).reply(200, [multiRoleToken])
+      uri: '/access/project/test-project/robots',
+    }).reply(200, robotsPage([multiRoleRobot]))
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'delete',
-      uri: '/projects/test-project/tokens/token-multi-123',
+      uri: '/access/project/test-project/robots/token-multi-123',
     }).reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(stdout).toBe('API token deleted\n')
     expect(select).toHaveBeenCalledWith({
-      choices: [{name: 'Multi Role Token (Editor, Viewer)', value: 'token-multi-123'}],
+      choices: [{name: 'Multi Role Token (editor, viewer)', value: 'token-multi-123'}],
       message: 'Select token to delete:',
     })
   })
 
   test('handles tokens with no roles', async () => {
     const {confirm, select} = await import('@sanity/cli-core/ux')
-    const noRoleToken = createToken({
+    const noRoleRobot = createRobot({
       id: 'token-no-role-123',
       label: 'No Role Token',
-      roles: [],
+      roleNames: [],
     })
     vi.mocked(select).mockResolvedValue('token-no-role-123')
     vi.mocked(confirm).mockResolvedValue(true)
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
-    }).reply(200, [noRoleToken])
+      uri: '/access/project/test-project/robots',
+    }).reply(200, robotsPage([noRoleRobot]))
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'delete',
-      uri: '/projects/test-project/tokens/token-no-role-123',
+      uri: '/access/project/test-project/robots/token-no-role-123',
     }).reply(204)
 
     const {stdout} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
@@ -244,7 +244,7 @@ describe('#tokens:delete', () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'delete',
-      uri: '/projects/test-project/tokens/nonexistent-token',
+      uri: '/access/project/test-project/robots/nonexistent-token',
     }).reply(404, {message: 'Token not found'})
 
     const {error} = await testCommand(DeleteTokensCommand, ['nonexistent-token', '--yes'], {
@@ -258,8 +258,8 @@ describe('#tokens:delete', () => {
   test('throws error when no tokens exist in project', async () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
-    }).reply(200, [])
+      uri: '/access/project/test-project/robots',
+    }).reply(200, robotsPage([]))
 
     const {error} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
     expect(error).toBeInstanceOf(Error)
@@ -274,7 +274,7 @@ describe('#tokens:delete', () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
       method: 'delete',
-      uri: '/projects/test-project/tokens/token-api-123',
+      uri: '/access/project/test-project/robots/token-api-123',
     }).reply(statusCode, {message})
 
     const {error} = await testCommand(DeleteTokensCommand, ['token-api-123', '--yes'], {
@@ -289,7 +289,7 @@ describe('#tokens:delete', () => {
   test('handles API error when fetching tokens', async () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
+      uri: '/access/project/test-project/robots',
     }).reply(404, {message: 'Project not found'})
 
     const {error} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})
@@ -303,7 +303,7 @@ describe('#tokens:delete', () => {
   test('handles API error with server error when fetching tokens', async () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: '/projects/test-project/tokens',
+      uri: '/access/project/test-project/robots',
     }).reply(500, {message: 'Internal Server Error'})
 
     const {error} = await testCommand(DeleteTokensCommand, [], {mocks: defaultMocks})

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/list.test.ts
@@ -17,44 +17,57 @@ const defaultMocks = {
   token: 'test-token',
 }
 
-const mockTokens = [
+const mockRobots = [
   {
     createdAt: '2023-01-01T00:00:00Z',
-    createdBy: 'user@example.com',
-    id: 'token-1',
+    id: 'robot-1',
     label: 'Production API',
-    lastUsedAt: '2023-12-01T00:00:00Z',
-    permissions: ['read', 'write'],
-    projectId: testProjectId,
-    projectUserId: 'user-1',
-    roles: [
-      {name: 'admin', title: 'Administrator'},
-      {name: 'editor', title: 'Editor'},
+    memberships: [
+      {
+        lastSeenAt: '2023-12-01T00:00:00Z',
+        resourceId: testProjectId,
+        resourceType: 'project',
+        resourceUserId: 'user-1',
+        roleNames: ['admin', 'editor'],
+      },
     ],
+    tokenId: 'robot-1-active-token',
   },
   {
     createdAt: '2023-02-01T00:00:00Z',
-    createdBy: 'dev@example.com',
-    id: 'token-2',
+    id: 'robot-2',
     label: 'Development API',
-    lastUsedAt: null,
-    permissions: ['read'],
-    projectId: testProjectId,
-    projectUserId: 'user-2',
-    roles: [{name: 'viewer', title: 'Viewer'}],
+    memberships: [
+      {
+        lastSeenAt: null,
+        resourceId: testProjectId,
+        resourceType: 'project',
+        resourceUserId: 'user-2',
+        roleNames: ['viewer'],
+      },
+    ],
+    tokenId: 'robot-2-active-token',
   },
   {
     createdAt: '2023-03-01T00:00:00Z',
-    createdBy: 'analytics@example.com',
-    id: 'token-3',
+    id: 'robot-3',
     label: 'Analytics Token',
-    lastUsedAt: '2023-11-15T00:00:00Z',
-    permissions: ['read'],
-    projectId: testProjectId,
-    projectUserId: 'user-3',
-    roles: [],
+    memberships: [
+      {
+        lastSeenAt: '2023-11-15T00:00:00Z',
+        resourceId: testProjectId,
+        resourceType: 'project',
+        resourceUserId: 'user-3',
+        roleNames: [],
+      },
+    ],
+    tokenId: 'robot-3-active-token',
   },
 ]
+
+function robotsPage(robots: unknown[]) {
+  return {data: robots, nextCursor: null}
+}
 
 describe('#tokens:list', () => {
   afterEach(() => {
@@ -67,52 +80,76 @@ describe('#tokens:list', () => {
   test('displays tokens in table format by default', async () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, mockTokens)
+      uri: `/access/project/${testProjectId}/robots`,
+    }).reply(200, robotsPage(mockRobots))
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
     expect(stdout).toContain('Found 3 API tokens')
     expect(stdout).toContain('Label')
-    expect(stdout).toContain('Token ID')
+    expect(stdout).toContain('ID')
     expect(stdout).toContain('Roles')
     expect(stdout).toContain('Production API')
-    expect(stdout).toContain('token-1')
-    expect(stdout).toContain('Administrator, Editor')
+    expect(stdout).toContain('robot-1')
+    expect(stdout).toContain('admin, editor')
     expect(stdout).toContain('Development API')
-    expect(stdout).toContain('token-2')
-    expect(stdout).toContain('Viewer')
+    expect(stdout).toContain('robot-2')
+    expect(stdout).toContain('viewer')
     expect(stdout).toContain('Analytics Token')
-    expect(stdout).toContain('token-3')
+    expect(stdout).toContain('robot-3')
     expect(stdout).toContain('No roles')
   })
 
-  test('displays tokens in JSON format when requested', async () => {
+  test('displays robots as JSON when requested', async () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, mockTokens)
+      uri: `/access/project/${testProjectId}/robots`,
+    }).reply(200, robotsPage(mockRobots))
 
     const {stdout} = await testCommand(TokensListCommand, ['--json'], {mocks: defaultMocks})
 
     const parsed = JSON.parse(stdout)
-    expect(parsed).toHaveLength(3)
-    expect(parsed[0]).toMatchObject({
-      createdBy: 'user@example.com',
-      id: 'token-1',
-      label: 'Production API',
-      roles: [
-        {name: 'admin', title: 'Administrator'},
-        {name: 'editor', title: 'Editor'},
+    expect(parsed).toEqual(mockRobots)
+  })
+
+  test('excludes robots managed by an organization', async () => {
+    const orgManagedRobot = {
+      createdAt: '2023-04-01T00:00:00Z',
+      id: 'robot-org',
+      label: 'Org Managed Token',
+      managedBy: {resourceId: 'org-1', resourceType: 'organization'},
+      memberships: [
+        {
+          resourceId: testProjectId,
+          resourceType: 'project',
+          roleNames: ['viewer'],
+        },
       ],
-    })
+      tokenId: 'robot-org-active-token',
+    }
+    const projectManagedRobot = {
+      ...mockRobots[0],
+      managedBy: {resourceId: testProjectId, resourceType: 'project'},
+    }
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      uri: `/access/project/${testProjectId}/robots`,
+    }).reply(200, robotsPage([orgManagedRobot, projectManagedRobot, mockRobots[1]]))
+
+    const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
+
+    expect(stdout).toContain('Found 2 API tokens')
+    expect(stdout).toContain('Production API')
+    expect(stdout).toContain('Development API')
+    expect(stdout).not.toContain('Org Managed Token')
   })
 
   test('handles empty tokens list', async () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, [])
+      uri: `/access/project/${testProjectId}/robots`,
+    }).reply(200, robotsPage([]))
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
@@ -122,7 +159,7 @@ describe('#tokens:list', () => {
   test('displays an error if the API request fails', async () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
+      uri: `/access/project/${testProjectId}/robots`,
     }).reply(500, {message: 'Internal Server Error'})
 
     const {error} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
@@ -182,7 +219,7 @@ describe('#tokens:list', () => {
   test('handles 404 error gracefully', async () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
+      uri: `/access/project/${testProjectId}/robots`,
     }).reply(404, {message: 'Project not found'})
 
     const {error} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
@@ -196,7 +233,7 @@ describe('#tokens:list', () => {
   test('handles 403 forbidden error', async () => {
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
+      uri: `/access/project/${testProjectId}/robots`,
     }).reply(403, {message: 'Forbidden'})
 
     const {error} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
@@ -208,68 +245,68 @@ describe('#tokens:list', () => {
   })
 
   test('displays single token correctly', async () => {
-    const singleToken = [mockTokens[0]]
-
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, singleToken)
+      uri: `/access/project/${testProjectId}/robots`,
+    }).reply(200, robotsPage([mockRobots[0]]))
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
     expect(stdout).toContain('Found 1 API tokens')
     expect(stdout).toContain('Production API')
-    expect(stdout).toContain('token-1')
-    expect(stdout).toContain('Administrator, Editor')
+    expect(stdout).toContain('robot-1')
+    expect(stdout).toContain('admin, editor')
   })
 
   test('handles tokens with special characters in labels', async () => {
-    const specialTokens = [
-      {
-        createdAt: '2023-01-01T00:00:00Z',
-        createdBy: 'user@café.com',
-        id: 'token-special',
-        label: 'API Token (Test & Dev)',
-        lastUsedAt: null,
-        permissions: ['read'],
-        projectId: testProjectId,
-        projectUserId: 'user-special',
-        roles: [{name: 'viewer', title: 'Viewer'}],
-      },
-    ]
+    const specialRobot = {
+      createdAt: '2023-01-01T00:00:00Z',
+      id: 'robot-special',
+      label: 'API Token (Test & Dev)',
+      memberships: [
+        {
+          resourceId: testProjectId,
+          resourceType: 'project',
+          resourceUserId: 'user-special',
+          roleNames: ['viewer'],
+        },
+      ],
+      tokenId: 'robot-special-active-token',
+    }
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, specialTokens)
+      uri: `/access/project/${testProjectId}/robots`,
+    }).reply(200, robotsPage([specialRobot]))
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
     expect(stdout).toContain('API Token (Test & Dev)')
-    expect(stdout).toContain('token-special')
-    expect(stdout).toContain('Viewer')
+    expect(stdout).toContain('robot-special')
+    expect(stdout).toContain('viewer')
   })
 
   test('truncates long labels correctly', async () => {
-    const longLabelTokens = [
-      {
-        createdAt: '2023-01-01T00:00:00Z',
-        createdBy: 'user@example.com',
-        id: 'token-long',
-        label:
-          'This is a very long token label that should be truncated because it exceeds the maximum length',
-        lastUsedAt: null,
-        permissions: ['read'],
-        projectId: testProjectId,
-        projectUserId: 'user-long',
-        roles: [{name: 'viewer', title: 'Viewer'}],
-      },
-    ]
+    const longLabelRobot = {
+      createdAt: '2023-01-01T00:00:00Z',
+      id: 'robot-long',
+      label:
+        'This is a very long token label that should be truncated because it exceeds the maximum length',
+      memberships: [
+        {
+          resourceId: testProjectId,
+          resourceType: 'project',
+          resourceUserId: 'user-long',
+          roleNames: ['viewer'],
+        },
+      ],
+      tokenId: 'robot-long-active-token',
+    }
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, longLabelTokens)
+      uri: `/access/project/${testProjectId}/robots`,
+    }).reply(200, robotsPage([longLabelRobot]))
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
@@ -278,33 +315,29 @@ describe('#tokens:list', () => {
   })
 
   test('truncates long roles correctly', async () => {
-    const longRolesTokens = [
-      {
-        createdAt: '2023-01-01T00:00:00Z',
-        createdBy: 'user@example.com',
-        id: 'token-roles',
-        label: 'Multi Role Token',
-        lastUsedAt: null,
-        permissions: ['read'],
-        projectId: testProjectId,
-        projectUserId: 'user-roles',
-        roles: [
-          {name: 'administrator', title: 'Administrator'},
-          {name: 'editor', title: 'Editor'},
-          {name: 'viewer', title: 'Viewer'},
-          {name: 'contributor', title: 'Contributor'},
-        ],
-      },
-    ]
+    const longRolesRobot = {
+      createdAt: '2023-01-01T00:00:00Z',
+      id: 'robot-roles',
+      label: 'Multi Role Token',
+      memberships: [
+        {
+          resourceId: testProjectId,
+          resourceType: 'project',
+          resourceUserId: 'user-roles',
+          roleNames: ['administrator', 'editor', 'viewer', 'contributor'],
+        },
+      ],
+      tokenId: 'robot-roles-active-token',
+    }
 
     mockApi({
       apiVersion: TOKENS_API_VERSION,
-      uri: `/projects/${testProjectId}/tokens`,
-    }).reply(200, longRolesTokens)
+      uri: `/access/project/${testProjectId}/robots`,
+    }).reply(200, robotsPage([longRolesRobot]))
 
     const {stdout} = await testCommand(TokensListCommand, [], {mocks: defaultMocks})
 
     expect(stdout).toContain('Multi Role Token')
-    expect(stdout).toContain('Administrator, Editor, View...')
+    expect(stdout).toContain('administrator, editor, view...')
   })
 })

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/list.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/list.test.ts
@@ -20,6 +20,7 @@ const defaultMocks = {
 const mockRobots = [
   {
     createdAt: '2023-01-01T00:00:00Z',
+    expiresAt: '2030-06-15T00:00:00Z',
     id: 'robot-1',
     label: 'Production API',
     memberships: [
@@ -89,15 +90,18 @@ describe('#tokens:list', () => {
     expect(stdout).toContain('Label')
     expect(stdout).toContain('ID')
     expect(stdout).toContain('Roles')
+    expect(stdout).toContain('Expires')
     expect(stdout).toContain('Production API')
     expect(stdout).toContain('robot-1')
     expect(stdout).toContain('admin, editor')
+    expect(stdout).toContain('2030-06-15')
     expect(stdout).toContain('Development API')
     expect(stdout).toContain('robot-2')
     expect(stdout).toContain('viewer')
     expect(stdout).toContain('Analytics Token')
     expect(stdout).toContain('robot-3')
     expect(stdout).toContain('No roles')
+    expect(stdout).toContain('Never')
   })
 
   test('displays robots as JSON when requested', async () => {

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/rotate.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/rotate.test.ts
@@ -1,0 +1,181 @@
+import {Readable} from 'node:stream'
+
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
+import {mockApi, testCommand} from '@sanity/cli-test'
+import {cleanAll, pendingMocks} from 'nock'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {TOKENS_API_VERSION} from '../../../actions/tokens/constants.js'
+import {RotateTokenCommand} from '../rotate.js'
+
+const defaultMocks = {
+  token: 'test-token',
+}
+
+const rotatedRobot = {
+  createdAt: '2023-01-01T00:00:00Z',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  id: 'robot-rotated',
+  label: 'CI Token',
+  memberships: [
+    {
+      resourceId: 'test-project',
+      resourceType: 'project',
+      roleNames: ['editor'],
+    },
+  ],
+  token: 'sk_new_secret',
+  tokenId: 'robot-rotated-new-token',
+}
+
+const originalStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin')
+type MockStdin = Readable & {isTTY?: boolean}
+
+function mockStdin(input: string, options: {isTTY?: boolean} = {}) {
+  const stdin: MockStdin = Readable.from([input])
+  stdin.isTTY = options.isTTY
+
+  Object.defineProperty(process, 'stdin', {
+    configurable: true,
+    value: stdin,
+  })
+}
+
+describe('#tokens:rotate', () => {
+  beforeEach(() => {
+    vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    if (originalStdinDescriptor) {
+      Object.defineProperty(process, 'stdin', originalStdinDescriptor)
+    }
+    const pending = pendingMocks()
+    cleanAll()
+    expect(pending, 'pending mocks').toEqual([])
+  })
+
+  test('rotates the token piped on standard input', async () => {
+    mockStdin('sk_old_secret\n')
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'post',
+      uri: '/access/robots/me/rotate',
+    }).reply(200, rotatedRobot)
+
+    const {error, stdout} = await testCommand(RotateTokenCommand, [], {mocks: defaultMocks})
+
+    expect(error).toBeUndefined()
+    expect(stdout).toContain('API token rotated')
+    expect(stdout).toContain('Label: CI Token')
+    expect(stdout).toContain('ID: robot-rotated')
+    expect(stdout).toContain('Expires: 2030-01-01T00:00:00.000Z')
+    expect(stdout).toContain('Token: sk_new_secret')
+    expect(stdout).toContain("Copy the token now. It won't be shown again.")
+    expect(stdout).toContain('The previous token was revoked and no longer works.')
+  })
+
+  test('rotates a token passed with --token', async () => {
+    mockStdin('', {isTTY: true})
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'post',
+      uri: '/access/robots/me/rotate',
+    }).reply(200, rotatedRobot)
+
+    const {error, stdout} = await testCommand(RotateTokenCommand, ['--token', 'sk_old_secret'], {
+      mocks: defaultMocks,
+    })
+
+    expect(error).toBeUndefined()
+    expect(stdout).toContain('API token rotated')
+  })
+
+  test('outputs the rotated robot as JSON', async () => {
+    mockStdin('sk_old_secret\n')
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'post',
+      uri: '/access/robots/me/rotate',
+    }).reply(200, rotatedRobot)
+
+    const {stdout} = await testCommand(RotateTokenCommand, ['--json'], {mocks: defaultMocks})
+
+    expect(JSON.parse(stdout)).toEqual(rotatedRobot)
+  })
+
+  test('requires a token when stdin is a TTY', async () => {
+    mockStdin('', {isTTY: true})
+
+    const {error} = await testCommand(RotateTokenCommand, [], {mocks: defaultMocks})
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Token is required')
+    expect(error?.message).toContain('sanity tokens rotate')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+  })
+
+  test('rejects empty standard input', async () => {
+    mockStdin('  \n')
+
+    const {error} = await testCommand(RotateTokenCommand, [], {mocks: defaultMocks})
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Token is required')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+  })
+
+  test('explains a 401 as an invalid or already-rotated token', async () => {
+    mockStdin('sk_old_secret\n')
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'post',
+      uri: '/access/robots/me/rotate',
+    }).reply(401, {message: 'Unauthorized'})
+
+    const {error} = await testCommand(RotateTokenCommand, [], {mocks: defaultMocks})
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('invalid, expired, or was already rotated or revoked')
+    expect(error?.oclif?.exit).toBe(exitCodes.RUNTIME_ERROR)
+  })
+
+  test('explains a 403 as a non-API token', async () => {
+    mockStdin('sk_personal_token\n')
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'post',
+      uri: '/access/robots/me/rotate',
+    }).reply(403, {message: 'Forbidden'})
+
+    const {error} = await testCommand(RotateTokenCommand, [], {mocks: defaultMocks})
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('is not an API token and cannot be rotated')
+    expect(error?.oclif?.exit).toBe(exitCodes.RUNTIME_ERROR)
+  })
+
+  test('handles other API errors', async () => {
+    mockStdin('sk_old_secret\n')
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'post',
+      uri: '/access/robots/me/rotate',
+    }).reply(429, {message: 'Too many requests'})
+
+    const {error} = await testCommand(RotateTokenCommand, [], {mocks: defaultMocks})
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('Token rotation failed')
+    expect(error?.message).toContain('Too many requests')
+    expect(error?.oclif?.exit).toBe(exitCodes.RUNTIME_ERROR)
+  })
+})

--- a/packages/@sanity/cli/src/commands/tokens/create.ts
+++ b/packages/@sanity/cli/src/commands/tokens/create.ts
@@ -2,6 +2,7 @@ import {Args, Flags} from '@oclif/core'
 import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 
+import {expiryInDays, parseExpiryDate} from '../../actions/tokens/expiry.js'
 import {type SelectedTokenRole} from '../../actions/tokens/types.js'
 import {validateRole} from '../../actions/tokens/validateRole.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
@@ -9,6 +10,9 @@ import {createToken, getTokenRoles} from '../../services/tokens.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
 
 const tokensCreateDebug = subdebug('tokens:create')
+
+// Mirrors the expiry presets offered by sanity.io/manage
+const EXPIRY_PRESET_DAYS = [30, 60, 90]
 
 export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand> {
   static override args = {
@@ -34,6 +38,10 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       description: 'Create a token in unattended mode',
     },
     {
+      command: '<%= config.bin %> <%= command.id %> "Build Token" --expires-at 2027-01-01',
+      description: 'Create a token that expires on a given date',
+    },
+    {
       command: '<%= config.bin %> <%= command.id %> "API Token" --json',
       description: 'Output token information as JSON',
     },
@@ -47,6 +55,10 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
     ...getProjectIdFlag({
       description: 'Project ID to create token in',
       semantics: 'override',
+    }),
+    'expires-at': Flags.string({
+      description: 'Date or timestamp the token expires (ISO 8601; tokens never expire by default)',
+      helpValue: '2027-01-01',
     }),
     json: Flags.boolean({
       default: false,
@@ -77,6 +89,8 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       })
     }
 
+    const flagExpiresAt = this.parseExpiryFlag(flags['expires-at'])
+
     const projectId = await this.getProjectId({
       fallback: () =>
         promptForProject({
@@ -91,12 +105,17 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       ? validateRole(role, projectId, this.output)
       : this.promptForRole(projectId))
 
+    const expiresAt =
+      flags['expires-at'] === undefined ? await this.promptForExpiry() : flagExpiresAt
+
     try {
       tokensCreateDebug(`Creating token for project ${projectId}`, {
+        expiresAt,
         label,
         roleName: selectedRole.name,
       })
       const token = await createToken({
+        expiresAt,
         label,
         projectId,
         role: selectedRole,
@@ -111,6 +130,9 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       this.log(`Label: ${token.label}`)
       this.log(`ID: ${token.id}`)
       this.log(`Role: ${selectedRole.title}`)
+      if (token.expiresAt) {
+        this.log(`Expires: ${token.expiresAt}`)
+      }
       this.log(`Token: ${token.token}`)
       this.log('')
       this.log("Copy the token now. It won't be shown again.")
@@ -120,6 +142,56 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       tokensCreateDebug(`Error creating token for project ${projectId}`, err)
       this.error(`Token creation failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
     }
+  }
+
+  private parseExpiryFlag(value: string | undefined): string | undefined {
+    if (value === undefined) {
+      return undefined
+    }
+
+    const parsed = parseExpiryDate(value)
+    if ('error' in parsed) {
+      this.error(parsed.error, {exit: exitCodes.USAGE_ERROR})
+    }
+
+    return parsed.expiresAt
+  }
+
+  private async promptForExpiry(): Promise<string | undefined> {
+    if (this.isUnattended()) {
+      return undefined // Tokens never expire by default
+    }
+
+    const choice = await select({
+      choices: [
+        {name: 'Never', value: 'never'},
+        ...EXPIRY_PRESET_DAYS.map((days) => ({
+          name: `${days} days (${expiryInDays(days).slice(0, 10)})`,
+          value: String(days),
+        })),
+        {name: 'Custom date', value: 'custom'},
+      ],
+      default: 'never',
+      message: 'Token expiry:',
+    })
+
+    if (choice === 'never') {
+      return undefined
+    }
+
+    if (choice === 'custom') {
+      const value = await input({
+        message: 'Expiry date (ISO 8601, e.g. 2027-01-01):',
+        validate: (input) => {
+          const parsed = parseExpiryDate(input.trim())
+          return 'error' in parsed ? parsed.error : true
+        },
+      })
+      const parsed = parseExpiryDate(value.trim())
+      return 'error' in parsed ? undefined : parsed.expiresAt
+    }
+
+    return expiryInDays(Number(choice))
   }
 
   private async promptForLabel(): Promise<string> {

--- a/packages/@sanity/cli/src/commands/tokens/create.ts
+++ b/packages/@sanity/cli/src/commands/tokens/create.ts
@@ -118,7 +118,7 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
         expiresAt,
         label,
         projectId,
-        role: selectedRole,
+        roleName: selectedRole.name,
       })
 
       if (json) {

--- a/packages/@sanity/cli/src/commands/tokens/create.ts
+++ b/packages/@sanity/cli/src/commands/tokens/create.ts
@@ -2,6 +2,7 @@ import {Args, Flags} from '@oclif/core'
 import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {input, select} from '@sanity/cli-core/ux'
 
+import {type SelectedTokenRole} from '../../actions/tokens/types.js'
 import {validateRole} from '../../actions/tokens/validateRole.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {createToken, getTokenRoles} from '../../services/tokens.js'
@@ -86,19 +87,19 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
         }),
     })
 
-    const roleName = await (role
+    const selectedRole = await (role
       ? validateRole(role, projectId, this.output)
       : this.promptForRole(projectId))
 
     try {
       tokensCreateDebug(`Creating token for project ${projectId}`, {
         label,
-        roleName,
+        roleName: selectedRole.name,
       })
       const token = await createToken({
         label,
         projectId,
-        roleName,
+        role: selectedRole,
       })
 
       if (json) {
@@ -109,8 +110,8 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       this.log('API token created')
       this.log(`Label: ${token.label}`)
       this.log(`ID: ${token.id}`)
-      this.log(`Role: ${token.roles.map((r) => r.title).join(', ')}`)
-      this.log(`Token: ${token.key}`)
+      this.log(`Role: ${selectedRole.title}`)
+      this.log(`Token: ${token.token}`)
       this.log('')
       this.log("Copy the token now. It won't be shown again.")
     } catch (error) {
@@ -141,9 +142,9 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
     return label.trim()
   }
 
-  private async promptForRole(projectId: string): Promise<string> {
+  private async promptForRole(projectId: string): Promise<SelectedTokenRole> {
     if (this.isUnattended()) {
-      return 'viewer' // Default role for unattended mode
+      return {name: 'viewer', title: 'Viewer'} // Default role for unattended mode
     }
 
     const roles = await getTokenRoles(projectId)
@@ -165,6 +166,11 @@ export class CreateTokenCommand extends SanityCommand<typeof CreateTokenCommand>
       message: 'Select role for the token:',
     })
 
-    return selectedRoleName
+    const selectedRole = robotRoles.find((r) => r.name === selectedRoleName)
+    if (!selectedRole) {
+      this.error('No roles available for tokens', {exit: exitCodes.RUNTIME_ERROR})
+    }
+
+    return {name: selectedRole.name, title: selectedRole.title}
   }
 }

--- a/packages/@sanity/cli/src/commands/tokens/delete.ts
+++ b/packages/@sanity/cli/src/commands/tokens/delete.ts
@@ -4,7 +4,7 @@ import {confirm, select} from '@sanity/cli-core/ux'
 import {ClientError} from '@sanity/client'
 
 import {promptForProject} from '../../prompts/promptForProject.js'
-import {deleteToken, getTokens} from '../../services/tokens.js'
+import {deleteToken, getProjectMembership, getTokens} from '../../services/tokens.js'
 import {formatCliErrorMessages} from '../../util/formatCliErrorMessages.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
 
@@ -141,7 +141,7 @@ export class DeleteTokensCommand extends SanityCommand<typeof DeleteTokensComman
     }
 
     const choices = tokens.map((token) => ({
-      name: `${token.label} (${(token.roles || []).map((r) => r.title).join(', ')})`,
+      name: `${token.label} (${getProjectMembership(token, this.projectId)?.roleNames.join(', ') ?? ''})`,
       value: token.id,
     }))
 

--- a/packages/@sanity/cli/src/commands/tokens/list.ts
+++ b/packages/@sanity/cli/src/commands/tokens/list.ts
@@ -73,10 +73,10 @@ export class TokensListCommand extends SanityCommand<typeof TokensListCommand> {
 
     const table = new Table({
       columns: [
-        {alignment: 'left', maxLen: 40, name: 'label', title: 'Label'},
-        {alignment: 'left', maxLen: 20, name: 'id', title: 'ID'},
-        {alignment: 'left', maxLen: 30, name: 'roles', title: 'Roles'},
-        {alignment: 'left', maxLen: 12, name: 'expires', title: 'Expires'},
+        {alignment: 'left', name: 'label', title: 'Label'},
+        {alignment: 'left', name: 'id', title: 'ID'},
+        {alignment: 'left', name: 'roles', title: 'Roles'},
+        {alignment: 'left', name: 'expires', title: 'Expires'},
       ],
       title: `Found ${tokens.length} API tokens`,
     })

--- a/packages/@sanity/cli/src/commands/tokens/list.ts
+++ b/packages/@sanity/cli/src/commands/tokens/list.ts
@@ -76,6 +76,7 @@ export class TokensListCommand extends SanityCommand<typeof TokensListCommand> {
         {alignment: 'left', maxLen: 40, name: 'label', title: 'Label'},
         {alignment: 'left', maxLen: 20, name: 'id', title: 'ID'},
         {alignment: 'left', maxLen: 30, name: 'roles', title: 'Roles'},
+        {alignment: 'left', maxLen: 12, name: 'expires', title: 'Expires'},
       ],
       title: `Found ${tokens.length} API tokens`,
     })
@@ -87,6 +88,7 @@ export class TokensListCommand extends SanityCommand<typeof TokensListCommand> {
       const truncatedRoles = roles.length > 27 ? `${roles.slice(0, 27)}...` : roles
 
       table.addRow({
+        expires: token.expiresAt ? token.expiresAt.slice(0, 10) : 'Never',
         id: token.id,
         label: truncatedLabel,
         roles: truncatedRoles,

--- a/packages/@sanity/cli/src/commands/tokens/list.ts
+++ b/packages/@sanity/cli/src/commands/tokens/list.ts
@@ -3,9 +3,9 @@ import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {Table} from 'console-table-printer'
 
-import {type Token} from '../../actions/tokens/types.js'
+import {type Robot} from '../../actions/tokens/types.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
-import {getTokens} from '../../services/tokens.js'
+import {getProjectMembership, getTokens} from '../../services/tokens.js'
 import {getProjectIdFlag} from '../../util/sharedFlags.js'
 
 const listTokenDebug = subdebug('tokens:list')
@@ -52,7 +52,7 @@ export class TokensListCommand extends SanityCommand<typeof TokensListCommand> {
         }),
     })
 
-    let tokens: Token[]
+    let tokens: Robot[]
     try {
       tokens = await getTokens(projectId)
     } catch (error) {
@@ -74,14 +74,14 @@ export class TokensListCommand extends SanityCommand<typeof TokensListCommand> {
     const table = new Table({
       columns: [
         {alignment: 'left', maxLen: 40, name: 'label', title: 'Label'},
-        {alignment: 'left', maxLen: 20, name: 'id', title: 'Token ID'},
+        {alignment: 'left', maxLen: 20, name: 'id', title: 'ID'},
         {alignment: 'left', maxLen: 30, name: 'roles', title: 'Roles'},
       ],
       title: `Found ${tokens.length} API tokens`,
     })
 
     for (const token of tokens) {
-      const roles = token.roles?.map((role) => role.title).join(', ') || 'No roles'
+      const roles = getProjectMembership(token, projectId)?.roleNames.join(', ') || 'No roles'
       const truncatedLabel =
         token.label.length > 37 ? `${token.label.slice(0, 37)}...` : token.label
       const truncatedRoles = roles.length > 27 ? `${roles.slice(0, 27)}...` : roles

--- a/packages/@sanity/cli/src/commands/tokens/rotate.ts
+++ b/packages/@sanity/cli/src/commands/tokens/rotate.ts
@@ -1,5 +1,6 @@
 import {Flags} from '@oclif/core'
 import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
+import {getErrorMessage} from '@sanity/cli-core/errors'
 import {isHttpError} from '@sanity/client'
 
 import {rotateToken} from '../../services/tokens.js'
@@ -83,8 +84,9 @@ export class RotateTokenCommand extends SanityCommand<typeof RotateTokenCommand>
         )
       }
 
-      const err = error as Error
-      this.error(`Token rotation failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
+      this.error(`Token rotation failed:\n${getErrorMessage(error)}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 
@@ -93,8 +95,7 @@ export class RotateTokenCommand extends SanityCommand<typeof RotateTokenCommand>
     try {
       token = await readTokenFromStdin(TOKEN_USAGE_HINT)
     } catch (error) {
-      const err = error as Error
-      return this.error(err.message, {exit: exitCodes.USAGE_ERROR})
+      return this.error(getErrorMessage(error), {exit: exitCodes.USAGE_ERROR})
     }
 
     if (!token) {

--- a/packages/@sanity/cli/src/commands/tokens/rotate.ts
+++ b/packages/@sanity/cli/src/commands/tokens/rotate.ts
@@ -1,0 +1,106 @@
+import {Flags} from '@oclif/core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
+import {isHttpError} from '@sanity/client'
+
+import {rotateToken} from '../../services/tokens.js'
+import {readTokenFromStdin} from '../../util/readTokenFromStdin.js'
+
+const tokensRotateDebug = subdebug('tokens:rotate')
+
+const TOKEN_USAGE_HINT =
+  'Token is required. Pipe it on standard input (`echo "$SANITY_TOKEN" | sanity tokens rotate`) to keep it out of shell history, or pass it with `--token`.'
+
+export class RotateTokenCommand extends SanityCommand<typeof RotateTokenCommand> {
+  static override description = 'Rotate an API token, replacing its secret with a new one'
+
+  static override examples = [
+    {
+      command: 'echo "$SANITY_TOKEN" | <%= config.bin %> <%= command.id %>',
+      description: 'Rotate the token piped on standard input',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> < token.txt',
+      description: 'Rotate a token read from a file',
+    },
+    {
+      command: 'echo "$SANITY_TOKEN" | <%= config.bin %> <%= command.id %> --json',
+      description: 'Output the rotated token as JSON',
+    },
+  ]
+
+  static override flags = {
+    json: Flags.boolean({
+      default: false,
+      description: 'Output as JSON',
+    }),
+    token: Flags.string({
+      char: 't',
+      description: 'Token to rotate (prefer standard input to keep it out of shell history)',
+      helpValue: '<token>',
+    }),
+  }
+
+  static override hiddenAliases: string[] = ['token:rotate']
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(RotateTokenCommand)
+    const {json} = flags
+
+    const token = flags.token?.trim() || (await this.readTokenArg())
+
+    try {
+      tokensRotateDebug('Rotating API token')
+      const robot = await rotateToken(token)
+
+      if (json) {
+        this.log(JSON.stringify(robot, null, 2))
+        return
+      }
+
+      this.log('API token rotated')
+      this.log(`Label: ${robot.label}`)
+      this.log(`ID: ${robot.id}`)
+      if (robot.expiresAt) {
+        this.log(`Expires: ${robot.expiresAt}`)
+      }
+      this.log(`Token: ${robot.token}`)
+      this.log('')
+      this.log("Copy the token now. It won't be shown again.")
+      this.log('The previous token was revoked and no longer works.')
+    } catch (error) {
+      tokensRotateDebug('Error rotating token', error)
+
+      if (isHttpError(error) && error.statusCode === 401) {
+        this.error(
+          'Token is invalid, expired, or was already rotated or revoked. Check that you are passing the current token.',
+          {exit: exitCodes.RUNTIME_ERROR},
+        )
+      }
+      if (isHttpError(error) && error.statusCode === 403) {
+        this.error(
+          'The token is not an API token and cannot be rotated. Personal tokens are renewed by logging in again.',
+          {exit: exitCodes.RUNTIME_ERROR},
+        )
+      }
+
+      const err = error as Error
+      this.error(`Token rotation failed:\n${err.message}`, {exit: exitCodes.RUNTIME_ERROR})
+    }
+  }
+
+  private async readTokenArg(): Promise<string> {
+    let token: string
+    try {
+      token = await readTokenFromStdin(TOKEN_USAGE_HINT)
+    } catch (error) {
+      const err = error as Error
+      return this.error(err.message, {exit: exitCodes.USAGE_ERROR})
+    }
+
+    if (!token) {
+      this.error(TOKEN_USAGE_HINT, {exit: exitCodes.USAGE_ERROR})
+    }
+
+    return token
+  }
+}

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -213,6 +213,8 @@ export const mcpPolicy: CommandPolicySet = {
   'tokens:delete': deny,
   // Exposes authentication credential metadata.
   'tokens:list': deny,
+  // Replaces authentication credentials and exposes the new secret.
+  'tokens:rotate': deny,
 
   // Loads local CLI and workbench configuration to identify the deployed Studio or application.
   undeploy: deny,

--- a/packages/@sanity/cli/src/services/__tests__/tokens.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/tokens.test.ts
@@ -9,6 +9,7 @@ import {
   getProjectMembership,
   getTokenRoles,
   getTokens,
+  rotateToken,
 } from '../tokens.js'
 
 const mockRequest = vi.hoisted(() => vi.fn())
@@ -145,6 +146,32 @@ describe('deleteToken', () => {
     await expect(deleteToken({projectId: testProjectId, tokenId: 'missing'})).rejects.toThrow(
       'Not found',
     )
+  })
+})
+
+describe('rotateToken', () => {
+  test('authenticates with the provided token and posts to the rotate endpoint', async () => {
+    const rotatedRobot = {...testRobot, token: 'sk_new_secret'}
+    mockRequest.mockResolvedValue(rotatedRobot)
+
+    const result = await rotateToken('sk_old_secret')
+
+    expect(mockGetGlobalCliClient).toHaveBeenCalledWith({
+      apiVersion: TOKENS_API_VERSION,
+      requireUser: true,
+      token: 'sk_old_secret',
+    })
+    expect(mockRequest).toHaveBeenCalledWith({
+      method: 'POST',
+      uri: '/access/robots/me/rotate',
+    })
+    expect(result).toEqual(rotatedRobot)
+  })
+
+  test('propagates errors from the API', async () => {
+    mockRequest.mockRejectedValue(new Error('Too many requests'))
+
+    await expect(rotateToken('sk_old_secret')).rejects.toThrow('Too many requests')
   })
 })
 

--- a/packages/@sanity/cli/src/services/__tests__/tokens.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/tokens.test.ts
@@ -58,7 +58,7 @@ describe('createToken', () => {
     const result = await createToken({
       label: 'Test Robot',
       projectId: testProjectId,
-      role: {name: 'editor', title: 'Editor'},
+      roleName: 'editor',
     })
 
     expect(mockGetGlobalCliClient).toHaveBeenCalledWith({
@@ -84,7 +84,7 @@ describe('createToken', () => {
       expiresAt: '2030-01-01T00:00:00.000Z',
       label: 'Test Robot',
       projectId: testProjectId,
-      role: {name: 'editor', title: 'Editor'},
+      roleName: 'editor',
     })
 
     expect(mockRequest).toHaveBeenCalledWith(
@@ -106,7 +106,7 @@ describe('createToken', () => {
     await createToken({
       label: 'Test Robot',
       projectId: testProjectId,
-      role: {name: 'editor', title: 'Editor'},
+      roleName: 'editor',
       sendNotification: false,
     })
 
@@ -122,7 +122,7 @@ describe('createToken', () => {
       createToken({
         label: 'Test Robot',
         projectId: testProjectId,
-        role: {name: 'editor', title: 'Editor'},
+        roleName: 'editor',
       }),
     ).rejects.toThrow('Forbidden')
   })

--- a/packages/@sanity/cli/src/services/__tests__/tokens.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/tokens.test.ts
@@ -1,0 +1,240 @@
+import {getGlobalCliClient} from '@sanity/cli-core'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {TOKENS_API_VERSION} from '../../actions/tokens/constants.js'
+import {type Membership, type Robot} from '../../actions/tokens/types.js'
+import {
+  createToken,
+  deleteToken,
+  getProjectMembership,
+  getTokenRoles,
+  getTokens,
+} from '../tokens.js'
+
+const mockRequest = vi.hoisted(() => vi.fn())
+
+vi.mock(import('@sanity/cli-core'), async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    getGlobalCliClient: vi.fn().mockResolvedValue({
+      request: mockRequest,
+    }),
+  }
+})
+
+const mockGetGlobalCliClient = vi.mocked(getGlobalCliClient)
+
+const testProjectId = 'test-project'
+
+const projectMembership: Membership = {
+  resourceId: testProjectId,
+  resourceType: 'project',
+  roleNames: ['editor', 'viewer'],
+}
+
+const testRobot: Robot = {
+  createdAt: '2023-01-01T00:00:00Z',
+  id: 'robot-1',
+  label: 'Test Robot',
+  memberships: [projectMembership],
+  tokenId: 'robot-1-active-token',
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createToken', () => {
+  test('posts the robot membership body and returns the robot with its token', async () => {
+    const robotWithToken = {
+      ...testRobot,
+      memberships: [{...projectMembership, roleNames: ['editor']}],
+      token: 'sk_secret',
+    }
+    mockRequest.mockResolvedValue(robotWithToken)
+
+    const result = await createToken({
+      label: 'Test Robot',
+      projectId: testProjectId,
+      role: {name: 'editor', title: 'Editor'},
+    })
+
+    expect(mockGetGlobalCliClient).toHaveBeenCalledWith({
+      apiVersion: TOKENS_API_VERSION,
+      requireUser: true,
+    })
+    expect(mockRequest).toHaveBeenCalledWith({
+      body: {
+        label: 'Test Robot',
+        memberships: [{resourceId: testProjectId, resourceType: 'project', roleNames: ['editor']}],
+      },
+      method: 'POST',
+      query: {},
+      uri: `/access/project/${testProjectId}/robots`,
+    })
+    expect(result).toEqual(robotWithToken)
+  })
+
+  test('passes sendNotification=false as a query parameter', async () => {
+    mockRequest.mockResolvedValue({...testRobot, token: 'sk_secret'})
+
+    await createToken({
+      label: 'Test Robot',
+      projectId: testProjectId,
+      role: {name: 'editor', title: 'Editor'},
+      sendNotification: false,
+    })
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({query: {sendNotification: 'false'}}),
+    )
+  })
+
+  test('propagates errors from the API', async () => {
+    mockRequest.mockRejectedValue(new Error('Forbidden'))
+
+    await expect(
+      createToken({
+        label: 'Test Robot',
+        projectId: testProjectId,
+        role: {name: 'editor', title: 'Editor'},
+      }),
+    ).rejects.toThrow('Forbidden')
+  })
+})
+
+describe('deleteToken', () => {
+  test('deletes the robot by id', async () => {
+    mockRequest.mockResolvedValue(undefined)
+
+    await deleteToken({projectId: testProjectId, tokenId: 'robot-1'})
+
+    expect(mockRequest).toHaveBeenCalledWith({
+      method: 'DELETE',
+      uri: `/access/project/${testProjectId}/robots/robot-1`,
+    })
+  })
+
+  test('propagates errors from the API', async () => {
+    mockRequest.mockRejectedValue(new Error('Not found'))
+
+    await expect(deleteToken({projectId: testProjectId, tokenId: 'missing'})).rejects.toThrow(
+      'Not found',
+    )
+  })
+})
+
+describe('getTokens', () => {
+  test('returns robots as reported by the API', async () => {
+    mockRequest.mockResolvedValue({data: [testRobot], nextCursor: null})
+
+    const tokens = await getTokens(testProjectId)
+
+    expect(mockRequest).toHaveBeenCalledWith({
+      query: {},
+      uri: `/access/project/${testProjectId}/robots`,
+    })
+    expect(tokens).toEqual([testRobot])
+  })
+
+  test('follows nextCursor across pages', async () => {
+    mockRequest
+      .mockResolvedValueOnce({data: [testRobot], nextCursor: 'cursor-1'})
+      .mockResolvedValueOnce({data: [{...testRobot, id: 'robot-2'}], nextCursor: null})
+
+    const tokens = await getTokens(testProjectId)
+
+    expect(mockRequest).toHaveBeenNthCalledWith(1, {
+      query: {},
+      uri: `/access/project/${testProjectId}/robots`,
+    })
+    expect(mockRequest).toHaveBeenNthCalledWith(2, {
+      query: {nextCursor: 'cursor-1'},
+      uri: `/access/project/${testProjectId}/robots`,
+    })
+    expect(tokens.map((token) => token.id)).toEqual(['robot-1', 'robot-2'])
+  })
+
+  test('excludes robots managed by an organization', async () => {
+    const orgManagedRobot: Robot = {
+      ...testRobot,
+      id: 'robot-org',
+      managedBy: {resourceId: 'org-1', resourceType: 'organization'},
+    }
+    const projectManagedRobot: Robot = {
+      ...testRobot,
+      id: 'robot-project',
+      managedBy: {resourceId: testProjectId, resourceType: 'project'},
+    }
+    mockRequest.mockResolvedValue({
+      data: [orgManagedRobot, projectManagedRobot, testRobot],
+      nextCursor: null,
+    })
+
+    const tokens = await getTokens(testProjectId)
+
+    expect(tokens.map((token) => token.id)).toEqual(['robot-project', 'robot-1'])
+  })
+
+  test('propagates errors from the API', async () => {
+    mockRequest.mockRejectedValue(new Error('Unauthorized'))
+
+    await expect(getTokens(testProjectId)).rejects.toThrow('Unauthorized')
+  })
+})
+
+describe('getProjectMembership', () => {
+  test('returns the membership matching the requested project', async () => {
+    const otherMembership: Membership = {
+      resourceId: 'other-project',
+      resourceType: 'project',
+      roleNames: ['administrator'],
+    }
+    const robot: Robot = {...testRobot, memberships: [otherMembership, projectMembership]}
+
+    expect(getProjectMembership(robot, testProjectId)).toBe(projectMembership)
+  })
+
+  test('returns undefined when the robot has no membership for the project', async () => {
+    expect(getProjectMembership({...testRobot, memberships: []}, testProjectId)).toBeUndefined()
+  })
+})
+
+describe('getTokenRoles', () => {
+  test('fetches roles across pages', async () => {
+    const viewerRole = {
+      appliesToRobots: true,
+      appliesToUsers: true,
+      description: 'Can read documents',
+      isCustom: false,
+      name: 'viewer',
+      resourceId: testProjectId,
+      resourceType: 'project',
+      title: 'Viewer',
+    }
+    const editorRole = {...viewerRole, name: 'editor', title: 'Editor'}
+
+    mockRequest
+      .mockResolvedValueOnce({data: [viewerRole], nextCursor: 'cursor-1'})
+      .mockResolvedValueOnce({data: [editorRole], nextCursor: null})
+
+    const roles = await getTokenRoles(testProjectId)
+
+    expect(mockRequest).toHaveBeenNthCalledWith(1, {
+      query: {},
+      uri: `/access/project/${testProjectId}/roles`,
+    })
+    expect(mockRequest).toHaveBeenNthCalledWith(2, {
+      query: {nextCursor: 'cursor-1'},
+      uri: `/access/project/${testProjectId}/roles`,
+    })
+    expect(roles.map((role) => role.name)).toEqual(['viewer', 'editor'])
+  })
+
+  test('propagates errors from the API', async () => {
+    mockRequest.mockRejectedValue(new Error('Unauthorized'))
+
+    await expect(getTokenRoles(testProjectId)).rejects.toThrow('Unauthorized')
+  })
+})

--- a/packages/@sanity/cli/src/services/__tests__/tokens.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/tokens.test.ts
@@ -76,6 +76,29 @@ describe('createToken', () => {
     expect(result).toEqual(robotWithToken)
   })
 
+  test('includes expiresAt in the body when provided', async () => {
+    mockRequest.mockResolvedValue({...testRobot, token: 'sk_secret'})
+
+    await createToken({
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      label: 'Test Robot',
+      projectId: testProjectId,
+      role: {name: 'editor', title: 'Editor'},
+    })
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: {
+          expiresAt: '2030-01-01T00:00:00.000Z',
+          label: 'Test Robot',
+          memberships: [
+            {resourceId: testProjectId, resourceType: 'project', roleNames: ['editor']},
+          ],
+        },
+      }),
+    )
+  })
+
   test('passes sendNotification=false as a query parameter', async () => {
     mockRequest.mockResolvedValue({...testRobot, token: 'sk_secret'})
 

--- a/packages/@sanity/cli/src/services/tokens.ts
+++ b/packages/@sanity/cli/src/services/tokens.ts
@@ -1,34 +1,85 @@
 import {getGlobalCliClient} from '@sanity/cli-core'
+import {type SanityClient} from '@sanity/client'
 
-import {type ProjectRole, type Token, type TokenResponse} from '../actions/tokens/types.js'
+import {TOKENS_API_VERSION} from '../actions/tokens/constants.js'
+import {
+  type Membership,
+  type Robot,
+  type RobotWithToken,
+  type Role,
+  type SelectedTokenRole,
+} from '../actions/tokens/types.js'
 
-const TOKENS_API_VERSION = 'v2025-08-18'
+interface PaginatedResponse<T> {
+  data: T[]
+  nextCursor: string | null
+}
+
+function getClient(): Promise<SanityClient> {
+  return getGlobalCliClient({
+    apiVersion: TOKENS_API_VERSION,
+    requireUser: true,
+  })
+}
+
+async function fetchAllPages<T>(client: SanityClient, uri: string): Promise<T[]> {
+  const items: T[] = []
+  let cursor: string | null = null
+
+  do {
+    const response: PaginatedResponse<T> = await client.request<PaginatedResponse<T>>({
+      query: cursor === null ? {} : {nextCursor: cursor},
+      uri,
+    })
+    items.push(...response.data)
+    cursor = response.nextCursor
+  } while (cursor !== null)
+
+  return items
+}
+
+/**
+ * Get the membership granting a robot access to the given project
+ * @param robot - The robot to inspect
+ * @param projectId - The project ID
+ * @returns The project membership, if any
+ *
+ * @internal
+ */
+export function getProjectMembership(robot: Robot, projectId: string): Membership | undefined {
+  return robot.memberships.find(
+    (membership) => membership.resourceType === 'project' && membership.resourceId === projectId,
+  )
+}
 
 interface CreateTokenOptions {
   label: string
   projectId: string
-  roleName: string
+  role: SelectedTokenRole
+
+  sendNotification?: boolean
 }
 
 /**
  * Add a token to a project
  * @param options - The options for adding a token to a project
- * @returns A promise that resolves to the token response
+ * @returns A promise that resolves to the created robot, including its secret token
  *
  * @internal
  */
-export async function createToken(options: CreateTokenOptions): Promise<TokenResponse> {
-  const {label, projectId, roleName} = options
+export async function createToken(options: CreateTokenOptions): Promise<RobotWithToken> {
+  const {label, projectId, role, sendNotification} = options
 
-  const client = await getGlobalCliClient({
-    apiVersion: TOKENS_API_VERSION,
-    requireUser: true,
-  })
+  const client = await getClient()
 
-  return client.request<TokenResponse>({
-    body: {label, roleName},
+  return client.request<RobotWithToken>({
+    body: {
+      label,
+      memberships: [{resourceId: projectId, resourceType: 'project', roleNames: [role.name]}],
+    },
     method: 'POST',
-    uri: `/projects/${projectId}/tokens`,
+    query: sendNotification === false ? {sendNotification: 'false'} : {},
+    uri: `/access/project/${projectId}/robots`,
   })
 }
 
@@ -39,7 +90,8 @@ interface DeleteTokenOptions {
 
 /**
  * Delete a token from a project
- * @param options - The options for deleting a token from a project
+ * @param options - The options for deleting a token from a project; `tokenId`
+ * is the id reported by `getTokens`/`createToken`
  * @returns A promise that resolves when the token is deleted
  *
  * @internal
@@ -47,33 +99,28 @@ interface DeleteTokenOptions {
 export async function deleteToken(options: DeleteTokenOptions): Promise<void> {
   const {projectId, tokenId} = options
 
-  const client = await getGlobalCliClient({
-    apiVersion: TOKENS_API_VERSION,
-    requireUser: true,
-  })
+  const client = await getClient()
 
   return client.request({
     method: 'DELETE',
-    uri: `/projects/${projectId}/tokens/${tokenId}`,
+    uri: `/access/project/${projectId}/robots/${tokenId}`,
   })
 }
 
 /**
- * Get all tokens for a project
+ * Get all tokens for a project. Tokens managed by an organization are
+ * excluded: they cannot be managed at the project scope.
  * @param projectId - The project ID
- * @returns A promise that resolves to an array of tokens
+ * @returns A promise that resolves to an array of robots
  *
  * @internal
  */
-export async function getTokens(projectId: string): Promise<Token[]> {
-  const client = await getGlobalCliClient({
-    apiVersion: TOKENS_API_VERSION,
-    requireUser: true,
-  })
+export async function getTokens(projectId: string): Promise<Robot[]> {
+  const client = await getClient()
 
-  return client.request<Token[]>({
-    uri: `/projects/${projectId}/tokens`,
-  })
+  const robots = await fetchAllPages<Robot>(client, `/access/project/${projectId}/robots`)
+
+  return robots.filter((robot) => robot.managedBy?.resourceType !== 'organization')
 }
 
 /**
@@ -83,11 +130,8 @@ export async function getTokens(projectId: string): Promise<Token[]> {
  *
  * @internal
  */
-export async function getTokenRoles(projectId: string): Promise<ProjectRole[]> {
-  const client = await getGlobalCliClient({
-    apiVersion: TOKENS_API_VERSION,
-    requireUser: true,
-  })
+export async function getTokenRoles(projectId: string): Promise<Role[]> {
+  const client = await getClient()
 
-  return client.request<ProjectRole[]>({uri: `/projects/${projectId}/roles`})
+  return fetchAllPages<Role>(client, `/access/project/${projectId}/roles`)
 }

--- a/packages/@sanity/cli/src/services/tokens.ts
+++ b/packages/@sanity/cli/src/services/tokens.ts
@@ -15,10 +15,11 @@ interface PaginatedResponse<T> {
   nextCursor: string | null
 }
 
-function getClient(): Promise<SanityClient> {
+function getClient(token?: string): Promise<SanityClient> {
   return getGlobalCliClient({
     apiVersion: TOKENS_API_VERSION,
     requireUser: true,
+    ...(token === undefined ? {} : {token}),
   })
 }
 
@@ -106,6 +107,24 @@ export async function deleteToken(options: DeleteTokenOptions): Promise<void> {
   return client.request({
     method: 'DELETE',
     uri: `/access/project/${projectId}/robots/${tokenId}`,
+  })
+}
+
+/**
+ * Rotate a robot token, replacing its secret while preserving the robot,
+ * its roles, and the token's expiry. The request authenticates as the robot
+ * itself; the previous secret is revoked immediately.
+ * @param token - The current robot token secret
+ * @returns A promise that resolves to the robot with its new secret token
+ *
+ * @internal
+ */
+export async function rotateToken(token: string): Promise<RobotWithToken> {
+  const client = await getClient(token)
+
+  return client.request<RobotWithToken>({
+    method: 'POST',
+    uri: '/access/robots/me/rotate',
   })
 }
 

--- a/packages/@sanity/cli/src/services/tokens.ts
+++ b/packages/@sanity/cli/src/services/tokens.ts
@@ -7,7 +7,6 @@ import {
   type Robot,
   type RobotWithToken,
   type Role,
-  type SelectedTokenRole,
 } from '../actions/tokens/types.js'
 
 interface PaginatedResponse<T> {
@@ -56,7 +55,7 @@ export function getProjectMembership(robot: Robot, projectId: string): Membershi
 interface CreateTokenOptions {
   label: string
   projectId: string
-  role: SelectedTokenRole
+  roleName: string
 
   expiresAt?: string
   sendNotification?: boolean
@@ -70,14 +69,14 @@ interface CreateTokenOptions {
  * @internal
  */
 export async function createToken(options: CreateTokenOptions): Promise<RobotWithToken> {
-  const {expiresAt, label, projectId, role, sendNotification} = options
+  const {expiresAt, label, projectId, roleName, sendNotification} = options
 
   const client = await getClient()
 
   return client.request<RobotWithToken>({
     body: {
       label,
-      memberships: [{resourceId: projectId, resourceType: 'project', roleNames: [role.name]}],
+      memberships: [{resourceId: projectId, resourceType: 'project', roleNames: [roleName]}],
       ...(expiresAt === undefined ? {} : {expiresAt}),
     },
     method: 'POST',

--- a/packages/@sanity/cli/src/services/tokens.ts
+++ b/packages/@sanity/cli/src/services/tokens.ts
@@ -57,6 +57,7 @@ interface CreateTokenOptions {
   projectId: string
   role: SelectedTokenRole
 
+  expiresAt?: string
   sendNotification?: boolean
 }
 
@@ -68,7 +69,7 @@ interface CreateTokenOptions {
  * @internal
  */
 export async function createToken(options: CreateTokenOptions): Promise<RobotWithToken> {
-  const {label, projectId, role, sendNotification} = options
+  const {expiresAt, label, projectId, role, sendNotification} = options
 
   const client = await getClient()
 
@@ -76,6 +77,7 @@ export async function createToken(options: CreateTokenOptions): Promise<RobotWit
     body: {
       label,
       memberships: [{resourceId: projectId, resourceType: 'project', roleNames: [role.name]}],
+      ...(expiresAt === undefined ? {} : {expiresAt}),
     },
     method: 'POST',
     query: sendNotification === false ? {sendNotification: 'false'} : {},

--- a/packages/@sanity/cli/src/util/readTokenFromStdin.ts
+++ b/packages/@sanity/cli/src/util/readTokenFromStdin.ts
@@ -1,0 +1,18 @@
+import {text} from 'node:stream/consumers'
+
+/**
+ * Read a secret token from standard input. Reading from stdin keeps the
+ * secret out of shell history, process lists, and terminal logs.
+ * @param usageHint - Error message shown when stdin is a TTY (i.e. nothing
+ * was piped in)
+ * @returns The piped input, trimmed
+ *
+ * @internal
+ */
+export async function readTokenFromStdin(usageHint: string): Promise<string> {
+  if (process.stdin.isTTY) {
+    throw new Error(usageHint)
+  }
+
+  return (await text(process.stdin)).trim()
+}


### PR DESCRIPTION
### Description

Migrates the `sanity tokens` commands (`create`, `list`, `delete`) from the Projects API tokens endpoints to the Access API, and adds the capabilities that unblocks:

- **Token expiry**: `tokens create --expires-at <date|timestamp>`, an interactive expiry step with the same presets as sanity.io/manage (never/30/60/90 days/custom date), and an Expires column in `tokens list`.
- **`sanity tokens rotate`**: replaces a token's secret while keeping its roles and expiry. The token is read from stdin (`echo "$SANITY_TOKEN" | sanity tokens rotate`) to keep secrets out of shell history; `-t, --token` is also accepted. The previous secret is revoked immediately.
- Token listing follows the Access API's cursor pagination, and excludes org-managed tokens since they cannot be managed at project scope.

**Breaking**: `--json` output now returns the Access API responses verbatim instead of the legacy Projects API shapes (see release notes below). Human-readable output is unchanged, except `tokens list` shows role names instead of titles and the "Token ID" column is now "ID".

Fixes [AIGRO-5284](https://linear.app/sanity/issue/AIGRO-5284/add-expiry-option-to-sanity-tokens-create). Supersedes #1633.

### What to review

- `services/tokens.ts` — all Access API calls (endpoints, pagination, rotate) live here.
- `commands/tokens/` — `create` (expiry flag + prompt), `list` (columns), `rotate` (new), `delete` (unchanged flow, robot ids).
- `actions/init/bootstrapRemoteTemplate.ts` — uses the same `createToken` service; call sites updated.

### Testing

- Unit tests cover the exact request bodies, pagination across cursors, response passthrough, the org-managed filter, expiry validation, the interactive expiry/rotate flows, and 401/403 error mappings for rotate. Coverage on the migrated files is 100%.
- Smoke-tested the full lifecycle against staging: create (with and without expiry) → authenticate → list → rotate (old secret rejected, new accepted, personal token correctly refused) → delete.

### Notes for release

The `sanity tokens` commands are now backed by the Access API and gain token expiry support and a `sanity tokens rotate` command.

- `tokens create --expires-at <date>` sets an expiry; interactive runs offer the same presets as sanity.io/manage. `tokens list` shows expiry in a new Expires column.
- `echo "$SANITY_TOKEN" | sanity tokens rotate` replaces a token's secret in place, revoking the previous secret immediately.
- **Breaking**: `--json` output now returns the Access API token shape verbatim. For `tokens create` the secret moved from `key` to `token`; for `tokens list`, `roles`/`createdBy`/`permissions`/`projectUserId`/`lastUsedAt` are replaced by `memberships`, and `id` is the token's stable identifier (used by `tokens delete`). `tokens list` also shows role names instead of display titles and excludes organization-managed tokens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major breaking change to token JSON contracts and credential identifiers, plus new rotate/revoke behavior that can immediately invalidate production API tokens if misused.
> 
> **Overview**
> **Breaking:** `tokens create`, `list`, and `delete` now call the **Access API** (`/access/project/.../robots` and roles) instead of the Projects API. `--json` echoes the new **robot** shape (secret on `.token`, roles in `.memberships[].roleNames`; several legacy fields dropped). Human list output uses role **names**, an **ID** column, and omits org-managed tokens. Init/bootstrap still uses `createToken` but reads `.token` instead of `.key`.
> 
> **New:** `tokens create --expires-at` plus interactive expiry presets (never / 30–90 days / custom). `tokens list` adds an **Expires** column. **`sanity tokens rotate`** posts to `/access/robots/me/rotate` with the current secret from stdin or `--token`, revoking the old secret immediately; MCP policy denies it like other token mutators.
> 
> Shared **`readTokenFromStdin`** replaces duplicated login stdin handling. API version constant switches to `v2025-07-11` with cursor pagination for list/roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c5a9ad7bb1063aea0112b07a9084268e859f9a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->