### PR TITLE
chore: fix Changeset headings being modified

### DIFF
--- a/.changeset/postversion.mjs
+++ b/.changeset/postversion.mjs
@@ -99,6 +99,8 @@ function transformChangelog(content, packageName, currentVersion) {
 
   const versionStart = match.index
   const afterHeading = content.slice(versionStart + match[0].length)
+  if (afterHeading.trimStart().startsWith('[Compare changes](')) return content
+
   const nextVersionMatch = afterHeading.match(/^## /m)
   const sectionEnd = nextVersionMatch
     ? versionStart + match[0].length + nextVersionMatch.index
@@ -118,9 +120,11 @@ function transformChangelog(content, packageName, currentVersion) {
     ? `${REPO_URL}/compare/${tagPrefix}${previousVersion}...${tagPrefix}${currentVersion}`
     : `${REPO_URL}/releases/tag/${tagPrefix}${currentVersion}`
 
+  // changesets/action finds a release entry by matching the version heading exactly.
+  // Keep the heading plain and put the comparison link below it.
   section = section.replace(
     `## ${currentVersion}`,
-    `## [${currentVersion}](${compareUrl})\n\n_${today}_`,
+    `## ${currentVersion}\n\n[Compare changes](${compareUrl})\n\n_${today}_`,
   )
 
   for (const [from, to] of Object.entries(SECTION_MAP)) {


### PR DESCRIPTION
Our `transformChangelog` function in the postversion script was adding in URLs for comparing the before/after of each version. This was silently breaking `changesets/action`, which relies on those headings being in a consistent format so it can extract the version. Since our link was different formatting, it'd include the entire changelog contents, instead of just a delta of A to B. That exceeded the max comment size on GitHub, so it'd omit the description entirely.

This changes the script to include a separate link to compare changes, which leaves the heading unaffected.

This started on June 9th when we upgraded `changesets/action` to v1.9.0. Their internal behavior changed from parsing the Markdown to looking at the raw string contents, which meant it'd see the Markdown link syntax and be unable to match the heading from that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-time changelog formatting only; no runtime or auth/data impact.
> 
> **Overview**
> Fixes **release notes from `changesets/action`** by changing how `transformChangelog` in `.changeset/postversion.mjs` formats new version sections.
> 
> Version headings stay as plain `## x.y.z` instead of turning the heading into a markdown link. The GitHub compare (or release) URL is added on the next line as **`[Compare changes](...)`**, with the date still below that. A short comment documents that `changesets/action` matches headings exactly.
> 
> Adds an **early return** when the section already starts with `[Compare changes](`, so re-running the script does not double-transform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71240652d3de66462c497cef88547eee607c1d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->