### PR TITLE
fix(ci): publish behind a holding tag until packages are installable

### DIFF
--- a/.github/actions/promote-npm-packages/action.yml
+++ b/.github/actions/promote-npm-packages/action.yml
@@ -1,0 +1,95 @@
+name: 'Promote npm packages'
+description: 'Waits for published versions to clear npm scanning, then moves the latest dist-tag onto them'
+
+inputs:
+  specs:
+    description: 'Newline-separated name@version specs to promote'
+    required: true
+  holding-tag:
+    description: 'Dist-tag the versions were published under, removed once they are promoted'
+    required: true
+  npm-token:
+    description: >-
+      npm token with publish rights. OIDC cannot be used here: trusted publishing only
+      covers `npm publish`, not `npm dist-tag` (https://github.com/npm/cli/issues/8547).
+    required: true
+  timeout-minutes:
+    description: 'How long to wait for every version to become installable'
+    default: '20'
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for packages to be installable
+      # npm holds newly published versions for malware scanning (usually 5-15
+      # minutes, sometimes longer) before they resolve on the registry. Poll
+      # until the whole set resolves, so `latest` is only moved onto versions
+      # that can actually be installed.
+      # https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/
+      shell: bash
+      env:
+        SPECS: ${{ inputs.specs }}
+        TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
+      run: |
+        mapfile -t pending < <(grep -v '^[[:space:]]*$' <<<"$SPECS")
+
+        if [ "${#pending[@]}" -eq 0 ]; then
+          echo "Error: no package specs were given"
+          exit 1
+        fi
+
+        echo "Waiting for ${#pending[@]} package(s) to resolve on the registry: ${pending[*]}"
+
+        deadline=$((SECONDS + TIMEOUT_MINUTES * 60))
+        while true; do
+          still_pending=()
+          for spec in "${pending[@]}"; do
+            if resolved=$(npm view "$spec" version --prefer-online 2>/dev/null) && [ -n "$resolved" ]; then
+              echo "✅ $spec is installable"
+            else
+              still_pending+=("$spec")
+            fi
+          done
+          pending=("${still_pending[@]}")
+
+          if [ "${#pending[@]}" -eq 0 ]; then
+            echo "✅ All packages are installable"
+            break
+          fi
+
+          if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "Error: timed out waiting for these packages to become installable:"
+            printf ' - %s\n' "${pending[@]}"
+            exit 1
+          fi
+
+          echo "⏳ Still waiting on ${#pending[@]} package(s): ${pending[*]} (retrying in 15s)"
+          sleep 15
+        done
+
+    - name: Move the latest tag
+      shell: bash
+      env:
+        SPECS: ${{ inputs.specs }}
+        HOLDING_TAG: ${{ inputs.holding-tag }}
+        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
+      run: |
+        # Single-quoted so the token is resolved from the environment at run
+        # time rather than written to disk
+        echo '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' >> .npmrc
+
+        mapfile -t specs < <(grep -v '^[[:space:]]*$' <<<"$SPECS")
+
+        for spec in "${specs[@]}"; do
+          echo "Tagging $spec as latest"
+          npm dist-tag add "$spec" latest
+        done
+
+        # Drop the holding tag now that latest points at these versions
+        for spec in "${specs[@]}"; do
+          name="${spec%@*}"
+          npm dist-tag rm "$name" "$HOLDING_TAG" ||
+            echo "Warning: could not remove the '$HOLDING_TAG' tag from $name"
+        done
+
+        echo "✅ Promoted ${#specs[@]} package(s) to latest"

--- a/.github/workflows/promote-latest.yml
+++ b/.github/workflows/promote-latest.yml
@@ -1,0 +1,88 @@
+name: Promote to latest
+
+# Recovery / break-glass counterpart to release.yml.
+#
+# release.yml publishes behind a holding dist-tag and only moves `latest` once
+# every published version has cleared npm's malware scan. If that wait times
+# out - or the job dies part way through - the versions are on the registry but
+# still parked on the holding tag, and re-running release.yml will not finish
+# the job: changesets reports nothing as newly published the second time, so its
+# promote step is skipped. Run this workflow instead. It reads the versions back
+# off the holding tag, so it needs no input and cannot promote a version that
+# release.yml did not park there.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    name: Promote to latest
+    runs-on: ubuntu-latest
+
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      # Keep in sync with HOLDING_TAG in release.yml
+      HOLDING_TAG: pending
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          node-version: 24
+
+      - name: Find packages awaiting promotion
+        id: specs
+        run: |
+          specs=()
+          for name in $(pnpm ls -r --json --depth -1 | jq -r '.[] | select(.private != true) | .name'); do
+            version=$(npm view "$name" "dist-tags.$HOLDING_TAG" --prefer-online 2>/dev/null || true)
+            if [ -n "$version" ]; then
+              echo "$name@$version is parked on '$HOLDING_TAG'"
+              specs+=("$name@$version")
+            else
+              echo "$name has nothing on '$HOLDING_TAG', skipping"
+            fi
+          done
+
+          if [ "${#specs[@]}" -eq 0 ]; then
+            echo "Error: no packages are tagged '$HOLDING_TAG', so there is nothing to promote"
+            exit 1
+          fi
+
+          {
+            echo 'specs<<SPECS_EOF'
+            printf '%s\n' "${specs[@]}"
+            echo 'SPECS_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Promote packages to latest
+        uses: ./.github/actions/promote-npm-packages
+        with:
+          specs: ${{ steps.specs.outputs.specs }}
+          holding-tag: ${{ env.HOLDING_TAG }}
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+      - name: Summary
+        env:
+          SPECS: ${{ steps.specs.outputs.specs }}
+        run: |
+          {
+            echo "## Promoted to latest 🚀"
+            echo ""
+            echo '```'
+            echo "$SPECS"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      # Temporary dist-tag that new versions are parked under until npm has
+      # finished scanning them. Must not collide with a tag anyone consumes.
+      HOLDING_TAG: pending
 
     steps:
       - name: Generate GitHub App Token
@@ -64,12 +67,35 @@ jobs:
       - name: Build packages
         run: pnpm run build:cli
 
+      - name: Determine publish mode
+        id: publish-mode
+        # npm holds newly published versions for malware scanning (usually 5-15
+        # minutes, sometimes longer) before they resolve on the registry. Since
+        # our packages pin each other (`create-sanity` pins `@sanity/cli`
+        # exactly; the `@sanity/cli*` packages pin each other with a caret
+        # range), a package whose scan clears first would become `latest` while
+        # a dependency it needs is still held, breaking `npm create sanity`.
+        # So publish behind a holding tag and only move `latest` once every
+        # version resolves. In prerelease mode changesets picks its own dist-tag
+        # from .changeset/pre.json, so leave it alone and never touch `latest`.
+        # https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/
+        run: |
+          if [ -f .changeset/pre.json ]; then
+            echo "Prerelease mode - publishing with the changesets-managed dist-tag"
+            echo "publish-args=" >> "$GITHUB_OUTPUT"
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing behind the '$HOLDING_TAG' tag, promoting to latest once installable"
+            echo "publish-args=--tag $HOLDING_TAG" >> "$GITHUB_OUTPUT"
+            echo "promote=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm version-packages
-          publish: pnpm publish-packages
+          publish: pnpm run publish-packages ${{ steps.publish-mode.outputs.publish-args }}
           title: 'chore: version packages'
           commit: 'chore: version packages'
           createGithubReleases: true
@@ -89,6 +115,75 @@ jobs:
           echo '```json' >> $GITHUB_STEP_SUMMARY
           echo "$PUBLISHED_PACKAGES" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Wait for packages to be installable
+        # Poll until every version npm just accepted has cleared scanning and
+        # resolves. On timeout the job fails with `latest` still pointing at the
+        # previous, mutually consistent set of versions.
+        if: ${{ steps.changesets.outputs.published == 'true' }}
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          mapfile -t pending < <(jq -r '.[] | "\(.name)@\(.version)"' <<<"$PUBLISHED_PACKAGES")
+
+          echo "Waiting for ${#pending[@]} package(s) to resolve on the registry: ${pending[*]}"
+
+          deadline=$((SECONDS + 20 * 60))
+          while true; do
+            still_pending=()
+            for spec in "${pending[@]}"; do
+              if resolved=$(npm view "$spec" version --prefer-online 2>/dev/null) && [ -n "$resolved" ]; then
+                echo "✅ $spec is installable"
+              else
+                still_pending+=("$spec")
+              fi
+            done
+            pending=("${still_pending[@]}")
+
+            if [ "${#pending[@]}" -eq 0 ]; then
+              echo "✅ All published packages are installable"
+              break
+            fi
+
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "Error: timed out waiting for these packages to become installable:"
+              printf ' - %s\n' "${pending[@]}"
+              exit 1
+            fi
+
+            echo "⏳ Still waiting on ${#pending[@]} package(s): ${pending[*]} (retrying in 15s)"
+            sleep 15
+          done
+
+      - name: Promote packages to latest
+        # Only now is the whole set installable, so it is safe to move `latest`.
+        # OIDC trusted publishing only covers `npm publish`, so this needs the
+        # npm token - the same one snapshot-release.yml publishes with.
+        # https://docs.npmjs.com/trusted-publishers/
+        if: ${{ steps.changesets.outputs.published == 'true' && steps.publish-mode.outputs.promote == 'true' }}
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: |
+          # Single-quoted so the token is resolved from the environment at run
+          # time rather than written to disk
+          echo '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' >> .npmrc
+
+          mapfile -t specs < <(jq -r '.[] | "\(.name)@\(.version)"' <<<"$PUBLISHED_PACKAGES")
+
+          for spec in "${specs[@]}"; do
+            echo "Tagging $spec as latest"
+            npm dist-tag add "$spec" latest
+          done
+
+          # Drop the holding tag now that latest points at these versions
+          for spec in "${specs[@]}"; do
+            name="${spec%@*}"
+            npm dist-tag rm "$name" "$HOLDING_TAG" ||
+              echo "Warning: could not remove the '$HOLDING_TAG' tag from $name"
+          done
+
+          echo "✅ Promoted ${#specs[@]} package(s) to latest"
 
   post-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,74 +116,31 @@ jobs:
           echo "$PUBLISHED_PACKAGES" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
-      - name: Wait for packages to be installable
-        # Poll until every version npm just accepted has cleared scanning and
-        # resolves. On timeout the job fails with `latest` still pointing at the
-        # previous, mutually consistent set of versions.
+      - name: Resolve published specs
+        id: specs
         if: ${{ steps.changesets.outputs.published == 'true' }}
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
-          mapfile -t pending < <(jq -r '.[] | "\(.name)@\(.version)"' <<<"$PUBLISHED_PACKAGES")
-
-          echo "Waiting for ${#pending[@]} package(s) to resolve on the registry: ${pending[*]}"
-
-          deadline=$((SECONDS + 20 * 60))
-          while true; do
-            still_pending=()
-            for spec in "${pending[@]}"; do
-              if resolved=$(npm view "$spec" version --prefer-online 2>/dev/null) && [ -n "$resolved" ]; then
-                echo "✅ $spec is installable"
-              else
-                still_pending+=("$spec")
-              fi
-            done
-            pending=("${still_pending[@]}")
-
-            if [ "${#pending[@]}" -eq 0 ]; then
-              echo "✅ All published packages are installable"
-              break
-            fi
-
-            if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "Error: timed out waiting for these packages to become installable:"
-              printf ' - %s\n' "${pending[@]}"
-              exit 1
-            fi
-
-            echo "⏳ Still waiting on ${#pending[@]} package(s): ${pending[*]} (retrying in 15s)"
-            sleep 15
-          done
+          {
+            echo 'specs<<SPECS_EOF'
+            jq -r '.[] | "\(.name)@\(.version)"' <<<"$PUBLISHED_PACKAGES"
+            echo 'SPECS_EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Promote packages to latest
-        # Only now is the whole set installable, so it is safe to move `latest`.
-        # OIDC trusted publishing only covers `npm publish`, so this needs the
-        # npm token - the same one snapshot-release.yml publishes with.
-        # https://docs.npmjs.com/trusted-publishers/
+        # Waits until the whole set has cleared npm's scan, then moves `latest`.
+        # If it times out the job fails with `latest` still pointing at the
+        # previous, mutually consistent set of versions; recover by re-running
+        # promote-latest.yml, which picks the versions back up from the holding
+        # tag (a re-run of this workflow will not, since changesets reports
+        # nothing as newly published the second time around).
         if: ${{ steps.changesets.outputs.published == 'true' && steps.publish-mode.outputs.promote == 'true' }}
-        env:
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        run: |
-          # Single-quoted so the token is resolved from the environment at run
-          # time rather than written to disk
-          echo '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' >> .npmrc
-
-          mapfile -t specs < <(jq -r '.[] | "\(.name)@\(.version)"' <<<"$PUBLISHED_PACKAGES")
-
-          for spec in "${specs[@]}"; do
-            echo "Tagging $spec as latest"
-            npm dist-tag add "$spec" latest
-          done
-
-          # Drop the holding tag now that latest points at these versions
-          for spec in "${specs[@]}"; do
-            name="${spec%@*}"
-            npm dist-tag rm "$name" "$HOLDING_TAG" ||
-              echo "Warning: could not remove the '$HOLDING_TAG' tag from $name"
-          done
-
-          echo "✅ Promoted ${#specs[@]} package(s) to latest"
+        uses: ./.github/actions/promote-npm-packages
+        with:
+          specs: ${{ steps.specs.outputs.specs }}
+          holding-tag: ${{ env.HOLDING_TAG }}
+          npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   post-release:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -731,6 +731,35 @@ This creates a changeset file in `.changeset/`. If you do this, write `N/A` in t
 3. **Merging the Version Packages PR** triggers publishing to npm
 4. **GitHub Releases** are automatically created for each published package
 
+### The `pending` Dist-Tag
+
+Step 3 does not publish straight to `latest`. npm [scans new versions for malware at publish time](https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/) and holds each one for roughly 5-15 minutes before it resolves on the registry. Our packages pin each other (`create-sanity` pins `@sanity/cli` exactly), so if one package clears the scan before a dependency does, `latest` would point at a version nobody can install and `npm create sanity` would break.
+
+So the Release workflow:
+
+1. Publishes everything under a temporary `pending` dist-tag, leaving `latest` on the previous, mutually consistent set of versions
+2. Polls the registry until every published version resolves (up to 20 minutes)
+3. Moves `latest` onto the new versions and drops the `pending` tag
+
+While this is running, `npm install @sanity/cli@latest` keeps returning the previous release. That is intentional.
+
+Note that step 3 needs the `NPM_PUBLISH_TOKEN` secret rather than OIDC, because npm's trusted publishing only covers `npm publish`, not `npm dist-tag` ([npm/cli#8547](https://github.com/npm/cli/issues/8547)).
+
+### Recovering From a Stuck Release
+
+If the Release workflow fails **after** publishing (most likely the wait in step 2 timing out because npm's scan is slow, or the job being cancelled), the new versions are on npm but still parked on `pending`, and `latest` has not moved. Users are unaffected, but the release has not landed.
+
+**Do not re-run the Release workflow.** It will not finish the job: changesets sees the versions as already published, reports nothing as newly published, and skips promotion entirely.
+
+Instead:
+
+1. Go to **Actions** → **Promote to latest** → **Run workflow**
+2. It finds every package with a version on `pending`, waits for those versions to become installable, then moves `latest` onto them
+
+The workflow takes no input and reads the versions off the registry, so it can only promote what the Release workflow already parked. If nothing is on `pending` it fails with a message saying so, which means either the release completed normally or it failed before publishing anything.
+
+If it keeps timing out, check [npm status](https://status.npmjs.org/) before digging further. A held-for-manual-review publish will not clear on its own.
+
 ### Propagating Releases to the Sanity Monorepo
 
 Publishing `@sanity/cli` and `create-sanity` to npm is only the first step. Most users do not depend on `@sanity/cli` directly — they invoke it through `npx sanity` or as a transitive dependency of the `sanity` package. For a release to actually reach those users, the CLI version must also be bumped in the [sanity-io/sanity](https://github.com/sanity-io/sanity) monorepo.


### PR DESCRIPTION
### Description

**Before:** the release workflow publishes straight to `latest`. npm [scans new versions for malware at publish time](https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/) and holds each one for roughly 5-15 minutes before it resolves on the registry. Our packages pin each other, so when one package's scan clears before a dependency's, `latest` points at a version that cannot be installed. `create-sanity` pins `@sanity/cli` exactly (`workspace:*`), so this breaks `npm create sanity`, and the `@sanity/cli*` packages pin each other with caret ranges. This is what bit the sanity monorepo during v6.8.0 (sanity-io/sanity#13823).

**After:** `release.yml` publishes everything behind a temporary `pending` dist-tag, polls until every published version resolves, then moves `latest`. During the hold `latest` keeps pointing at the previous, mutually consistent set of versions. If the wait times out, `latest` is never moved: the release is invisible rather than broken.

This is deliberately not a straight port of sanity-io/sanity#13823. That PR gates downstream jobs so the release is not *announced* before it is installable, which works there because announcement lives in separate jobs. Here `changesets/action` creates the GitHub releases inside its own step, so the only downstream job is `post-release` (Linear issue bookkeeping). A gate alone would just hold the workflow open without protecting anyone, so this moves the protection to the dist-tag instead.

Three commits:

- `20bfc978c` publish behind the holding tag, wait, then promote
- `3c7436392` add `promote-latest.yml` and extract the shared logic into a composite action
- `fab229b5f` document both in CONTRIBUTING.md

**Why the recovery workflow:** if the release job dies after publishing, the versions are on npm but still parked on `pending`, and re-running `release.yml` does *not* finish the job. Changesets sees them as already published, reports nothing as newly published, and skips promotion. `promote-latest.yml` is a `workflow_dispatch` that reads the versions back off the `pending` tag and promotes them. It takes no input, so it cannot promote anything the release workflow did not park there.

**Why a token instead of OIDC:** npm's trusted publishing [only covers `npm publish`](https://docs.npmjs.com/trusted-publishers/), not `npm dist-tag`. That gap is [npm/cli#8547](https://github.com/npm/cli/issues/8547), open since September 2025 with no response from npm; the workarounds people tried (`electron/npm-trusted-auth-action`, calling the dist-tags endpoint directly) are archived or return 401. So the promote step uses `NPM_PUBLISH_TOKEN`, the same secret `snapshot-release.yml` already publishes with. Publishing itself still uses OIDC, and the token is only written to `.npmrc` after the publish step so it cannot interfere with the OIDC exchange.

### What to review

`.github/workflows/release.yml` is the important one. Worth checking:

- **The `--tag` forwarding.** `publish:` is now `pnpm run publish-packages --tag pending`, built by the new "Determine publish mode" step. I first wrote it with a `--` separator, which pnpm passes through literally, so changesets' meow parser would have treated `--tag pending` as positional input and silently published to `latest` anyway. Verified the current form forwards cleanly on pnpm 10.34.4, the version pinned in `packageManager`.
- **The prerelease guard.** In prerelease mode changesets picks its own dist-tag from `.changeset/pre.json`, so forcing `--tag pending` would clobber it and promoting would put a prerelease on `latest`. The step skips both. `pre.json` has never appeared in this repo's history, so this path is untested by construction, but the failure mode is bad enough to guard.
- **Holding tag choice.** `pending`, picked after checking existing dist-tags on these packages. `next`, `canary`, `stable`, `alpha`, `beta` and `rc` are all in use.
- **Whether GitHub releases should also be gated.** They are still created by `changesets/action` inside its own step, so for a few minutes they announce a version that is not on `latest` yet. Gating that means `createGithubReleases: false` plus a separate step, which I left out as a separate decision.

Known caveats: the release job now holds a runner for the length of the scan hold, and npm sets `latest` on a package's first-ever version regardless of `--tag` (harmless, nothing depends on a prior version).

### Testing

Manual. This is CI workflow bash, not practical to unit test. I extracted each `run:` block and executed it in isolation:

- **Wait loop, live registry:** all specs resolve and it exits 0; with an injected `@sanity/cli@99.99.99` and a shortened deadline it retries, then fails with the missing-package list and exits 1. Empty input is rejected.
- **Publish mode:** both branches produce the expected `$GITHUB_OUTPUT`, and arg forwarding verified on both pnpm 10.34.4 and 11.5.2 with a script that prints raw argv.
- **Promote, stubbed `npm`:** correct `dist-tag` commands, scoped-name parsing works (`@sanity/cli@7.19.0` to `@sanity/cli`), a failed `dist-tag rm` warns without failing the step, a failed `dist-tag add` exits 1. `.npmrc` ends up containing the literal `${NODE_AUTH_TOKEN}` placeholder, not the token value.
- **Discovery in `promote-latest.yml`:** against the real registry today it correctly reports nothing to promote and exits 1; with a stub it picks up exactly the parked packages.
- All three YAML files parse; step order and `if` conditions confirmed.
- `pnpm check:format` passes. `pnpm check:deps` fails identically on `main` (unlisted `get-it` in a `dist/` file), so it is pre-existing and unrelated.

Not verified: an end-to-end run against a real release, since that needs an actual publish inside the scan window.

### Notes for release

N/A - Internal only (CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm release semantics and dist-tags for all public packages; misconfiguration could leave `latest` stale or promote wrong versions, though prerelease guards and registry-only recovery limit blast radius.
> 
> **Overview**
> **Release CI** no longer publishes straight to `latest`. Stable releases go out under a temporary **`pending`** dist-tag while npm finishes publish-time malware scanning; **`latest` stays on the previous release** until every published `name@version` resolves on the registry, then promotion moves `latest` and removes `pending`.
> 
> `release.yml` adds **Determine publish mode** (prerelease via `.changeset/pre.json` skips `--tag pending` and promotion), forwards **`--tag pending`** into `pnpm run publish-packages`, and after changesets publishes runs a new **Promote packages to latest** step. Promotion uses **`NPM_PUBLISH_TOKEN`** because OIDC trusted publishing does not cover `npm dist-tag`.
> 
> Shared logic lives in **`.github/actions/promote-npm-packages`**: poll `npm view` until specs are installable (default 20 min), then `dist-tag add … latest` and `dist-tag rm` the holding tag.
> 
> **`promote-latest.yml`** is a manual **break-glass** workflow: discovers versions parked on `pending` from the registry and runs the same composite action—needed when release fails after publish (re-running release skips promotion because changesets reports nothing new).
> 
> **CONTRIBUTING.md** documents the `pending` tag, token requirement, and recovery steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fab229b5f6a2c4eb16cc3dc9f21bc79cf72b73e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->