### PR TITLE
feat(cli): add sanity -v as an alias for sanity --version

### DIFF
--- a/.changeset/full-islands-add.md
+++ b/.changeset/full-islands-add.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": minor
+---
+
+feat(cli): sanity -v now works as an alias for sanity --version

--- a/packages/@sanity/cli/oclif.config.js
+++ b/packages/@sanity/cli/oclif.config.js
@@ -1,4 +1,5 @@
 export default {
+  additionalVersionFlags: ['-v'],
   bin: 'sanity',
   commands: './dist/commands',
   dirname: 'sanity',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line oclif config change with no impact on auth, data, or command behavior beyond the new version alias.
> 
> **Overview**
> Adds **`sanity -v`** as a shorthand for **`sanity --version`** by setting oclif’s `additionalVersionFlags: ['-v']` in `oclif.config.js`.
> 
> Ships as a **minor** `@sanity/cli` release (changeset included).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b61d9c914c27dead30c3eda538b65fafb07c379d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->