### PR TITLE
fix(deploy): show schema extraction errors during studio deploy

### DIFF
--- a/.changeset/pr-1677.md
+++ b/.changeset/pr-1677.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(deploy): show schema extraction errors during studio deploy

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployStudio.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployStudio.test.ts
@@ -1,5 +1,5 @@
-import {type CliConfig, type Output} from '@sanity/cli-core'
 import {SchemaExtractionError} from '@sanity/cli-build/_internal/extract'
+import {type CliConfig, type Output} from '@sanity/cli-core'
 import {createStudio, deployWorkbenchApp, listApplications} from '@sanity/workbench-cli/deploy'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployStudio.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployStudio.test.ts
@@ -1,4 +1,5 @@
 import {type CliConfig, type Output} from '@sanity/cli-core'
+import {SchemaExtractionError} from '@sanity/cli-build/_internal/extract'
 import {createStudio, deployWorkbenchApp, listApplications} from '@sanity/workbench-cli/deploy'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -156,5 +157,23 @@ describe('deployStudio (federated studio)', () => {
     expect(error.mock.calls[0][0]).toContain('already exists at slug "my-studio"')
     expect(mockCreateStudio).not.toHaveBeenCalled()
     expect(mockBuildStudio).not.toHaveBeenCalled()
+  })
+
+  test('reports schema extraction errors without validation details', async () => {
+    const options = deployOptions()
+    vi.mocked(deployStudioSchemasAndManifests).mockRejectedValue(
+      new SchemaExtractionError('Workspace base paths must share the same first segment'),
+    )
+    const outputError = vi.mocked(options.output.error).mockImplementation((message) => {
+      throw new Error(String(message))
+    })
+
+    await expect(deployStudio(options)).rejects.toThrow(
+      'Workspace base paths must share the same first segment',
+    )
+    expect(outputError).toHaveBeenCalledWith(
+      expect.stringContaining('Workspace base paths must share the same first segment'),
+      {exit: 1},
+    )
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -338,8 +338,8 @@ async function uploadStudioSchema(
     )
   } catch (error) {
     deployDebug('Error deploying studio schemas and manifests', error)
-    if (error instanceof SchemaExtractionError) {
-      output.error(formatSchemaValidation(error.validation || []), {exit: 1})
+    if (error instanceof SchemaExtractionError && error.validation?.length) {
+      output.error(formatSchemaValidation(error.validation), {exit: 1})
     }
     output.error(`Error deploying studio schemas and manifests: ${error}`, {exit: 1})
   }

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -1836,6 +1836,51 @@ describe('#deploy studio', () => {
       expect(error?.oclif?.exit).toBe(1)
     })
 
+    test('should show the worker error when SchemaExtractionError has no validation details', async () => {
+      const cwd = await testFixture('basic-studio')
+      process.cwd = () => cwd
+
+      const projectId = 'test-project-id'
+      const studioHost = 'existing-studio'
+      const studioAppId = 'studio-app-id'
+
+      mockStudioWorkerTask.mockResolvedValue({
+        error: 'Workspace base paths must share the same first segment',
+        type: 'error',
+      })
+
+      mockApi({
+        apiVersion: USER_APPLICATIONS_API_VERSION,
+        query: {
+          appHost: studioHost,
+          appType: 'studio',
+        },
+        uri: `/projects/${projectId}/user-applications`,
+      }).reply(200, {
+        appHost: studioHost,
+        createdAt: '2024-01-01T00:00:00Z',
+        id: studioAppId,
+        projectId,
+        title: 'Existing Studio',
+        type: 'studio',
+        updatedAt: '2024-01-01T00:00:00Z',
+        urlType: 'internal',
+      })
+
+      const {error} = await testCommand(DeployCommand, [], {
+        config: {root: cwd},
+        mocks: {
+          cliConfig: {
+            api: {projectId},
+            studioHost,
+          },
+        },
+      })
+
+      expect(error?.message).toContain('Workspace base paths must share the same first segment')
+      expect(error?.oclif?.exit).toBe(1)
+    })
+
     test('should handle worker generic error', async () => {
       const cwd = await testFixture('basic-studio')
       process.cwd = () => cwd


### PR DESCRIPTION
## Summary

- Preserve schema validation output when validation details are available
- Surface the original schema extraction error when validation details are absent
- Add unit and integration coverage for schema extraction failures

## Testing

- Added Vitest unit and integration tests for deployment error handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI deploy error-handling only; behavior is narrower and more informative on failure with no security or data-path changes.
> 
> **Overview**
> **Studio deploy** no longer hides schema extraction failures when the worker returns an error message but no structured validation list.
> 
> The catch block in `deployStudio` only routes through `formatSchemaValidation` when `SchemaExtractionError` includes validation details; otherwise the deploy exits with the underlying error text (e.g. workspace base path rules). Unit and integration tests cover both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55470915462394cc8948df6e471892bec53f039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->