### PR TITLE
feat(workbench): register tile view type

### DIFF
--- a/.changeset/tile-register-view-type.md
+++ b/.changeset/tile-register-view-type.md
@@ -1,0 +1,6 @@
+---
+'@sanity/cli': minor
+'@sanity/workbench-cli': minor
+---
+
+feat(workbench): register tile view type

--- a/packages/@sanity/cli/src/exports/runtime.ts
+++ b/packages/@sanity/cli/src/exports/runtime.ts
@@ -22,6 +22,10 @@ export type {
   ServiceContext,
   ServiceInfo,
   ServiceType,
+  TileComponent,
+  TileSize,
+  TileViewComponents,
+  TileViewProps,
   ViewComponentsByType,
 } from '@sanity/workbench-cli'
 export {unstable_defineService, unstable_defineView} from '@sanity/workbench-cli'

--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -314,6 +314,87 @@ describe('DefineAppInputSchema (build-time validation)', () => {
     expect(result.success).toBe(true)
   })
 
+  test('accepts a tile view declaration with a footprint size and optional priority', () => {
+    const parsed = DefineAppInputSchema.parse(
+      validInput({
+        views: [
+          {
+            name: 'agent-widget',
+            priority: 100,
+            size: 'large',
+            src: './src/tile.tsx',
+            title: 'Agent',
+            type: 'tile',
+          },
+        ],
+      }),
+    )
+    expect(parsed.views?.[0]).toEqual({
+      name: 'agent-widget',
+      priority: 100,
+      size: 'large',
+      src: './src/tile.tsx',
+      title: 'Agent',
+      type: 'tile',
+    })
+  })
+
+  test('requires a size on a tile view', () => {
+    const result = DefineAppInputSchema.safeParse(
+      validInput({
+        views: [{name: 'agent-widget', src: './src/tile.tsx', title: 'Agent', type: 'tile'}],
+      }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects an unknown tile size', () => {
+    const result = DefineAppInputSchema.safeParse(
+      validInput({
+        views: [
+          {name: 'agent-widget', size: 'huge', src: './src/tile.tsx', title: 'Agent', type: 'tile'},
+        ],
+      }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  test('accepts an `entry` alongside a tile view', () => {
+    const result = DefineAppInputSchema.safeParse(
+      validInput({
+        entry: './src/App.tsx',
+        views: [
+          {
+            name: 'agent-widget',
+            size: 'banner',
+            src: './src/tile.tsx',
+            title: 'Agent',
+            type: 'tile',
+          },
+        ],
+      }),
+    )
+    expect(result.success).toBe(true)
+  })
+
+  test('does not count a tile view toward the one-panel cap', () => {
+    const result = DefineAppInputSchema.safeParse(
+      validInput({
+        views: [
+          {name: 'feed', src: './src/panel.tsx', title: 'feed', type: 'panel'},
+          {
+            name: 'agent-widget',
+            size: 'small',
+            src: './src/tile.tsx',
+            title: 'Agent',
+            type: 'tile',
+          },
+        ],
+      }),
+    )
+    expect(result.success).toBe(true)
+  })
+
   test('rejects `entry` on a studio with a not-yet-implemented error', () => {
     const result = DefineAppInputSchema.safeParse(
       validInput({applicationType: 'studio', entry: './src/App.tsx'}),

--- a/packages/@sanity/workbench-cli/src/__tests__/defineView.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineView.test.ts
@@ -1,12 +1,18 @@
 import {type AssetSourceComponentProps} from '@sanity/types'
 import {describe, expect, expectTypeOf, test} from 'vitest'
 
-import {VIEW_CONTRACT_VERSION} from '../contract.js'
-import {type DefinedView, type PanelViewProps, unstable_defineView} from '../defineView.js'
+import {type TileSize, VIEW_CONTRACT_VERSION} from '../contract.js'
+import {
+  type DefinedView,
+  type PanelViewProps,
+  type TileViewProps,
+  unstable_defineView,
+} from '../defineView.js'
 
 const title = ({view}: PanelViewProps) => view.name
 const panel = ({view}: PanelViewProps) => view.name
 const assetSource = (props: AssetSourceComponentProps) => props.assetSource.name
+const tile = ({view}: TileViewProps) => view.size
 
 describe('unstable_defineView', () => {
   test('returns the view type, contract version, and the author components', () => {
@@ -78,5 +84,39 @@ describe('asset_source view', () => {
   test('rejects a panel component record for an asset_source view', () => {
     // @ts-expect-error — asset_source exposes only the `asset_source` slot.
     unstable_defineView('asset_source', {panel: () => null, title: () => null})
+  })
+})
+
+describe('tile view', () => {
+  test('returns the view type, contract version, and the author component', () => {
+    const view = unstable_defineView('tile', {tile})
+
+    expect(view.type).toBe('tile')
+    expect(view.version).toBe(VIEW_CONTRACT_VERSION)
+    expect(view.components.tile).toBe(tile)
+  })
+
+  test('narrows the component record and props (incl. footprint size) from the view type argument', () => {
+    const view = unstable_defineView('tile', {
+      tile: (props) => {
+        expectTypeOf(props).toEqualTypeOf<TileViewProps>()
+        expectTypeOf(props.view).toEqualTypeOf<{
+          name: string
+          size: TileSize
+          src: string
+          title: string
+          type: 'tile'
+        }>()
+        return null
+      },
+    })
+
+    expectTypeOf(view).toEqualTypeOf<DefinedView<'tile'>>()
+    expectTypeOf(view.components).toHaveProperty('tile')
+  })
+
+  test('rejects a panel component record for a tile view', () => {
+    // @ts-expect-error — tile exposes only the `tile` slot.
+    unstable_defineView('tile', {panel: () => null, title: () => null})
   })
 })

--- a/packages/@sanity/workbench-cli/src/_exports/index.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/index.ts
@@ -1,5 +1,5 @@
 export {resolveAppId} from '../appId.js'
-export type {InterfaceType, ServiceType} from '../contract.js'
+export type {InterfaceType, ServiceType, TileSize} from '../contract.js'
 export {isWorkbenchApp, unstable_defineApp, unstable_defineMediaLibrary} from '../defineApp.js'
 export type {
   DefineAppInput,
@@ -24,5 +24,8 @@ export type {
   PanelComponent,
   PanelViewComponents,
   PanelViewProps,
+  TileComponent,
+  TileViewComponents,
+  TileViewProps,
   ViewComponentsByType,
 } from '../defineView.js'

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-extension-artifacts.node.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/plugins/plugin-sanity-extension-artifacts.node.test.ts
@@ -100,6 +100,30 @@ describe('sanityExtensionArtifacts', () => {
     expect(picker).toContain('import.meta.hot.accept')
   })
 
+  it('emits a single render-contract artifact for a tile view', () => {
+    const root = makeRoot()
+    runConfigResolved(
+      sanityExtensionArtifacts({
+        artifacts: workbenchArtifacts({
+          views: [
+            {name: 'agent', size: 'large', src: './src/tile.tsx', title: 'agent', type: 'tile'},
+          ],
+        }),
+      }),
+      root,
+    )
+
+    // A tile exposes a single `tile` island.
+    const agentDir = path.join(root, '.sanity/federation/views/agent')
+    expect(fs.readdirSync(agentDir).toSorted()).toEqual(['tile.js'])
+
+    const tile = fs.readFileSync(path.join(agentDir, 'tile.js'), 'utf8')
+    expect(tile).toContain('import view from "../../../../src/tile.tsx"')
+    expect(tile).toContain('view.components["tile"]')
+    expect(tile).toContain('export function render(rootElement, props')
+    expect(tile).toContain('import.meta.hot.accept')
+  })
+
   it('writes nothing when no views are declared', () => {
     const root = makeRoot()
     runConfigResolved(sanityExtensionArtifacts({artifacts: workbenchArtifacts({views: []})}), root)

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -205,6 +205,49 @@ describe('deployWorkbenchApp', () => {
     expect(fields.map(([name]) => name)).toContain('tarball')
   })
 
+  test('sends a tile interface carrying its size + priority as metadata', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'}).mockResolvedValueOnce(undefined)
+
+    const tileApp = unstable_defineApp({
+      entry: './src/App.tsx',
+      organizationId: 'org-1',
+      slug: 'drop-desk',
+      title: 'Drop Desk',
+      views: [
+        {
+          name: 'agent',
+          priority: 100,
+          size: 'large',
+          src: './src/tile.tsx',
+          title: 'Agent',
+          type: 'tile',
+        },
+      ],
+    })
+
+    await deployWorkbenchApp({
+      app: tileApp,
+      applicationId: 'app_1',
+      isApp: true,
+      isAutoUpdating: false,
+      sourceDir: '/tmp/build/app',
+      title: 'Drop Desk',
+      version: '1.0.0',
+    })
+
+    const fields = appendedFields()
+    const interfaces = JSON.parse(String(fields.find(([name]) => name === 'interfaces')?.[1]))
+    // Brett owns `id`/`src`, so they're stripped; `size`/`priority` ride as metadata.
+    expect(interfaces).toContainEqual({
+      metadata: {priority: 100, size: 'large'},
+      moduleId: 'views/agent',
+      name: 'agent',
+      title: 'Agent',
+      type: 'tile',
+      version: '1.0.0',
+    })
+  })
+
   test('sends workspaces for a studio deployment', async () => {
     mockClient.request.mockResolvedValueOnce({id: 'dep_1'}).mockResolvedValueOnce(undefined)
 

--- a/packages/@sanity/workbench-cli/src/actions/deploy/viewDeployment.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/viewDeployment.ts
@@ -7,7 +7,7 @@ import {z} from 'zod/mini'
 const viewRecordSchema = z.looseObject({
   name: z.string().check(z.regex(/^[a-zA-Z0-9_-]+$/, 'View `name` must match /^[a-zA-Z0-9_-]+$/')),
   src: z.string(),
-  type: z.enum(['panel', 'asset_source']),
+  type: z.enum(['panel', 'asset_source', 'tile']),
 })
 
 /**

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/deriveInterfaces.test.ts
@@ -47,6 +47,51 @@ describe('deriveInterfaces', () => {
     ])
   })
 
+  test('maps tile views to tile interfaces, carrying size and priority metadata', () => {
+    const app = workbenchApp({
+      views: [
+        {
+          name: 'agent',
+          priority: 100,
+          size: 'large',
+          src: './src/Tile.tsx',
+          title: 'agent',
+          type: 'tile',
+        },
+      ],
+    })
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {
+        id: 'test-app-tile-agent',
+        metadata: {priority: 100, size: 'large'},
+        moduleId: 'views/agent',
+        name: 'agent',
+        src: './src/Tile.tsx',
+        title: 'agent',
+        type: 'tile',
+        version: '1',
+      },
+    ])
+  })
+
+  test('maps a tile view without priority to size-only metadata', () => {
+    const app = workbenchApp({
+      views: [{name: 'agent', size: 'small', src: './src/Tile.tsx', title: 'agent', type: 'tile'}],
+    })
+    expect(deriveInterfaces(app, {isApp: true})).toEqual([
+      {
+        id: 'test-app-tile-agent',
+        metadata: {size: 'small'},
+        moduleId: 'views/agent',
+        name: 'agent',
+        src: './src/Tile.tsx',
+        title: 'agent',
+        type: 'tile',
+        version: '1',
+      },
+    ])
+  })
+
   test('maps services to worker interfaces', () => {
     const app = workbenchApp({
       services: [{name: 'unread', src: './src/service.ts', title: 'unread', type: 'worker'}],

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/registry.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/registry.test.ts
@@ -151,6 +151,31 @@ describe('registerDevServer', () => {
     expect(getRegisteredServers()[0]).toMatchObject({id: 'app-abc', projectId: 'x1g7jygt'})
   })
 
+  test('forwards a tile interface with its size + priority metadata through a round-trip', () => {
+    const tile = {
+      id: 'test-app-tile-agent',
+      metadata: {priority: 100, size: 'large' as const},
+      moduleId: 'views/agent',
+      name: 'agent',
+      src: './src/tile.tsx',
+      title: 'Agent',
+      type: 'tile' as const,
+      version: '1',
+    }
+
+    registerDevServer({
+      host: 'localhost',
+      interfaces: [tile],
+      port: 3334,
+      type: 'coreApp',
+      workDir: '/tmp/project',
+    })
+
+    // The read-back parses through `devServerInterfaceSchema`, so the tile's
+    // metadata survives write → read intact.
+    expect(getRegisteredServers()[0]?.interfaces).toEqual([tile])
+  })
+
   test('omits optional metadata when not provided', () => {
     registerDevServer({host: 'localhost', port: 3334, type: 'studio', workDir: '/tmp/project'})
 

--- a/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/registry.ts
@@ -17,7 +17,7 @@ import {
 } from '@sanity/cli-core'
 import {z} from 'zod/mini'
 
-import {AppInterfaceMetadataSchema} from '../../contract.js'
+import {AppInterfaceMetadataSchema, TileInterfaceMetadataSchema} from '../../contract.js'
 import {canonicalizeWatchDir} from './canonicalizeWatchDir.js'
 import {getProcessStartTime, isOurProcess} from './processLiveness.js'
 
@@ -79,6 +79,11 @@ const devServerInterfaceSchema = z.discriminatedUnion('type', [
   }),
   z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('panel')}),
   z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('asset_source')}),
+  z.object({
+    ...interfaceBaseFields,
+    metadata: TileInterfaceMetadataSchema,
+    type: z.literal('tile'),
+  }),
   z.object({...interfaceBaseFields, metadata: z.null(), type: z.literal('worker')}),
 ])
 

--- a/packages/@sanity/workbench-cli/src/contract.ts
+++ b/packages/@sanity/workbench-cli/src/contract.ts
@@ -33,10 +33,23 @@ export interface ViewComponentBaseProps<TView> {
 export const VIEW_COMPONENTS = {
   asset_source: ['asset_source'],
   panel: ['title', 'panel'],
+  tile: ['tile'],
 } as const satisfies Record<string, readonly string[]>
 
 /** @public */
 export type InterfaceType = keyof typeof VIEW_COMPONENTS
+
+/**
+ * A tile's footprint family — the shape it occupies on the dashboard. Modelled
+ * on iOS WidgetKit families, not a linear scale: `banner` is full-width and
+ * shallow, which a `small`→`large` magnitude can't express. The host maps a
+ * family to a layout slot; the component reads it to render per footprint.
+ * @public
+ */
+export const TileSizeSchema = z.enum(['small', 'large', 'banner'])
+
+/** @public */
+export type TileSize = z.infer<typeof TileSizeSchema>
 
 /** @public */
 export type ServiceType = 'worker'
@@ -55,6 +68,21 @@ export const AppInterfaceMetadataSchema = z.object({
 export type AppInterfaceMetadata = z.infer<typeof AppInterfaceMetadataSchema>
 
 /**
+ * A tile's interface metadata: its footprint `size` and an optional `priority`
+ * the dashboard sorts on, ascending. Both are authored as top-level view fields
+ * (see {@link InterfaceDeclarationSchema}) but stored on the record as metadata.
+ * Mirrors `app`'s dock metadata; tile is the first view type to carry any.
+ * @internal
+ */
+export const TileInterfaceMetadataSchema = z.object({
+  priority: z.optional(z.number()),
+  size: TileSizeSchema,
+})
+
+/** @internal */
+export type TileInterfaceMetadata = z.infer<typeof TileInterfaceMetadataSchema>
+
+/**
  * The contract version each interface type advertises, so the host can check it
  * renders/runs what it expects.
  * @internal
@@ -63,6 +91,7 @@ const INTERFACE_CONTRACT_VERSIONS = {
   app: undefined,
   asset_source: VIEW_CONTRACT_VERSION,
   panel: VIEW_CONTRACT_VERSION,
+  tile: VIEW_CONTRACT_VERSION,
   worker: SERVICE_CONTRACT_VERSION,
 } as const
 
@@ -86,7 +115,8 @@ export function interfaceModuleId(type: string, name: string): string {
       return 'App'
     }
     case 'asset_source':
-    case 'panel': {
+    case 'panel':
+    case 'tile': {
       return `views/${name}`
     }
     case 'worker': {
@@ -126,10 +156,20 @@ const AssetSourceViewSchema = z.object({
   ...interfaceDeclarationFields('View'),
 })
 
+const TileViewSchema = z.object({
+  type: z.literal('tile'),
+  ...interfaceDeclarationFields('View'),
+  /** Sort position within its layout track, ascending. Optional. */
+  priority: z.optional(z.number()),
+  /** Footprint family the dashboard lays the tile out by. */
+  size: TileSizeSchema,
+})
+
 /** @internal */
 export const InterfaceDeclarationSchema = z.discriminatedUnion('type', [
   PanelViewSchema,
   AssetSourceViewSchema,
+  TileViewSchema,
 ])
 
 const WorkerServiceSchema = z.object({

--- a/packages/@sanity/workbench-cli/src/defineApp.ts
+++ b/packages/@sanity/workbench-cli/src/defineApp.ts
@@ -146,13 +146,19 @@ export type AssetSourceView = Extract<
   {type: 'asset_source'}
 >
 
+/** The `tile` variant of an app's `views`. @public */
+export type TileView = Extract<
+  NonNullable<z.output<typeof DefineAppInputSchema>['views']>[number],
+  {type: 'tile'}
+>
+
 /**
  * User-facing input for `unstable_defineApp`. Excludes the internal
  * `applicationType`, `isSingleton`, and `config` — validated by the schema but
  * not part of the public surface (Sanity-owned apps set them via
  * `@ts-expect-error`). A union: an app declares an app `entry` (navigable) or
- * panel `views`, never both — but an `asset_source` view is a separate kind and
- * may accompany either.
+ * panel `views`, never both — but `asset_source` and `tile` views are separate
+ * kinds and may accompany either.
  * @public
  */
 export type DefineAppInput = Omit<
@@ -161,7 +167,7 @@ export type DefineAppInput = Omit<
 > &
   (
     | {entry?: never; views?: NonNullable<z.output<typeof DefineAppInputSchema>['views']>}
-    | {entry?: string; views?: AssetSourceView[]}
+    | {entry?: string; views?: (AssetSourceView | TileView)[]}
   )
 
 /**

--- a/packages/@sanity/workbench-cli/src/defineView.ts
+++ b/packages/@sanity/workbench-cli/src/defineView.ts
@@ -2,6 +2,7 @@ import {type AssetSourceComponentProps} from '@sanity/types'
 
 import {
   type InterfaceType,
+  type TileSize,
   VIEW_CONTRACT_VERSION,
   type ViewComponent,
   type ViewComponentBaseProps,
@@ -56,12 +57,43 @@ export interface AssetSourceViewComponents {
 export type AssetSourceComponent = keyof AssetSourceViewComponents
 
 /**
+ * Props a tile component receives: its own interface record (name/src/title/
+ * type) plus its footprint `size`, so it can render per family. Mirrors the
+ * `tile` record the dashboard host renders from; drift is guarded by the stamped
+ * contract version. Placement `priority` is host-only metadata, not surfaced here.
+ * @public
+ */
+export type TileViewProps = ViewComponentBaseProps<{
+  name: string
+  size: TileSize
+  src: string
+  title: string
+  type: 'tile'
+}>
+
+/**
+ * The component slot a `tile` view exposes — a single island, typed with the
+ * tile props.
+ * @public
+ */
+export interface TileViewComponents {
+  tile: ViewComponent<TileViewProps>
+}
+
+/**
+ * A tile's view-component slot — the module-federation expose for its one island.
+ * @public
+ */
+export type TileComponent = keyof TileViewComponents
+
+/**
  * The components each interface type exposes, keyed by type.
  * @public
  */
 export interface ViewComponentsByType {
   asset_source: AssetSourceViewComponents
   panel: PanelViewComponents
+  tile: TileViewComponents
 }
 
 /**

--- a/packages/@sanity/workbench-cli/src/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/deriveInterfaces.ts
@@ -6,6 +6,7 @@ import {
   interfaceContractVersion,
   type InterfaceKind,
   interfaceModuleId,
+  type TileInterfaceMetadata,
 } from './contract.js'
 import {isWorkbenchApp} from './defineApp.js'
 
@@ -29,6 +30,7 @@ export type DerivedInterface =
   | (DerivedInterfaceBase & {metadata: null; type: 'asset_source'})
   | (DerivedInterfaceBase & {metadata: null; type: 'panel'})
   | (DerivedInterfaceBase & {metadata: null; type: 'worker'})
+  | (DerivedInterfaceBase & {metadata: TileInterfaceMetadata; type: 'tile'})
 
 /**
  * `appTitle` titles the app view where a deploy resolved one through `--title`;
@@ -62,9 +64,20 @@ export function deriveInterfaces(
   })
 
   return [
-    ...(app.views ?? []).map(
-      (view): DerivedInterface => ({...shared(view.type, view), metadata: null}),
-    ),
+    ...(app.views ?? []).map((view): DerivedInterface => {
+      // Tile is the only view type with interface metadata: its footprint `size`
+      // (required) and an optional sort `priority`. Both authored top-level.
+      if (view.type === 'tile') {
+        return {
+          ...shared(view.type, view),
+          metadata:
+            view.priority === undefined
+              ? {size: view.size}
+              : {priority: view.priority, size: view.size},
+        }
+      }
+      return {...shared(view.type, view), metadata: null}
+    }),
     ...(app.services ?? []).map(
       (service): DerivedInterface => ({...shared('worker', service), metadata: null}),
     ),

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -5,7 +5,7 @@ import {type AppVisibility, getGlobalCliClient} from '@sanity/cli-core'
 import {isStaging} from '@sanity/cli-core/util'
 import FormData from 'form-data'
 
-import {type AppInterfaceMetadata} from '../contract.js'
+import {type AppInterfaceMetadata, type TileInterfaceMetadata} from '../contract.js'
 import {APP_WORKBENCH_API_VERSION} from './apiVersion.js'
 
 export type ApplicationType = 'coreApp' | 'studio'
@@ -35,6 +35,7 @@ export type BrettInterface =
   | (BrettInterfaceBase & {metadata: null; type: 'asset_source'})
   | (BrettInterfaceBase & {metadata: null; type: 'panel'})
   | (BrettInterfaceBase & {metadata: null; type: 'worker'})
+  | (BrettInterfaceBase & {metadata: TileInterfaceMetadata; type: 'tile'})
 
 /** A studio workspace as Brett stores it. */
 export interface BrettWorkspace {


### PR DESCRIPTION
### Description

Registers `tile` as a workbench view type, so an app can author a dashboard widget with `unstable_defineView('tile', …)` and declare it in `unstable_defineApp`. A tile declares a required `size` footprint family (`small`, `large`, `banner`) that tells the dashboard how to lay it out, plus an optional `priority` for ordering. Both are stored as the interface's metadata; `size` is also passed to the component so it can render per footprint, while `priority` stays host-only. The authoring types are re-exported through `@sanity/cli` and `sanity`.

Resolves SDK-2226.

### Notes for release

Add a `tile` workbench view type: author dashboard widgets with `unstable_defineView('tile', …)`, with a required footprint `size` (`small` | `large` | `banner`) and optional `priority`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and schema extension with broad test coverage; no changes to auth, data handling, or existing panel/asset_source behavior beyond new tile paths.
> 
> **Overview**
> Adds **`tile`** as a workbench view type so apps can declare dashboard widgets via `unstable_defineView('tile', …)` and `unstable_defineApp` `views`.
> 
> Tile declarations require a footprint **`size`** (`small` | `large` | `banner`) and may set optional **`priority`**. **`size`** is passed into tile component props; **`priority`** is interface metadata only. Tiles can sit alongside an app **`entry`** and do not count toward the one-panel limit.
> 
> The change wires tiles through validation, **`deriveInterfaces`**, dev registry, deploy payloads, federation **`tile.js`** artifacts, and public exports on **`@sanity/workbench-cli`** / **`@sanity/cli`** runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd99446bfd03eeb01157a1004ac7418a9627cce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->