### PR TITLE
feat(assets): add local asset upload command

### DIFF
--- a/.changeset/assets-upload.md
+++ b/.changeset/assets-upload.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': minor
+---
+
+feat(assets): add `sanity assets upload` for uploading a local image or file to a dataset

--- a/packages/@sanity/cli/src/actions/assets/__tests__/uploadAssetFromFile.test.ts
+++ b/packages/@sanity/cli/src/actions/assets/__tests__/uploadAssetFromFile.test.ts
@@ -1,0 +1,121 @@
+import {open} from 'node:fs/promises'
+import {Readable} from 'node:stream'
+
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {AssetFileError} from '../assetFileError.js'
+import {uploadAssetFromFile} from '../uploadAssetFromFile.js'
+
+const mockUploadAsset = vi.hoisted(() => vi.fn())
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs/promises')>()),
+  open: vi.fn(),
+}))
+
+vi.mock('../../../services/assets.js', () => ({uploadAsset: mockUploadAsset}))
+
+const mockOpen = vi.mocked(open)
+
+function createFileHandle({isFile = true, size = 123} = {}) {
+  const fileStream = new Readable({read() {}})
+  return {
+    fileHandle: {
+      close: vi.fn().mockResolvedValue(undefined),
+      createReadStream: vi.fn().mockReturnValue(fileStream),
+      stat: vi.fn().mockResolvedValue({isFile: () => isFile, size}),
+    },
+    fileStream,
+  }
+}
+
+describe('uploadAssetFromFile', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('uploads from the same file handle used to determine the size', async () => {
+    const {fileHandle, fileStream} = createFileHandle()
+    const asset = {_id: 'image-abc-1x1-png'}
+    mockOpen.mockResolvedValue(fileHandle as never)
+    mockUploadAsset.mockResolvedValue(asset)
+
+    await expect(
+      uploadAssetFromFile({
+        assetType: 'image',
+        contentType: 'image/png',
+        dataset: 'production',
+        filename: 'hero.png',
+        filePath: '/private/tmp/hero.png',
+        projectId: 'test-project',
+      }),
+    ).resolves.toBe(asset)
+
+    expect(mockOpen).toHaveBeenCalledWith('/private/tmp/hero.png', 'r')
+    expect(fileHandle.createReadStream).toHaveBeenCalledWith({autoClose: false})
+    expect(mockUploadAsset).toHaveBeenCalledWith({
+      assetType: 'image',
+      body: fileStream,
+      contentType: 'image/png',
+      dataset: 'production',
+      filename: 'hero.png',
+      fileSize: 123,
+      projectId: 'test-project',
+    })
+    expect(fileHandle.close).toHaveBeenCalledOnce()
+    expect(fileStream.destroyed).toBe(true)
+  })
+
+  test('rejects directories without starting an upload', async () => {
+    const {fileHandle} = createFileHandle({isFile: false})
+    mockOpen.mockResolvedValue(fileHandle as never)
+
+    await expect(
+      uploadAssetFromFile({
+        assetType: 'file',
+        dataset: 'production',
+        filename: 'fixtures',
+        filePath: '/private/tmp/fixtures',
+        projectId: 'test-project',
+      }),
+    ).rejects.toMatchObject<AssetFileError>({reason: 'not-file'})
+
+    expect(fileHandle.close).toHaveBeenCalledOnce()
+    expect(mockUploadAsset).not.toHaveBeenCalled()
+  })
+
+  test('reports files that cannot be opened as unreadable', async () => {
+    mockOpen.mockRejectedValue(new Error('ENOENT'))
+
+    await expect(
+      uploadAssetFromFile({
+        assetType: 'image',
+        dataset: 'production',
+        filename: 'missing.png',
+        filePath: '/private/tmp/missing.png',
+        projectId: 'test-project',
+      }),
+    ).rejects.toMatchObject<AssetFileError>({reason: 'unreadable'})
+
+    expect(mockUploadAsset).not.toHaveBeenCalled()
+  })
+
+  test('closes the file handle when the upload fails', async () => {
+    const {fileHandle, fileStream} = createFileHandle()
+    mockOpen.mockResolvedValue(fileHandle as never)
+    mockUploadAsset.mockRejectedValue(new Error('upload failed'))
+
+    await expect(
+      uploadAssetFromFile({
+        assetType: 'image',
+        dataset: 'production',
+        filename: 'hero.png',
+        filePath: '/private/tmp/hero.png',
+        projectId: 'test-project',
+      }),
+    ).rejects.toThrow('upload failed')
+
+    expect(fileHandle.close).toHaveBeenCalledOnce()
+    expect(fileStream.destroyed).toBe(true)
+  })
+})

--- a/packages/@sanity/cli/src/actions/assets/__tests__/uploadAssetFromFile.test.ts
+++ b/packages/@sanity/cli/src/actions/assets/__tests__/uploadAssetFromFile.test.ts
@@ -3,7 +3,6 @@ import {Readable} from 'node:stream'
 
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {AssetFileError} from '../assetFileError.js'
 import {uploadAssetFromFile} from '../uploadAssetFromFile.js'
 
 const mockUploadAsset = vi.hoisted(() => vi.fn())
@@ -78,7 +77,7 @@ describe('uploadAssetFromFile', () => {
         filePath: '/private/tmp/fixtures',
         projectId: 'test-project',
       }),
-    ).rejects.toMatchObject<AssetFileError>({reason: 'not-file'})
+    ).rejects.toMatchObject({reason: 'not-file'})
 
     expect(fileHandle.close).toHaveBeenCalledOnce()
     expect(mockUploadAsset).not.toHaveBeenCalled()
@@ -95,7 +94,7 @@ describe('uploadAssetFromFile', () => {
         filePath: '/private/tmp/missing.png',
         projectId: 'test-project',
       }),
-    ).rejects.toMatchObject<AssetFileError>({reason: 'unreadable'})
+    ).rejects.toMatchObject({reason: 'unreadable'})
 
     expect(mockUploadAsset).not.toHaveBeenCalled()
   })

--- a/packages/@sanity/cli/src/actions/assets/__tests__/uploadAssetWithProgress.test.ts
+++ b/packages/@sanity/cli/src/actions/assets/__tests__/uploadAssetWithProgress.test.ts
@@ -1,0 +1,145 @@
+import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
+import {spinner, spinnerSucceed, spinnerText} from '@sanity/cli-test/mocks/cli-core/ux'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {uploadAssetWithProgress} from '../uploadAssetWithProgress.js'
+
+const mockUploadAssetFromFile = vi.hoisted(() => vi.fn())
+
+vi.mock('../uploadAssetFromFile.js', () => ({uploadAssetFromFile: mockUploadAssetFromFile}))
+vi.mock('@sanity/cli-core/ux', () => import('@sanity/cli-test/mocks/cli-core/ux'))
+
+const imageAsset = {_id: 'image-abc-100x100-png'}
+const defaultOptions = {
+  assetType: 'image' as const,
+  dataset: 'production',
+  filename: 'hero.png',
+  filePath: '/private/tmp/hero.png',
+  isInteractive: false,
+  logToStderr: vi.fn(),
+  projectId: 'test-project',
+}
+
+describe('uploadAssetWithProgress', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('reports bounded progress outside an interactive terminal', async () => {
+    mockUploadAssetFromFile.mockImplementation(async ({onProgress}) => {
+      onProgress(8)
+      onProgress(23)
+      onProgress(27)
+      onProgress(27)
+      onProgress(24)
+      onProgress(52)
+      onProgress(108)
+      return imageAsset
+    })
+
+    await expect(uploadAssetWithProgress(defaultOptions)).resolves.toBe(imageAsset)
+
+    expect(spinner).toHaveBeenCalledWith(
+      'Uploading image asset. Large uploads may take several minutes.',
+    )
+    expect(spinnerText.mock.calls).toEqual([
+      ['Uploading image asset [8%]'],
+      ['Uploading image asset [23%]'],
+      ['Uploading image asset [27%]'],
+      ['Uploading image asset [52%]'],
+      ['Creating image asset document'],
+    ])
+    expect(defaultOptions.logToStderr.mock.calls).toEqual([
+      ['Uploading image asset [25%]'],
+      ['Uploading image asset [50%]'],
+      ['Creating image asset document'],
+    ])
+    expect(spinnerSucceed).toHaveBeenCalledWith(`Uploaded image asset: ${imageAsset._id}`)
+  })
+
+  test('reports progress through an execution context', async () => {
+    const progress: string[] = []
+    mockUploadAssetFromFile.mockImplementation(async ({onProgress}) => {
+      onProgress(26)
+      onProgress(51)
+      onProgress(76)
+      onProgress(100)
+      return imageAsset
+    })
+
+    await runWithCliExecutionContext({stderr: (line) => progress.push(line)}, () =>
+      uploadAssetWithProgress({...defaultOptions, logToStderr: (line) => progress.push(line)}),
+    )
+
+    expect(progress).toEqual([
+      'Uploading image asset. Large uploads may take several minutes.',
+      'Uploading image asset [25%]',
+      'Uploading image asset [50%]',
+      'Uploading image asset [75%]',
+      'Creating image asset document',
+      `Uploaded image asset: ${imageAsset._id}`,
+    ])
+  })
+
+  test('preserves completed upload phases in an interactive terminal', async () => {
+    mockUploadAssetFromFile.mockImplementation(async ({onProgress}) => {
+      onProgress(50)
+      onProgress(100)
+      return imageAsset
+    })
+
+    await uploadAssetWithProgress({...defaultOptions, isInteractive: true})
+
+    expect(spinner).toHaveBeenNthCalledWith(
+      1,
+      'Uploading image asset [0%]. Large uploads may take several minutes.',
+    )
+    expect(spinner).toHaveBeenNthCalledWith(2, 'Creating image asset document')
+    expect(spinner).toHaveBeenNthCalledWith(3)
+    expect(spinnerSucceed.mock.calls).toEqual([
+      ['Uploading image asset [100%]'],
+      ['Creating image asset document'],
+      [`Uploaded image asset: ${imageAsset._id}`],
+    ])
+  })
+
+  test('aborts on SIGINT and leaves process exit to the command', async () => {
+    let interruptUpload: (() => void) | undefined
+    const onceSpy = vi.spyOn(process, 'once').mockImplementation((event, listener) => {
+      if (event === 'SIGINT') interruptUpload = listener as () => void
+      return process
+    })
+    const offSpy = vi.spyOn(process, 'off').mockReturnValue(process)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    mockUploadAssetFromFile.mockImplementation(
+      ({signal}: {signal: AbortSignal}) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), {once: true})
+        }),
+    )
+
+    try {
+      const upload = uploadAssetWithProgress({...defaultOptions, isInteractive: true})
+      await vi.waitFor(() => expect(mockUploadAssetFromFile).toHaveBeenCalledOnce())
+      interruptUpload?.()
+
+      await expect(upload).rejects.toThrow('SIGINT')
+      expect(exitSpy).not.toHaveBeenCalled()
+      expect(offSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function))
+      expect(spinner.mock.results[0]?.value.stop).toHaveBeenCalledOnce()
+    } finally {
+      onceSpy.mockRestore()
+      offSpy.mockRestore()
+      exitSpy.mockRestore()
+    }
+  })
+
+  test('stops progress and preserves upload errors', async () => {
+    const error = new Error('upload failed')
+    mockUploadAssetFromFile.mockRejectedValue(error)
+
+    await expect(uploadAssetWithProgress(defaultOptions)).rejects.toBe(error)
+
+    expect(spinner.mock.results[0]?.value.stop).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/@sanity/cli/src/actions/assets/__tests__/uploadAssetWithProgress.test.ts
+++ b/packages/@sanity/cli/src/actions/assets/__tests__/uploadAssetWithProgress.test.ts
@@ -134,6 +134,60 @@ describe('uploadAssetWithProgress', () => {
     }
   })
 
+  test('lets Ora receive Ctrl+C when it has put stdin in raw mode', async () => {
+    const stdinDescriptors = Object.fromEntries(
+      ['isTTY', 'isRaw', 'readableFlowing'].map((property) => [
+        property,
+        Object.getOwnPropertyDescriptor(process.stdin, property),
+      ]),
+    )
+    Object.defineProperties(process.stdin, {
+      isRaw: {configurable: true, value: true},
+      isTTY: {configurable: true, value: true},
+      readableFlowing: {configurable: true, value: null},
+    })
+
+    const uploadProgress = spinner.getMockImplementation()?.()
+    if (!uploadProgress) throw new Error('Expected a spinner mock implementation')
+    Object.defineProperty(uploadProgress, 'isSpinning', {value: true})
+    spinner.mockReturnValueOnce(uploadProgress)
+
+    const stdinResumeSpy = vi.spyOn(process.stdin, 'resume').mockReturnValue(process.stdin)
+    const stdinPauseSpy = vi.spyOn(process.stdin, 'pause').mockReturnValue(process.stdin)
+    let interruptUpload: (() => void) | undefined
+    const onceSpy = vi.spyOn(process, 'once').mockImplementation((event, listener) => {
+      if (event === 'SIGINT') interruptUpload = listener as () => void
+      return process
+    })
+    const offSpy = vi.spyOn(process, 'off').mockReturnValue(process)
+    mockUploadAssetFromFile.mockImplementation(
+      ({signal}: {signal: AbortSignal}) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), {once: true})
+        }),
+    )
+
+    try {
+      const upload = uploadAssetWithProgress({...defaultOptions, isInteractive: true})
+      await vi.waitFor(() => expect(mockUploadAssetFromFile).toHaveBeenCalledOnce())
+      expect(stdinResumeSpy).toHaveBeenCalledOnce()
+
+      interruptUpload?.()
+
+      await expect(upload).rejects.toThrow('SIGINT')
+      expect(stdinPauseSpy).toHaveBeenCalledOnce()
+    } finally {
+      onceSpy.mockRestore()
+      offSpy.mockRestore()
+      stdinResumeSpy.mockRestore()
+      stdinPauseSpy.mockRestore()
+      for (const [property, descriptor] of Object.entries(stdinDescriptors)) {
+        if (descriptor) Object.defineProperty(process.stdin, property, descriptor)
+        else delete (process.stdin as unknown as Record<string, unknown>)[property]
+      }
+    }
+  })
+
   test('stops progress and preserves upload errors', async () => {
     const error = new Error('upload failed')
     mockUploadAssetFromFile.mockRejectedValue(error)

--- a/packages/@sanity/cli/src/actions/assets/assetFileError.ts
+++ b/packages/@sanity/cli/src/actions/assets/assetFileError.ts
@@ -1,0 +1,6 @@
+export class AssetFileError extends Error {
+  constructor(public readonly reason: 'not-file' | 'unreadable') {
+    super(reason)
+    this.name = 'AssetFileError'
+  }
+}

--- a/packages/@sanity/cli/src/actions/assets/uploadAssetFromFile.ts
+++ b/packages/@sanity/cli/src/actions/assets/uploadAssetFromFile.ts
@@ -1,0 +1,49 @@
+import {type FileHandle, open} from 'node:fs/promises'
+
+import {type AssetType, uploadAsset} from '../../services/assets.js'
+import {AssetFileError} from './assetFileError.js'
+
+interface UploadAssetFromFileOptions {
+  assetType: AssetType
+  dataset: string
+  filename: string
+  filePath: string
+  projectId: string
+
+  contentType?: string
+  onProgress?: (percent: number) => void
+  signal?: AbortSignal
+}
+
+async function openAssetFile(
+  filePath: string,
+): Promise<{fileHandle: FileHandle; fileSize: number}> {
+  let fileHandle: FileHandle | undefined
+
+  try {
+    fileHandle = await open(filePath, 'r')
+    const fileStat = await fileHandle.stat()
+    if (!fileStat.isFile()) throw new AssetFileError('not-file')
+
+    return {fileHandle, fileSize: fileStat.size}
+  } catch (error) {
+    await fileHandle?.close()
+    if (error instanceof AssetFileError) throw error
+    throw new AssetFileError('unreadable')
+  }
+}
+
+export async function uploadAssetFromFile(options: UploadAssetFromFileOptions) {
+  options.signal?.throwIfAborted()
+  const {filePath, ...uploadOptions} = options
+  const {fileHandle, fileSize} = await openAssetFile(filePath)
+  const fileStream = fileHandle.createReadStream({autoClose: false})
+
+  try {
+    options.signal?.throwIfAborted()
+    return await uploadAsset({...uploadOptions, body: fileStream, fileSize})
+  } finally {
+    fileStream.destroy()
+    await fileHandle.close()
+  }
+}

--- a/packages/@sanity/cli/src/actions/assets/uploadAssetWithProgress.ts
+++ b/packages/@sanity/cli/src/actions/assets/uploadAssetWithProgress.ts
@@ -52,6 +52,16 @@ export async function uploadAssetWithProgress(options: UploadAssetWithProgressOp
   const handlesInterrupt = !executionContext
   if (handlesInterrupt) process.once('SIGINT', interruptUpload)
 
+  // Ora uses raw mode for Ctrl+C, but its input listener does not always make stdin flow.
+  const resumesInterruptInput =
+    handlesInterrupt &&
+    isTTY &&
+    uploadProgress.isSpinning &&
+    process.stdin.isTTY &&
+    process.stdin.isRaw &&
+    process.stdin.readableFlowing !== true
+  if (resumesInterruptInput) process.stdin.resume()
+
   try {
     const asset = await uploadAssetFromFile({
       ...uploadOptions,
@@ -95,5 +105,6 @@ export async function uploadAssetWithProgress(options: UploadAssetWithProgressOp
     throw error
   } finally {
     if (handlesInterrupt) process.off('SIGINT', interruptUpload)
+    if (resumesInterruptInput) process.stdin.pause()
   }
 }

--- a/packages/@sanity/cli/src/actions/assets/uploadAssetWithProgress.ts
+++ b/packages/@sanity/cli/src/actions/assets/uploadAssetWithProgress.ts
@@ -99,9 +99,7 @@ export async function uploadAssetWithProgress(options: UploadAssetWithProgressOp
   } catch (error) {
     const activeProgress = assetDocumentProgress ?? uploadProgress
     activeProgress.stop()
-    if (uploadController.signal.aborted) {
-      throw uploadController.signal.reason
-    }
+    uploadController.signal.throwIfAborted()
     throw error
   } finally {
     if (handlesInterrupt) process.off('SIGINT', interruptUpload)

--- a/packages/@sanity/cli/src/actions/assets/uploadAssetWithProgress.ts
+++ b/packages/@sanity/cli/src/actions/assets/uploadAssetWithProgress.ts
@@ -1,0 +1,99 @@
+import {getCliExecutionContext} from '@sanity/cli-core/executionContext'
+import {spinner} from '@sanity/cli-core/ux'
+
+import {type AssetType} from '../../services/assets.js'
+import {uploadAssetFromFile} from './uploadAssetFromFile.js'
+
+interface UploadAssetWithProgressOptions {
+  assetType: AssetType
+  dataset: string
+  filename: string
+  filePath: string
+  isInteractive: boolean
+  logToStderr: (message: string) => void
+  projectId: string
+
+  contentType?: string
+}
+
+export async function uploadAssetWithProgress(options: UploadAssetWithProgressOptions) {
+  const {assetType, isInteractive, logToStderr, ...uploadOptions} = options
+  const uploadMessage = `Uploading ${assetType} asset`
+  const assetDocumentMessage = `Creating ${assetType} asset document`
+  const executionContext = getCliExecutionContext()
+  const isTTY = !executionContext && isInteractive
+  const uploadProgress = spinner(
+    isTTY
+      ? `${uploadMessage} [0%]. Large uploads may take several minutes.`
+      : `${uploadMessage}. Large uploads may take several minutes.`,
+  ).start()
+  if (executionContext) logToStderr(`${uploadMessage}. Large uploads may take several minutes.`)
+
+  let assetDocumentProgress: ReturnType<typeof spinner> | undefined
+  let assetDocumentStarted = false
+  let lastReportedProgress = 0
+  let nextNonInteractiveCheckpoint = 25
+
+  const startAssetDocument = () => {
+    if (assetDocumentStarted) return
+    assetDocumentStarted = true
+    if (!isTTY) {
+      uploadProgress.text = assetDocumentMessage
+      logToStderr(assetDocumentMessage)
+      return
+    }
+
+    uploadProgress.succeed(`${uploadMessage} [100%]`)
+    assetDocumentProgress = spinner(assetDocumentMessage).start()
+  }
+
+  const uploadController = new AbortController()
+  const interruptUpload = () => uploadController.abort(new Error('SIGINT'))
+  const handlesInterrupt = !executionContext
+  if (handlesInterrupt) process.once('SIGINT', interruptUpload)
+
+  try {
+    const asset = await uploadAssetFromFile({
+      ...uploadOptions,
+      assetType,
+      onProgress: (percent) => {
+        const progress = Math.min(100, Math.floor(percent))
+        if (progress <= lastReportedProgress) return
+
+        lastReportedProgress = progress
+        if (progress === 100) {
+          startAssetDocument()
+        } else {
+          uploadProgress.text = `${uploadMessage} [${progress}%]`
+          if (!isTTY && progress >= nextNonInteractiveCheckpoint) {
+            const checkpoint = Math.min(75, Math.floor(progress / 25) * 25)
+            logToStderr(`${uploadMessage} [${checkpoint}%]`)
+            nextNonInteractiveCheckpoint = checkpoint + 25
+          }
+        }
+      },
+      signal: uploadController.signal,
+    })
+
+    if (isTTY) {
+      startAssetDocument()
+      assetDocumentProgress?.succeed(assetDocumentMessage)
+      spinner().succeed(`Uploaded ${assetType} asset: ${asset._id}`)
+    } else if (executionContext) {
+      logToStderr(`Uploaded ${assetType} asset: ${asset._id}`)
+    } else {
+      uploadProgress.succeed(`Uploaded ${assetType} asset: ${asset._id}`)
+    }
+
+    return asset
+  } catch (error) {
+    const activeProgress = assetDocumentProgress ?? uploadProgress
+    activeProgress.stop()
+    if (uploadController.signal.aborted) {
+      throw uploadController.signal.reason
+    }
+    throw error
+  } finally {
+    if (handlesInterrupt) process.off('SIGINT', interruptUpload)
+  }
+}

--- a/packages/@sanity/cli/src/commands/assets/__tests__/upload.test.ts
+++ b/packages/@sanity/cli/src/commands/assets/__tests__/upload.test.ts
@@ -1,0 +1,368 @@
+import {resolve} from 'node:path'
+
+import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
+import {exitCodes} from '@sanity/cli-core/ExitCodes'
+import {testCommand} from '@sanity/cli-test'
+import {spinner, spinnerSucceed, spinnerText} from '@sanity/cli-test/mocks/cli-core/ux'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {parseArguments} from '../../../util/parseArguments.js'
+import {UploadAssetCommand} from '../upload.js'
+
+const mockStat = vi.hoisted(() => vi.fn())
+const mockUploadAsset = vi.hoisted(() => vi.fn())
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs/promises')>()),
+  stat: mockStat,
+}))
+
+vi.mock('../../../services/assets.js', () => ({uploadAsset: mockUploadAsset}))
+vi.mock('@sanity/cli-core/ux', () => import('@sanity/cli-test/mocks/cli-core/ux'))
+
+const defaultMocks = {
+  cliConfig: {api: {dataset: 'production', projectId: 'test-project'}},
+  projectRoot: {
+    directory: '/test/path',
+    path: '/test/path/sanity.config.ts',
+    type: 'studio' as const,
+  },
+  token: 'test-token',
+}
+
+const imageAsset = {
+  _id: 'image-abc-100x100-png',
+  _type: 'sanity.imageAsset',
+  extension: 'png',
+  mimeType: 'image/png',
+  originalFilename: 'hero.png',
+  size: 123,
+  url: 'https://cdn.sanity.io/images/test-project/production/abc-100x100.png',
+}
+
+describe('#assets:upload', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('redacts local paths and filenames from command telemetry', () => {
+    const result = parseArguments(
+      [
+        'node',
+        'sanity',
+        'assets',
+        'upload',
+        '--file=/Users/test/private/hero.png',
+        '--filename=private-hero.png',
+        '--dataset=production',
+      ],
+      UploadAssetCommand.telemetry,
+    )
+
+    expect(result.extraArguments).toEqual(['--file', '--filename', '--dataset=production'])
+  })
+
+  test('uploads an image and prints a reusable image reference', async () => {
+    mockStat.mockResolvedValue({isFile: () => true, size: 123})
+    mockUploadAsset.mockImplementation(async ({onProgress}) => {
+      onProgress(8)
+      onProgress(23)
+      onProgress(27)
+      onProgress(100)
+      return imageAsset
+    })
+
+    const {error, stderr, stdout} = await testCommand(
+      UploadAssetCommand,
+      ['--file', './hero.png', '--content-type', 'image/png'],
+      {mocks: defaultMocks},
+    )
+
+    if (error) throw error
+    expect(mockUploadAsset).toHaveBeenCalledWith({
+      assetType: 'image',
+      contentType: 'image/png',
+      dataset: 'production',
+      filename: 'hero.png',
+      filePath: resolve('./hero.png'),
+      fileSize: 123,
+      onProgress: expect.any(Function),
+      projectId: 'test-project',
+      signal: expect.any(AbortSignal),
+    })
+    expect(spinner).toHaveBeenCalledWith(
+      'Uploading image asset. Large uploads may take several minutes.',
+    )
+    expect(spinnerText.mock.calls).toEqual([
+      ['Uploading image asset [8%]'],
+      ['Uploading image asset [23%]'],
+      ['Uploading image asset [27%]'],
+      ['Creating image asset document'],
+    ])
+    expect(spinnerSucceed).toHaveBeenCalledWith(`Uploaded image asset: ${imageAsset._id}`)
+    expect(stderr).toBe('Uploading image asset [25%]\nCreating image asset document\n')
+    expect(JSON.parse(stdout)).toEqual({
+      asset: imageAsset,
+      reference: {
+        _type: 'image',
+        asset: {_ref: imageAsset._id, _type: 'reference'},
+      },
+    })
+  })
+
+  test('reports bounded progress through the agent execution context', async () => {
+    const progress: string[] = []
+    mockStat.mockResolvedValue({isFile: () => true, size: 123})
+    mockUploadAsset.mockImplementation(async ({onProgress}) => {
+      onProgress(26)
+      onProgress(51)
+      onProgress(76)
+      onProgress(100)
+      return imageAsset
+    })
+
+    const {error} = await runWithCliExecutionContext({stderr: (line) => progress.push(line)}, () =>
+      testCommand(UploadAssetCommand, ['--file', './hero.png', '--content-type', 'image/png'], {
+        mocks: defaultMocks,
+      }),
+    )
+
+    if (error) throw error
+    expect(progress).toEqual([
+      'Uploading image asset. Large uploads may take several minutes.',
+      'Uploading image asset [25%]',
+      'Uploading image asset [50%]',
+      'Uploading image asset [75%]',
+      'Creating image asset document',
+      `Uploaded image asset: ${imageAsset._id}`,
+    ])
+  })
+
+  test('supports file assets and explicit target metadata outside a project', async () => {
+    mockStat.mockResolvedValue({isFile: () => true, size: 123})
+    mockUploadAsset.mockResolvedValue({
+      ...imageAsset,
+      _id: 'file-def-pdf',
+      _type: 'sanity.fileAsset',
+      extension: 'pdf',
+      mimeType: 'application/pdf',
+      originalFilename: 'public-name.pdf',
+    })
+
+    const {error, stdout} = await testCommand(
+      UploadAssetCommand,
+      [
+        '--file',
+        './private-name.pdf',
+        '--type',
+        'file',
+        '--filename',
+        'public-name.pdf',
+        '--project-id',
+        'other-project',
+        '--dataset',
+        'staging',
+      ],
+      {mocks: {token: 'test-token'}},
+    )
+
+    if (error) throw error
+    expect(mockUploadAsset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetType: 'file',
+        dataset: 'staging',
+        filename: 'public-name.pdf',
+        projectId: 'other-project',
+      }),
+    )
+    expect(JSON.parse(stdout).reference._type).toBe('file')
+  })
+
+  test('preserves completed upload phases in a terminal', async () => {
+    const isTTYDescriptor = Object.getOwnPropertyDescriptor(process.stderr, 'isTTY')
+    Object.defineProperty(process.stderr, 'isTTY', {configurable: true, value: true})
+    mockStat.mockResolvedValue({isFile: () => true, size: 123})
+    mockUploadAsset.mockImplementation(async ({onProgress}) => {
+      onProgress(50)
+      onProgress(100)
+      return imageAsset
+    })
+
+    try {
+      const {error} = await testCommand(
+        UploadAssetCommand,
+        ['--file', './hero.png', '--content-type', 'image/png'],
+        {mocks: defaultMocks},
+      )
+
+      if (error) throw error
+      expect(spinner).toHaveBeenNthCalledWith(
+        1,
+        'Uploading image asset [0%]. Large uploads may take several minutes.',
+      )
+      expect(spinner).toHaveBeenNthCalledWith(2, 'Creating image asset document')
+      expect(spinner).toHaveBeenNthCalledWith(3)
+      expect(spinnerSucceed.mock.calls).toEqual([
+        ['Uploading image asset [100%]'],
+        ['Creating image asset document'],
+        [`Uploaded image asset: ${imageAsset._id}`],
+      ])
+    } finally {
+      if (isTTYDescriptor) {
+        Object.defineProperty(process.stderr, 'isTTY', isTTYDescriptor)
+      } else {
+        delete (process.stderr as {isTTY?: boolean}).isTTY
+      }
+    }
+  })
+
+  test('aborts an active upload on SIGINT', async () => {
+    let interruptUpload: (() => void) | undefined
+    const onceSpy = vi.spyOn(process, 'once').mockImplementation((event, listener) => {
+      if (event === 'SIGINT') interruptUpload = listener as () => void
+      return process
+    })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    mockStat.mockResolvedValue({isFile: () => true, size: 123})
+    mockUploadAsset.mockImplementation(
+      ({signal}: {signal: AbortSignal}) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), {once: true})
+        }),
+    )
+
+    try {
+      const command = testCommand(
+        UploadAssetCommand,
+        ['--file', './hero.png', '--content-type', 'image/png'],
+        {mocks: defaultMocks},
+      )
+      await vi.waitFor(() => expect(mockUploadAsset).toHaveBeenCalledOnce())
+      expect(interruptUpload).toBeDefined()
+      interruptUpload?.()
+      expect(exitSpy).toHaveBeenCalledWith(exitCodes.SIGINT)
+
+      const {error, stderr} = await command
+      expect(error?.oclif?.exit).toBe(exitCodes.SIGINT)
+      expect(stderr).toContain('Aborted by user')
+    } finally {
+      onceSpy.mockRestore()
+      exitSpy.mockRestore()
+    }
+  })
+
+  test('aborts on a Ctrl+C input byte when the terminal does not emit SIGINT', async () => {
+    const isTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
+    Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
+    let interruptInput: ((input: Buffer) => void) | undefined
+    const stdinOnSpy = vi.spyOn(process.stdin, 'on').mockImplementation(((
+      event: string,
+      listener: (input: Buffer) => void,
+    ) => {
+      if (event === 'data') interruptInput = listener
+      return process.stdin
+    }) as typeof process.stdin.on)
+    const stdinOffSpy = vi.spyOn(process.stdin, 'off').mockReturnValue(process.stdin)
+    const stdinResumeSpy = vi.spyOn(process.stdin, 'resume').mockReturnValue(process.stdin)
+    const stdinPauseSpy = vi.spyOn(process.stdin, 'pause').mockReturnValue(process.stdin)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    mockStat.mockResolvedValue({isFile: () => true, size: 123})
+    mockUploadAsset.mockImplementation(
+      ({signal}: {signal: AbortSignal}) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), {once: true})
+        }),
+    )
+
+    try {
+      const command = testCommand(
+        UploadAssetCommand,
+        ['--file', './hero.png', '--content-type', 'image/png'],
+        {mocks: defaultMocks},
+      )
+      await vi.waitFor(() => expect(mockUploadAsset).toHaveBeenCalledOnce())
+      expect(interruptInput).toBeDefined()
+      interruptInput?.(Buffer.from([3]))
+      expect(exitSpy).toHaveBeenCalledWith(exitCodes.SIGINT)
+
+      const {error, stderr} = await command
+      expect(error?.oclif?.exit).toBe(exitCodes.SIGINT)
+      expect(stderr).toContain('Aborted by user')
+      expect(stdinOffSpy).toHaveBeenCalledWith('data', expect.any(Function))
+      expect(stdinPauseSpy).toHaveBeenCalledOnce()
+    } finally {
+      stdinOnSpy.mockRestore()
+      stdinOffSpy.mockRestore()
+      stdinResumeSpy.mockRestore()
+      stdinPauseSpy.mockRestore()
+      exitSpy.mockRestore()
+      if (isTTYDescriptor) {
+        Object.defineProperty(process.stdin, 'isTTY', isTTYDescriptor)
+      } else {
+        delete (process.stdin as {isTTY?: boolean}).isTTY
+      }
+    }
+  })
+
+  test('rejects a directory before making an API request', async () => {
+    mockStat.mockResolvedValue({isFile: () => false})
+
+    const {error} = await testCommand(UploadAssetCommand, ['--file', '.'], {
+      mocks: defaultMocks,
+    })
+
+    expect(error?.message).toContain('--file must point to a file, not a directory')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+    expect(mockUploadAsset).not.toHaveBeenCalled()
+  })
+
+  test('reports unreadable paths with a fix', async () => {
+    mockStat.mockRejectedValue(new Error('ENOENT'))
+
+    const {error} = await testCommand(UploadAssetCommand, ['--file', './missing.png'], {
+      mocks: defaultMocks,
+    })
+
+    expect(error?.message).toContain('Cannot read the local file')
+    expect(error?.message).toContain('Check that --file points to a readable file, then retry')
+    expect(error?.message).not.toContain('missing.png')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+    expect(mockUploadAsset).not.toHaveBeenCalled()
+  })
+
+  test('requires a dataset', async () => {
+    mockStat.mockResolvedValue({isFile: () => true, size: 123})
+
+    const {error} = await testCommand(UploadAssetCommand, ['--file', './hero.png'], {
+      mocks: {...defaultMocks, cliConfig: {api: {projectId: 'test-project'}}},
+    })
+
+    expect(error?.message).toContain('Dataset is required')
+    expect(error?.message).toContain('Pass --dataset')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+  })
+
+  test('reports upload failures with authentication and permission guidance', async () => {
+    mockStat.mockResolvedValue({isFile: () => true, size: 123})
+    mockUploadAsset.mockRejectedValue(new Error('Forbidden'))
+
+    const {error} = await testCommand(UploadAssetCommand, ['--file', './hero.png'], {
+      mocks: defaultMocks,
+    })
+
+    expect(error?.message).toContain('Asset upload failed')
+    expect(error?.message).toContain(
+      'Check authentication, write access, and that the local file is still readable, then retry',
+    )
+    expect(error?.message).not.toContain('Forbidden')
+    expect(error?.message).not.toContain('hero.png')
+    expect(error?.oclif?.exit).toBe(exitCodes.RUNTIME_ERROR)
+  })
+
+  test('requires --file', async () => {
+    const {error} = await testCommand(UploadAssetCommand, [], {mocks: defaultMocks})
+
+    expect(error?.message).toContain('Missing required flag file')
+    expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
+  })
+})

--- a/packages/@sanity/cli/src/commands/assets/__tests__/upload.test.ts
+++ b/packages/@sanity/cli/src/commands/assets/__tests__/upload.test.ts
@@ -6,18 +6,15 @@ import {testCommand} from '@sanity/cli-test'
 import {spinner, spinnerSucceed, spinnerText} from '@sanity/cli-test/mocks/cli-core/ux'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
+import {AssetFileError} from '../../../actions/assets/assetFileError.js'
 import {parseArguments} from '../../../util/parseArguments.js'
 import {UploadAssetCommand} from '../upload.js'
 
-const mockStat = vi.hoisted(() => vi.fn())
-const mockUploadAsset = vi.hoisted(() => vi.fn())
+const mockUploadAssetFromFile = vi.hoisted(() => vi.fn())
 
-vi.mock('node:fs/promises', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('node:fs/promises')>()),
-  stat: mockStat,
+vi.mock('../../../actions/assets/uploadAssetFromFile.js', () => ({
+  uploadAssetFromFile: mockUploadAssetFromFile,
 }))
-
-vi.mock('../../../services/assets.js', () => ({uploadAsset: mockUploadAsset}))
 vi.mock('@sanity/cli-core/ux', () => import('@sanity/cli-test/mocks/cli-core/ux'))
 
 const defaultMocks = {
@@ -63,8 +60,7 @@ describe('#assets:upload', () => {
   })
 
   test('uploads an image and prints a reusable image reference', async () => {
-    mockStat.mockResolvedValue({isFile: () => true, size: 123})
-    mockUploadAsset.mockImplementation(async ({onProgress}) => {
+    mockUploadAssetFromFile.mockImplementation(async ({onProgress}) => {
       onProgress(8)
       onProgress(23)
       onProgress(27)
@@ -79,13 +75,12 @@ describe('#assets:upload', () => {
     )
 
     if (error) throw error
-    expect(mockUploadAsset).toHaveBeenCalledWith({
+    expect(mockUploadAssetFromFile).toHaveBeenCalledWith({
       assetType: 'image',
       contentType: 'image/png',
       dataset: 'production',
       filename: 'hero.png',
       filePath: resolve('./hero.png'),
-      fileSize: 123,
       onProgress: expect.any(Function),
       projectId: 'test-project',
       signal: expect.any(AbortSignal),
@@ -112,8 +107,7 @@ describe('#assets:upload', () => {
 
   test('reports bounded progress through the agent execution context', async () => {
     const progress: string[] = []
-    mockStat.mockResolvedValue({isFile: () => true, size: 123})
-    mockUploadAsset.mockImplementation(async ({onProgress}) => {
+    mockUploadAssetFromFile.mockImplementation(async ({onProgress}) => {
       onProgress(26)
       onProgress(51)
       onProgress(76)
@@ -139,8 +133,7 @@ describe('#assets:upload', () => {
   })
 
   test('supports file assets and explicit target metadata outside a project', async () => {
-    mockStat.mockResolvedValue({isFile: () => true, size: 123})
-    mockUploadAsset.mockResolvedValue({
+    mockUploadAssetFromFile.mockResolvedValue({
       ...imageAsset,
       _id: 'file-def-pdf',
       _type: 'sanity.fileAsset',
@@ -167,7 +160,7 @@ describe('#assets:upload', () => {
     )
 
     if (error) throw error
-    expect(mockUploadAsset).toHaveBeenCalledWith(
+    expect(mockUploadAssetFromFile).toHaveBeenCalledWith(
       expect.objectContaining({
         assetType: 'file',
         dataset: 'staging',
@@ -181,8 +174,7 @@ describe('#assets:upload', () => {
   test('preserves completed upload phases in a terminal', async () => {
     const isTTYDescriptor = Object.getOwnPropertyDescriptor(process.stderr, 'isTTY')
     Object.defineProperty(process.stderr, 'isTTY', {configurable: true, value: true})
-    mockStat.mockResolvedValue({isFile: () => true, size: 123})
-    mockUploadAsset.mockImplementation(async ({onProgress}) => {
+    mockUploadAssetFromFile.mockImplementation(async ({onProgress}) => {
       onProgress(50)
       onProgress(100)
       return imageAsset
@@ -223,8 +215,7 @@ describe('#assets:upload', () => {
       return process
     })
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
-    mockStat.mockResolvedValue({isFile: () => true, size: 123})
-    mockUploadAsset.mockImplementation(
+    mockUploadAssetFromFile.mockImplementation(
       ({signal}: {signal: AbortSignal}) =>
         new Promise((_resolve, reject) => {
           signal.addEventListener('abort', () => reject(signal.reason), {once: true})
@@ -237,7 +228,7 @@ describe('#assets:upload', () => {
         ['--file', './hero.png', '--content-type', 'image/png'],
         {mocks: defaultMocks},
       )
-      await vi.waitFor(() => expect(mockUploadAsset).toHaveBeenCalledOnce())
+      await vi.waitFor(() => expect(mockUploadAssetFromFile).toHaveBeenCalledOnce())
       expect(interruptUpload).toBeDefined()
       interruptUpload?.()
       expect(exitSpy).toHaveBeenCalledWith(exitCodes.SIGINT)
@@ -266,8 +257,7 @@ describe('#assets:upload', () => {
     const stdinResumeSpy = vi.spyOn(process.stdin, 'resume').mockReturnValue(process.stdin)
     const stdinPauseSpy = vi.spyOn(process.stdin, 'pause').mockReturnValue(process.stdin)
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
-    mockStat.mockResolvedValue({isFile: () => true, size: 123})
-    mockUploadAsset.mockImplementation(
+    mockUploadAssetFromFile.mockImplementation(
       ({signal}: {signal: AbortSignal}) =>
         new Promise((_resolve, reject) => {
           signal.addEventListener('abort', () => reject(signal.reason), {once: true})
@@ -280,7 +270,7 @@ describe('#assets:upload', () => {
         ['--file', './hero.png', '--content-type', 'image/png'],
         {mocks: defaultMocks},
       )
-      await vi.waitFor(() => expect(mockUploadAsset).toHaveBeenCalledOnce())
+      await vi.waitFor(() => expect(mockUploadAssetFromFile).toHaveBeenCalledOnce())
       expect(interruptInput).toBeDefined()
       interruptInput?.(Buffer.from([3]))
       expect(exitSpy).toHaveBeenCalledWith(exitCodes.SIGINT)
@@ -304,8 +294,8 @@ describe('#assets:upload', () => {
     }
   })
 
-  test('rejects a directory before making an API request', async () => {
-    mockStat.mockResolvedValue({isFile: () => false})
+  test('rejects a directory', async () => {
+    mockUploadAssetFromFile.mockRejectedValue(new AssetFileError('not-file'))
 
     const {error} = await testCommand(UploadAssetCommand, ['--file', '.'], {
       mocks: defaultMocks,
@@ -313,11 +303,11 @@ describe('#assets:upload', () => {
 
     expect(error?.message).toContain('--file must point to a file, not a directory')
     expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
-    expect(mockUploadAsset).not.toHaveBeenCalled()
+    expect(mockUploadAssetFromFile).toHaveBeenCalledOnce()
   })
 
   test('reports unreadable paths with a fix', async () => {
-    mockStat.mockRejectedValue(new Error('ENOENT'))
+    mockUploadAssetFromFile.mockRejectedValue(new AssetFileError('unreadable'))
 
     const {error} = await testCommand(UploadAssetCommand, ['--file', './missing.png'], {
       mocks: defaultMocks,
@@ -327,12 +317,10 @@ describe('#assets:upload', () => {
     expect(error?.message).toContain('Check that --file points to a readable file, then retry')
     expect(error?.message).not.toContain('missing.png')
     expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
-    expect(mockUploadAsset).not.toHaveBeenCalled()
+    expect(mockUploadAssetFromFile).toHaveBeenCalledOnce()
   })
 
   test('requires a dataset', async () => {
-    mockStat.mockResolvedValue({isFile: () => true, size: 123})
-
     const {error} = await testCommand(UploadAssetCommand, ['--file', './hero.png'], {
       mocks: {...defaultMocks, cliConfig: {api: {projectId: 'test-project'}}},
     })
@@ -343,8 +331,7 @@ describe('#assets:upload', () => {
   })
 
   test('reports upload failures with authentication and permission guidance', async () => {
-    mockStat.mockResolvedValue({isFile: () => true, size: 123})
-    mockUploadAsset.mockRejectedValue(new Error('Forbidden'))
+    mockUploadAssetFromFile.mockRejectedValue(new Error('Forbidden'))
 
     const {error} = await testCommand(UploadAssetCommand, ['--file', './hero.png'], {
       mocks: defaultMocks,

--- a/packages/@sanity/cli/src/commands/assets/__tests__/upload.test.ts
+++ b/packages/@sanity/cli/src/commands/assets/__tests__/upload.test.ts
@@ -1,24 +1,22 @@
 import {resolve} from 'node:path'
 
-import {runWithCliExecutionContext} from '@sanity/cli-core/executionContext'
 import {exitCodes} from '@sanity/cli-core/ExitCodes'
 import {testCommand} from '@sanity/cli-test'
-import {spinner, spinnerSucceed, spinnerText} from '@sanity/cli-test/mocks/cli-core/ux'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {AssetFileError} from '../../../actions/assets/assetFileError.js'
 import {parseArguments} from '../../../util/parseArguments.js'
 import {UploadAssetCommand} from '../upload.js'
 
-const mockUploadAssetFromFile = vi.hoisted(() => vi.fn())
+const mockUploadAssetWithProgress = vi.hoisted(() => vi.fn())
 
-vi.mock('../../../actions/assets/uploadAssetFromFile.js', () => ({
-  uploadAssetFromFile: mockUploadAssetFromFile,
+vi.mock('../../../actions/assets/uploadAssetWithProgress.js', () => ({
+  uploadAssetWithProgress: mockUploadAssetWithProgress,
 }))
-vi.mock('@sanity/cli-core/ux', () => import('@sanity/cli-test/mocks/cli-core/ux'))
 
 const defaultMocks = {
   cliConfig: {api: {dataset: 'production', projectId: 'test-project'}},
+  isInteractive: false,
   projectRoot: {
     directory: '/test/path',
     path: '/test/path/sanity.config.ts',
@@ -60,11 +58,8 @@ describe('#assets:upload', () => {
   })
 
   test('uploads an image and prints a reusable image reference', async () => {
-    mockUploadAssetFromFile.mockImplementation(async ({onProgress}) => {
-      onProgress(8)
-      onProgress(23)
-      onProgress(27)
-      onProgress(100)
+    mockUploadAssetWithProgress.mockImplementation(async ({logToStderr}) => {
+      logToStderr('Uploading image asset [25%]')
       return imageAsset
     })
 
@@ -75,27 +70,17 @@ describe('#assets:upload', () => {
     )
 
     if (error) throw error
-    expect(mockUploadAssetFromFile).toHaveBeenCalledWith({
+    expect(mockUploadAssetWithProgress).toHaveBeenCalledWith({
       assetType: 'image',
       contentType: 'image/png',
       dataset: 'production',
       filename: 'hero.png',
       filePath: resolve('./hero.png'),
-      onProgress: expect.any(Function),
+      isInteractive: false,
+      logToStderr: expect.any(Function),
       projectId: 'test-project',
-      signal: expect.any(AbortSignal),
     })
-    expect(spinner).toHaveBeenCalledWith(
-      'Uploading image asset. Large uploads may take several minutes.',
-    )
-    expect(spinnerText.mock.calls).toEqual([
-      ['Uploading image asset [8%]'],
-      ['Uploading image asset [23%]'],
-      ['Uploading image asset [27%]'],
-      ['Creating image asset document'],
-    ])
-    expect(spinnerSucceed).toHaveBeenCalledWith(`Uploaded image asset: ${imageAsset._id}`)
-    expect(stderr).toBe('Uploading image asset [25%]\nCreating image asset document\n')
+    expect(stderr).toBe('Uploading image asset [25%]\n')
     expect(JSON.parse(stdout)).toEqual({
       asset: imageAsset,
       reference: {
@@ -105,35 +90,8 @@ describe('#assets:upload', () => {
     })
   })
 
-  test('reports bounded progress through the agent execution context', async () => {
-    const progress: string[] = []
-    mockUploadAssetFromFile.mockImplementation(async ({onProgress}) => {
-      onProgress(26)
-      onProgress(51)
-      onProgress(76)
-      onProgress(100)
-      return imageAsset
-    })
-
-    const {error} = await runWithCliExecutionContext({stderr: (line) => progress.push(line)}, () =>
-      testCommand(UploadAssetCommand, ['--file', './hero.png', '--content-type', 'image/png'], {
-        mocks: defaultMocks,
-      }),
-    )
-
-    if (error) throw error
-    expect(progress).toEqual([
-      'Uploading image asset. Large uploads may take several minutes.',
-      'Uploading image asset [25%]',
-      'Uploading image asset [50%]',
-      'Uploading image asset [75%]',
-      'Creating image asset document',
-      `Uploaded image asset: ${imageAsset._id}`,
-    ])
-  })
-
   test('supports file assets and explicit target metadata outside a project', async () => {
-    mockUploadAssetFromFile.mockResolvedValue({
+    mockUploadAssetWithProgress.mockResolvedValue({
       ...imageAsset,
       _id: 'file-def-pdf',
       _type: 'sanity.fileAsset',
@@ -156,146 +114,37 @@ describe('#assets:upload', () => {
         '--dataset',
         'staging',
       ],
-      {mocks: {token: 'test-token'}},
+      {mocks: {isInteractive: true, token: 'test-token'}},
     )
 
     if (error) throw error
-    expect(mockUploadAssetFromFile).toHaveBeenCalledWith(
+    expect(mockUploadAssetWithProgress).toHaveBeenCalledWith(
       expect.objectContaining({
         assetType: 'file',
         dataset: 'staging',
         filename: 'public-name.pdf',
+        isInteractive: true,
         projectId: 'other-project',
       }),
     )
     expect(JSON.parse(stdout).reference._type).toBe('file')
   })
 
-  test('preserves completed upload phases in a terminal', async () => {
-    const isTTYDescriptor = Object.getOwnPropertyDescriptor(process.stderr, 'isTTY')
-    Object.defineProperty(process.stderr, 'isTTY', {configurable: true, value: true})
-    mockUploadAssetFromFile.mockImplementation(async ({onProgress}) => {
-      onProgress(50)
-      onProgress(100)
-      return imageAsset
-    })
+  test('lets the base command handle SIGINT', async () => {
+    mockUploadAssetWithProgress.mockRejectedValue(new Error('SIGINT'))
 
-    try {
-      const {error} = await testCommand(
-        UploadAssetCommand,
-        ['--file', './hero.png', '--content-type', 'image/png'],
-        {mocks: defaultMocks},
-      )
-
-      if (error) throw error
-      expect(spinner).toHaveBeenNthCalledWith(
-        1,
-        'Uploading image asset [0%]. Large uploads may take several minutes.',
-      )
-      expect(spinner).toHaveBeenNthCalledWith(2, 'Creating image asset document')
-      expect(spinner).toHaveBeenNthCalledWith(3)
-      expect(spinnerSucceed.mock.calls).toEqual([
-        ['Uploading image asset [100%]'],
-        ['Creating image asset document'],
-        [`Uploaded image asset: ${imageAsset._id}`],
-      ])
-    } finally {
-      if (isTTYDescriptor) {
-        Object.defineProperty(process.stderr, 'isTTY', isTTYDescriptor)
-      } else {
-        delete (process.stderr as {isTTY?: boolean}).isTTY
-      }
-    }
-  })
-
-  test('aborts an active upload on SIGINT', async () => {
-    let interruptUpload: (() => void) | undefined
-    const onceSpy = vi.spyOn(process, 'once').mockImplementation((event, listener) => {
-      if (event === 'SIGINT') interruptUpload = listener as () => void
-      return process
-    })
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
-    mockUploadAssetFromFile.mockImplementation(
-      ({signal}: {signal: AbortSignal}) =>
-        new Promise((_resolve, reject) => {
-          signal.addEventListener('abort', () => reject(signal.reason), {once: true})
-        }),
+    const {error, stderr} = await testCommand(
+      UploadAssetCommand,
+      ['--file', './hero.png', '--content-type', 'image/png'],
+      {mocks: defaultMocks},
     )
 
-    try {
-      const command = testCommand(
-        UploadAssetCommand,
-        ['--file', './hero.png', '--content-type', 'image/png'],
-        {mocks: defaultMocks},
-      )
-      await vi.waitFor(() => expect(mockUploadAssetFromFile).toHaveBeenCalledOnce())
-      expect(interruptUpload).toBeDefined()
-      interruptUpload?.()
-      expect(exitSpy).toHaveBeenCalledWith(exitCodes.SIGINT)
-
-      const {error, stderr} = await command
-      expect(error?.oclif?.exit).toBe(exitCodes.SIGINT)
-      expect(stderr).toContain('Aborted by user')
-    } finally {
-      onceSpy.mockRestore()
-      exitSpy.mockRestore()
-    }
-  })
-
-  test('aborts on a Ctrl+C input byte when the terminal does not emit SIGINT', async () => {
-    const isTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
-    Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
-    let interruptInput: ((input: Buffer) => void) | undefined
-    const stdinOnSpy = vi.spyOn(process.stdin, 'on').mockImplementation(((
-      event: string,
-      listener: (input: Buffer) => void,
-    ) => {
-      if (event === 'data') interruptInput = listener
-      return process.stdin
-    }) as typeof process.stdin.on)
-    const stdinOffSpy = vi.spyOn(process.stdin, 'off').mockReturnValue(process.stdin)
-    const stdinResumeSpy = vi.spyOn(process.stdin, 'resume').mockReturnValue(process.stdin)
-    const stdinPauseSpy = vi.spyOn(process.stdin, 'pause').mockReturnValue(process.stdin)
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
-    mockUploadAssetFromFile.mockImplementation(
-      ({signal}: {signal: AbortSignal}) =>
-        new Promise((_resolve, reject) => {
-          signal.addEventListener('abort', () => reject(signal.reason), {once: true})
-        }),
-    )
-
-    try {
-      const command = testCommand(
-        UploadAssetCommand,
-        ['--file', './hero.png', '--content-type', 'image/png'],
-        {mocks: defaultMocks},
-      )
-      await vi.waitFor(() => expect(mockUploadAssetFromFile).toHaveBeenCalledOnce())
-      expect(interruptInput).toBeDefined()
-      interruptInput?.(Buffer.from([3]))
-      expect(exitSpy).toHaveBeenCalledWith(exitCodes.SIGINT)
-
-      const {error, stderr} = await command
-      expect(error?.oclif?.exit).toBe(exitCodes.SIGINT)
-      expect(stderr).toContain('Aborted by user')
-      expect(stdinOffSpy).toHaveBeenCalledWith('data', expect.any(Function))
-      expect(stdinPauseSpy).toHaveBeenCalledOnce()
-    } finally {
-      stdinOnSpy.mockRestore()
-      stdinOffSpy.mockRestore()
-      stdinResumeSpy.mockRestore()
-      stdinPauseSpy.mockRestore()
-      exitSpy.mockRestore()
-      if (isTTYDescriptor) {
-        Object.defineProperty(process.stdin, 'isTTY', isTTYDescriptor)
-      } else {
-        delete (process.stdin as {isTTY?: boolean}).isTTY
-      }
-    }
+    expect(error?.oclif?.exit).toBe(exitCodes.SIGINT)
+    expect(stderr).toContain('Aborted by user')
   })
 
   test('rejects a directory', async () => {
-    mockUploadAssetFromFile.mockRejectedValue(new AssetFileError('not-file'))
+    mockUploadAssetWithProgress.mockRejectedValue(new AssetFileError('not-file'))
 
     const {error} = await testCommand(UploadAssetCommand, ['--file', '.'], {
       mocks: defaultMocks,
@@ -303,11 +152,11 @@ describe('#assets:upload', () => {
 
     expect(error?.message).toContain('--file must point to a file, not a directory')
     expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
-    expect(mockUploadAssetFromFile).toHaveBeenCalledOnce()
+    expect(mockUploadAssetWithProgress).toHaveBeenCalledOnce()
   })
 
   test('reports unreadable paths with a fix', async () => {
-    mockUploadAssetFromFile.mockRejectedValue(new AssetFileError('unreadable'))
+    mockUploadAssetWithProgress.mockRejectedValue(new AssetFileError('unreadable'))
 
     const {error} = await testCommand(UploadAssetCommand, ['--file', './missing.png'], {
       mocks: defaultMocks,
@@ -317,7 +166,7 @@ describe('#assets:upload', () => {
     expect(error?.message).toContain('Check that --file points to a readable file, then retry')
     expect(error?.message).not.toContain('missing.png')
     expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
-    expect(mockUploadAssetFromFile).toHaveBeenCalledOnce()
+    expect(mockUploadAssetWithProgress).toHaveBeenCalledOnce()
   })
 
   test('requires a dataset', async () => {
@@ -331,7 +180,7 @@ describe('#assets:upload', () => {
   })
 
   test('reports upload failures with authentication and permission guidance', async () => {
-    mockUploadAssetFromFile.mockRejectedValue(new Error('Forbidden'))
+    mockUploadAssetWithProgress.mockRejectedValue(new Error('Forbidden'))
 
     const {error} = await testCommand(UploadAssetCommand, ['--file', './hero.png'], {
       mocks: defaultMocks,

--- a/packages/@sanity/cli/src/commands/assets/upload.ts
+++ b/packages/@sanity/cli/src/commands/assets/upload.ts
@@ -1,4 +1,3 @@
-import {stat} from 'node:fs/promises'
 import {basename, resolve} from 'node:path'
 
 import {Flags} from '@oclif/core'
@@ -7,8 +6,10 @@ import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getCliExecutionContext} from '@sanity/cli-core/executionContext'
 import {spinner} from '@sanity/cli-core/ux'
 
+import {AssetFileError} from '../../actions/assets/assetFileError.js'
+import {uploadAssetFromFile} from '../../actions/assets/uploadAssetFromFile.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
-import {type AssetType, uploadAsset} from '../../services/assets.js'
+import {type AssetType} from '../../services/assets.js'
 import {getDatasetFlag, getProjectIdFlag} from '../../util/sharedFlags.js'
 import {defineCommandTelemetry} from '../../util/telemetry/commandTelemetry.js'
 
@@ -68,19 +69,6 @@ export class UploadAssetCommand extends SanityCommand<typeof UploadAssetCommand>
   public async run(): Promise<void> {
     const {flags} = await this.parse(UploadAssetCommand)
     const filePath = resolve(flags.file)
-
-    const fileStat = await stat(filePath).catch(() => {})
-    if (!fileStat) {
-      this.error(
-        'Asset upload failed: Cannot read the local file. Check that --file points to a readable file, then retry.',
-        {exit: exitCodes.USAGE_ERROR},
-      )
-    }
-    if (!fileStat.isFile()) {
-      this.error('Asset upload failed: --file must point to a file, not a directory.', {
-        exit: exitCodes.USAGE_ERROR,
-      })
-    }
 
     const cliConfig = await this.tryGetCliConfig()
     const projectId = await this.getProjectId({fallback: () => promptForProject({})})
@@ -144,13 +132,12 @@ export class UploadAssetCommand extends SanityCommand<typeof UploadAssetCommand>
       let lastReportedProgress = 0
       let nextNonInteractiveCheckpoint = 25
 
-      const asset = await uploadAsset({
+      const asset = await uploadAssetFromFile({
         assetType: flags.type,
         contentType: flags['content-type'],
         dataset,
         filename: flags.filename ?? basename(filePath),
         filePath,
-        fileSize: fileStat.size,
         onProgress: (percent) => {
           const progress = Math.min(100, Math.floor(percent))
           if (progress <= lastReportedProgress) return
@@ -209,6 +196,17 @@ export class UploadAssetCommand extends SanityCommand<typeof UploadAssetCommand>
         throw uploadController.signal.reason instanceof Error
           ? uploadController.signal.reason
           : new Error('SIGINT')
+      }
+      if (error instanceof AssetFileError) {
+        if (error.reason === 'not-file') {
+          this.error('Asset upload failed: --file must point to a file, not a directory.', {
+            exit: exitCodes.USAGE_ERROR,
+          })
+        }
+        this.error(
+          'Asset upload failed: Cannot read the local file. Check that --file points to a readable file, then retry.',
+          {exit: exitCodes.USAGE_ERROR},
+        )
       }
       uploadAssetDebug('Asset upload failed', error)
       this.error(

--- a/packages/@sanity/cli/src/commands/assets/upload.ts
+++ b/packages/@sanity/cli/src/commands/assets/upload.ts
@@ -3,11 +3,9 @@ import {basename, resolve} from 'node:path'
 import {Flags} from '@oclif/core'
 import {type FlagInput} from '@oclif/core/interfaces'
 import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
-import {getCliExecutionContext} from '@sanity/cli-core/executionContext'
-import {spinner} from '@sanity/cli-core/ux'
 
 import {AssetFileError} from '../../actions/assets/assetFileError.js'
-import {uploadAssetFromFile} from '../../actions/assets/uploadAssetFromFile.js'
+import {uploadAssetWithProgress} from '../../actions/assets/uploadAssetWithProgress.js'
 import {promptForProject} from '../../prompts/promptForProject.js'
 import {type AssetType} from '../../services/assets.js'
 import {getDatasetFlag, getProjectIdFlag} from '../../util/sharedFlags.js'
@@ -80,94 +78,19 @@ export class UploadAssetCommand extends SanityCommand<typeof UploadAssetCommand>
       )
     }
 
-    const uploadMessage = `Uploading ${flags.type} asset`
-    const assetDocumentMessage = `Creating ${flags.type} asset document`
-    const executionContext = getCliExecutionContext()
-    const isTTY = !executionContext && Boolean(process.stderr.isTTY)
-    const uploadProgress = spinner(
-      isTTY
-        ? `${uploadMessage} [0%]. Large uploads may take several minutes.`
-        : `${uploadMessage}. Large uploads may take several minutes.`,
-    ).start()
-    if (executionContext) {
-      this.logToStderr(`${uploadMessage}. Large uploads may take several minutes.`)
-    }
-    let assetDocumentProgress: ReturnType<typeof spinner> | undefined
-    let assetDocumentStarted = false
-    const uploadController = new AbortController()
-    const interruptUpload = () => {
-      uploadController.abort(new Error('SIGINT'))
-      const activeProgress = assetDocumentProgress ?? uploadProgress
-      activeProgress.stop()
-      this.logToStderr('\u{203A} Aborted by user')
-      process.exit(exitCodes.SIGINT)
-    }
-    const interruptOnInput = (input: Buffer | string) => {
-      if (Buffer.from(input).includes(3)) interruptUpload()
-    }
-    const handlesInterrupt = !executionContext
-    const readsInterruptInput = handlesInterrupt && process.stdin.isTTY
-    if (handlesInterrupt) {
-      process.once('SIGINT', interruptUpload)
-      if (readsInterruptInput) {
-        process.stdin.on('data', interruptOnInput)
-        process.stdin.resume()
-      }
-    }
-
-    const startAssetDocument = () => {
-      if (assetDocumentStarted) return
-      assetDocumentStarted = true
-      if (!isTTY) {
-        uploadProgress.text = assetDocumentMessage
-        this.logToStderr(assetDocumentMessage)
-        return
-      }
-
-      uploadProgress.succeed(`${uploadMessage} [100%]`)
-      assetDocumentProgress = spinner(assetDocumentMessage).start()
-    }
-
     try {
-      let lastReportedProgress = 0
-      let nextNonInteractiveCheckpoint = 25
-
-      const asset = await uploadAssetFromFile({
+      const asset = await uploadAssetWithProgress({
         assetType: flags.type,
         contentType: flags['content-type'],
         dataset,
         filename: flags.filename ?? basename(filePath),
         filePath,
-        onProgress: (percent) => {
-          const progress = Math.min(100, Math.floor(percent))
-          if (progress <= lastReportedProgress) return
-
-          lastReportedProgress = progress
-          if (progress === 100) {
-            startAssetDocument()
-          } else {
-            uploadProgress.text = `${uploadMessage} [${progress}%]`
-            if (!isTTY && progress >= nextNonInteractiveCheckpoint) {
-              const checkpoint = Math.min(75, Math.floor(progress / 25) * 25)
-              this.logToStderr(`${uploadMessage} [${checkpoint}%]`)
-              nextNonInteractiveCheckpoint = checkpoint + 25
-            }
-          }
-        },
+        isInteractive: this.resolveIsInteractive(),
+        logToStderr: (message) => this.logToStderr(message),
         projectId,
-        signal: uploadController.signal,
       })
       const fieldType = flags.type === 'image' ? 'image' : 'file'
 
-      if (isTTY) {
-        startAssetDocument()
-        assetDocumentProgress?.succeed(assetDocumentMessage)
-        spinner().succeed(`Uploaded ${flags.type} asset: ${asset._id}`)
-      } else if (executionContext) {
-        this.logToStderr(`Uploaded ${flags.type} asset: ${asset._id}`)
-      } else {
-        uploadProgress.succeed(`Uploaded ${flags.type} asset: ${asset._id}`)
-      }
       this.log(
         JSON.stringify(
           {
@@ -190,13 +113,7 @@ export class UploadAssetCommand extends SanityCommand<typeof UploadAssetCommand>
         ),
       )
     } catch (error) {
-      const activeProgress = assetDocumentProgress ?? uploadProgress
-      activeProgress.stop()
-      if (uploadController.signal.aborted) {
-        throw uploadController.signal.reason instanceof Error
-          ? uploadController.signal.reason
-          : new Error('SIGINT')
-      }
+      if (error instanceof Error && error.message === 'SIGINT') throw error
       if (error instanceof AssetFileError) {
         if (error.reason === 'not-file') {
           this.error('Asset upload failed: --file must point to a file, not a directory.', {
@@ -215,14 +132,6 @@ export class UploadAssetCommand extends SanityCommand<typeof UploadAssetCommand>
           exit: exitCodes.RUNTIME_ERROR,
         },
       )
-    } finally {
-      if (handlesInterrupt) {
-        process.off('SIGINT', interruptUpload)
-        if (readsInterruptInput) {
-          process.stdin.off('data', interruptOnInput)
-          process.stdin.pause()
-        }
-      }
     }
   }
 }

--- a/packages/@sanity/cli/src/commands/assets/upload.ts
+++ b/packages/@sanity/cli/src/commands/assets/upload.ts
@@ -1,0 +1,230 @@
+import {stat} from 'node:fs/promises'
+import {basename, resolve} from 'node:path'
+
+import {Flags} from '@oclif/core'
+import {type FlagInput} from '@oclif/core/interfaces'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
+import {getCliExecutionContext} from '@sanity/cli-core/executionContext'
+import {spinner} from '@sanity/cli-core/ux'
+
+import {promptForProject} from '../../prompts/promptForProject.js'
+import {type AssetType, uploadAsset} from '../../services/assets.js'
+import {getDatasetFlag, getProjectIdFlag} from '../../util/sharedFlags.js'
+import {defineCommandTelemetry} from '../../util/telemetry/commandTelemetry.js'
+
+const uploadAssetDebug = subdebug('assets:upload')
+
+const flags = {
+  ...getProjectIdFlag({
+    description: 'Project ID to upload the asset to',
+    semantics: 'override',
+  }),
+  ...getDatasetFlag({description: 'Dataset to upload the asset to', semantics: 'override'}),
+  'content-type': Flags.string({
+    description: 'MIME type of the asset, such as image/png or application/pdf',
+    helpValue: '<mime-type>',
+  }),
+  file: Flags.string({
+    description: 'Path to the local file to upload',
+    helpValue: '<path>',
+    required: true,
+  }),
+  filename: Flags.string({
+    description: 'Original filename stored on the asset document. Defaults to the local filename',
+    helpValue: '<filename>',
+  }),
+  type: Flags.custom<AssetType>({
+    default: 'image',
+    description: 'Asset type to create',
+    options: ['image', 'file'],
+  })(),
+} satisfies FlagInput
+
+export class UploadAssetCommand extends SanityCommand<typeof UploadAssetCommand> {
+  static override description =
+    'Upload one local image or file to a Sanity dataset and print the asset document as JSON'
+
+  static override examples = [
+    {
+      command:
+        '<%= config.bin %> <%= command.id %> --file ./hero.png --type image --dataset production',
+      description: 'Upload an image using the configured project',
+    },
+    {
+      command:
+        '<%= config.bin %> <%= command.id %> --file ./brief.pdf --type file --content-type application/pdf --project-id abc123 --dataset production',
+      description: 'Upload a file with explicit project, dataset, and MIME type',
+    },
+  ]
+
+  static override flags = flags
+
+  static override hiddenAliases: string[] = ['asset:upload']
+
+  static telemetry = defineCommandTelemetry(flags, {
+    redact: ['file', 'filename'],
+  })
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(UploadAssetCommand)
+    const filePath = resolve(flags.file)
+
+    const fileStat = await stat(filePath).catch(() => {})
+    if (!fileStat) {
+      this.error(
+        'Asset upload failed: Cannot read the local file. Check that --file points to a readable file, then retry.',
+        {exit: exitCodes.USAGE_ERROR},
+      )
+    }
+    if (!fileStat.isFile()) {
+      this.error('Asset upload failed: --file must point to a file, not a directory.', {
+        exit: exitCodes.USAGE_ERROR,
+      })
+    }
+
+    const cliConfig = await this.tryGetCliConfig()
+    const projectId = await this.getProjectId({fallback: () => promptForProject({})})
+    const dataset = flags.dataset ?? cliConfig.api?.dataset
+    if (!dataset) {
+      this.error(
+        'Asset upload failed: Dataset is required. Pass --dataset <name> or configure a dataset in sanity.cli.ts.',
+        {exit: exitCodes.USAGE_ERROR},
+      )
+    }
+
+    const uploadMessage = `Uploading ${flags.type} asset`
+    const assetDocumentMessage = `Creating ${flags.type} asset document`
+    const executionContext = getCliExecutionContext()
+    const isTTY = !executionContext && Boolean(process.stderr.isTTY)
+    const uploadProgress = spinner(
+      isTTY
+        ? `${uploadMessage} [0%]. Large uploads may take several minutes.`
+        : `${uploadMessage}. Large uploads may take several minutes.`,
+    ).start()
+    if (executionContext) {
+      this.logToStderr(`${uploadMessage}. Large uploads may take several minutes.`)
+    }
+    let assetDocumentProgress: ReturnType<typeof spinner> | undefined
+    let assetDocumentStarted = false
+    const uploadController = new AbortController()
+    const interruptUpload = () => {
+      uploadController.abort(new Error('SIGINT'))
+      const activeProgress = assetDocumentProgress ?? uploadProgress
+      activeProgress.stop()
+      this.logToStderr('\u{203A} Aborted by user')
+      process.exit(exitCodes.SIGINT)
+    }
+    const interruptOnInput = (input: Buffer | string) => {
+      if (Buffer.from(input).includes(3)) interruptUpload()
+    }
+    const handlesInterrupt = !executionContext
+    const readsInterruptInput = handlesInterrupt && process.stdin.isTTY
+    if (handlesInterrupt) {
+      process.once('SIGINT', interruptUpload)
+      if (readsInterruptInput) {
+        process.stdin.on('data', interruptOnInput)
+        process.stdin.resume()
+      }
+    }
+
+    const startAssetDocument = () => {
+      if (assetDocumentStarted) return
+      assetDocumentStarted = true
+      if (!isTTY) {
+        uploadProgress.text = assetDocumentMessage
+        this.logToStderr(assetDocumentMessage)
+        return
+      }
+
+      uploadProgress.succeed(`${uploadMessage} [100%]`)
+      assetDocumentProgress = spinner(assetDocumentMessage).start()
+    }
+
+    try {
+      let lastReportedProgress = 0
+      let nextNonInteractiveCheckpoint = 25
+
+      const asset = await uploadAsset({
+        assetType: flags.type,
+        contentType: flags['content-type'],
+        dataset,
+        filename: flags.filename ?? basename(filePath),
+        filePath,
+        fileSize: fileStat.size,
+        onProgress: (percent) => {
+          const progress = Math.min(100, Math.floor(percent))
+          if (progress <= lastReportedProgress) return
+
+          lastReportedProgress = progress
+          if (progress === 100) {
+            startAssetDocument()
+          } else {
+            uploadProgress.text = `${uploadMessage} [${progress}%]`
+            if (!isTTY && progress >= nextNonInteractiveCheckpoint) {
+              const checkpoint = Math.min(75, Math.floor(progress / 25) * 25)
+              this.logToStderr(`${uploadMessage} [${checkpoint}%]`)
+              nextNonInteractiveCheckpoint = checkpoint + 25
+            }
+          }
+        },
+        projectId,
+        signal: uploadController.signal,
+      })
+      const fieldType = flags.type === 'image' ? 'image' : 'file'
+
+      if (isTTY) {
+        startAssetDocument()
+        assetDocumentProgress?.succeed(assetDocumentMessage)
+        spinner().succeed(`Uploaded ${flags.type} asset: ${asset._id}`)
+      } else if (executionContext) {
+        this.logToStderr(`Uploaded ${flags.type} asset: ${asset._id}`)
+      } else {
+        uploadProgress.succeed(`Uploaded ${flags.type} asset: ${asset._id}`)
+      }
+      this.log(
+        JSON.stringify(
+          {
+            asset: {
+              _id: asset._id,
+              _type: asset._type,
+              extension: asset.extension,
+              mimeType: asset.mimeType,
+              originalFilename: asset.originalFilename,
+              size: asset.size,
+              url: asset.url,
+            },
+            reference: {
+              _type: fieldType,
+              asset: {_ref: asset._id, _type: 'reference'},
+            },
+          },
+          null,
+          2,
+        ),
+      )
+    } catch (error) {
+      const activeProgress = assetDocumentProgress ?? uploadProgress
+      activeProgress.stop()
+      if (uploadController.signal.aborted) {
+        throw uploadController.signal.reason instanceof Error
+          ? uploadController.signal.reason
+          : new Error('SIGINT')
+      }
+      uploadAssetDebug('Asset upload failed', error)
+      this.error(
+        'Asset upload failed. Check authentication, write access, and that the local file is still readable, then retry.',
+        {
+          exit: exitCodes.RUNTIME_ERROR,
+        },
+      )
+    } finally {
+      if (handlesInterrupt) {
+        process.off('SIGINT', interruptUpload)
+        if (readsInterruptInput) {
+          process.stdin.off('data', interruptOnInput)
+          process.stdin.pause()
+        }
+      }
+    }
+  }
+}

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -65,8 +65,7 @@ export const mcpPolicy: CommandPolicySet = {
     validate: apiValidator,
   }),
 
-  // Reads a file from the machine running the command. The MCP asset bridge
-  // returns this command for a client to run locally; Mellon must not run it.
+  // Reads a file from the machine running the command and must only run locally.
   'assets:upload': deny,
 
   'backups:disable': allow,

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/commandPolicies/mcpPolicy.ts
@@ -65,6 +65,10 @@ export const mcpPolicy: CommandPolicySet = {
     validate: apiValidator,
   }),
 
+  // Reads a file from the machine running the command. The MCP asset bridge
+  // returns this command for a client to run locally; Mellon must not run it.
+  'assets:upload': deny,
+
   'backups:disable': allow,
   // Writes a downloaded backup to the local filesystem.
   'backups:download': deny,

--- a/packages/@sanity/cli/src/services/__tests__/assets.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/assets.test.ts
@@ -1,4 +1,3 @@
-import {createReadStream} from 'node:fs'
 import {Readable} from 'node:stream'
 
 import {getProjectCliClient} from '@sanity/cli-core'
@@ -7,17 +6,11 @@ import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {ASSETS_API_VERSION, uploadAsset} from '../assets.js'
 
-vi.mock('node:fs', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('node:fs')>()),
-  createReadStream: vi.fn(),
-}))
-
 vi.mock('@sanity/cli-core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@sanity/cli-core')>()),
   getProjectCliClient: vi.fn(),
 }))
 
-const mockCreateReadStream = vi.mocked(createReadStream)
 const mockGetProjectCliClient = vi.mocked(getProjectCliClient)
 
 function uploadResponse(asset: {_id: string}) {
@@ -42,16 +35,15 @@ describe('uploadAsset', () => {
     const asset = {_id: 'image-abc-1x1-png'}
     const upload = vi.fn(uploadResponse(asset))
     const onProgress = vi.fn()
-    mockCreateReadStream.mockReturnValue(stream as never)
     mockGetProjectCliClient.mockResolvedValue({observable: {assets: {upload}}} as never)
 
     await expect(
       uploadAsset({
         assetType: 'image',
+        body: stream,
         contentType: 'image/png',
         dataset: 'production',
         filename: 'hero.png',
-        filePath: '/private/tmp/hero.png',
         fileSize: 100,
         onProgress,
         projectId: 'test-project',
@@ -65,7 +57,6 @@ describe('uploadAsset', () => {
       requestTagPrefix: 'sanity.assets.upload',
       requireUser: true,
     })
-    expect(mockCreateReadStream).toHaveBeenCalledWith('/private/tmp/hero.png')
     expect(upload).toHaveBeenCalledWith('image', expect.any(Readable), {
       contentType: 'image/png',
       filename: 'hero.png',
@@ -76,14 +67,13 @@ describe('uploadAsset', () => {
 
   test('lets the client infer content type when none is supplied', async () => {
     const upload = vi.fn(uploadResponse({_id: 'file-abc-txt'}))
-    mockCreateReadStream.mockReturnValue(Readable.from([Buffer.from('notes')]) as never)
     mockGetProjectCliClient.mockResolvedValue({observable: {assets: {upload}}} as never)
 
     await uploadAsset({
       assetType: 'file',
+      body: Readable.from([Buffer.from('notes')]),
       dataset: 'production',
       filename: 'notes.txt',
-      filePath: '/private/tmp/notes.txt',
       fileSize: 5,
       projectId: 'test-project',
     })
@@ -100,14 +90,13 @@ describe('uploadAsset', () => {
     const requestTeardown = vi.fn()
     const upload = vi.fn(() => new Observable(() => requestTeardown))
     const controller = new AbortController()
-    mockCreateReadStream.mockReturnValue(stream as never)
     mockGetProjectCliClient.mockResolvedValue({observable: {assets: {upload}}} as never)
 
     const result = uploadAsset({
       assetType: 'image',
+      body: stream,
       dataset: 'production',
       filename: 'hero.png',
-      filePath: '/private/tmp/hero.png',
       fileSize: 100,
       projectId: 'test-project',
       signal: controller.signal,

--- a/packages/@sanity/cli/src/services/__tests__/assets.test.ts
+++ b/packages/@sanity/cli/src/services/__tests__/assets.test.ts
@@ -1,0 +1,122 @@
+import {createReadStream} from 'node:fs'
+import {Readable} from 'node:stream'
+
+import {getProjectCliClient} from '@sanity/cli-core'
+import {Observable} from 'rxjs'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {ASSETS_API_VERSION, uploadAsset} from '../assets.js'
+
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs')>()),
+  createReadStream: vi.fn(),
+}))
+
+vi.mock('@sanity/cli-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sanity/cli-core')>()),
+  getProjectCliClient: vi.fn(),
+}))
+
+const mockCreateReadStream = vi.mocked(createReadStream)
+const mockGetProjectCliClient = vi.mocked(getProjectCliClient)
+
+function uploadResponse(asset: {_id: string}) {
+  return (_assetType: string, body: Readable) =>
+    new Observable((subscriber) => {
+      body.on('data', () => {})
+      body.on('end', () => {
+        subscriber.next({body: {document: asset}, type: 'response'})
+        subscriber.complete()
+      })
+      body.on('error', (error) => subscriber.error(error))
+    })
+}
+
+describe('uploadAsset', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('streams the local file to the configured dataset', async () => {
+    const stream = Readable.from([Buffer.alloc(25), Buffer.alloc(75)])
+    const asset = {_id: 'image-abc-1x1-png'}
+    const upload = vi.fn(uploadResponse(asset))
+    const onProgress = vi.fn()
+    mockCreateReadStream.mockReturnValue(stream as never)
+    mockGetProjectCliClient.mockResolvedValue({observable: {assets: {upload}}} as never)
+
+    await expect(
+      uploadAsset({
+        assetType: 'image',
+        contentType: 'image/png',
+        dataset: 'production',
+        filename: 'hero.png',
+        filePath: '/private/tmp/hero.png',
+        fileSize: 100,
+        onProgress,
+        projectId: 'test-project',
+      }),
+    ).resolves.toBe(asset)
+
+    expect(mockGetProjectCliClient).toHaveBeenCalledWith({
+      apiVersion: ASSETS_API_VERSION,
+      dataset: 'production',
+      projectId: 'test-project',
+      requestTagPrefix: 'sanity.assets.upload',
+      requireUser: true,
+    })
+    expect(mockCreateReadStream).toHaveBeenCalledWith('/private/tmp/hero.png')
+    expect(upload).toHaveBeenCalledWith('image', expect.any(Readable), {
+      contentType: 'image/png',
+      filename: 'hero.png',
+      tag: 'asset.upload',
+    })
+    expect(onProgress.mock.calls).toEqual([[25], [100]])
+  })
+
+  test('lets the client infer content type when none is supplied', async () => {
+    const upload = vi.fn(uploadResponse({_id: 'file-abc-txt'}))
+    mockCreateReadStream.mockReturnValue(Readable.from([Buffer.from('notes')]) as never)
+    mockGetProjectCliClient.mockResolvedValue({observable: {assets: {upload}}} as never)
+
+    await uploadAsset({
+      assetType: 'file',
+      dataset: 'production',
+      filename: 'notes.txt',
+      filePath: '/private/tmp/notes.txt',
+      fileSize: 5,
+      projectId: 'test-project',
+    })
+
+    expect(upload).toHaveBeenCalledWith(
+      'file',
+      expect.anything(),
+      expect.not.objectContaining({contentType: expect.anything()}),
+    )
+  })
+
+  test('cancels the streams and request when aborted', async () => {
+    const stream = new Readable({read() {}})
+    const requestTeardown = vi.fn()
+    const upload = vi.fn(() => new Observable(() => requestTeardown))
+    const controller = new AbortController()
+    mockCreateReadStream.mockReturnValue(stream as never)
+    mockGetProjectCliClient.mockResolvedValue({observable: {assets: {upload}}} as never)
+
+    const result = uploadAsset({
+      assetType: 'image',
+      dataset: 'production',
+      filename: 'hero.png',
+      filePath: '/private/tmp/hero.png',
+      fileSize: 100,
+      projectId: 'test-project',
+      signal: controller.signal,
+    })
+    await vi.waitFor(() => expect(upload).toHaveBeenCalledOnce())
+    controller.abort(new Error('SIGINT'))
+
+    await expect(result).rejects.toThrow('SIGINT')
+    expect(stream.destroyed).toBe(true)
+    expect(requestTeardown).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/@sanity/cli/src/services/assets.ts
+++ b/packages/@sanity/cli/src/services/assets.ts
@@ -1,0 +1,82 @@
+import {createReadStream} from 'node:fs'
+import {Transform} from 'node:stream'
+
+import {getProjectCliClient} from '@sanity/cli-core'
+import {filter, lastValueFrom, map, Observable, race} from 'rxjs'
+
+export const ASSETS_API_VERSION = 'v2024-06-24'
+
+export type AssetType = 'file' | 'image'
+
+interface UploadAssetOptions {
+  assetType: AssetType
+  dataset: string
+  filename: string
+  filePath: string
+  fileSize: number
+  projectId: string
+
+  contentType?: string
+  onProgress?: (percent: number) => void
+  signal?: AbortSignal
+}
+
+export async function uploadAsset({
+  assetType,
+  contentType,
+  dataset,
+  filename,
+  filePath,
+  fileSize,
+  onProgress,
+  projectId,
+  signal,
+}: UploadAssetOptions) {
+  signal?.throwIfAborted()
+
+  const client = await getProjectCliClient({
+    apiVersion: ASSETS_API_VERSION,
+    dataset,
+    projectId,
+    requestTagPrefix: 'sanity.assets.upload',
+    requireUser: true,
+  })
+  signal?.throwIfAborted()
+
+  let uploadedBytes = 0
+  const fileStream = createReadStream(filePath)
+  const uploadStream = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      uploadedBytes += chunk.length
+      onProgress?.((uploadedBytes / fileSize) * 100)
+      callback(null, chunk)
+    },
+  })
+  fileStream.on('error', (error) => uploadStream.destroy(error)).pipe(uploadStream)
+
+  const response$ = client.observable.assets
+    .upload(assetType, uploadStream, {
+      ...(contentType ? {contentType} : {}),
+      filename,
+      tag: 'asset.upload',
+    })
+    .pipe(
+      filter((event) => event.type === 'response'),
+      map((event) => event.body.document),
+    )
+
+  if (!signal) return lastValueFrom(response$)
+
+  const abort$ = new Observable<never>((subscriber) => {
+    const abortUpload = () => {
+      fileStream.destroy()
+      uploadStream.destroy()
+      subscriber.error(signal.reason instanceof Error ? signal.reason : new Error('SIGINT'))
+    }
+
+    signal.addEventListener('abort', abortUpload, {once: true})
+    return () => signal.removeEventListener('abort', abortUpload)
+  })
+
+  return lastValueFrom(race(response$, abort$))
+}

--- a/packages/@sanity/cli/src/services/assets.ts
+++ b/packages/@sanity/cli/src/services/assets.ts
@@ -1,5 +1,4 @@
-import {createReadStream} from 'node:fs'
-import {Transform} from 'node:stream'
+import {type Readable, Transform} from 'node:stream'
 
 import {getProjectCliClient} from '@sanity/cli-core'
 import {filter, lastValueFrom, map, Observable, race} from 'rxjs'
@@ -10,9 +9,9 @@ export type AssetType = 'file' | 'image'
 
 interface UploadAssetOptions {
   assetType: AssetType
+  body: Readable
   dataset: string
   filename: string
-  filePath: string
   fileSize: number
   projectId: string
 
@@ -23,10 +22,10 @@ interface UploadAssetOptions {
 
 export async function uploadAsset({
   assetType,
+  body,
   contentType,
   dataset,
   filename,
-  filePath,
   fileSize,
   onProgress,
   projectId,
@@ -44,7 +43,6 @@ export async function uploadAsset({
   signal?.throwIfAborted()
 
   let uploadedBytes = 0
-  const fileStream = createReadStream(filePath)
   const uploadStream = new Transform({
     transform(chunk: Buffer, _encoding, callback) {
       uploadedBytes += chunk.length
@@ -52,7 +50,7 @@ export async function uploadAsset({
       callback(null, chunk)
     },
   })
-  fileStream.on('error', (error) => uploadStream.destroy(error)).pipe(uploadStream)
+  body.on('error', (error) => uploadStream.destroy(error)).pipe(uploadStream)
 
   const response$ = client.observable.assets
     .upload(assetType, uploadStream, {
@@ -69,7 +67,7 @@ export async function uploadAsset({
 
   const abort$ = new Observable<never>((subscriber) => {
     const abortUpload = () => {
-      fileStream.destroy()
+      body.destroy()
       uploadStream.destroy()
       subscriber.error(signal.reason instanceof Error ? signal.reason : new Error('SIGINT'))
     }

--- a/packages/@sanity/cli/src/topicAliases.ts
+++ b/packages/@sanity/cli/src/topicAliases.ts
@@ -19,6 +19,7 @@
  * (plural to singular) makes the CLI predictable for users.
  */
 export const topicAliases: Record<string, string[]> = {
+  assets: ['asset'],
   backups: ['backup'],
   blueprints: ['blueprint'],
   datasets: ['dataset'],

--- a/packages/@sanity/cli/test/integration/commands/assets/upload.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/assets/upload.test.ts
@@ -1,0 +1,91 @@
+import {mkdtemp, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {testCommand} from '@sanity/cli-test'
+import nock, {cleanAll, pendingMocks} from 'nock'
+import {afterAll, afterEach, beforeAll, describe, expect, test} from 'vitest'
+
+import {UploadAssetCommand} from '../../../../src/commands/assets/upload.js'
+import {ASSETS_API_VERSION} from '../../../../src/services/assets.js'
+
+describe('#assets:upload integration', () => {
+  const projectId = 'test-project'
+  const dataset = 'production'
+  const bytes = Buffer.from([0, 1, 2, 3, 255])
+  let fixtureDirectory: string
+  let fixturePath: string
+
+  beforeAll(async () => {
+    fixtureDirectory = await mkdtemp(join(tmpdir(), 'sanity-assets-upload-'))
+    fixturePath = join(fixtureDirectory, 'fixture.png')
+    await writeFile(fixturePath, bytes)
+  })
+
+  afterEach(() => {
+    const pending = pendingMocks()
+    cleanAll()
+    expect(pending).toEqual([])
+  })
+
+  afterAll(async () => {
+    await rm(fixtureDirectory, {force: true, recursive: true})
+  })
+
+  test('sends unchanged bytes and prints the returned asset document', async () => {
+    let uploadedBody: Buffer | undefined
+    const asset = {
+      _id: 'image-abc-1x1-png',
+      _type: 'sanity.imageAsset',
+      extension: 'png',
+      mimeType: 'image/png',
+      originalFilename: 'fixture.png',
+      size: bytes.length,
+      url: `https://cdn.sanity.io/images/${projectId}/${dataset}/abc-1x1.png`,
+    }
+
+    nock(`https://${projectId}.api.sanity.io`)
+      .post(`/${ASSETS_API_VERSION}/assets/images/${dataset}`, (body) => {
+        // Nock represents an application/octet-stream request body as a hex string.
+        uploadedBody = Buffer.isBuffer(body) ? body : Buffer.from(body as string, 'hex')
+        return true
+      })
+      .query(true)
+      .reply(200, {document: asset})
+
+    const {error, stderr, stdout} = await testCommand(
+      UploadAssetCommand,
+      [
+        '--file',
+        fixturePath,
+        '--type',
+        'image',
+        '--content-type',
+        'image/png',
+        '--project-id',
+        projectId,
+        '--dataset',
+        dataset,
+      ],
+      {mocks: {token: 'test-token'}},
+    )
+
+    if (error) throw error
+    expect(uploadedBody).toEqual(bytes)
+    expect(stderr).toBe(
+      [
+        '- Uploading image asset. Large uploads may take several minutes.',
+        'Creating image asset document',
+        `✔ Uploaded image asset: ${asset._id}`,
+        '',
+      ].join('\n'),
+    )
+    expect(JSON.parse(stdout)).toEqual({
+      asset,
+      reference: {
+        _type: 'image',
+        asset: {_ref: asset._id, _type: 'reference'},
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Description

Agents can create and edit Sanity content but cannot finish workflows that depend on a local or generated image without a manual Studio upload.

This adds `sanity assets upload` as a local image and file upload primitive. It streams one asset with the user's CLI authentication, reports bounded progress on stderr, and returns the uploaded asset ID plus ready-to-use reference JSON on stdout. Interactive terminals update progress in place; non-interactive callers receive a small number of meaningful progress states. Ctrl+C cancels both upload and asset-document creation and exits with code 130.

The command supports a feature-flagged MCP handoff while a presigned upload solution goes through API and security review. The command-owned telemetry policy redacts values for both `--file` and `--filename` while preserving useful flag signals such as asset type and content type. Upload errors are sanitized, and `assets:upload` is explicitly denied in MCP-hosted CLI execution.

Context: [AIGRO-5250](https://linear.app/sanity/issue/AIGRO-5250/mcp-managed-studio-decide-what-capability-gaps-to-support)

Privacy prerequisite: [CLI #1694](https://github.com/sanity-io/cli/pull/1694) / [AIGRO-5379](https://linear.app/sanity/issue/AIGRO-5379/redact-file-paths-and-filenames-from-cli-telemetry)

### What to review

- The `assets upload --file` command surface and JSON response.
- TTY and non-interactive progress behavior.
- Ctrl+C cancellation during upload and asset-document creation.
- Authentication, dataset selection, error redaction, command-owned telemetry, and MCP policy boundaries.

### Testing

- Upload command unit tests: 12 passed, including telemetry redaction coverage.
- Real image upload with telemetry debugging confirmed that `--file` and `--filename` values are absent while non-sensitive flags remain visible.
- CLI unit suite: 3,725 passed and 4 skipped. Two ANSI snapshot assertions also fail unchanged on `origin/main` under Node 26.
- CLI integration suite: 497 passed and 10 skipped.
- Format, type, lint, dependency, build, and diff checks passed.

### UAT

#### happy, interactive progress
<img width="960" height="831" alt="shapiro assets-upload cli" src="https://github.com/user-attachments/assets/f8169aca-e6e3-4a6c-93b8-62d087ba88b4" />

#### happy, with redacted telemetry
<img width="862" height="521" alt="cli assets-upload success-with-telemetry-redacted" src="https://github.com/user-attachments/assets/efa1e48a-d414-4379-9b4c-bd7f7b5ce2c5" />

#### happy, with result payload
<img width="864" height="474" alt="Screenshot 2026-08-12 at 6 35 25 PM" src="https://github.com/user-attachments/assets/222ebccf-b4ec-457a-b67d-dcf3797fe744" />

#### happy, non-interactive agent output shows progress checkpoints
<img width="680" height="181" alt="Screenshot 2026-08-12 at 6 40 36 PM" src="https://github.com/user-attachments/assets/e4bda02f-056c-4f2e-b809-6f9fa0d63111" />

#### sad, SIGINT during upload
<img width="798" height="265" alt="Screenshot 2026-08-12 at 6 33 52 PM" src="https://github.com/user-attachments/assets/278c7e43-6ed0-41cb-8b9f-0e316f4bf46e" />
 / document creation steps
