### PR TITLE
refactor: use exitCodes enum everywhere

### DIFF
--- a/packages/@sanity/cli-build/src/actions/build/__tests__/buildApp.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/buildApp.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {type Output} from '@sanity/cli-core/types'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -129,7 +130,7 @@ describe('#buildApp', () => {
 
     expect(output.error).toHaveBeenCalledWith(
       'Failed to find installed @sanity/sdk-react version',
-      {exit: 1},
+      {exit: exitCodes.RUNTIME_ERROR},
     )
   })
 
@@ -142,7 +143,7 @@ describe('#buildApp', () => {
 
     expect(output.error).toHaveBeenCalledWith(
       'Failed to build Sanity application: build static files error',
-      {exit: 1},
+      {exit: exitCodes.RUNTIME_ERROR},
     )
   })
 
@@ -189,7 +190,9 @@ describe('#buildApp', () => {
       }),
     )
 
-    expect(output.error).toHaveBeenCalledWith('Declined to continue with build', {exit: 1})
+    expect(output.error).toHaveBeenCalledWith('Declined to continue with build', {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   })
 
   test('should continue build when user confirms version diff prompt', async () => {

--- a/packages/@sanity/cli-build/src/actions/build/__tests__/checkStudioDependencyVersions.test.ts
+++ b/packages/@sanity/cli-build/src/actions/build/__tests__/checkStudioDependencyVersions.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {type Output} from '@sanity/cli-core/types'
 import {
   getLocalPackageVersion,
@@ -115,15 +116,15 @@ describe('checkStudioDependencyVersions', () => {
         expect.stringContaining(
           'The following package versions are no longer supported and needs to be upgraded:',
         ),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('react (installed: 16.14.0, want: ^19.2.2)'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('To upgrade, run either:'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
 
@@ -139,11 +140,11 @@ describe('checkStudioDependencyVersions', () => {
         expect.stringContaining(
           'The following package versions are no longer supported and needs to be upgraded:',
         ),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('react (installed: 18.2.0, want: ^19.2.2)'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
 
@@ -240,7 +241,7 @@ describe('checkStudioDependencyVersions', () => {
       // Should error about unsupported versions
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('react (installed: 16.14.0, want: ^19.2.2)'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
   })
@@ -275,7 +276,7 @@ describe('checkStudioDependencyVersions', () => {
       // Should still generate instructions even with invalid version range
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('To upgrade, run either:'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
       vi.mocked(coerce).mockReset()
     })
@@ -290,19 +291,19 @@ describe('checkStudioDependencyVersions', () => {
 
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('npm install "react@^19.2.2"'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('yarn add "react@^19.2.2"'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('pnpm add "react@^19.2.2"'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('Read more at https://www.sanity.io/docs/help/upgrade-packages'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
 
@@ -341,11 +342,11 @@ describe('checkStudioDependencyVersions', () => {
 
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('react (installed: 16.14.0, want: ^19.2.2)'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
       expect(mockOutput.error).toHaveBeenCalledWith(
         expect.stringContaining('react-dom (installed: 16.14.0, want: ^19.2.2)'),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
   })

--- a/packages/@sanity/cli-build/src/actions/build/buildApp.ts
+++ b/packages/@sanity/cli-build/src/actions/build/buildApp.ts
@@ -2,6 +2,7 @@ import {rm} from 'node:fs/promises'
 import path from 'node:path'
 import {styleText} from 'node:util'
 
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {getLocalPackageVersion} from '@sanity/cli-core/package-manager'
 import {getCliTelemetry} from '@sanity/cli-core/telemetry'
 import {type CliConfig, type Output, type UserViteConfig} from '@sanity/cli-core/types'
@@ -71,7 +72,9 @@ export async function buildApp(options: BuildOptions): Promise<void> {
   const installedSanityVersion = await getLocalPackageVersion('sanity', workDir)
 
   if (!installedSdkVersion) {
-    output.error(`Failed to find installed @sanity/sdk-react version`, {exit: 1})
+    output.error(`Failed to find installed @sanity/sdk-react version`, {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
     return
   }
 
@@ -82,7 +85,9 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     // Get the clean version without build metadata: https://semver.org/#spec-item-10
     const cleanSDKVersion = semverParse(installedSdkVersion)?.version
     if (!cleanSDKVersion) {
-      output.error(`Failed to parse installed SDK version: ${installedSdkVersion}`, {exit: 1})
+      output.error(`Failed to parse installed SDK version: ${installedSdkVersion}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
       return
     }
 
@@ -135,7 +140,7 @@ export async function buildApp(options: BuildOptions): Promise<void> {
         })
 
         if (!shouldContinue) {
-          output.error('Declined to continue with build', {exit: 1})
+          output.error('Declined to continue with build', {exit: exitCodes.RUNTIME_ERROR})
           return
         }
       } else {
@@ -228,6 +233,6 @@ export async function buildApp(options: BuildOptions): Promise<void> {
     trace.error(error)
     const message = error instanceof Error ? error.message : String(error)
     buildDebug(`Failed to build Sanity application`, {error})
-    output.error(`Failed to build Sanity application: ${message}`, {exit: 1})
+    output.error(`Failed to build Sanity application: ${message}`, {exit: exitCodes.RUNTIME_ERROR})
   }
 }

--- a/packages/@sanity/cli-build/src/actions/build/checkStudioDependencyVersions.ts
+++ b/packages/@sanity/cli-build/src/actions/build/checkStudioDependencyVersions.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {getLocalPackageVersion, readPackageJson} from '@sanity/cli-core/package-manager'
 import {type Output} from '@sanity/cli-core/types'
 import {coerce, gtr, ltr, rcompare, satisfies, type SemVer} from 'semver'
@@ -114,7 +115,7 @@ You _may_ encounter bugs while using these versions.
 
   ${getUpgradeInstructions(unsupported)}
 `,
-      {exit: 1},
+      {exit: exitCodes.RUNTIME_ERROR},
     )
   }
 }

--- a/packages/@sanity/cli-core/src/errors/NonInteractiveError.ts
+++ b/packages/@sanity/cli-core/src/errors/NonInteractiveError.ts
@@ -1,5 +1,7 @@
 import {CLIError} from '@oclif/core/errors'
 
+import {exitCodes} from '../exitCodes.js'
+
 /**
  * Error thrown when a prompt is attempted in a non-interactive environment
  * (e.g., CI, non-TTY, piped stdin). Callers can catch this specific error
@@ -12,7 +14,7 @@ export class NonInteractiveError extends CLIError {
     super(
       `Cannot run "${promptName}" prompt in a non-interactive environment. ` +
         'Provide the required value via flags or environment variables, or run in an interactive terminal.',
-      {code: 'NON_INTERACTIVE', exit: 1},
+      {code: 'NON_INTERACTIVE', exit: exitCodes.RUNTIME_ERROR},
     )
     this.name = 'NonInteractiveError'
   }

--- a/packages/@sanity/cli-core/src/errors/ProjectRootNotFoundError.ts
+++ b/packages/@sanity/cli-core/src/errors/ProjectRootNotFoundError.ts
@@ -1,5 +1,6 @@
 import {CLIError} from '@oclif/core/errors'
 
+import {exitCodes} from '../exitCodes.js'
 import {isRecord} from '../util/isRecord.js'
 
 /**
@@ -14,7 +15,11 @@ import {isRecord} from '../util/isRecord.js'
  */
 export class ProjectRootNotFoundError extends CLIError {
   constructor(message: string, options?: {cause?: Error; suggestions?: string[]}) {
-    super(message, {code: 'PROJECT_ROOT_NOT_FOUND', exit: 1, suggestions: options?.suggestions})
+    super(message, {
+      code: 'PROJECT_ROOT_NOT_FOUND',
+      exit: exitCodes.RUNTIME_ERROR,
+      suggestions: options?.suggestions,
+    })
     this.name = 'ProjectRootNotFoundError'
     if (options?.cause) {
       this.cause = options.cause

--- a/packages/@sanity/cli/src/actions/backup/assertDatasetExist.ts
+++ b/packages/@sanity/cli/src/actions/backup/assertDatasetExist.ts
@@ -1,4 +1,4 @@
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {type DatasetsResponse} from '@sanity/client'
 
 /**
@@ -17,7 +17,7 @@ export function assertDatasetExists(
   if (!exists) {
     output.error(
       `Dataset '${datasetName}' not found in this project. Available datasets: ${datasets.map((d) => d.name).join(', ')}`,
-      {exit: 1},
+      {exit: exitCodes.RUNTIME_ERROR},
     )
   }
 }

--- a/packages/@sanity/cli/src/actions/build/__tests__/shouldAutoUpdate.test.ts
+++ b/packages/@sanity/cli/src/actions/build/__tests__/shouldAutoUpdate.test.ts
@@ -1,4 +1,4 @@
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {beforeEach, describe, expect, it} from 'vitest'
 
 import {createMockOutput, workbenchApp} from '../../dev/__tests__/testHelpers.js'
@@ -131,7 +131,7 @@ describe('shouldAutoUpdate', () => {
 
       expect(mockOutput.error).toHaveBeenCalledWith(
         'Found both `autoUpdates` (deprecated) and `deployment.autoUpdates` in sanity.cli.js/.ts. Please remove the deprecated top level `autoUpdates` config.',
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
   })

--- a/packages/@sanity/cli/src/actions/build/buildStudio.ts
+++ b/packages/@sanity/cli/src/actions/build/buildStudio.ts
@@ -4,6 +4,7 @@ import {
   compareDependencyVersions,
   buildStudio as internalBuildStudio,
 } from '@sanity/cli-build/_internal/build'
+import {exitCodes} from '@sanity/cli-core'
 import {confirm, logSymbols, select, spinner} from '@sanity/cli-core/ux'
 import {buildAppId, resolveWorkbenchApp} from '@sanity/workbench-cli/build'
 
@@ -85,7 +86,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
           buildSpinner.fail()
         }
 
-        output.error(message, {exit: 1})
+        output.error(message, {exit: exitCodes.RUNTIME_ERROR})
       },
       onBuildStart({message}) {
         if (!buildSpinner) {
@@ -135,7 +136,7 @@ export async function buildStudio(options: BuildOptions): Promise<void> {
         })
 
         if (choice === 'cancel') {
-          output.error('Declined to continue with build', {exit: 1})
+          output.error('Declined to continue with build', {exit: exitCodes.RUNTIME_ERROR})
           return {stopBuild: true}
         }
 

--- a/packages/@sanity/cli/src/actions/build/eventListenerFactory.ts
+++ b/packages/@sanity/cli/src/actions/build/eventListenerFactory.ts
@@ -1,6 +1,6 @@
 import {styleText} from 'node:util'
 
-import {Output} from '@sanity/cli-core'
+import {exitCodes, Output} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 
 /**
@@ -15,16 +15,16 @@ export function checkDependenciesEventListenerFactory(output: Output) {
       output.warn(message)
     },
     onInvalidStyledComponentsVersionRange({message}: {message: string}) {
-      output.error(message, {exit: 1})
+      output.error(message, {exit: exitCodes.RUNTIME_ERROR})
     },
     onNoDeclaredStyledComponentsVersion({message}: {message: string}) {
-      output.error(message, {exit: 1})
+      output.error(message, {exit: exitCodes.RUNTIME_ERROR})
     },
     onNoInstalledSanityVersion({message}: {message: string}) {
-      output.error(message, {exit: 1})
+      output.error(message, {exit: exitCodes.RUNTIME_ERROR})
     },
     onNoInstalledStyledComponentsVersion({message}: {message: string}) {
-      output.error(message, {exit: 1})
+      output.error(message, {exit: exitCodes.RUNTIME_ERROR})
     },
   }
 }
@@ -48,14 +48,14 @@ export function preReleaseEventListenerFactory(output: Output) {
       })
 
       if (choice === 'cancel') {
-        output.error('Declined to continue with build', {exit: 1})
+        output.error('Declined to continue with build', {exit: exitCodes.RUNTIME_ERROR})
         return
       }
 
       output.warn('Auto-updates disabled for this build')
     },
     onPreReleaseInNonInteractiveAutoUpdate({message}: {message: string}) {
-      output.error(message, {exit: 1})
+      output.error(message, {exit: exitCodes.RUNTIME_ERROR})
     },
   }
 }

--- a/packages/@sanity/cli/src/actions/build/shouldAutoUpdate.ts
+++ b/packages/@sanity/cli/src/actions/build/shouldAutoUpdate.ts
@@ -1,6 +1,6 @@
 import {styleText} from 'node:util'
 
-import {type CliConfig, type Output} from '@sanity/cli-core'
+import {type CliConfig, exitCodes, type Output} from '@sanity/cli-core'
 import {isWorkbenchApp} from '@sanity/workbench-cli'
 
 import {type DeployFlags} from '../deploy/types.js'
@@ -135,7 +135,7 @@ export function shouldAutoUpdate({
 
   switch (issue?.type) {
     case 'conflicting-config': {
-      output.error(getAutoUpdateIssueMessage(issue), {exit: 1})
+      output.error(getAutoUpdateIssueMessage(issue), {exit: exitCodes.RUNTIME_ERROR})
       break
     }
     case 'deprecated-config': {

--- a/packages/@sanity/cli/src/actions/cors/filterAndValidateOrigin.ts
+++ b/packages/@sanity/cli/src/actions/cors/filterAndValidateOrigin.ts
@@ -1,4 +1,4 @@
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 
 const wildcardReplacement = 'a-wild-card-r3pl4c3m3n7-a'
 const portReplacement = ':7777777'
@@ -19,7 +19,9 @@ export async function filterAndValidateOrigin(
 
   // Special validation for file:// protocols
   if (/^file:\/\//.test(givenOrigin)) {
-    output.error('Only a local file wildcard is currently allowed: file:///*', {exit: 1})
+    output.error('Only a local file wildcard is currently allowed: file:///*', {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   }
 
   try {
@@ -43,7 +45,7 @@ export async function filterAndValidateOrigin(
     return `${parsed.protocol}//${host}`
   } catch {
     output.error(`Invalid origin "${givenOrigin}", must include protocol (https://some.host)`, {
-      exit: 1,
+      exit: exitCodes.RUNTIME_ERROR,
     })
   }
 }

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
@@ -1,5 +1,5 @@
 import {CLIError} from '@oclif/core/errors'
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {describe, expect, test, vi} from 'vitest'
 
 import {type DeploySpec, runDeploy} from '../deployRunner.js'
@@ -146,7 +146,9 @@ describe('runDeploy real deploy', () => {
     expect(payload.deployed).toBe(false)
     expect(payload.error.message).toContain('boom')
     // The envelope and the stderr message are the same diagnosis
-    expect(output.error).toHaveBeenCalledWith(payload.error.message, {exit: 1})
+    expect(output.error).toHaveBeenCalledWith(payload.error.message, {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   })
 
   test('without --json a failed deploy stays on stderr, with no envelope', async () => {
@@ -162,7 +164,9 @@ describe('runDeploy real deploy', () => {
     await runDeploy({...dryRunOptions(output), flags: {}} as DeployAppOptions, spec)
 
     expect(output.log).not.toHaveBeenCalled()
-    expect(output.error).toHaveBeenCalledWith(expect.stringContaining('boom'), {exit: 1})
+    expect(output.error).toHaveBeenCalledWith(expect.stringContaining('boom'), {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   })
 
   test('surfaces the server message on a rejected deploy, not a raw error dump', async () => {
@@ -190,7 +194,7 @@ describe('runDeploy real deploy', () => {
 
     expect(output.error).toHaveBeenCalledWith(
       'Error deploying application: You are not allowed to deploy this application as a singleton',
-      {exit: 1},
+      {exit: exitCodes.RUNTIME_ERROR},
     )
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployStudio.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployStudio.test.ts
@@ -1,5 +1,5 @@
 import {SchemaExtractionError} from '@sanity/cli-build/_internal/extract'
-import {type CliConfig, type Output} from '@sanity/cli-core'
+import {type CliConfig, exitCodes, type Output} from '@sanity/cli-core'
 import {createStudio, deployWorkbenchApp, listApplications} from '@sanity/workbench-cli/deploy'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -201,7 +201,7 @@ describe('deployStudio (federated studio)', () => {
     )
     expect(outputError).toHaveBeenCalledWith(
       expect.stringContaining('Workspace base paths must share the same first segment'),
-      {exit: 1},
+      {exit: exitCodes.RUNTIME_ERROR},
     )
   })
 })

--- a/packages/@sanity/cli/src/actions/deploy/createUserApplication.ts
+++ b/packages/@sanity/cli/src/actions/deploy/createUserApplication.ts
@@ -1,5 +1,5 @@
 import {CLIError} from '@oclif/core/errors'
-import {type AppVisibility} from '@sanity/cli-core'
+import {type AppVisibility, exitCodes} from '@sanity/cli-core'
 import {input, spinner} from '@sanity/cli-core/ux'
 import {customAlphabet} from 'nanoid'
 
@@ -79,7 +79,7 @@ export async function createStudioUserApplication(options: CreateStudioUserAppli
 
         deployDebug('Error creating user application', e)
         // otherwise, it's a fatal error
-        throw new CLIError('Error creating user application', {exit: 1})
+        throw new CLIError('Error creating user application', {exit: exitCodes.RUNTIME_ERROR})
       }
     },
   })

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -1,5 +1,5 @@
 import {CLIError} from '@oclif/core/errors'
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {type DeployedExpose} from '@sanity/workbench-cli/deploy'
 
@@ -120,7 +120,7 @@ function normalizeFailure(
 ): {exit: number; message: string} {
   // Ctrl+C on an interactive prompt isn't a real failure
   if (error instanceof Error && error.name === 'ExitPromptError') {
-    return {exit: 1, message: 'Deployment cancelled by user'}
+    return {exit: exitCodes.RUNTIME_ERROR, message: 'Deployment cancelled by user'}
   }
   // A failed check already carries its own message and exit code
   if (error instanceof CLIError) {
@@ -128,7 +128,7 @@ function normalizeFailure(
   }
   deployDebug(`Error deploying ${type === 'coreApp' ? 'application' : 'studio'}`, error)
   return {
-    exit: 1,
+    exit: exitCodes.RUNTIME_ERROR,
     message: `Error deploying ${type === 'coreApp' ? 'application' : 'studio'}: ${getErrorMessage(error)}`,
   }
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -341,14 +341,16 @@ async function uploadStudioSchema(
   } catch (error) {
     deployDebug('Error deploying studio schemas and manifests', error)
     if (error instanceof SchemaExtractionError && error.validation?.length) {
-      output.error(formatSchemaValidation(error.validation), {exit: 1})
+      output.error(formatSchemaValidation(error.validation), {exit: exitCodes.RUNTIME_ERROR})
     }
-    output.error(`Error deploying studio schemas and manifests: ${error}`, {exit: 1})
+    output.error(`Error deploying studio schemas and manifests: ${error}`, {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   }
 
   if (!studioManifest) {
     output.error('Failed to generate studio manifest. Please check your schemas and manifests.', {
-      exit: 1,
+      exit: exitCodes.RUNTIME_ERROR,
     })
   }
 

--- a/packages/@sanity/cli/src/actions/deploy/findUserApplication.ts
+++ b/packages/@sanity/cli/src/actions/deploy/findUserApplication.ts
@@ -4,7 +4,7 @@
  * and exits. Dry runs consume the same verdicts read-only (see deployChecks).
  */
 
-import {type CliConfig, type Output} from '@sanity/cli-core'
+import {type CliConfig, exitCodes, type Output} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {select, Separator, spinner} from '@sanity/cli-core/ux'
 
@@ -41,7 +41,7 @@ export async function findUserApplication(
   } catch (error) {
     spin.clear()
     deployDebug('Error finding user application for app', error)
-    output.error(describeAppTargetError(error, organizationId), {exit: 1})
+    output.error(describeAppTargetError(error, organizationId), {exit: exitCodes.RUNTIME_ERROR})
     return null
   }
 
@@ -65,7 +65,7 @@ export async function findUserApplication(
   // 'blocked' diagnoses as a skip (its root cause fails an earlier check), so it
   // needs an explicit exit here to not fall through to application creation
   if (resolution.type === 'blocked') {
-    output.error(resolution.message, {exit: 1})
+    output.error(resolution.message, {exit: exitCodes.RUNTIME_ERROR})
     return null
   }
   createFailFastReporter(output).report(describeAppTarget(resolution))
@@ -113,7 +113,9 @@ export async function findUserApplicationForStudio(
   } catch (error) {
     spin.fail()
     deployDebug('Error finding user application', error)
-    output.error(`Failed to resolve deploy target: ${getErrorMessage(error)}`, {exit: 1})
+    output.error(`Failed to resolve deploy target: ${getErrorMessage(error)}`, {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
     return {application: null, created: false}
   }
 
@@ -151,7 +153,7 @@ export async function findUserApplicationForStudio(
   // 'blocked' diagnoses as a skip (its root cause fails an earlier check), so it
   // needs an explicit exit here
   if (resolution.type === 'blocked') {
-    output.error(resolution.message, {exit: 1})
+    output.error(resolution.message, {exit: exitCodes.RUNTIME_ERROR})
     return {application: null, created: false}
   }
   createFailFastReporter(output).report(describeStudioTarget(resolution, {isExternal}))
@@ -200,14 +202,14 @@ async function createFromConfiguredHost({
     spin.fail()
     // if the name is taken, it should return a 409 so we relay to the user
     if ([402, 409].includes(e?.statusCode)) {
-      output.error(e?.response?.body?.message || 'Bad request', {exit: 1})
+      output.error(e?.response?.body?.message || 'Bad request', {exit: exitCodes.RUNTIME_ERROR})
       return null
     }
     // otherwise, it's a fatal error
     deployDebug('Error creating user application from config', e)
     output.error(
       `Error creating user application from config: ${e instanceof Error ? e.message : e}`,
-      {exit: 1},
+      {exit: exitCodes.RUNTIME_ERROR},
     )
     return null
   }

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/startAppDevServer.test.ts
@@ -1,4 +1,4 @@
-import {type CliConfig} from '@sanity/cli-core'
+import {type CliConfig, exitCodes} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {
@@ -58,7 +58,7 @@ describe('startAppDevServer', () => {
 
     expect(output.error).toHaveBeenCalledWith(
       expect.stringContaining('organization ID'),
-      expect.objectContaining({exit: 1}),
+      expect.objectContaining({exit: exitCodes.RUNTIME_ERROR}),
     )
     expect(result).toEqual({reason: 'missing-organization-id', started: false})
     expect(mockStartDevServer).not.toHaveBeenCalled()
@@ -70,7 +70,7 @@ describe('startAppDevServer', () => {
 
     expect(output.error).toHaveBeenCalledWith(
       expect.stringContaining('organization ID'),
-      expect.objectContaining({exit: 1}),
+      expect.objectContaining({exit: exitCodes.RUNTIME_ERROR}),
     )
     expect(result).toEqual({reason: 'missing-organization-id', started: false})
   })

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/startStudioDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/startStudioDevServer.test.ts
@@ -1,4 +1,4 @@
-import {type CliConfig} from '@sanity/cli-core'
+import {type CliConfig, exitCodes} from '@sanity/cli-core'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {
@@ -179,7 +179,7 @@ describe('startStudioDevServer', () => {
       )
 
       expect(output.error).toHaveBeenCalledWith('Project Id is required to load in dashboard', {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     })
 

--- a/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startAppDevServer.ts
@@ -1,5 +1,6 @@
 import {styleText} from 'node:util'
 
+import {exitCodes} from '@sanity/cli-core'
 import {isWorkbenchApp as determineIsWorkbenchApp} from '@sanity/workbench-cli'
 
 import {startDevServer} from '../../../server/devServer.js'
@@ -37,7 +38,7 @@ export async function startAppDevServer(options: DevActionOptions): Promise<Star
 
   if (!organizationId) {
     output.error(`Apps require an organization ID (orgId) specified in your sanity.cli.ts file`, {
-      exit: 1,
+      exit: exitCodes.RUNTIME_ERROR,
     })
     return {reason: 'missing-organization-id', started: false}
   }

--- a/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
@@ -5,7 +5,7 @@ import {
   checkStudioDependencyVersions,
   compareDependencyVersions,
 } from '@sanity/cli-build/_internal/build'
-import {getLocalPackageVersion, isInteractive} from '@sanity/cli-core'
+import {exitCodes, getLocalPackageVersion, isInteractive} from '@sanity/cli-core'
 import {confirm, logSymbols, spinner} from '@sanity/cli-core/ux'
 import {isWorkbenchApp} from '@sanity/workbench-cli'
 import {parse as semverParse} from 'semver'
@@ -114,7 +114,7 @@ export async function startStudioDevServer(
 
   if (loadInDashboard) {
     if (!projectId) {
-      output.error('Project Id is required to load in dashboard', {exit: 1})
+      output.error('Project Id is required to load in dashboard', {exit: exitCodes.RUNTIME_ERROR})
     }
 
     try {
@@ -122,7 +122,7 @@ export async function startStudioDevServer(
       organizationId = project.organizationId!
     } catch (error) {
       devDebug('Error getting organization id from project id', error)
-      output.error('Failed to get organization id from project id', {exit: 1})
+      output.error('Failed to get organization id from project id', {exit: exitCodes.RUNTIME_ERROR})
     }
   }
 

--- a/packages/@sanity/cli/src/actions/init/env/createOrAppendEnvVars.ts
+++ b/packages/@sanity/cli/src/actions/init/env/createOrAppendEnvVars.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {CLIError} from '@oclif/core/errors'
-import {Output} from '@sanity/cli-core'
+import {exitCodes, Output} from '@sanity/cli-core'
 
 import {VersionedFramework} from '../types.js'
 import {writeEnvVarsToFile} from './writeEnvVarsToFile.js'
@@ -42,6 +42,6 @@ export async function createOrAppendEnvVars({
     })
   } catch (err) {
     output.error(err)
-    throw new CLIError('An error occurred while creating .env', {exit: 1})
+    throw new CLIError('An error occurred while creating .env', {exit: exitCodes.RUNTIME_ERROR})
   }
 }

--- a/packages/@sanity/cli/src/actions/schema/extractSchema.ts
+++ b/packages/@sanity/cli/src/actions/schema/extractSchema.ts
@@ -6,7 +6,7 @@ import {
   SchemaExtractedTrace,
   SchemaExtractionError,
 } from '@sanity/cli-build/_internal/extract'
-import {getCliTelemetry, type Output} from '@sanity/cli-core'
+import {exitCodes, getCliTelemetry, type Output} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 
 import {schemasExtractDebug} from './utils/debug.js'
@@ -63,6 +63,8 @@ export async function extractSchema(options: ExtractSchemaActionOptions): Promis
       exit(1)
     }
 
-    output.error(err instanceof Error ? err.message : 'Failed to extract schema', {exit: 1})
+    output.error(err instanceof Error ? err.message : 'Failed to extract schema', {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   }
 }

--- a/packages/@sanity/cli/src/actions/schema/extractSchemaWatcher.ts
+++ b/packages/@sanity/cli/src/actions/schema/extractSchemaWatcher.ts
@@ -7,7 +7,7 @@ import {
   runSchemaExtraction,
   SchemaExtractionError,
 } from '@sanity/cli-build/_internal/extract'
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {spinner} from '@sanity/cli-core/ux'
 import {watch as chokidarWatch, type FSWatcher} from 'chokidar'
 import debounce from 'lodash-es/debounce.js'
@@ -136,7 +136,7 @@ export async function startExtractSchemaWatcher(
         output.log('')
         output.log(formatSchemaValidation(err.validation))
       } else if (err instanceof Error) {
-        output.error(err.message, {exit: 1})
+        output.error(err.message, {exit: exitCodes.RUNTIME_ERROR})
       }
 
       return false

--- a/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
@@ -91,7 +91,9 @@ describe('runUndeploy dry run', () => {
     expect(output.log).toHaveBeenCalledWith(
       expect.stringContaining('Failed to resolve undeploy target: network down'),
     )
-    expect(output.error).toHaveBeenCalledWith('Undeploy blocked by failing checks.', {exit: 1})
+    expect(output.error).toHaveBeenCalledWith('Undeploy blocked by failing checks.', {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   })
 })
 
@@ -192,7 +194,9 @@ describe('runUndeploy real run', () => {
       }),
     )
 
-    expect(output.error).toHaveBeenCalledWith('Error undeploying studio: boom', {exit: 1})
+    expect(output.error).toHaveBeenCalledWith('Error undeploying studio: boom', {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   })
 
   test('a failed config deletion is labeled as the installation config', async () => {
@@ -211,7 +215,7 @@ describe('runUndeploy real run', () => {
     )
 
     expect(output.error).toHaveBeenCalledWith('Error undeploying installation config: boom', {
-      exit: 1,
+      exit: exitCodes.RUNTIME_ERROR,
     })
   })
 
@@ -285,7 +289,9 @@ describe('runUndeploy --json', () => {
     const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
     expect(payload.undeployed).toBe(false)
     expect(payload.error.message).toContain('boom')
-    expect(output.error).toHaveBeenCalledWith(payload.error.message, {exit: 1})
+    expect(output.error).toHaveBeenCalledWith(payload.error.message, {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   })
 })
 

--- a/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
@@ -133,7 +133,9 @@ async function undeployApp(
     spin.fail()
     undeployDebug(`Error undeploying ${label}`, error)
     // Labeled here, where the target is known — `normalizeFailure` only sees the adapter type.
-    throw new CLIError(`Error undeploying ${label}: ${getErrorMessage(error)}`, {exit: 1})
+    throw new CLIError(`Error undeploying ${label}: ${getErrorMessage(error)}`, {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   }
   spin.succeed()
 
@@ -231,5 +233,8 @@ function normalizeFailure(
   }
   const label = type === 'coreApp' ? 'application' : 'studio'
   undeployDebug(`Error undeploying ${label}`, error)
-  return {exit: 1, message: `Error undeploying ${label}: ${getErrorMessage(error)}`}
+  return {
+    exit: exitCodes.RUNTIME_ERROR,
+    message: `Error undeploying ${label}: ${getErrorMessage(error)}`,
+  }
 }

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/copy.test.ts
@@ -181,7 +181,7 @@ describe('#dataset:copy', () => {
       await CopyDatasetCommand.run(['--list'])
       expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
         expect.stringMatching(/failed to list dataset copy jobs.*boom/i),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
   })
@@ -192,7 +192,7 @@ describe('#dataset:copy', () => {
 
       expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
         expect.stringMatching(/supply a valid jobId/i),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
     test('attaches to running job and shows progress', async () => {
@@ -222,7 +222,7 @@ describe('#dataset:copy', () => {
 
       expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
         expect.stringMatching(/failed to attach to copy.*boom/i),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
 
@@ -476,7 +476,7 @@ describe('#dataset:copy', () => {
 
       expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
         expect.stringMatching(/dataset copying failed: boom/i),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
 
@@ -487,7 +487,7 @@ describe('#dataset:copy', () => {
 
       expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
         expect.stringMatching(/failed to fetch datasets: boom/i),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
   })

--- a/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
+++ b/packages/@sanity/cli/src/commands/datasets/__tests__/import.test.ts
@@ -265,7 +265,7 @@ describe('#dataset:import', () => {
 
       expect(mocks.SanityCmdOutputError).toHaveBeenCalledWith(
         expect.stringContaining(`Failed to create dataset ${newDatasetName}`),
-        {exit: 1},
+        {exit: exitCodes.RUNTIME_ERROR},
       )
     })
 
@@ -276,7 +276,7 @@ describe('#dataset:import', () => {
       await ImportDatasetCommand.run(BASE_FLAGS)
 
       expect(mocks.SanityCmdOutputError).toHaveBeenCalledWith(expect.stringContaining(err), {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
     })
 
@@ -293,7 +293,7 @@ describe('#dataset:import', () => {
       await ImportDatasetCommand.run(BASE_FLAGS)
 
       expect(mocks.SanityCmdOutputError).toHaveBeenCalledWith(expect.stringContaining(err), {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       })
       // Verify clearInterval was called to clean up the spinInterval
       expect(clearIntervalSpy).toHaveBeenCalled()
@@ -311,7 +311,7 @@ describe('#dataset:import', () => {
       expect(mocks.SanityCmdOutputError).toHaveBeenCalledWith(
         expect.stringContaining(err.message),
         {
-          exit: 1,
+          exit: exitCodes.RUNTIME_ERROR,
         },
       )
     })

--- a/packages/@sanity/cli/src/commands/documents/__tests__/validate.test.ts
+++ b/packages/@sanity/cli/src/commands/documents/__tests__/validate.test.ts
@@ -50,7 +50,7 @@ describe('ValidateDocumentsCommand', () => {
 
     expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
       expect.stringContaining('must be run from within a Sanity project'),
-      {exit: 1},
+      {exit: exitCodes.RUNTIME_ERROR},
     )
   })
 
@@ -155,7 +155,9 @@ describe('ValidateDocumentsCommand', () => {
 
     await ValidateDocumentsCommand.run(['--file', ndjsonFilePath, '--dataset', dataset])
 
-    expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith('boom', {exit: 1})
+    expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith('boom', {
+      exit: exitCodes.RUNTIME_ERROR,
+    })
   })
 
   describe('bad flags', () => {

--- a/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/create.test.ts
@@ -100,7 +100,7 @@ describe('#projects:create', () => {
     expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
       expect.stringMatching(/Failed to retrieve an organization.*boom/i),
       {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       },
     )
   })
@@ -113,7 +113,7 @@ describe('#projects:create', () => {
     expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
       expect.stringMatching(/Failed to create project.*boom/i),
       {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       },
     )
   })

--- a/packages/@sanity/cli/src/commands/projects/__tests__/unclaimed.test.ts
+++ b/packages/@sanity/cli/src/commands/projects/__tests__/unclaimed.test.ts
@@ -1,5 +1,6 @@
 import {stripVTControlCharacters} from 'node:util'
 
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -294,7 +295,7 @@ describe('#projects:unclaimed', () => {
 
     expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
       expect.stringContaining('No local recovery record found for project "missing"'),
-      {exit: 1},
+      {exit: exitCodes.RUNTIME_ERROR},
     )
 
     expect(outputText()).not.toContain(robotToken)
@@ -310,7 +311,7 @@ describe('#projects:unclaimed', () => {
 
     expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith(
       expect.stringContaining('Could not read local unclaimed projects'),
-      {exit: 1},
+      {exit: exitCodes.RUNTIME_ERROR},
     )
 
     const errorCalls = vi.mocked(mocks.SanityCmdOutput.error).mock.calls.flat().join('\n')

--- a/packages/@sanity/cli/src/commands/schemas/__tests__/validate.test.ts
+++ b/packages/@sanity/cli/src/commands/schemas/__tests__/validate.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {mocks} from '@sanity/cli-test/mocks/cli-core/SanityCommand'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -25,7 +26,7 @@ describe('schema validate command', () => {
     mockValidateAction.mockRejectedValue(new Error('boom'))
     await SchemaValidate.run([])
     expect(mocks.SanityCmdOutput.error).toHaveBeenCalledWith('Error validating schema: boom', {
-      exit: 1,
+      exit: exitCodes.RUNTIME_ERROR,
     })
   })
 })

--- a/packages/@sanity/cli/src/commands/telemetry/__tests__/disable.test.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/__tests__/disable.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {createMockSanityCommand} from '../../../../test/mockSanityCommand.js'
@@ -52,7 +53,7 @@ describe('telemetry disable command', () => {
     await Disable.run([])
     expect(cmdMocks.SanityCmdOutputError).toHaveBeenCalledWith(
       'boom',
-      expect.objectContaining({exit: 1}),
+      expect.objectContaining({exit: exitCodes.RUNTIME_ERROR}),
     )
   })
 })

--- a/packages/@sanity/cli/src/commands/telemetry/__tests__/enable.test.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/__tests__/enable.test.ts
@@ -1,3 +1,4 @@
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {createMockSanityCommand} from '../../../../test/mockSanityCommand.js'
@@ -52,7 +53,7 @@ describe('telemetry enable command', () => {
     await Enable.run([])
     expect(cmdMocks.SanityCmdOutputError).toHaveBeenCalledWith(
       'boom',
-      expect.objectContaining({exit: 1}),
+      expect.objectContaining({exit: exitCodes.RUNTIME_ERROR}),
     )
   })
 })

--- a/packages/@sanity/cli/src/util/__tests__/checks.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/checks.test.ts
@@ -1,4 +1,4 @@
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {describe, expect, test, vi} from 'vitest'
 
 import {
@@ -21,7 +21,7 @@ describe('createFailFastReporter', () => {
   test('a fail without an exit code defaults to 1', () => {
     const output = mockOutput()
     createFailFastReporter(output).report({message: 'boom', status: 'fail'})
-    expect(output.error).toHaveBeenCalledWith('boom', {exit: 1})
+    expect(output.error).toHaveBeenCalledWith('boom', {exit: exitCodes.RUNTIME_ERROR})
   })
 
   test('a warn prints and does not exit', () => {
@@ -43,7 +43,7 @@ describe('createFailFastReporter', () => {
   test('a fail appends its solution to the message', () => {
     const output = mockOutput()
     createFailFastReporter(output).report({message: 'boom', solution: 'do X', status: 'fail'})
-    expect(output.error).toHaveBeenCalledWith('boom: do X', {exit: 1})
+    expect(output.error).toHaveBeenCalledWith('boom: do X', {exit: exitCodes.RUNTIME_ERROR})
   })
 
   test('a warn appends its solution to the message', () => {

--- a/packages/@sanity/cli/src/util/appId.ts
+++ b/packages/@sanity/cli/src/util/appId.ts
@@ -1,6 +1,6 @@
 import {styleText} from 'node:util'
 
-import {type CliConfig, type Output} from '@sanity/cli-core'
+import {type CliConfig, exitCodes, type Output} from '@sanity/cli-core'
 
 interface Options {
   cliConfig: CliConfig
@@ -54,7 +54,7 @@ export function checkForDeprecatedAppId({cliConfig, output}: Options): void {
 
 Please remove app.id from your sanity.cli.js or sanity.cli.ts file.`,
       {
-        exit: 1,
+        exit: exitCodes.RUNTIME_ERROR,
       },
     )
   }

--- a/packages/@sanity/cli/test/integration/actions/schema/extractSchemaWatcher.test.ts
+++ b/packages/@sanity/cli/test/integration/actions/schema/extractSchemaWatcher.test.ts
@@ -1,4 +1,4 @@
-import {type Output} from '@sanity/cli-core'
+import {exitCodes, type Output} from '@sanity/cli-core'
 import {testFixture} from '@sanity/cli-test'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
@@ -87,7 +87,7 @@ describe('extractSchemaWatcher', () => {
       watchPatterns: ['**/*.ts'],
     })
 
-    expect(output.error).toHaveBeenCalledWith('Fatal error', {exit: 1})
+    expect(output.error).toHaveBeenCalledWith('Fatal error', {exit: exitCodes.RUNTIME_ERROR})
   })
 
   test('close function closes the watcher', async () => {


### PR DESCRIPTION
Apparently #1570 only touched @sanity/cli and ignored everything else. This should address the "everywhere else" portion of the refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with no intended change to exit values (RUNTIME_ERROR remains 1); risk is limited to missed call sites still using literal `1`.
> 
> **Overview**
> Extends the **`exitCodes`** convention from `@sanity/cli-core` into **`@sanity/cli-build`** and the remaining **`@sanity/cli`** surfaces that still used literal **`{exit: 1}`** on `output.error`, `CLIError`, and shared error classes.
> 
> Production code now passes **`exitCodes.RUNTIME_ERROR`** for typical failure paths (build/deploy/dev, dataset ops, schema extract/watch, CORS, app ID checks, undeploy normalization, etc.). **`NonInteractiveError`** and **`ProjectRootNotFoundError`** use the same constant instead of hard-coded **`1`**.
> 
> Tests are updated to assert **`exitCodes.RUNTIME_ERROR`** (and import from **`@sanity/cli-core`** / **`ExitCodes`** where needed). Numeric exit behavior for those cases stays **1**; the change is naming and consistency with the documented exit-code scheme, not new semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 982474313b3bfc605e2b08dfa87aeb028a01229d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->