### PR TITLE
test: keep cli-core/ux test snapshots stable regardless of terminal color support

### DIFF
--- a/packages/@sanity/cli/src/actions/documents/validation/reporters/prettyReporter/__tests__/formatDocumentValidation.test.ts
+++ b/packages/@sanity/cli/src/actions/documents/validation/reporters/prettyReporter/__tests__/formatDocumentValidation.test.ts
@@ -11,6 +11,11 @@ vi.mock(import('node:tty'), async (importOriginal) => {
   }
 })
 
+// Keep snapshots stable regardless of terminal color support.
+vi.mock(import('@sanity/cli-core/ux'), () => ({
+  logSymbols: {error: '✖', info: 'ℹ', success: '✔', warning: '⚠'},
+}))
+
 describe('formatDocumentValidation', () => {
   it('formats a set of markers in to a printed tree, sorting markers, and adding spacing', () => {
     const result = formatDocumentValidation({
@@ -33,16 +38,16 @@ describe('formatDocumentValidation', () => {
     expect(result).toMatchInlineSnapshot(
       `
       "[ERROR] [person] my-document-id
-      │  (root) ........................ [31m✖[39m Top-level marker
-      │                                  [31m✖[39m 2nd top-level marker
-      ├─ foo ........................... [31m✖[39m Property marker
+      │  (root) ........................ ✖ Top-level marker
+      │                                  ✖ 2nd top-level marker
+      ├─ foo ........................... ✖ Property marker
       ├─ bar
-      │ └─ title ....................... [31m✖[39m Nested marker
-      │                                  [31m✖[39m 2nd nested marker
-      ├─ baz ........................... [31m✖[39m 2nd property marker
+      │ └─ title ....................... ✖ Nested marker
+      │                                  ✖ 2nd nested marker
+      ├─ baz ........................... ✖ 2nd property marker
       └─ beep
-        └─ boop ........................ [31m✖[39m Errors sorted first
-                                         [33m⚠[39m Warning"
+        └─ boop ........................ ✖ Errors sorted first
+                                         ⚠ Warning"
     `,
     )
   })
@@ -63,9 +68,9 @@ describe('formatDocumentValidation', () => {
     expect(result).toMatchInlineSnapshot(
       `
       "[ERROR] [person] my-document-id
-      └─ (root) ........................ [31m✖[39m Lone top-level marker (should get elbow)
-                                         [33m⚠[39m Warning, should come second
-                                         [34mℹ[39m 2nd top-level marker (should come last)"
+      └─ (root) ........................ ✖ Lone top-level marker (should get elbow)
+                                         ⚠ Warning, should come second
+                                         ℹ 2nd top-level marker (should come last)"
     `,
     )
   })


### PR DESCRIPTION
Keep `cli-core/ux` test snapshots stable, even when terminals don't support colors (or NO_COLOR is provided)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to mocks and snapshots; no runtime CLI validation formatting behavior is modified.
> 
> **Overview**
> **Stabilizes** `formatDocumentValidation` inline snapshots so they no longer depend on whether the terminal (or `NO_COLOR`) enables ANSI styling on `@sanity/cli-core/ux` log symbols.
> 
> Adds a Vitest mock of `@sanity/cli-core/ux` that returns fixed plain `logSymbols` (✖, ℹ, ✔, ⚠), alongside the existing `node:tty` `isatty` mock. Inline expectations are updated to match uncolored output instead of embedded escape sequences like `[31m✖[39m`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c1056e2cbacde23c8ea04f3d845831232f26b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->