### PR TITLE
fix(tokens): transparently resolve legacy token ids in tokens delete

### DIFF
--- a/.changeset/tokens-access-api.md
+++ b/.changeset/tokens-access-api.md
@@ -8,5 +8,4 @@ The `tokens create`, `tokens list` and `tokens delete` commands are now backed b
 
 - `tokens create --json`: read the secret from `.token` instead of `.key`
 - `tokens list --json`: roles now live in `.memberships[].roleNames` instead of `.roles[].name`; `createdBy`, `permissions`, `projectUserId` and `lastUsedAt` are no longer returned
-- `.id` is still the identifier to pass to `tokens delete`, but existing ids change with the backing API
 - `tokens list` shows role names instead of display titles, and no longer includes organization-managed tokens, which cannot be managed at project scope

--- a/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
+++ b/packages/@sanity/cli/src/commands/tokens/__tests__/delete.test.ts
@@ -247,12 +247,45 @@ describe('#tokens:delete', () => {
       uri: '/access/project/test-project/robots/nonexistent-token',
     }).reply(404, {message: 'Token not found'})
 
+    // A 404 triggers legacy token id resolution against the robots list
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      uri: '/access/project/test-project/robots',
+    }).reply(200, robotsPage([TEST_ROBOTS.API_TOKEN]))
+
     const {error} = await testCommand(DeleteTokensCommand, ['nonexistent-token', '--yes'], {
       mocks: defaultMocks,
     })
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toContain('Token with ID "nonexistent-token" not found')
     expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test('deletes by a legacy token id via the robot it belongs to', async () => {
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'delete',
+      uri: '/access/project/test-project/robots/token-api-123-active-token',
+    }).reply(404, {message: 'Robot not found'})
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      uri: '/access/project/test-project/robots',
+    }).reply(200, robotsPage([TEST_ROBOTS.API_TOKEN]))
+
+    mockApi({
+      apiVersion: TOKENS_API_VERSION,
+      method: 'delete',
+      uri: '/access/project/test-project/robots/token-api-123',
+    }).reply(204)
+
+    const {error, stdout} = await testCommand(
+      DeleteTokensCommand,
+      ['token-api-123-active-token', '--yes'],
+      {mocks: defaultMocks},
+    )
+    expect(error).toBeUndefined()
+    expect(stdout).toBe('API token deleted\n')
   })
 
   test('throws error when no tokens exist in project', async () => {

--- a/packages/@sanity/cli/src/services/__tests__/tokens.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/tokens.test.ts
@@ -1,6 +1,7 @@
 import {getGlobalCliClient} from '@sanity/cli-core'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
+import {httpError} from '../../../test/helpers/httpError.js'
 import {TOKENS_API_VERSION} from '../../actions/tokens/constants.js'
 import {type Membership, type Robot} from '../../actions/tokens/types.js'
 import {
@@ -134,10 +135,53 @@ describe('deleteToken', () => {
 
     await deleteToken({projectId: testProjectId, tokenId: 'robot-1'})
 
+    expect(mockRequest).toHaveBeenCalledTimes(1)
     expect(mockRequest).toHaveBeenCalledWith({
       method: 'DELETE',
       uri: `/access/project/${testProjectId}/robots/robot-1`,
     })
+  })
+
+  test('resolves a legacy token id to its robot on 404', async () => {
+    mockRequest
+      .mockRejectedValueOnce(httpError(404))
+      .mockResolvedValueOnce({data: [testRobot], nextCursor: null})
+      .mockResolvedValueOnce(undefined)
+
+    await deleteToken({projectId: testProjectId, tokenId: 'robot-1-active-token'})
+
+    expect(mockRequest).toHaveBeenNthCalledWith(1, {
+      method: 'DELETE',
+      uri: `/access/project/${testProjectId}/robots/robot-1-active-token`,
+    })
+    expect(mockRequest).toHaveBeenNthCalledWith(2, {
+      query: {},
+      uri: `/access/project/${testProjectId}/robots`,
+    })
+    expect(mockRequest).toHaveBeenNthCalledWith(3, {
+      method: 'DELETE',
+      uri: `/access/project/${testProjectId}/robots/robot-1`,
+    })
+  })
+
+  test('rethrows the 404 when no robot matches the legacy id', async () => {
+    mockRequest
+      .mockRejectedValueOnce(httpError(404))
+      .mockResolvedValueOnce({data: [testRobot], nextCursor: null})
+
+    await expect(deleteToken({projectId: testProjectId, tokenId: 'unknown-id'})).rejects.toThrow(
+      'HTTP 404',
+    )
+    expect(mockRequest).toHaveBeenCalledTimes(2)
+  })
+
+  test('does not attempt legacy resolution for non-404 errors', async () => {
+    mockRequest.mockRejectedValueOnce(httpError(403))
+
+    await expect(deleteToken({projectId: testProjectId, tokenId: 'robot-1'})).rejects.toThrow(
+      'HTTP 403',
+    )
+    expect(mockRequest).toHaveBeenCalledTimes(1)
   })
 
   test('propagates errors from the API', async () => {

--- a/packages/@sanity/cli/src/services/tokens.ts
+++ b/packages/@sanity/cli/src/services/tokens.ts
@@ -1,5 +1,5 @@
 import {getGlobalCliClient} from '@sanity/cli-core'
-import {type SanityClient} from '@sanity/client'
+import {isHttpError, type SanityClient} from '@sanity/client'
 
 import {TOKENS_API_VERSION} from '../actions/tokens/constants.js'
 import {
@@ -93,7 +93,9 @@ interface DeleteTokenOptions {
 /**
  * Delete a token from a project
  * @param options - The options for deleting a token from a project; `tokenId`
- * is the id reported by `getTokens`/`createToken`
+ * is the id reported by `getTokens`/`createToken`. Ids issued before the
+ * Access API migration are transparently resolved: they live on as the
+ * robot's `tokenId`, so a failed delete retries against the matching robot.
  * @returns A promise that resolves when the token is deleted
  *
  * @internal
@@ -103,10 +105,27 @@ export async function deleteToken(options: DeleteTokenOptions): Promise<void> {
 
   const client = await getClient()
 
-  return client.request({
-    method: 'DELETE',
-    uri: `/access/project/${projectId}/robots/${tokenId}`,
-  })
+  try {
+    return await client.request({
+      method: 'DELETE',
+      uri: `/access/project/${projectId}/robots/${tokenId}`,
+    })
+  } catch (error) {
+    if (!isHttpError(error) || error.statusCode !== 404) {
+      throw error
+    }
+
+    const robots = await fetchAllPages<Robot>(client, `/access/project/${projectId}/robots`)
+    const robot = robots.find((candidate) => candidate.tokenId === tokenId)
+    if (!robot) {
+      throw error
+    }
+
+    return await client.request({
+      method: 'DELETE',
+      uri: `/access/project/${projectId}/robots/${robot.id}`,
+    })
+  }
 }
 
 /**


### PR DESCRIPTION
### Description

Token ids issued before the Access API migration (#1646) live on as the robot's `tokenId` — verified against the API. `tokens delete` now resolves them transparently: on a 404 it looks the id up in the robots list and deletes the matching robot, so ids stored from earlier CLI versions keep working. Also trims the now-moot id caveat from the unreleased migration changeset.

### What to review

`deleteToken` in `services/tokens.ts` — the 404 fallback path.

### Testing

Service and command tests cover the fallback sequence, no-match rethrow, and non-404 passthrough. Verified live against staging with a token created through the legacy Projects API and deleted by its legacy id.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes API tokens via an extra list-and-match path on 404; wrong matching logic could delete the wrong robot, though scope is limited to failed direct deletes.
> 
> **Overview**
> **`tokens delete`** now accepts **pre–Access API token ids** without breaking scripts that still pass the old identifier.
> 
> `deleteToken` still deletes by the given id first; on **404** it loads the project robots, finds the robot whose **`tokenId`** matches, and deletes that robot instead. Non-404 errors skip the lookup. The unreleased migration changeset no longer warns that delete ids change with the new API.
> 
> Service and CLI delete tests cover the happy path, no matching robot (404 rethrown), and non-404 passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6df8e3c65b2ca50e981868a7b0496109c8d8cf72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->