### PR TITLE
test(workbench): fix pre-existing type errors in test fixtures

### DIFF
--- a/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/__tests__/defineApp.test.ts
@@ -420,7 +420,7 @@ describe('DefineAppInputSchema (build-time validation)', () => {
 
 describe('type surface', () => {
   test('exposes title/icon/entry/organizationId/group/priority', () => {
-    expectTypeOf<DefineAppResult['name']>().toEqualTypeOf<string>()
+    expectTypeOf<DefineAppResult['slug']>().toEqualTypeOf<string>()
     expectTypeOf<DefineAppResult['title']>().toEqualTypeOf<string>()
     expectTypeOf<DefineAppResult['icon']>().toEqualTypeOf<string | undefined>()
     expectTypeOf<DefineAppResult['entry']>().toEqualTypeOf<string | undefined>()
@@ -437,8 +437,8 @@ describe('type surface', () => {
 })
 
 describe('interface union (entry vs views)', () => {
-  type Base = {name: string; organizationId: string; slug: string; title: string}
-  type PanelView = {name: string; src: string; type: 'panel'}
+  type Base = {organizationId: string; slug: string; title: string}
+  type PanelView = {name: string; src: string; title: string; type: 'panel'}
 
   test('allows an app entry without panel views', () => {
     expectTypeOf<Base & {entry: string}>().toExtend<DefineAppInput>()

--- a/packages/@sanity/workbench-cli/src/actions/build/vite/__tests__/workbench-vite-plugins.unit.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/build/vite/__tests__/workbench-vite-plugins.unit.test.ts
@@ -86,8 +86,8 @@ describe('workbenchVitePlugins', () => {
   })
 
   test('passes the declared views and services through to federation', async () => {
-    const views = [{name: 'feed', src: './src/panel.tsx', type: 'panel' as const}]
-    const services = [{name: 'sync', src: './src/sync.ts', type: 'worker' as const}]
+    const views = [{name: 'feed', src: './src/panel.tsx', title: 'feed', type: 'panel' as const}]
+    const services = [{name: 'sync', src: './src/sync.ts', title: 'sync', type: 'worker' as const}]
     await workbenchVitePlugins({
       cwd,
       entries: {relativeConfigLocation: null, relativeEntry: '../../src/App'},

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -22,7 +22,6 @@ vi.mock('tar-fs', () => ({pack: () => ({pipe: () => Readable.from(['tar'])})}))
 const mockClient = {request: vi.fn()}
 const app = unstable_defineApp({
   entry: './src/App.tsx',
-  name: 'drop-desk',
   organizationId: 'org-1',
   services: [{name: 'unread', src: './src/unread.ts', title: 'unread', type: 'worker'}],
   slug: 'drop-desk',

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/devTestHelpers.ts
@@ -69,10 +69,10 @@ export function createDevOptions(
  * flow reads (bound address, config, ws channel, lifecycle). */
 export function createMockViteServer({host, port = 3333}: {host?: string; port?: number} = {}) {
   return {
-    close: vi.fn().mockResolvedValue(),
+    close: vi.fn<() => Promise<void>>().mockResolvedValue(),
     config: {server: {host, port}},
     httpServer: {address: vi.fn().mockReturnValue({address: '127.0.0.1', family: 'IPv4', port})},
-    listen: vi.fn().mockResolvedValue(),
+    listen: vi.fn<() => Promise<void>>().mockResolvedValue(),
     ws: {on: vi.fn(), send: vi.fn()},
   }
 }
@@ -86,7 +86,7 @@ export function mockWorkbenchServer(
   } = {},
 ) {
   return {
-    close: vi.fn().mockResolvedValue(),
+    close: vi.fn<() => Promise<void>>().mockResolvedValue(),
     httpHost: 'localhost',
     workbenchAvailable: true,
     workbenchPort: 3333,

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/exposesSetId.test.ts
@@ -5,12 +5,18 @@ import {createExposesTracker, exposesSetId, trackExposesSet} from '../exposesSet
 import {type DevServerManifest} from '../registry.js'
 
 const panel = (name: string, src = `./src/${name}.tsx`): DevServerInterface => ({
+  id: `test-app-panel-${name}`,
+  metadata: null,
+  moduleId: `views/${name}`,
   name,
   src,
   title: name,
   type: 'panel',
 })
 const worker = (name: string, src = `./src/${name}.ts`): DevServerInterface => ({
+  id: `test-app-worker-${name}`,
+  metadata: null,
+  moduleId: `services/${name}`,
   name,
   src,
   title: name,

--- a/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/dev/__tests__/startDevManifestWatcher.test.ts
@@ -1,5 +1,6 @@
 import {afterEach, beforeEach, describe, expect, type Mock, test, vi} from 'vitest'
 
+import {type DevServerInterface} from '../deriveConfigs.js'
 import {startDevManifestWatcher} from '../startDevManifestWatcher.js'
 import {createMockOutput, FakeFsWatcher} from './devTestHelpers.js'
 
@@ -29,7 +30,7 @@ describe('startDevManifestWatcher', () => {
   let fakeWatcher: FakeFsWatcher
   let mockExtract: Mock<
     (params: {configPath: string; workDir: string}) => Promise<{
-      interfaces?: {name: string; src: string; type: string}[] | undefined
+      interfaces?: DevServerInterface[] | undefined
       manifest: unknown
     }>
   >
@@ -260,7 +261,17 @@ describe('startDevManifestWatcher', () => {
     const appManifest = {icon: '<svg/>', title: 'My App', version: '1'}
     // Interfaces ride alongside the manifest (not inside it) and re-sync on
     // every config edit.
-    const appInterfaces = [{name: 'feed', src: './src/FeedPanel.tsx', title: 'feed', type: 'panel'}]
+    const appInterfaces: DevServerInterface[] = [
+      {
+        id: 'sdk-app-panel-feed',
+        metadata: null,
+        moduleId: 'views/feed',
+        name: 'feed',
+        src: './src/FeedPanel.tsx',
+        title: 'feed',
+        type: 'panel',
+      },
+    ]
     mockFindProjectRoot.mockResolvedValue({
       directory: APP_WORK_DIR,
       path: APP_CONFIG_PATH,

--- a/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
+++ b/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
@@ -26,7 +26,7 @@ const mockClient = {request: vi.fn()}
 // A gzip stream is opaque to the service; a readable stands in for the tarball.
 const tarball = () => Readable.from(['remote']) as unknown as Gzip
 const interfaces: BrettInterface[] = [
-  {moduleId: 'App', name: 'app', title: 'App', type: 'app', version: '1.0.0'},
+  {metadata: null, moduleId: 'App', name: 'app', title: 'App', type: 'app', version: '1.0.0'},
 ]
 const workspaces: BrettWorkspace[] = [
   {


### PR DESCRIPTION
### Description

Fixes 19 pre-existing TypeScript errors in `@sanity/workbench-cli` test fixtures and mocks that surface on a fresh `pnpm check:types` but stay hidden because CI type-checks only source (via `tsconfig.lib.json`, which excludes `__tests__`) and the turbo cache serves a green result until it's busted.

The fixtures had drifted from the current types: an app `name` that is now `slug`, view declarations missing the required `title`, interface fixtures missing `metadata`/`id`/`moduleId`, a vitest `mockResolvedValue` arity change, and an `extractManifest` mock annotated with a simplified interface shape. This aligns them so `tsc --noEmit` passes cleanly (0 errors). Test-only — no runtime or behaviour change.

Resolves SDK-2235.

### Notes for release

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test files and mocks; no production runtime or API behavior is modified.
> 
> **Overview**
> Updates **`@sanity/workbench-cli`** test mocks and fixtures so they match current types and **`tsc --noEmit`** passes on test files (errors were hidden when CI only type-checks lib sources).
> 
> **`DefineApp` / app config:** Drops obsolete app **`name`** in favor of **`slug`**; type tests assert **`slug`** on **`DefineAppResult`** and require **`title`** on panel view shapes.
> 
> **Views, services, interfaces:** Federation and deploy tests add required **`title`** on view/service declarations; **`DevServerInterface`** / **`BrettInterface`** fixtures gain **`id`**, **`moduleId`**, and **`metadata`**.
> 
> **Mocks:** Vitest **`mockResolvedValue`** on server **`close`** / **`listen`** uses explicit **`vi.fn<() => Promise<void>>()`** typing; manifest watcher **`extract`** mock is typed with **`DevServerInterface[]`** instead of a simplified inline shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5a3fe2ee143487ee48922b1d61d0e2273791ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->