### PR TITLE
chore(deps): update tar to 7.5.22

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -140,7 +140,7 @@
     "skills": "^1.5.9",
     "smol-toml": "^1.6.1",
     "string-argv": "^0.3.2",
-    "tar": "^7.5.15",
+    "tar": "^7.5.18",
     "tar-fs": "catalog:",
     "tar-stream": "^3.2.0",
     "tinyglobby": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -718,8 +718,8 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       tar:
-        specifier: ^7.5.15
-        version: 7.5.16
+        specifier: ^7.5.18
+        version: 7.5.22
       tar-fs:
         specifier: 'catalog:'
         version: 3.1.3
@@ -9012,8 +9012,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -13243,7 +13243,7 @@ snapshots:
       get-it: 8.8.0
       json-stream-stringify: 3.1.6
       p-queue: 9.3.0
-      tar: 7.5.16
+      tar: 7.5.22
       tar-stream: 3.2.0
     transitivePeerDependencies:
       - bare-abort-controller
@@ -18264,7 +18264,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.16:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
### Description

Updates the CLI's direct `tar` dependency range to start at 7.5.18 and refreshes the lockfile to 7.5.22, resolving High-severity Dependabot alert #119.

The resolved 7.5.22 release also clears the newer Critical `GHSA-23hp-3jrh-7fpw` finding reported by `pnpm audit`.

### What to review

Please review the direct dependency range and lockfile-only tar update. No CLI source code changes are included.

### Testing

- `pnpm install --frozen-lockfile`
- `pnpm check:format`
- `pnpm check:types`
- `pnpm check:lint`
- `pnpm check:deps`
- `pnpm build:cli`
- `pnpm audit --audit-level high` confirms no tar advisory remains
- `pnpm test:unit --changed --bail=1` reached 561 passing tests before the existing ANSI snapshot mismatch in `formatDocumentValidation.test.ts`; the same failure reproduces on `origin/main`
- `pnpm test:integration --changed --bail=1` reached 123 passing tests before the existing unauthenticated `deploy.studio.external.test.ts` failure; the same failure reproduces on `origin/main`

### Notes for release

N/A: dependency security maintenance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch with no source changes; `tar` is used for archive extraction (e.g. remote templates) but the bump is a targeted security fix.
> 
> **Overview**
> Bumps the **`tar`** dependency for **`@sanity/cli`** from **`^7.5.15`** to **`^7.5.18`** and refreshes **`pnpm-lock.yaml`** so the tree resolves **`7.5.22`** (from **`7.5.16`**), including the copy pulled in by **`@sanity/export`**.
> 
> This is a lockfile-only security maintenance change to clear Dependabot **`#119`** and the **`GHSA-23hp-3jrh-7fpw`** advisory; no CLI source or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f1972a9bf7a1be722467016d3f6ad7b685fb1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->