### PR TITLE
fix(cli): disallow url-embedded credentials in programmatic sanity api invocations

### DIFF
--- a/.changeset/pr-1655.md
+++ b/.changeset/pr-1655.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix: disallow url-embedded credentials in mcp api invocations

--- a/.changeset/pr-1655.md
+++ b/.changeset/pr-1655.md
@@ -1,6 +1,7 @@
-<!-- auto-generated -->
 ---
 '@sanity/cli': patch
 ---
 
-fix: disallow url-embedded credentials in mcp api invocations
+fix: disallow url-embedded credentials in programmatic `sanity api` invocations
+
+Fixes a bug that allows users to specify a username and password in the URL passed to `sanity api` when using `run_sanity_cli` via the Sanity MCP server.

--- a/.changeset/pr-1655.md
+++ b/.changeset/pr-1655.md
@@ -2,6 +2,6 @@
 '@sanity/cli': patch
 ---
 
-fix: disallow url-embedded credentials in programmatic `sanity api` invocations
+fix(cli): disallow url-embedded credentials in programmatic `sanity api` invocations
 
 Fixes a bug that allows users to specify a username and password in the URL passed to `sanity api` when using `run_sanity_cli` via the Sanity MCP server.

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -505,11 +505,25 @@ describe('invokeSanityCli', () => {
     expect(result.output).toBe('This invocation of `api` is not supported here')
   })
 
+  test.each([
+    ['username and password', 'api https://user:pass@api.sanity.io/v1/users/me --anonymous'],
+    ['username only', 'api https://user@api.sanity.io/v1/users/me --anonymous'],
+  ])('`api` URLs embedding a %s are refused', async (_credentials, args) => {
+    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+
+    expect(result.exitCode).toBe(2)
+    expect(result.output).toBe('This invocation of `api` is not supported here')
+  })
+
   test('the api policy refuses authentication overrides and host input channels', () => {
     const policy = commandPolicies.mcp.api
-    const validate = (flags: Record<string, unknown>) => policy.validate({args: {}, flags})
+    const validate = (flags: Record<string, unknown>, endpoint: unknown = 'users/me') =>
+      policy.validate({args: {endpoint}, flags})
 
     expect(validate({})).toBe(true)
+    expect(validate({}, 'https://api.sanity.io/v1/users/me')).toBe(true)
+    expect(validate({}, 'not a URL')).toBe(true)
+    expect(validate({}, 42)).toBe(true)
     expect(validate({field: ['key=value', 'count=1']})).toBe(true)
     expect(validate({field: [42, 'invalid']})).toBe(true)
     expect(validate({header: ['Content-Type: application/json', 'X-Custom: value']})).toBe(true)
@@ -524,6 +538,9 @@ describe('invokeSanityCli', () => {
     expect(validate({header: [' aUtHoRiZaTiOn : Basic credentials']})).toBe(false)
     expect(validate({field: ['body=@payload.json']})).toBe(false)
     expect(validate({field: ['key=value', 'body=@-']})).toBe(false)
+    expect(validate({}, 'https://user:pass@api.sanity.io/v1/users/me')).toBe(false)
+    expect(validate({}, 'https://user@api.sanity.io/v1/users/me')).toBe(false)
+    expect(validate({}, 'https://:pass@api.sanity.io/v1/users/me')).toBe(false)
   })
 
   test('the api policy stops checking after finding a host-reading field', () => {

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -555,6 +555,19 @@ describe('invokeSanityCli', () => {
     expect(policy.validate({args: {}, flags})).toBe(false)
   })
 
+  test('the api policy stops checking after finding an authentication header', () => {
+    const policy = commandPolicies.mcp.api
+    const args = {
+      get endpoint(): never {
+        throw new Error('endpoint should not be read')
+      },
+    }
+
+    expect(
+      policy.validate({args, flags: {header: ['Authorization: Bearer other-user-token']}}),
+    ).toBe(false)
+  })
+
   test('conditional policies see parsed flags, not raw tokens', async () => {
     // `--web` after `--` is a positional argument, not a flag, so the policy
     // must not refuse it. The command is strict, so oclif's parser rejects

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -6,7 +6,13 @@ import {
   deny,
 } from './policy.js'
 
-function apiValidator({flags}: {flags: Readonly<Record<string, unknown>>}): boolean {
+function apiValidator({
+  args,
+  flags,
+}: {
+  args: Readonly<Record<string, unknown>>
+  flags: Readonly<Record<string, unknown>>
+}): boolean {
   const fields: unknown[] = Array.isArray(flags.field) ? flags.field : []
 
   const fieldReadsFromHost = fields.some((field) => {
@@ -26,7 +32,13 @@ function apiValidator({flags}: {flags: Readonly<Record<string, unknown>>}): bool
     )
   })
 
-  return !headerOverridesAuthentication
+  if (headerOverridesAuthentication) return false
+
+  const endpoint = typeof args.endpoint === 'string' ? URL.parse(args.endpoint) : null
+  const urlEmbedsCredentials =
+    endpoint !== null && (endpoint.username !== '' || endpoint.password !== '')
+
+  return !urlEmbedsCredentials
 }
 
 /**
@@ -44,6 +56,7 @@ export const mcpPolicy: CommandPolicySet = {
   // Special exception, this can be very dangerous but is also super useful
   // to expose. Refuse authentication overrides and host input channels:
   // `--token` and an Authorization header replace the MCP user's token,
+  // URL-embedded credentials replace it with Basic authentication,
   // `--input` reads the request body from the host's filesystem or stdin, and
   // `-F key=@<file>` / `-F key=@-` field values do the same.
   api: conditionalPolicy({


### PR DESCRIPTION
Fixes a bug that allows users to specify a username and password in the URL passed to `sanity api` when using `run_sanity_cli` via the MCP

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-hardening in MCP authentication policy for `api`; behavior change is deny-only for credential-in-URL patterns and is covered by tests, with no impact on normal interactive CLI usage.
> 
> **Overview**
> Closes a gap in the MCP programmatic **`sanity api`** policy where an endpoint URL could include **embedded username/password** (e.g. `https://user:pass@api.sanity.io/...`), which would switch the request to **Basic authentication** instead of the MCP user’s Bearer token.
> 
> The MCP **`api`** validator now inspects the parsed **`endpoint`** argument with **`URL.parse`** and rejects invocations when **`username`** or **`password`** is non-empty, alongside existing blocks for **`--token`**, **`Authorization`** headers, and host file/stdin input. Integration and unit tests cover refused URL forms and confirm validation short-circuits before reading **`endpoint`** when an auth header override is already present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d243074f3f57ffe6cf7d8159c070658518835283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->