### PR TITLE
ci: mark AI Growth issues done on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,3 +105,11 @@ jobs:
           repository_name: ${{ github.event.repository.name }}
           initial_state_id: 'c56956cd-c281-4ca5-889f-6189ce231a6d'
           done_state_id: '5a35b7bf-6d37-4cc2-854a-2f18d160e2e5'
+
+      - name: Mark AI Growth issues as done
+        uses: sanity-io/mark-issues-done-action@88e6a3e6bc5a9c86d45873c4dba3302a4cafcb65 # main
+        with:
+          linear_api_key: ${{ secrets.LINEAR_API_KEY }}
+          repository_name: ${{ github.event.repository.name }}
+          initial_state_id: 'f39e3f44-58e1-4c01-8cb7-8497b7f27e52'
+          done_state_id: 'c7fa599f-2b6e-4361-a229-d8db2a901f8a'


### PR DESCRIPTION
### Description

Add an AI Growth invocation of `mark-issues-done-action` to the post-release job while preserving the existing SDK invocation.

AI Growth issues linked to this repository move to `In Staging` when their pull requests merge, but the release workflow only queried the SDK team's `In Staging` status ID. As a result, production releases could complete successfully while AI Growth issues remained in staging.

This uses AI Growth's existing workflow status IDs:

- `In Staging`: `f39e3f44-58e1-4c01-8cb7-8497b7f27e52`
- `Done`: `c7fa599f-2b6e-4361-a229-d8db2a901f8a`

Tracks [AIGRO-5297](https://linear.app/sanity/issue/AIGRO-5297/address-the-linear-auto-close-workflow).

### What to review

Confirm that the new step runs only after a package is published, preserves the SDK close behavior, and uses the AI Growth status IDs already configured in other Sanity repositories.

### Testing

- `git diff --check`
- Parsed `.github/workflows/release.yml` successfully with Ruby's YAML parser
- No package changes; a changeset and CLI test suite are not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no runtime or application code impact; misconfigured Linear IDs would only affect issue automation.
> 
> **Overview**
> Extends the **post-release** job so AI Growth Linear issues linked to this repo are moved to **Done** after a successful publish, matching what the workflow already does for SDK issues.
> 
> A new step calls the same `sanity-io/mark-issues-done-action` with AI Growth **In Staging** (`f39e3f44-…`) and **Done** (`c7fa599f-…`) status IDs. The existing SDK step is unchanged; both run only when `needs.release.outputs.published == 'true'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c2808f9a162fbf317348f50f87dfc630f673ed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->