### PR TITLE
fix: ensure programmatic CLI calls don't use host lineage or debug configuration

### DIFF
--- a/.changeset/quiet-tools-run.md
+++ b/.changeset/quiet-tools-run.md
@@ -3,4 +3,6 @@
 '@sanity/cli-core': patch
 ---
 
-fix(cli): isolate programmatic requests from host lineage and debug output
+fix: ensure programmatic CLI calls don't use host lineage or debug configuration
+
+Fixes a bug where programmatic CLI use would inherit the host's [Sanity lineage](https://www.sanity.io/docs/functions/functions-cheatsheet#k7a3b783ece7d) and `DEBUG` configuration

--- a/.changeset/quiet-tools-run.md
+++ b/.changeset/quiet-tools-run.md
@@ -1,0 +1,6 @@
+---
+'@sanity/cli': patch
+'@sanity/cli-core': patch
+---
+
+fix(cli): isolate programmatic requests from host lineage and debug output

--- a/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/apiClient.test.ts
@@ -9,6 +9,7 @@ const mockRequesterUse = vi.hoisted(() => vi.fn())
 const mockGetCliToken = vi.hoisted(() => vi.fn())
 const mockGenerateHelpUrl = vi.hoisted(() => vi.fn())
 const mockIsHttpError = vi.hoisted(() => vi.fn())
+const mockCreateIsolatedRequester = vi.hoisted(() => vi.fn())
 
 vi.mock('@sanity/client', () => ({
   createClient: mockCreateClient,
@@ -22,6 +23,10 @@ vi.mock('../config/cli/cliUserConfig.js', () => ({
   getCliToken: mockGetCliToken,
 }))
 
+vi.mock('../request/createIsolatedRequester.js', () => ({
+  createIsolatedRequester: mockCreateIsolatedRequester,
+}))
+
 vi.mock('../util/generateHelpUrl.js', () => ({
   generateHelpUrl: mockGenerateHelpUrl,
 }))
@@ -30,6 +35,7 @@ describe('getGlobalCliClient', () => {
   beforeEach(() => {
     const mockRequester = {use: mockRequesterUse}
     mockRequesterClone.mockReturnValueOnce(mockRequester)
+    mockCreateIsolatedRequester.mockReturnValue(mockRequester)
   })
   afterEach(() => {
     vi.clearAllMocks()
@@ -160,6 +166,16 @@ describe('getGlobalCliClient', () => {
     )
   })
 
+  test('uses an isolated requester inside an execution context', async () => {
+    mockCreateClient.mockResolvedValue({})
+    mockGetCliToken.mockResolvedValue('stored-token')
+
+    await runWithCliExecutionContext({}, () => getGlobalCliClient({apiVersion: '2021-06-07'}))
+
+    expect(mockCreateIsolatedRequester).toHaveBeenCalledOnce()
+    expect(mockRequesterClone).not.toHaveBeenCalled()
+  })
+
   test('explicit client apiHost overrides invocation environment', async () => {
     mockCreateClient.mockResolvedValue({})
     mockGetCliToken.mockResolvedValue('stored-token')
@@ -183,6 +199,7 @@ describe('getProjectCliClient', () => {
   beforeEach(() => {
     const mockRequester = {use: mockRequesterUse}
     mockRequesterClone.mockReturnValueOnce(mockRequester)
+    mockCreateIsolatedRequester.mockReturnValue(mockRequester)
   })
   afterEach(() => {
     vi.clearAllMocks()

--- a/packages/@sanity/cli-core/src/__tests__/debug.test.ts
+++ b/packages/@sanity/cli-core/src/__tests__/debug.test.ts
@@ -1,0 +1,42 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {debug, subdebug} from '../_exports/debug.js'
+import {runWithCliExecutionContext} from '../executionContext.js'
+
+describe('debug', () => {
+  const originalEnabled = debug.enabled
+
+  afterEach(() => {
+    debug.enabled = originalEnabled
+    vi.restoreAllMocks()
+  })
+
+  test('does not write to host stderr inside an execution context', () => {
+    debug.enabled = true
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    runWithCliExecutionContext({}, () => debug('secret request body'))
+
+    expect(write).not.toHaveBeenCalled()
+  })
+
+  test('subdebug instances inherit execution-context suppression', () => {
+    const child = subdebug('test')
+    child.enabled = true
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    runWithCliExecutionContext({}, () => child('secret response body'))
+
+    expect(write).not.toHaveBeenCalled()
+  })
+
+  test('keeps regular CLI debug output unchanged', () => {
+    debug.enabled = true
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    debug('visible outside context')
+
+    expect(write).toHaveBeenCalledOnce()
+    expect(write.mock.calls[0][0]).toContain('visible outside context')
+  })
+})

--- a/packages/@sanity/cli-core/src/_exports/debug.ts
+++ b/packages/@sanity/cli-core/src/_exports/debug.ts
@@ -1,11 +1,21 @@
 import debugIt from 'debug'
 
+import {getCliExecutionContext} from '../executionContext.js'
+
 /**
  * `debug` instance for the CLI
  *
  * @internal
  */
 export const debug = debugIt('sanity:cli')
+
+const defaultLog: (...args: unknown[]) => void = debugIt.log
+debug.log = (...args: unknown[]) => {
+  // DEBUG belongs to the embedding process, not to an individual invocation.
+  // Suppress it inside the execution context so it cannot bypass output sinks or expose request details to unrelated host logs.
+  if (getCliExecutionContext()) return
+  defaultLog(...args)
+}
 
 /**
  * Get a `debug` instance which extends the CLI debug instance with the given namespace,

--- a/packages/@sanity/cli-core/src/apiClient.ts
+++ b/packages/@sanity/cli-core/src/apiClient.ts
@@ -11,6 +11,8 @@ import {
 } from '@sanity/client'
 
 import {getCliToken} from './config/cli/cliUserConfig.js'
+import {getCliExecutionContext} from './executionContext.js'
+import {createIsolatedRequester} from './request/createIsolatedRequester.js'
 import {generateHelpUrl} from './util/generateHelpUrl.js'
 import {getSanityUrl} from './util/getSanityUrl.js'
 import {isStaging} from './util/isStaging.js'
@@ -57,7 +59,8 @@ export async function getGlobalCliClient({
   unauthenticated,
   ...config
 }: GlobalCliClientOptions): Promise<SanityClient> {
-  const requester = defaultRequester.clone()
+  const context = getCliExecutionContext()
+  const requester = context ? createIsolatedRequester() : defaultRequester.clone()
   requester.use(authErrors())
 
   const apiHost = isStaging() ? STAGING_API_HOST : undefined
@@ -123,7 +126,8 @@ export async function getProjectCliClient({
   token: providedToken,
   ...config
 }: ProjectCliClientOptions): Promise<SanityClient> {
-  const requester = defaultRequester.clone()
+  const context = getCliExecutionContext()
+  const requester = context ? createIsolatedRequester() : defaultRequester.clone()
   requester.use(authErrors(config.projectId))
 
   const apiHost = isStaging() ? STAGING_API_HOST : undefined

--- a/packages/@sanity/cli-core/src/executionContext.ts
+++ b/packages/@sanity/cli-core/src/executionContext.ts
@@ -16,8 +16,11 @@ export type SanityEnvironment = 'production' | 'staging'
  *
  * - `token` takes precedence over `SANITY_AUTH_TOKEN` and the stored CLI
  *   config token, and never touches the process-wide token cache
+ * - the embedding process's `X_SANITY_LINEAGE` is never propagated to API
+ *   requests
  * - `stdout`/`stderr` receive the output that commands would otherwise write
  *   to the process streams
+ * - debug logging is disabled, even when the embedding process enables it
  * - interactivity checks report non-interactive, so commands fail fast with
  *   actionable errors instead of prompting
  * - project root resolution from the filesystem is disabled: commands never

--- a/packages/@sanity/cli-core/src/request/__tests__/createRequester.test.ts
+++ b/packages/@sanity/cli-core/src/request/__tests__/createRequester.test.ts
@@ -222,6 +222,22 @@ describe('#createRequester', () => {
     expect(mockGetIt).toHaveBeenCalledWith([httpErrorsResult, headersResult, promiseResult])
   })
 
+  test('disables debug inside a CLI execution context', async () => {
+    const httpErrorsResult = {id: 'httpErrors'}
+    const headersResult = {id: 'headers'}
+    const promiseResult = {id: 'promise'}
+
+    mockHttpErrors.mockReturnValue(httpErrorsResult)
+    mockHeaders.mockReturnValue(headersResult)
+    mockPromise.mockReturnValue(promiseResult)
+
+    const {runWithCliExecutionContext} = await import('../../executionContext.js')
+    runWithCliExecutionContext({}, () => createRequester())
+
+    expect(mockDebug).not.toHaveBeenCalled()
+    expect(mockGetIt).toHaveBeenCalledWith([httpErrorsResult, headersResult, promiseResult])
+  })
+
   test('customizes debug options', () => {
     mockHttpErrors.mockReturnValue({})
     mockHeaders.mockReturnValue({})

--- a/packages/@sanity/cli-core/src/request/createIsolatedRequester.ts
+++ b/packages/@sanity/cli-core/src/request/createIsolatedRequester.ts
@@ -1,0 +1,80 @@
+import {createRequire} from 'node:module'
+
+import {ClientError, isHttpError, ServerError} from '@sanity/client'
+import {getIt, type HttpContext, type Middleware, type Requester, type RequestOptions} from 'get-it'
+import {
+  agent,
+  headers,
+  jsonRequest,
+  jsonResponse,
+  observable,
+  progress,
+  retry,
+} from 'get-it/middleware'
+import {Observable} from 'rxjs'
+
+const requireFromHere = createRequire(import.meta.url)
+const clientPackage: unknown = requireFromHere('@sanity/client/package.json')
+const clientVersion =
+  typeof clientPackage === 'object' &&
+  clientPackage !== null &&
+  'version' in clientPackage &&
+  typeof clientPackage.version === 'string'
+    ? clientPackage.version
+    : 'unknown'
+
+/**
+ * Create the requester used by Sanity clients inside a CLI execution context.
+ *
+ * This mirrors the Node requester from `@sanity/client`, except that it has no
+ * debug or lineage middleware. The client requester's defaults cannot be
+ * safely reused here because they read `DEBUG` and `X_SANITY_LINEAGE` from the
+ * embedding process.
+ */
+export function createIsolatedRequester(): Requester {
+  return getIt([
+    retry({shouldRetry}),
+    headers({'User-Agent': `@sanity/client ${clientVersion}`}),
+    removeLineage(),
+    agent({keepAlive: true, maxSockets: 30, maxTotalSockets: 256}),
+    jsonRequest(),
+    jsonResponse(),
+    progress(),
+    httpErrors,
+    observable({implementation: Observable}),
+  ])
+}
+
+function removeLineage(): Middleware {
+  return {
+    processOptions(options: RequestOptions) {
+      const requestHeaders = {...options.headers}
+      for (const name of Object.keys(requestHeaders)) {
+        if (name.toLowerCase() === 'x-sanity-lineage') delete requestHeaders[name]
+      }
+      return {...options, headers: requestHeaders}
+    },
+  }
+}
+
+const httpErrors: Middleware = {
+  onResponse(response, context: HttpContext) {
+    if (response.statusCode >= 500) throw new ServerError(response)
+    if (response.statusCode >= 400) throw new ClientError(response, context)
+    return response
+  },
+}
+
+function shouldRetry(error: unknown, attempt: number, options: RequestOptions): boolean {
+  if (options.maxRetries === 0) return false
+
+  const isSafe = options.method === 'GET' || options.method === 'HEAD'
+  const uri = 'uri' in options && typeof options.uri === 'string' ? options.uri : options.url
+  const isQuery = uri.startsWith('/data/query')
+  const isRetriableResponse =
+    isHttpError(error) && [429, 502, 503].includes(error.response.statusCode)
+
+  return (isSafe || isQuery) && isRetriableResponse
+    ? true
+    : retry.shouldRetry(error, attempt, options)
+}

--- a/packages/@sanity/cli-core/src/request/createRequester.ts
+++ b/packages/@sanity/cli-core/src/request/createRequester.ts
@@ -4,6 +4,8 @@ import {up as packageUp} from 'empathic/package'
 import {getIt, type Requester} from 'get-it'
 import {debug, headers, httpErrors, promise} from 'get-it/middleware'
 
+import {getCliExecutionContext} from '../executionContext.js'
+
 let cachedPkg: {name: string; version: string} | undefined
 
 /**
@@ -60,7 +62,8 @@ export function createRequester(options?: {middleware?: MiddlewareOptions}): Req
   }
 
   // 3. debug
-  if (opts?.debug !== false) {
+  // A programmatic invocation must not inherit the embedding process's DEBUG setting or write request/response bodies outside its output sinks.
+  if (!getCliExecutionContext() && opts?.debug !== false) {
     const debugDefaults = {namespace: 'sanity:cli', verbose: true}
     const customDebug = typeof opts?.debug === 'object' ? opts.debug : {}
     middleware.push(debug({...debugDefaults, ...customDebug}))

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -86,7 +86,10 @@ describe('invokeSanityCli', () => {
   test('an allowed invocation does not consult or mutate representative host state', async () => {
     mockApi({apiVersion: CORS_API_VERSION, uri: `/projects/${projectId}/cors`})
       .matchHeader('authorization', 'Bearer invocation-token')
-      .reply(200, [corsOrigin('https://isolated.example.com')])
+      .reply(function () {
+        expect(this.req.headers['x-sanity-lineage']).toBeUndefined()
+        return [200, [corsOrigin('https://isolated.example.com')]]
+      })
 
     const globalRegistry = globalThis as Record<symbol, unknown>
     const previousTelemetry = globalRegistry[CLI_TELEMETRY_SYMBOL]
@@ -94,9 +97,11 @@ describe('invokeSanityCli', () => {
     globalRegistry[CLI_TELEMETRY_SYMBOL] = hostTelemetry
     const previousEnv = {
       authToken: process.env.SANITY_AUTH_TOKEN,
+      lineage: process.env.X_SANITY_LINEAGE,
       sanityEnv: process.env.SANITY_INTERNAL_ENV,
     }
     process.env.SANITY_AUTH_TOKEN = 'host-token'
+    process.env.X_SANITY_LINEAGE = 'host-lineage'
     process.env.SANITY_INTERNAL_ENV = 'staging'
 
     const cwd = vi.spyOn(process, 'cwd').mockImplementation(() => {
@@ -127,6 +132,7 @@ describe('invokeSanityCli', () => {
       expect(off).not.toHaveBeenCalledWith('SIGINT', expect.any(Function))
       expect(globalRegistry[CLI_TELEMETRY_SYMBOL]).toBe(hostTelemetry)
       expect(process.env.SANITY_AUTH_TOKEN).toBe('host-token')
+      expect(process.env.X_SANITY_LINEAGE).toBe('host-lineage')
       expect(process.env.SANITY_INTERNAL_ENV).toBe('staging')
     } finally {
       cwd.mockRestore()
@@ -137,6 +143,8 @@ describe('invokeSanityCli', () => {
       globalRegistry[CLI_TELEMETRY_SYMBOL] = previousTelemetry
       if (previousEnv.authToken === undefined) delete process.env.SANITY_AUTH_TOKEN
       else process.env.SANITY_AUTH_TOKEN = previousEnv.authToken
+      if (previousEnv.lineage === undefined) delete process.env.X_SANITY_LINEAGE
+      else process.env.X_SANITY_LINEAGE = previousEnv.lineage
       if (previousEnv.sanityEnv === undefined) delete process.env.SANITY_INTERNAL_ENV
       else process.env.SANITY_INTERNAL_ENV = previousEnv.sanityEnv
     }


### PR DESCRIPTION
Programmatic CLI usage (ex. run_sanity_cli) was inheriting the host's `DEBUG` env var and Sanity execution lineage (used to prevent infinitely recursive function invocations)

This updates the debug logger to check if it's running in a programmatic execution context, and disables debug loggic if that's the case.
Also changes how we instantiate the Sanity API client to not inherit the host's Sanity lineage value.

Practically neither of these matter for the MCP use case, but this is the right thing to do from a correctness standpoint. 

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request/debug behavior for embedded CLI only; regular CLI is unchanged, but incorrect isolation could still leak sensitive debug output or wrong lineage on API calls.
> 
> **Overview**
> Fixes programmatic CLI invocations (e.g. MCP via `runWithCliExecutionContext`) **leaking the embedding host’s `DEBUG` settings and `X_SANITY_LINEAGE`** into CLI behavior and API traffic.
> 
> **Debug:** The shared `sanity:cli` debug logger and `createRequester` **skip debug output/middleware** when an execution context is active, so verbose request/response logging cannot write to the host’s stderr or bypass invocation output sinks.
> 
> **API clients:** `getGlobalCliClient` / `getProjectCliClient` **use a new `createIsolatedRequester`** instead of cloning `@sanity/client`’s default requester in that context. The isolated stack mirrors the Node client requester but **omits debug/lineage middleware** and **strips `x-sanity-lineage` headers** so host lineage is not sent on API calls.
> 
> Execution-context docs and integration tests are updated to assert **no lineage header** and unchanged behavior for the normal `sanity` binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de084f33aa6ac43b650d448221bacdeabb3ecf8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->