### PR TITLE
feat(cli): add sanity new --instructions for the full setup guide

### DIFF
--- a/.changeset/aigro-5295-new-instructions.md
+++ b/.changeset/aigro-5295-new-instructions.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': minor
+---
+
+feat(new): add `sanity new --instructions` to print the sanity.new setup guide verbatim

--- a/packages/@sanity/cli/src/commands/__tests__/new.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/new.test.ts
@@ -8,6 +8,7 @@ const mockRecordUnclaimedProject = vi.hoisted(() => vi.fn())
 const mockGetUnavailableScaffoldTarget = vi.hoisted(() => vi.fn())
 const mockInput = vi.hoisted(() => vi.fn())
 const mockScaffoldProject = vi.hoisted(() => vi.fn())
+const mockFetchNewInstructions = vi.hoisted(() => vi.fn())
 
 vi.mock(
   '@sanity/cli-core/SanityCommand',
@@ -22,6 +23,10 @@ vi.mock('../../services/mintProject.js', () => ({
 }))
 vi.mock('../../util/unclaimedProjects.js', () => ({
   recordUnclaimedProject: mockRecordUnclaimedProject,
+}))
+vi.mock('../../services/newInstructions.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../services/newInstructions.js')>()),
+  fetchNewInstructions: mockFetchNewInstructions,
 }))
 vi.mock('../../actions/scaffold/scaffoldProject.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../actions/scaffold/scaffoldProject.js')>()),
@@ -54,7 +59,18 @@ const result = {
   token: project.token,
 }
 
+const INSTRUCTIONS_MARKDOWN = [
+  '# Set up a Sanity project (mint and claim)',
+  '',
+  '## 1. Mint a project',
+  '',
+  '```sh',
+  'npx sanity@latest new "My Project" --yes',
+  '```',
+].join('\n')
+
 const {NewCommand} = await import('../new.js')
+const {InstructionsUnavailableError} = await import('../../services/newInstructions.js')
 
 function outputText(): string {
   return stripVTControlCharacters(vi.mocked(mocks.SanityCmdOutput.log).mock.calls.flat().join('\n'))
@@ -78,6 +94,7 @@ beforeEach(() => {
     frontendPath: '/tmp/project/web',
     studioPath: '/tmp/project/sanity',
   })
+  mockFetchNewInstructions.mockResolvedValue(INSTRUCTIONS_MARKDOWN)
   mocks.SanityCmdIsUnattended.mockReturnValue(true)
 })
 
@@ -207,6 +224,60 @@ describe('#new', () => {
     expect(outputLines()).toContain(`◇  Token: ${project.token}`)
     expect(outputLines()).toContain(`│  Claim link: ${project.claimUrl}`)
     expect(outputText()).toContain('Claim your project by 1 August 2026, 00:00 UTC')
+  })
+
+  test('--instructions prints the guide verbatim under a header and creates nothing', async () => {
+    await expect(NewCommand.run(['--instructions'])).resolves.toBeUndefined()
+
+    expect(outputText()).toBe(
+      `# Nothing has been created yet — follow these steps.\n\n${INSTRUCTIONS_MARKDOWN}`,
+    )
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+    expect(mockScaffoldProject).not.toHaveBeenCalled()
+    expect(mockRecordUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('--instructions skips the directory check that would otherwise block the command', async () => {
+    mockGetUnavailableScaffoldTarget.mockResolvedValue('sanity')
+
+    await expect(NewCommand.run(['--instructions'])).resolves.toBeUndefined()
+
+    expect(outputText()).toContain(INSTRUCTIONS_MARKDOWN)
+    expect(mockGetUnavailableScaffoldTarget).not.toHaveBeenCalled()
+  })
+
+  test('--instructions fails with the direct fetch fallback when sanity.new is unreachable', async () => {
+    mockFetchNewInstructions.mockRejectedValue(
+      new InstructionsUnavailableError('the server responded with HTTP 503'),
+    )
+
+    await expect(NewCommand.run(['--instructions'])).rejects.toMatchObject({
+      code: 'INSTRUCTIONS_UNAVAILABLE',
+      message: expect.stringContaining('the server responded with HTTP 503'),
+      suggestions: [
+        'Fetch them directly: curl -sSL https://sanity.new/llms.txt',
+        'Or open https://sanity.new in a browser',
+      ],
+    })
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  // In json mode oclif reports the error itself and sets a non-zero exit code rather than
+  // rejecting, so the observable contract is the failure plus doing neither of the two things.
+  test('--instructions cannot be combined with --json', async () => {
+    await NewCommand.run(['--instructions', '--json']).catch(() => null)
+
+    expect(process.exitCode).not.toBe(0)
+    expect(process.exitCode).toBeDefined()
+    expect(mockFetchNewInstructions).not.toHaveBeenCalled()
+    expect(mockMintUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  test('a project named "instructions" still mints, so the flag is the only guide path', async () => {
+    await NewCommand.run(['instructions', '--no-scaffold'])
+
+    expect(mockMintUnclaimedProject).toHaveBeenCalledWith({displayName: 'instructions'})
+    expect(mockFetchNewInstructions).not.toHaveBeenCalled()
   })
 
   test('refuses a non-empty Studio target before creating a project', async () => {

--- a/packages/@sanity/cli/src/commands/new.ts
+++ b/packages/@sanity/cli/src/commands/new.ts
@@ -16,6 +16,11 @@ import {
   STUDIO_ENV_FILE,
 } from '../actions/scaffold/scaffoldProject.js'
 import {type MintedProject, mintUnclaimedProject} from '../services/mintProject.js'
+import {
+  fetchNewInstructions,
+  INSTRUCTIONS_URL,
+  InstructionsUnavailableError,
+} from '../services/newInstructions.js'
 import {formatClaimDeadline} from '../util/formatClaimDeadline.js'
 import {CLAIM_WINDOW_HOURS, SANITY_NEW_URL} from '../util/mintProjectConstants.js'
 import {renderNewCommandSplash} from '../util/newCommandSplash.js'
@@ -23,6 +28,12 @@ import {recordUnclaimedProject} from '../util/unclaimedProjects.js'
 
 const DEFAULT_PROJECT_NAME = 'My Sanity project'
 const HELP_DESCRIPTION_WIDTH = 78
+
+/**
+ * Prepended to the fetched instructions so an agent cannot read this command's success as the
+ * project already existing. The only addition to an otherwise verbatim document.
+ */
+const INSTRUCTIONS_HEADER = '# Nothing has been created yet — follow these steps.'
 
 function formatHelpDescription(...paragraphs: string[]): string {
   return paragraphs
@@ -127,7 +138,7 @@ export class NewCommand extends SanityCommand<typeof NewCommand> {
       `and the access token saved in ./${STUDIO_ENV_FILE} and ./${FRONTEND_ENV_FILE}, because it ` +
       'can read and change everything in the project. Keep both env files out of git, and never ' +
       'put the token in code that runs in the browser.',
-    `Fetch ${SANITY_NEW_URL} for full instructions, or point your AI agent at it.`,
+    'Run this command with --instructions for the full agent setup guide.',
   )
 
   static override enableJsonFlag = true
@@ -153,9 +164,18 @@ export class NewCommand extends SanityCommand<typeof NewCommand> {
       command: '<%= config.bin %> <%= command.id %> --json',
       description: 'Create a project and print its details as JSON',
     },
+
+    {
+      command: '<%= config.bin %> <%= command.id %> --instructions',
+      description: 'Print the full setup guide for an AI agent, without creating anything',
+    },
   ]
 
   static override flags = {
+    instructions: Flags.boolean({
+      default: false,
+      description: `Print the full setup guide from ${SANITY_NEW_URL} and exit, creating nothing`,
+    }),
     scaffold: Flags.boolean({
       allowNo: true,
       default: true,
@@ -170,12 +190,30 @@ export class NewCommand extends SanityCommand<typeof NewCommand> {
 
   static override summary = `Create a Sanity project without an account, and claim it within ${CLAIM_WINDOW_HOURS} hours to keep it.`
 
-  public async run(): Promise<NewProjectResult> {
+  public async run(): Promise<NewProjectResult | undefined> {
     const {output} = this
     const json = this.jsonEnabled()
     const flow = createFlow(output.log)
     const invoked = [this.config.bin, ...(this.id?.split(':') ?? [])].join(' ')
     const cwd = process.cwd()
+
+    // Runs before every precondition and side effect: this flag creates nothing.
+    if (this.flags.instructions) {
+      // oclif's `exclusive` does not cover the json flag added by enableJsonFlag, so guard it here.
+      if (json) {
+        throw new CLIError('--instructions cannot be combined with --json.', {
+          code: 'INSTRUCTIONS_JSON_CONFLICT',
+          exit: exitCodes.USAGE_ERROR,
+          suggestions: [
+            `Run \`${invoked} --instructions\` for the setup guide as markdown`,
+            `Or run \`${invoked} --json\` to create a project and print its details as JSON`,
+          ],
+        })
+      }
+
+      await this.printInstructions()
+      return undefined
+    }
 
     const unavailableScaffoldTarget =
       !json && this.flags.scaffold ? await getUnavailableScaffoldTarget(cwd) : undefined
@@ -214,8 +252,12 @@ export class NewCommand extends SanityCommand<typeof NewCommand> {
       displayName = DEFAULT_PROJECT_NAME
     } else if (!displayName) {
       displayName =
-        (await input({default: DEFAULT_PROJECT_NAME, message: 'Project name'})).trim() ||
-        DEFAULT_PROJECT_NAME
+        (
+          await input({
+            default: DEFAULT_PROJECT_NAME,
+            message: 'Project name',
+          })
+        ).trim() || DEFAULT_PROJECT_NAME
     }
 
     const spin = json ? undefined : flow.spin('Creating your project...')
@@ -383,5 +425,30 @@ export class NewCommand extends SanityCommand<typeof NewCommand> {
     }
 
     return toResult(project)
+  }
+
+  /**
+   * Dumps the guide from sanity.new verbatim, so an agent gets the whole document rather than a
+   * summary produced by whatever fetched it.
+   */
+  private async printInstructions(): Promise<void> {
+    let instructions: string
+    try {
+      instructions = await fetchNewInstructions()
+    } catch (err) {
+      if (err instanceof InstructionsUnavailableError) {
+        throw new CLIError(err.message, {
+          code: 'INSTRUCTIONS_UNAVAILABLE',
+          exit: exitCodes.RUNTIME_ERROR,
+          suggestions: [
+            `Fetch them directly: curl -sSL ${INSTRUCTIONS_URL}`,
+            `Or open ${SANITY_NEW_URL} in a browser`,
+          ],
+        })
+      }
+      throw err
+    }
+
+    this.output.log(`${INSTRUCTIONS_HEADER}\n\n${instructions}`)
   }
 }

--- a/packages/@sanity/cli/src/services/__tests__/newInstructions.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/newInstructions.test.ts
@@ -1,0 +1,79 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {
+  fetchNewInstructions,
+  INSTRUCTIONS_URL,
+  InstructionsUnavailableError,
+} from '../newInstructions.js'
+
+const MARKDOWN = '# Set up a Sanity project (mint and claim)\n\n## 1. Mint a project\n'
+
+function mockFetch(response: Partial<Response> & Pick<Response, 'text'>): void {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue({ok: true, status: 200, ...response} as Response)
+}
+
+beforeEach(() => {
+  mockFetch({text: () => Promise.resolve(MARKDOWN)})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('fetchNewInstructions', () => {
+  test('requests markdown from the prerendered sanity.new route', async () => {
+    await fetchNewInstructions()
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://sanity.new/llms.txt',
+      expect.objectContaining({
+        headers: {Accept: 'text/markdown'},
+        method: 'GET',
+      }),
+    )
+    expect(INSTRUCTIONS_URL).toBe('https://sanity.new/llms.txt')
+  })
+
+  test('returns the document without reformatting its contents', async () => {
+    await expect(fetchNewInstructions()).resolves.toBe(MARKDOWN.trim())
+  })
+
+  test('rejects an HTTP error rather than returning an error page as instructions', async () => {
+    mockFetch({ok: false, status: 503, text: () => Promise.resolve('Service Unavailable')})
+
+    await expect(fetchNewInstructions()).rejects.toThrow(InstructionsUnavailableError)
+    await expect(fetchNewInstructions()).rejects.toThrow('the server responded with HTTP 503')
+  })
+
+  test('rejects HTML, which means the markdown route regressed to the landing page', async () => {
+    mockFetch({text: () => Promise.resolve('<!doctype html>\n<html lang="en">')})
+
+    await expect(fetchNewInstructions()).rejects.toThrow('HTML rather than markdown')
+  })
+
+  test('rejects an empty body', async () => {
+    mockFetch({text: () => Promise.resolve('   \n  ')})
+
+    await expect(fetchNewInstructions()).rejects.toThrow('the response was empty')
+  })
+
+  test('reports a timeout as a timeout', async () => {
+    const timeout = new Error('The operation was aborted due to timeout')
+    timeout.name = 'TimeoutError'
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(timeout)
+
+    await expect(fetchNewInstructions()).rejects.toThrow('the request timed out after 10 seconds')
+  })
+
+  test('reports a network failure with the underlying reason', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('getaddrinfo ENOTFOUND sanity.new'))
+
+    await expect(fetchNewInstructions()).rejects.toThrow('getaddrinfo ENOTFOUND sanity.new')
+  })
+
+  test('names the URL in every failure so the fallback is obvious', async () => {
+    mockFetch({ok: false, status: 500, text: () => Promise.resolve('')})
+
+    await expect(fetchNewInstructions()).rejects.toThrow(INSTRUCTIONS_URL)
+  })
+})

--- a/packages/@sanity/cli/src/services/newInstructions.ts
+++ b/packages/@sanity/cli/src/services/newInstructions.ts
@@ -1,0 +1,62 @@
+import {subdebug} from '@sanity/cli-core/debug'
+
+import {SANITY_NEW_URL} from '../util/mintProjectConstants.js'
+
+const debug = subdebug('new:instructions')
+
+const INSTRUCTIONS_TIMEOUT = 10_000
+
+/**
+ * Prerendered markdown route on sanity.new. Preferred over content negotiation on `/`, which
+ * depends on request headers and can fall through to the HTML page.
+ */
+export const INSTRUCTIONS_URL = `${SANITY_NEW_URL}/llms.txt`
+
+const HTML_PATTERN = /^\s*(?:<!doctype html|<html[\s>])/iu
+
+export class InstructionsUnavailableError extends Error {
+  constructor(reason: string) {
+    super(`Could not fetch the setup instructions from ${INSTRUCTIONS_URL}: ${reason}`)
+    this.name = 'InstructionsUnavailableError'
+  }
+}
+
+/**
+ * Fetches the agent setup instructions from sanity.new, which is the single source of truth for
+ * them. Deliberately not bundled with the CLI: a stale local copy is worse than a clear failure.
+ */
+export async function fetchNewInstructions(): Promise<string> {
+  debug('fetching instructions from %s', INSTRUCTIONS_URL)
+
+  let response: Response
+  try {
+    response = await fetch(INSTRUCTIONS_URL, {
+      headers: {Accept: 'text/markdown'},
+      method: 'GET',
+      signal: AbortSignal.timeout(INSTRUCTIONS_TIMEOUT),
+    })
+  } catch (err) {
+    const reason =
+      err instanceof Error && err.name === 'TimeoutError'
+        ? `the request timed out after ${INSTRUCTIONS_TIMEOUT / 1000} seconds`
+        : `${err instanceof Error ? err.message : err}`
+    throw new InstructionsUnavailableError(reason)
+  }
+
+  if (!response.ok) {
+    throw new InstructionsUnavailableError(`the server responded with HTTP ${response.status}`)
+  }
+
+  const body = (await response.text()).trim()
+
+  if (!body) {
+    throw new InstructionsUnavailableError('the response was empty')
+  }
+
+  if (HTML_PATTERN.test(body)) {
+    throw new InstructionsUnavailableError('the response was HTML rather than markdown')
+  }
+
+  debug('fetched %d characters', body.length)
+  return body
+}


### PR DESCRIPTION
### Description

When an agent is told to fetch sanity.new, it usually goes through a web fetch tool that hands the page to a small model with something like "what is this page about?" and passes the summary back. The setup guide is 200 lines of exact commands, flags and file paths, and none of that survives a summary, so the agent gets the setup wrong.

`sanity new --instructions` fetches https://sanity.new/llms.txt and prints it straight to stdout. Nothing summarises it on the way.

A few decisions worth knowing about:

- It's a flag on `new` rather than a subcommand. `sanity new instructions` would mint a project literally called "instructions" on any CLI released before this, because `new` takes a free text project name. The flag fails loudly instead.
- It fetches `/llms.txt` rather than `/` with an Accept header, as /llms.txt is prerendered and can't fall through to the HTML page.
- No bundled copy of the markdown. sanity.new stays the single source of truth and a stale copy shipped inside the CLI would be worse than a clear error, so a failed fetch gives you the URL and a curl command instead.
- One line is added above the document ("Nothing has been created yet") so an agent can't read the command succeeding as the project already existing. Everything else is verbatim.

Note: oclif's `exclusive` doesn't cover the `json` flag that `enableJsonFlag` injects, it silently accepted both, so `--instructions --json` is guarded by hand.

### What to review

- The short circuit in `run()` sits before the empty directory check and before minting. Worth confirming there's no path where `--instructions` creates anything.
- `newInstructions.ts` rejects HTML, empty bodies and HTTP errors. That's deliberately strict so a middleware regression on sanity.new surfaces as an error rather than garbage in an agent's context.
- `run()` return type widened to `NewProjectResult | undefined`. Nothing outside the command consumes it.

### Testing

8 unit tests on the service covering HTTP errors, HTML responses, empty bodies, timeouts and network failure, plus 5 on the command including one asserting a project named "instructions" still mints normally.

Ran against live sanity.new with `node ./bin/run.js new --instructions`, which prints the header then all 212 lines of the document.

Two things fail on origin/main as well and aren't from this change: the `formatDocumentValidation` snapshot tests, and one `check:types` error in `workbench-cli/src/defineView.ts`.

Related: https://linear.app/sanity/issue/AIGRO-5295

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI flag with early exit and no change to default project-creation flow; network fetch only affects the optional instructions path.
> 
> **Overview**
> Adds **`sanity new --instructions`**, which fetches `https://sanity.new/llms.txt` and prints the agent setup guide to stdout **without minting, scaffolding, or recording anything**. A single header line is prepended so agents do not treat a successful run as an existing project; the rest of the document is verbatim from the remote source (not bundled in the CLI).
> 
> The flag is handled **first** in `run()` (before empty-directory checks and project creation). **`--instructions` cannot be used with `--json`** (explicit guard because oclif does not treat the JSON flag as exclusive). Fetch failures surface as `INSTRUCTIONS_UNAVAILABLE` with curl/browser fallbacks.
> 
> New **`newInstructions`** service: GET with markdown accept, 10s timeout, and strict validation (HTTP errors, empty body, HTML mistaken for markdown). Help text now points agents to `--instructions` instead of only linking sanity.new.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc559eb83aca75bd0c619f75a33609f906bb9e6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->