### PR TITLE
test: fix EMFILE errors when running tests on macOS

### DIFF
--- a/packages/@sanity/cli/vitest.config.integration.ts
+++ b/packages/@sanity/cli/vitest.config.integration.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     },
     disableConsoleIntercept: true, // helps oclif test helpers
     env: {
+      // Fix EMFILE errors on macOS
+      ...(process.platform === 'darwin' ? {CHOKIDAR_USEPOLLING: '1'} : {}),
       OCLIF_TEST_ROOT: 'packages/@sanity/cli',
     },
     environment: 'node',


### PR DESCRIPTION
Fix EMFILE errors from not enough available file descriptors when running tests on macOS by enabling Chokidar polling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Vitest env tweak scoped to macOS; no production or runtime behavior changes.
> 
> **Overview**
> Integration tests for `@sanity/cli` were hitting **EMFILE** (too many open file descriptors) on macOS when file watchers piled up during the Vitest run.
> 
> The integration Vitest config now sets **`CHOKIDAR_USEPOLLING=1`** in `test.env`, but **only when `process.platform === 'darwin'`**, so Chokidar uses polling instead of native watchers and descriptor pressure stays lower. Other platforms are unchanged; existing env such as `OCLIF_TEST_ROOT` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a3bdfa8c308b823cd61539bf0061d8fde24abd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->