### PR TITLE
fix(cli): disallow setting cookies in programmatic sanity api invocations

### DIFF
--- a/.changeset/good-zoos-cover.md
+++ b/.changeset/good-zoos-cover.md
@@ -1,0 +1,7 @@
+---
+"@sanity/cli": patch
+---
+
+fix: disallow setting cookies in programmatic `sanity api` invocations
+
+Fixes a bug that allows users to set a `Cookie` header `sanity api` when using `run_sanity_cli` via the Sanity MCP server.

--- a/.changeset/good-zoos-cover.md
+++ b/.changeset/good-zoos-cover.md
@@ -2,6 +2,6 @@
 "@sanity/cli": patch
 ---
 
-fix: disallow setting cookies in programmatic `sanity api` invocations
+fix(cli): disallow setting cookies in programmatic `sanity api` invocations
 
-Fixes a bug that allows users to set a `Cookie` header `sanity api` when using `run_sanity_cli` via the Sanity MCP server.
+Fixes a bug that allows users to provide a `Cookie` header to `sanity api` when using `run_sanity_cli` via the Sanity MCP server.

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -496,9 +496,23 @@ describe('invokeSanityCli', () => {
   })
 
   test.each([
-    ['long flag', 'api users/me --header "Authorization: Bearer other-user-token"'],
-    ['short flag with mixed casing', 'api users/me -H "aUtHoRiZaTiOn: Basic credentials"'],
-  ])('`api` Authorization headers using the %s are refused', async (_style, args) => {
+    [
+      'Authorization',
+      'long flag',
+      'api users/me --header "Authorization: Bearer other-user-token"',
+    ],
+    [
+      'Authorization',
+      'short flag with mixed casing',
+      'api users/me -H "aUtHoRiZaTiOn: Basic credentials"',
+    ],
+    ['Cookie', 'long flag', 'api users/me --anonymous --header "Cookie: sid=other-user-session"'],
+    [
+      'Cookie',
+      'short flag with mixed casing',
+      'api users/me --anonymous -H " cOoKiE : sid=other-user-session"',
+    ],
+  ])('`api` %s headers using the %s are refused', async (_header, _style, args) => {
     const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
     expect(result.exitCode).toBe(2)
@@ -536,6 +550,8 @@ describe('invokeSanityCli', () => {
     expect(validate({token: 'other-user-token'})).toBe(false)
     expect(validate({header: ['Authorization: Bearer other-user-token']})).toBe(false)
     expect(validate({header: [' aUtHoRiZaTiOn : Basic credentials']})).toBe(false)
+    expect(validate({header: ['Cookie: sid=other-user-session']})).toBe(false)
+    expect(validate({header: [' cOoKiE : sid=other-user-session']})).toBe(false)
     expect(validate({field: ['body=@payload.json']})).toBe(false)
     expect(validate({field: ['key=value', 'body=@-']})).toBe(false)
     expect(validate({}, 'https://user:pass@api.sanity.io/v1/users/me')).toBe(false)

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -27,9 +27,10 @@ function apiValidator({
   const headerOverridesAuthentication = headers.some((header) => {
     if (typeof header !== 'string') return false
     const separatorIndex = header.indexOf(':')
-    return (
-      separatorIndex > 0 && header.slice(0, separatorIndex).trim().toLowerCase() === 'authorization'
-    )
+    if (separatorIndex <= 0) return false
+
+    const name = header.slice(0, separatorIndex).trim().toLowerCase()
+    return name === 'authorization' || name === 'cookie'
   })
 
   if (headerOverridesAuthentication) return false
@@ -55,7 +56,7 @@ function apiValidator({
 export const mcpPolicy: CommandPolicySet = {
   // Special exception, this can be very dangerous but is also super useful
   // to expose. Refuse authentication overrides and host input channels:
-  // `--token` and an Authorization header replace the MCP user's token,
+  // `--token`, Authorization, and Cookie headers replace the MCP user's authentication,
   // URL-embedded credentials replace it with Basic authentication,
   // `--input` reads the request body from the host's filesystem or stdin, and
   // `-F key=@<file>` / `-F key=@-` field values do the same.


### PR DESCRIPTION
Fixes a bug that allows users to provide a `Cookie` header to `sanity api` when using `run_sanity_cli` via the Sanity MCP server.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows authentication boundaries for MCP-exposed `api` calls; change is small and well-tested but sits in a security-sensitive policy path.
> 
> **Overview**
> Closes a gap in the MCP **`sanity api`** policy where callers could pass a **`Cookie`** header (via `--header` / `-H`, including mixed casing) to substitute another user’s session when using **`run_sanity_cli`**.
> 
> The **`apiValidator`** in **`mcpPolicy.ts`** now treats **`cookie`** like **`authorization`**: any such header makes the invocation unsafe and is rejected with the same “not supported here” path as other auth overrides. Comments and tests were extended to cover long/short flags and validator unit cases; a patch changeset documents the **`@sanity/cli`** fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b049a7c37792724cb387e05b8edd1da2d111593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->