### PR TITLE
fix(cli): preserve responsive table borders

### DIFF
--- a/.changeset/users-list-table-width.md
+++ b/.changeset/users-list-table-width.md
@@ -4,4 +4,4 @@
 
 fix(cli): keep table output within the terminal width
 
-CLI tables now wrap long values instead of overflowing the terminal or truncating content.
+CLI tables now wrap long values instead of truncating content and preserve borders when Unicode width estimates differ.

--- a/packages/@sanity/cli/src/util/__tests__/responsiveTable.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/responsiveTable.test.ts
@@ -73,12 +73,23 @@ describe('responsiveTable', () => {
     const lines = output.split('\n')
     expect(output).toContain('👨‍👩‍👧‍👦')
     expect(output).toContain('Cafe')
-    expect(lines[0]).toMatch(/^┌.*┐$/u)
-    expect(lines.at(-1)).toMatch(/^└.*┘$/u)
-    for (const line of lines.slice(1, -1)) {
-      expect(line).toMatch(/^(?:│.*│|├.*┤)$/u)
-      expect(stringWidth(line)).toBeLessThanOrEqual(20)
-    }
+
+    // The family emoji is a ZWJ sequence that `string-width` measures as 2 columns and
+    // `console-table-printer` as 8. That disagreement pushes the rendered table past the
+    // width this helper estimated, which is what previously let `wrap-ansi` reflow the
+    // finished output and split the horizontal rules across lines.
+    //
+    // The guarantee under test is that every border survives on a single line. Note that
+    // the table is 20 columns wide while the helper estimated 17, so the disagreement is
+    // still visible: the data row pads to the printer's 8-column reading of the emoji and
+    // renders short wherever the sequence composes into a single glyph. Asserting an
+    // overall width bound here would only pass by coincidence.
+    expect(lines).toHaveLength(5)
+    expect(lines[0]).toBe('┌──────────┬───────┐')
+    expect(lines[2]).toBe('├──────────┼───────┤')
+    expect(lines[4]).toBe('└──────────┴───────┘')
+    expect(lines[1]).toMatch(/^│.*│$/u)
+    expect(lines[3]).toMatch(/^│.*│$/u)
   })
 
   test('wraps column titles within the terminal width', () => {

--- a/packages/@sanity/cli/src/util/__tests__/responsiveTable.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/responsiveTable.test.ts
@@ -57,6 +57,30 @@ describe('responsiveTable', () => {
     }
   })
 
+  test('keeps borders intact for multi-code-point emoji', () => {
+    Object.defineProperty(process.stdout, 'columns', {configurable: true, value: 20})
+    const table = new Table({
+      columns: [
+        {alignment: 'left', name: 'emoji', title: 'Emoji'},
+        {alignment: 'left', name: 'value', title: 'Value'},
+      ],
+      shouldDisableColors: true,
+    })
+
+    table.addRow({emoji: '👨‍👩‍👧‍👦', value: 'Cafe'})
+
+    const output = table.render()
+    const lines = output.split('\n')
+    expect(output).toContain('👨‍👩‍👧‍👦')
+    expect(output).toContain('Cafe')
+    expect(lines[0]).toMatch(/^┌.*┐$/u)
+    expect(lines.at(-1)).toMatch(/^└.*┘$/u)
+    for (const line of lines.slice(1, -1)) {
+      expect(line).toMatch(/^(?:│.*│|├.*┤)$/u)
+      expect(stringWidth(line)).toBeLessThanOrEqual(20)
+    }
+  })
+
   test('wraps column titles within the terminal width', () => {
     Object.defineProperty(process.stdout, 'columns', {configurable: true, value: 40})
     const table = new Table({

--- a/packages/@sanity/cli/src/util/__tests__/responsiveTable.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/responsiveTable.test.ts
@@ -1,5 +1,5 @@
 import stringWidth from 'string-width'
-import {afterEach, describe, expect, test} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {Table} from '../responsiveTable.js'
 
@@ -139,5 +139,30 @@ describe('responsiveTable', () => {
     for (const line of output.split('\n')) {
       expect(stringWidth(line)).toBeLessThanOrEqual(20)
     }
+  })
+
+  test('filters titled table rows only once', () => {
+    let remainingRows = 1
+    const filter = vi.fn(() => remainingRows-- > 0)
+    const table = new Table({
+      columns: [
+        {alignment: 'left', name: 'name', title: 'Name'},
+        {alignment: 'left', name: 'role', title: 'Role'},
+      ],
+      filter,
+      shouldDisableColors: true,
+      title: 'Users',
+    })
+
+    table.addRows([
+      {name: 'Ada', role: 'Administrator'},
+      {name: 'Grace', role: 'Developer'},
+    ])
+
+    const output = table.render()
+    expect(output).toContain('Users')
+    expect(output).toContain('Ada')
+    expect(output).not.toContain('Grace')
+    expect(filter).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/@sanity/cli/src/util/responsiveTable.ts
+++ b/packages/@sanity/cli/src/util/responsiveTable.ts
@@ -72,36 +72,43 @@ export class Table {
     }
 
     const tableWidth = borderWidth + columnWidths.reduce((total, width) => total + width, 0)
-    const renderTable = (title?: string) => {
-      const table = new ConsoleTable({
-        rowSeparator: true,
-        ...this.#options,
-        columns: columns.map((column, index) => ({
-          ...column,
-          maxLen: columnWidths[index],
-          title: wrapAnsi(columnTitles[index], columnWidths[index], {hard: true}),
-        })),
-        title,
-      })
+    const renderedColumns = columns.map((column, index) => ({
+      ...column,
+      maxLen: columnWidths[index],
+      title: wrapAnsi(columnTitles[index], columnWidths[index], {hard: true}),
+    }))
+    const table = new ConsoleTable({
+      rowSeparator: true,
+      ...this.#options,
+      columns: renderedColumns,
+      title: undefined,
+    })
 
-      for (const {cells, options} of this.#rows) {
-        const wrappedCells = {...cells}
-        for (const [index, {name}] of columns.entries()) {
-          wrappedCells[name] = wrapAnsi(cellText(cells[name]), columnWidths[index], {hard: true})
-        }
-        table.addRow(wrappedCells, options)
+    for (const {cells, options} of this.#rows) {
+      const wrappedCells = {...cells}
+      for (const [index, {name}] of columns.entries()) {
+        wrappedCells[name] = wrapAnsi(cellText(cells[name]), columnWidths[index], {hard: true})
       }
-
-      return table.render()
+      table.addRow(wrappedCells, options)
     }
 
-    const renderedTable = renderTable()
+    const renderedTable = table.render()
     if (!this.#options.title) return renderedTable
 
-    const renderedWithTitle = renderTable(this.#options.title)
-    const tableSuffix = `\n${renderedTable}`
-    const renderedTitle = renderedWithTitle.slice(0, -tableSuffix.length)
+    // Use empty tables to preserve the printer's title styling without invoking row callbacks again.
+    const titleTableOptions = {
+      ...this.#options,
+      columns: renderedColumns,
+      rows: undefined,
+    }
+    const renderedTitleTable = new ConsoleTable({
+      ...titleTableOptions,
+      title: this.#options.title,
+    }).render()
+    const renderedEmptyTable = new ConsoleTable({...titleTableOptions, title: undefined}).render()
+    const emptyTableSuffix = `\n${renderedEmptyTable}`
+    const renderedTitle = renderedTitleTable.slice(0, -emptyTableSuffix.length)
     const wrappedTitle = wrapAnsi(renderedTitle, tableWidth, {hard: true, trim: false})
-    return `${wrappedTitle}${tableSuffix}`
+    return `${wrappedTitle}\n${renderedTable}`
   }
 }

--- a/packages/@sanity/cli/src/util/responsiveTable.ts
+++ b/packages/@sanity/cli/src/util/responsiveTable.ts
@@ -72,24 +72,36 @@ export class Table {
     }
 
     const tableWidth = borderWidth + columnWidths.reduce((total, width) => total + width, 0)
-    const table = new ConsoleTable({
-      rowSeparator: true,
-      ...this.#options,
-      columns: columns.map((column, index) => ({
-        ...column,
-        maxLen: columnWidths[index],
-        title: wrapAnsi(columnTitles[index], columnWidths[index], {hard: true}),
-      })),
-    })
+    const renderTable = (title?: string) => {
+      const table = new ConsoleTable({
+        rowSeparator: true,
+        ...this.#options,
+        columns: columns.map((column, index) => ({
+          ...column,
+          maxLen: columnWidths[index],
+          title: wrapAnsi(columnTitles[index], columnWidths[index], {hard: true}),
+        })),
+        title,
+      })
 
-    for (const {cells, options} of this.#rows) {
-      const wrappedCells = {...cells}
-      for (const [index, {name}] of columns.entries()) {
-        wrappedCells[name] = wrapAnsi(cellText(cells[name]), columnWidths[index], {hard: true})
+      for (const {cells, options} of this.#rows) {
+        const wrappedCells = {...cells}
+        for (const [index, {name}] of columns.entries()) {
+          wrappedCells[name] = wrapAnsi(cellText(cells[name]), columnWidths[index], {hard: true})
+        }
+        table.addRow(wrappedCells, options)
       }
-      table.addRow(wrappedCells, options)
+
+      return table.render()
     }
 
-    return wrapAnsi(table.render(), tableWidth, {hard: true, trim: false})
+    const renderedTable = renderTable()
+    if (!this.#options.title) return renderedTable
+
+    const renderedWithTitle = renderTable(this.#options.title)
+    const tableSuffix = `\n${renderedTable}`
+    const renderedTitle = renderedWithTitle.slice(0, -tableSuffix.length)
+    const wrappedTitle = wrapAnsi(renderedTitle, tableWidth, {hard: true, trim: false})
+    return `${wrappedTitle}${tableSuffix}`
   }
 }


### PR DESCRIPTION
### Description

Follow-up to #1680 for AIGRO-5358. This addresses the unresolved [Cursor Bugbot review](https://github.com/sanity-io/cli/pull/1680#discussion_r3737883018).

The responsive table helper wrapped the complete `console-table-printer` output. When `string-width` and the table printer disagree about the width of a multi-code-point character, the rendered table can be wider than the helper's estimate. Passing that completed output through `wrap-ansi` then splits rows and horizontal borders.

This change renders the table rows once without a title, derives the printer-styled title from empty tables, wraps only that title segment, and appends the untouched table. Keeping title extraction row-free prevents filter, sort, transform, and computed-column callbacks from running a second time. It keeps the table printer's existing title styling while ensuring finished borders are never reflowed. It adds no dependencies or installed weight.

Synthetic 20-column example:

Before:

```text
┌──────────┬─────
──┐
│ Emoji    │
Value │
├──────────┼─────
──┤
│ 👨‍👩‍👧‍👦 │ Cafe  │
└──────────┴─────
──┘
```

After:

```text
┌──────────┬───────┐
│ Emoji    │ Value │
├──────────┼───────┤
│ 👨‍👩‍👧‍👦 │ Cafe  │
└──────────┴───────┘
```

Note that the data row still looks short above, and that is expected rather than a leftover bug. `console-table-printer` measures this ZWJ sequence as 8 columns and pads the cell to match, while `string-width` measures it as 2, so the row renders narrow anywhere the sequence composes into a single glyph (GitHub, iTerm2, Ghostty, WezTerm). Terminals that draw the four faces separately line it up exactly.

That underlying disagreement is the cause of the bug, so it cannot be demonstrated with a character that avoids it: `string-width` and the table printer agree on CJK text and on single-code-point emoji, and those inputs never trigger the reflow. The scope here is strictly that finished borders stay on one line. Column padding for such characters, and the fact that the printer can size a table wider than this helper's estimate, remain open and predate this change.

### What to review

- Confirm only the title segment is passed through `wrap-ansi` after rendering.
- Confirm titled tables invoke stateful row callbacks only once per row.
- Confirm tables without titles and tables with wrapped titles retain their existing output.
- Confirm multi-code-point emoji cannot split the surrounding borders.
- Note the regression test pins the exact border lines rather than an overall width bound: the emoji table renders 20 columns wide against a 17-column estimate, so a width assertion would pass by coincidence.

### Testing

- Responsive table unit tests with coverage: 6 passed; 100% statements, functions, and lines.
- Affected unit tests: 122 passed across 11 files.
- Projects list integration tests: 4 passed.
- `pnpm check:format`, `pnpm check:types`, `pnpm check:lint`, `pnpm check:deps`, and repeated `pnpm build:cli` runs passed.
- The broader unit run reached 592 passing tests before the known, unchanged ANSI snapshot mismatch in `formatDocumentValidation.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in the CLI table helper with no auth, data, or API impact; behavior is narrowed to border preservation and titled-table rendering.
> 
> **Overview**
> **CLI responsive tables** no longer run the full `console-table-printer` output through `wrap-ansi`, which could break horizontal rules when `string-width` and the printer disagree on wide characters (e.g. ZWJ emoji).
> 
> Rendering now leaves the data table untouched; only the optional title is wrapped to the computed table width, using a separate printer pass so title styling stays the same without re-running row filters. Tables without a title skip post-render wrapping entirely.
> 
> Regression coverage adds a multi-code-point emoji case (borders stay on one line) and asserts titled tables with a `filter` invoke that callback only once per row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5521380397aff922364ba2a00b079d03ffd87f26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

