### PR TITLE
feat: add resource bindings script tag

### DIFF
--- a/.changeset/pr-1678.md
+++ b/.changeset/pr-1678.md
@@ -2,7 +2,6 @@
 ---
 '@sanity/cli-build': minor
 '@sanity/cli': minor
-'@sanity/workbench-cli': minor
 ---
 
 feat: add resource bindings script tag

--- a/.changeset/pr-1678.md
+++ b/.changeset/pr-1678.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-build': minor
+---
+
+feat: add resource bindings script tag

--- a/.changeset/pr-1678.md
+++ b/.changeset/pr-1678.md
@@ -1,6 +1,8 @@
 <!-- auto-generated -->
 ---
 '@sanity/cli-build': minor
+'@sanity/cli': minor
+'@sanity/workbench-cli': minor
 ---
 
 feat: add resource bindings script tag

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/DefaultDocument.tsx
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/DefaultDocument.tsx
@@ -151,6 +151,7 @@ export function DefaultDocument(props: DefaultDocumentProps): React.JSX.Element 
       </head>
       <body>
         <div id="sanity" />
+        <script type="application/json" id="sanity-resource-bindings">[]</script>
         <script src={entryPath} type="module" />
         <NoJavascript />
       </body>

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/DefaultDocument.tsx
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/DefaultDocument.tsx
@@ -151,7 +151,9 @@ export function DefaultDocument(props: DefaultDocumentProps): React.JSX.Element 
       </head>
       <body>
         <div id="sanity" />
-        <script type="application/json" id="sanity-resource-bindings">[]</script>
+        <script type="application/json" id="sanity-resource-bindings">
+          []
+        </script>
         <script src={entryPath} type="module" />
         <NoJavascript />
       </body>

--- a/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/DefaultDocument.tsx
+++ b/packages/@sanity/cli-build/src/actions/build/renderDocumentWorker/components/DefaultDocument.tsx
@@ -151,6 +151,8 @@ export function DefaultDocument(props: DefaultDocumentProps): React.JSX.Element 
       </head>
       <body>
         <div id="sanity" />
+        {/* Note: disable lint rule as brett depends on this specific ordering */}
+        {/* eslint-disable-next-line perfectionist/sort-jsx-props */}
         <script type="application/json" id="sanity-resource-bindings">
           []
         </script>

--- a/packages/@sanity/cli/test/integration/commands/build.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/build.studio.test.ts
@@ -81,6 +81,12 @@ describe('#build studio', {timeout: (platform() === 'win32' ? 120 : 60) * 1000},
     expect(files).toContain('index.html')
     expect(files).toContain('static')
 
+    // verify index.html contains `sanity-resource-bindings` script tag
+    const indexHtml = await readFile(join(outputFolder, 'index.html'), 'utf8')
+    expect(indexHtml).toContain(
+      '<script type="application/json" id="sanity-resource-bindings">[]</script>',
+    )
+
     // Federation artifacts should NOT be present when federation is not enabled
     expect(files).not.toContain('federation')
     expect(files).not.toContain('mf-manifest.json')

--- a/packages/@sanity/workbench-cli/src/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/deriveInterfaces.ts
@@ -78,10 +78,9 @@ export function deriveInterfaces(
       }
       return {...shared(view.type, view), metadata: null}
     }),
-    ...(app.services ?? []).map((service): DerivedInterface => ({
-      ...shared('worker', service),
-      metadata: null,
-    })),
+    ...(app.services ?? []).map(
+      (service): DerivedInterface => ({...shared('worker', service), metadata: null}),
+    ),
     ...(entry === undefined
       ? []
       : [

--- a/packages/@sanity/workbench-cli/src/deriveInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/deriveInterfaces.ts
@@ -78,9 +78,10 @@ export function deriveInterfaces(
       }
       return {...shared(view.type, view), metadata: null}
     }),
-    ...(app.services ?? []).map(
-      (service): DerivedInterface => ({...shared('worker', service), metadata: null}),
-    ),
+    ...(app.services ?? []).map((service): DerivedInterface => ({
+      ...shared('worker', service),
+      metadata: null,
+    })),
     ...(entry === undefined
       ? []
       : [


### PR DESCRIPTION
### Description

Small change to allow the deployment process to inject bindings into the index.html file that is rendered as part of the build.

See this [document](https://docs.google.com/document/d/13bfaSLYmxgGEol2Tn6jASJ4vq3Ed4N-kfZW_KIpu8g4/edit?usp=sharing) for details.

### Testing

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to the static HTML document template and a build assertion; no auth, data, or runtime logic changes.
> 
> **Overview**
> Adds a **deployment hook** in the built Studio `index.html`: a `<script type="application/json" id="sanity-resource-bindings">` block defaulting to `[]`, placed **immediately before** the main module entry script so deploy tooling can replace or inject resource bindings without changing app code.
> 
> Studio build integration tests now assert that `dist/index.html` includes that exact tag. `@sanity/cli` and `@sanity/cli-build` are bumped as a **minor** release via changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f89a34f2e2db70395f2cb5279e79489a1be55e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->