### PR TITLE
feat: send deployment access array for workbench studios

### DIFF
--- a/.changeset/pr-1676.md
+++ b/.changeset/pr-1676.md
@@ -1,0 +1,7 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': minor
+'@sanity/workbench-cli': minor
+---
+
+feat: send deployment access array for workbench studios

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployStudio.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployStudio.test.ts
@@ -134,6 +134,34 @@ describe('deployStudio (federated studio)', () => {
     expect(target).not.toHaveProperty('slug')
   })
 
+  test('derives one deduped datasets access entry per unique workspace dataset', async () => {
+    // Two workspaces share proj-1.production; a third adds proj-1.staging.
+    vi.mocked(deployStudioSchemasAndManifests).mockResolvedValue({
+      workspaces: [
+        {dataset: 'production', projectId: 'proj-1'},
+        {dataset: 'production', projectId: 'proj-1'},
+        {dataset: 'staging', projectId: 'proj-1'},
+      ],
+    } as unknown as Awaited<ReturnType<typeof deployStudioSchemasAndManifests>>)
+
+    await deployStudio(deployOptions())
+
+    expect(mockDeployWorkbenchApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        access: [
+          {resourceId: 'proj-1.production', resourceType: 'dataset'},
+          {resourceId: 'proj-1.staging', resourceType: 'dataset'},
+        ],
+      }),
+    )
+  })
+
+  test('derives empty access when the manifest has no workspaces', async () => {
+    await deployStudio(deployOptions())
+
+    expect(mockDeployWorkbenchApp).toHaveBeenCalledWith(expect.objectContaining({access: []}))
+  })
+
   test('a taken slug blocks the deploy before anything is created', async () => {
     const options = deployOptions()
     // A real run exits inside output.error; throwing stands in for that, and

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -6,6 +6,7 @@ import {formatSchemaValidation, SchemaExtractionError} from '@sanity/cli-build/_
 import {exitCodes} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {
+  type BrettAccess,
   type BrettWorkspace,
   createStudio,
   deployWorkbenchApp,
@@ -194,6 +195,7 @@ async function runStudioDeployment(
     // build, so this only ships the deployment; plain studios use user-applications.
     if (workbench && !isExternal && organizationId && applicationId) {
       await deployWorkbenchApp({
+        access: toAccess(studioManifest),
         app: cliConfig.app,
         applicationId,
         icon: appIcon,
@@ -416,6 +418,19 @@ export default defineCliConfig({
   output.log(`\n${example}`)
 
   return location
+}
+
+/**
+ * One `datasets` access entry per unique workspace dataset, with a `resourceId`
+ * of `"<projectId>.<dataset>"`. Deduped, since workspaces can share a dataset.
+ */
+function toAccess(manifest: StudioManifest | null): BrettAccess[] {
+  const resourceIds = new Set(
+    (manifest?.workspaces ?? []).map((w) => `${w.projectId}.${w.dataset}`),
+  )
+  return [...resourceIds].map(
+    (resourceId) => ({resourceId, resourceType: 'dataset'}) satisfies BrettAccess,
+  )
 }
 
 function toWorkspaces(manifest: StudioManifest | null): BrettWorkspace[] {

--- a/packages/@sanity/workbench-cli/src/_exports/deploy.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/deploy.ts
@@ -14,6 +14,7 @@ export {getWorkbench} from '../actions/deploy/getWorkbench.js'
 export {type DeployedExpose, summarizeInterfaces} from '../actions/deploy/summarizeInterfaces.js'
 export {
   type Application,
+  type BrettAccess,
   type BrettWorkspace,
   getApplication,
   getApplicationUrl,

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -5,7 +5,7 @@ import FormData from 'form-data'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {unstable_defineApp} from '../../../defineApp.js'
-import {type BrettWorkspace} from '../../../services/applications.js'
+import {type BrettAccess, type BrettWorkspace} from '../../../services/applications.js'
 import {createCoreApp, createStudio, deployWorkbenchApp} from '../deployWorkbenchApp.js'
 
 vi.mock(import('@sanity/cli-core'), async (importOriginal) => ({
@@ -37,6 +37,7 @@ const workspaces: BrettWorkspace[] = [
     title: 'Default',
   },
 ]
+const access: BrettAccess[] = [{resourceId: 'proj-1.production', resourceType: 'dataset'}]
 const icon = '<svg viewBox="0 0 16 16"><path d="M2 2h12v12H2z"/></svg>'
 
 /** The (name, value) pairs a call appended to its FormData. */
@@ -262,6 +263,24 @@ describe('deployWorkbenchApp', () => {
     })
 
     expect(appendedFields()).toContainEqual(['workspaces', JSON.stringify(workspaces)])
+  })
+
+  test('forwards access to the deployment when provided', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'}).mockResolvedValueOnce(undefined)
+
+    await deployWorkbenchApp({
+      access,
+      app: {...app, entry: undefined},
+      applicationId: 'studio_1',
+      isApp: false,
+      isAutoUpdating: false,
+      sourceDir: '/tmp/build/studio',
+      title: 'My Studio',
+      version: '3.0.0',
+      workspaces,
+    })
+
+    expect(appendedFields()).toContainEqual(['access', JSON.stringify(access)])
   })
 
   test('syncs the title and icon after shipping the deployment', async () => {

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
@@ -7,6 +7,7 @@ import {pack} from 'tar-fs'
 
 import {deriveInterfaces} from '../../deriveInterfaces.js'
 import {
+  type BrettAccess,
   type BrettInterface,
   type BrettWorkspace,
   createApplication,
@@ -83,6 +84,7 @@ export async function createStudio(options: {
  * @internal
  */
 export async function deployWorkbenchApp(options: {
+  access?: readonly BrettAccess[]
   app: CliConfig['app']
   applicationId: string
   icon?: string
@@ -97,6 +99,7 @@ export async function deployWorkbenchApp(options: {
   workspaces?: readonly BrettWorkspace[]
 }): Promise<void> {
   const {
+    access,
     app,
     applicationId,
     icon,
@@ -115,6 +118,7 @@ export async function deployWorkbenchApp(options: {
   const spin = spinner(label).start()
   try {
     await createDeployment({
+      access,
       applicationId,
       // Brett assigns the id and resolves modules by `moduleId`, so neither travels.
       interfaces: deriveInterfaces(app, {appTitle: title, isApp}).map(

--- a/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
+++ b/packages/@sanity/workbench-cli/src/services/__tests__/applications.test.ts
@@ -6,6 +6,7 @@ import FormData from 'form-data'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {
+  type BrettAccess,
   type BrettInterface,
   type BrettWorkspace,
   createApplication,
@@ -38,6 +39,7 @@ const workspaces: BrettWorkspace[] = [
     title: 'Default',
   },
 ]
+const access: BrettAccess[] = [{resourceId: 'proj-1.production', resourceType: 'dataset'}]
 
 /** The (name, value) pairs a call appended to its FormData. */
 function appendedFields(): Array<[string, unknown]> {
@@ -202,6 +204,7 @@ describe('createDeployment', () => {
     expect(fields).toContainEqual(['interfaces', JSON.stringify(interfaces)])
     expect(fields.map(([name]) => name)).not.toContain('config')
     expect(fields.map(([name]) => name)).not.toContain('workspaces')
+    expect(fields.map(([name]) => name)).not.toContain('access')
   })
 
   test('includes workspaces as a JSON part when provided', async () => {
@@ -217,6 +220,36 @@ describe('createDeployment', () => {
     })
 
     expect(appendedFields()).toContainEqual(['workspaces', JSON.stringify(workspaces)])
+  })
+
+  test('includes access as a JSON part when provided', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'})
+
+    await createDeployment({
+      access,
+      applicationId: 'app_1',
+      interfaces,
+      isAutoUpdating: false,
+      tarball: tarball(),
+      version: '3.0.1',
+    })
+
+    expect(appendedFields()).toContainEqual(['access', JSON.stringify(access)])
+  })
+
+  test('omits the access part when the array is empty', async () => {
+    mockClient.request.mockResolvedValueOnce({id: 'dep_1'})
+
+    await createDeployment({
+      access: [],
+      applicationId: 'app_1',
+      interfaces,
+      isAutoUpdating: false,
+      tarball: tarball(),
+      version: '3.0.1',
+    })
+
+    expect(appendedFields().map(([name]) => name)).not.toContain('access')
   })
 })
 

--- a/packages/@sanity/workbench-cli/src/services/applications.ts
+++ b/packages/@sanity/workbench-cli/src/services/applications.ts
@@ -37,6 +37,15 @@ export type BrettInterface =
   | (BrettInterfaceBase & {metadata: null; type: 'worker'})
   | (BrettInterfaceBase & {metadata: TileInterfaceMetadata; type: 'tile'})
 
+/**
+ * A resource a deployment may interact with, as Brett stores it. Per-deployment
+ * and forbidden for singletons (the server 400s).
+ */
+export interface BrettAccess {
+  resourceId: string
+  resourceType: 'canvas' | 'dashboard' | 'dataset' | 'media-library'
+}
+
 /** A studio workspace as Brett stores it. */
 export interface BrettWorkspace {
   dataset: string
@@ -136,6 +145,7 @@ export async function updateApplication(
 
 /** Deploy a new active version to an existing application. */
 export async function createDeployment(options: {
+  access?: readonly BrettAccess[]
   applicationId: string
   interfaces: readonly BrettInterface[]
   isAutoUpdating: boolean
@@ -143,10 +153,10 @@ export async function createDeployment(options: {
   version: string
   workspaces?: readonly BrettWorkspace[]
 }): Promise<{id: string}> {
-  const {applicationId, interfaces, isAutoUpdating, tarball, version, workspaces} = options
+  const {access, applicationId, interfaces, isAutoUpdating, tarball, version, workspaces} = options
   const formData = new FormData()
   formData.append('isAutoUpdating', isAutoUpdating.toString())
-  appendDeploymentParts(formData, {interfaces, tarball, version, workspaces})
+  appendDeploymentParts(formData, {access, interfaces, tarball, version, workspaces})
   return request(`/applications/${applicationId}/deployments`, formData)
 }
 
@@ -163,11 +173,13 @@ export async function deleteApplication(applicationId: string): Promise<void> {
 function appendDeploymentParts(
   formData: FormData,
   {
+    access,
     interfaces,
     tarball,
     version,
     workspaces,
   }: {
+    access?: readonly BrettAccess[]
     interfaces: readonly BrettInterface[]
     tarball: Gzip
     version: string
@@ -178,6 +190,8 @@ function appendDeploymentParts(
   appendJson(formData, 'interfaces', interfaces)
   // Studio-only — the server rejects a workspaces part on non-studio types.
   if (workspaces?.length) appendJson(formData, 'workspaces', workspaces)
+  // Per-deployment; forbidden for singletons, so callers omit it there.
+  if (access?.length) appendJson(formData, 'access', access)
   formData.append('tarball', tarball, {contentType: 'application/gzip', filename: 'app.tar.gz'})
 }
 


### PR DESCRIPTION
### Description

Workbench studio deploys now declare which datasets the studio can interact with. The workbench deployment endpoint accepts an optional `access` array, but the CLI never sent it, so deployed studios shipped with no declared access. This derives that access automatically from the studio's workspaces — one `dataset` entry per unique `<projectId>.<dataset>` — and threads it through to the deployment POST, mirroring how `workspaces` already flows. coreApp and SDK apps send no `access` part, as their resource model isn't defined yet.

Resolves SDK-2241.

Needs https://github.com/sanity-io/brett/pull/557 to be released to production.

### Notes for release

Workbench studio deployments now send a declared dataset access array.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployment authorization metadata for hosted workbench studios; incorrect derivation could mis-declare dataset access, though scope is limited to the new optional field and studio-only path.
> 
> **Overview**
> Workbench **studio** deploys now declare which datasets the deployment may use by sending an optional **`access`** array on the Brett deployment POST, matching how **`workspaces`** already flows.
> 
> **`deployStudio`** derives that list from the uploaded studio manifest via new **`toAccess`**: one `resourceType: 'dataset'` entry per unique `projectId.dataset`, with duplicates across workspaces collapsed. An empty manifest yields **`access: []`**, which is not serialized on the wire.
> 
> **`@sanity/workbench-cli`** threads optional **`access`** through **`deployWorkbenchApp`** → **`createDeployment`** → multipart **`access`** JSON (omitted when empty). **`BrettAccess`** is exported from the deploy package. **coreApp** / SDK app deploy paths are unchanged and still send no **`access`** part.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1fa12638975c563f41d6ee4463d41aca07440a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->