### PR TITLE
test: isolate env vars from interfering with tests

### DIFF
--- a/packages/@repo/coverage-delta/vitest.config.ts
+++ b/packages/@repo/coverage-delta/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: false,
+    setupFiles: ['../../../test/vitest/setup.ts'],
   },
 })

--- a/packages/@sanity/cli-build/vitest.config.ts
+++ b/packages/@sanity/cli-build/vitest.config.ts
@@ -18,5 +18,6 @@ export default defineConfig({
     exclude: ['**/node_modules/**', '**/dist/**', 'test/integration/**'],
     globals: false,
     name: '@sanity/cli-build/unit',
+    setupFiles: ['../../../test/vitest/setup.ts'],
   },
 })

--- a/packages/@sanity/cli-core/vitest.config.ts
+++ b/packages/@sanity/cli-core/vitest.config.ts
@@ -25,5 +25,6 @@ export default defineConfig({
     },
     globals: false,
     name: '@sanity/cli-core/unit',
+    setupFiles: ['../../../test/vitest/setup.ts'],
   },
 })

--- a/packages/@sanity/cli-e2e/vitest.config.ts
+++ b/packages/@sanity/cli-e2e/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     // 2. Initialize test fixtures (copies fixtures, installs deps)
     globalSetup: ['./globalSetup.ts'],
     hookTimeout: 120_000,
+    setupFiles: ['../../../test/vitest/setup.ts'],
     // E2E tests spawn real processes and need longer timeouts
     testTimeout: 30_000,
   },

--- a/packages/@sanity/cli-test/vitest.config.ts
+++ b/packages/@sanity/cli-test/vitest.config.ts
@@ -19,5 +19,6 @@ export default defineConfig({
     environment: 'node',
     exclude: ['**/node_modules/**', '**/dist/**'],
     globals: false,
+    setupFiles: ['../../../test/vitest/setup.ts'],
   },
 })

--- a/packages/@sanity/cli/test/integration/hooks/prerun/injectEnvVariables.test.ts
+++ b/packages/@sanity/cli/test/integration/hooks/prerun/injectEnvVariables.test.ts
@@ -79,6 +79,7 @@ describe('#injectEnvVariables', () => {
   test('should inject SANITY_INTERNAL_ENV from .env', async () => {
     const cwd = await testFixture('basic-studio')
     process.chdir(cwd)
+    delete process.env.SANITY_INTERNAL_ENV
 
     await writeFile(join(cwd, '.env'), 'SANITY_INTERNAL_ENV=staging')
 

--- a/packages/@sanity/cli/vitest.config.integration.ts
+++ b/packages/@sanity/cli/vitest.config.integration.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     globalSetup: ['test/workerBuild.ts', '@sanity/cli-test/vitest'],
     include: ['test/integration/**/*.test.ts'],
     name: '@sanity/cli/integration',
-    setupFiles: ['test/setup.ts'],
+    setupFiles: ['../../../test/vitest/setup.ts', 'test/setup.ts'],
     snapshotSerializers: ['test/snapshotSerializer.ts'],
   },
 })

--- a/packages/@sanity/cli/vitest.config.ts
+++ b/packages/@sanity/cli/vitest.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
     exclude: ['**/node_modules/**', '**/dist/**', 'test/integration/**'],
     globals: false,
     name: '@sanity/cli/unit',
-    setupFiles: ['test/setup.ts'],
+    setupFiles: ['../../../test/vitest/setup.ts', 'test/setup.ts'],
   },
 })

--- a/packages/@sanity/workbench-cli/vitest.config.integration.ts
+++ b/packages/@sanity/workbench-cli/vitest.config.integration.ts
@@ -16,5 +16,6 @@ export default defineConfig({
     globals: false,
     include: ['test/integration/**/*.test.ts'],
     name: '@sanity/workbench-cli/integration',
+    setupFiles: ['../../../test/vitest/setup.ts'],
   },
 })

--- a/packages/@sanity/workbench-cli/vitest.config.ts
+++ b/packages/@sanity/workbench-cli/vitest.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
     exclude: ['**/node_modules/**', '**/dist/**', 'test/integration/**'],
     globals: false,
     name: '@sanity/workbench-cli/unit',
+    setupFiles: ['../../../test/vitest/setup.ts'],
   },
 })

--- a/packages/create-sanity/vitest.config.mjs
+++ b/packages/create-sanity/vitest.config.mjs
@@ -1,7 +1,9 @@
+// eslint-disable-next-line import-x/no-extraneous-dependencies
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
   test: {
     include: ['test.js'],
+    setupFiles: ['../../test/vitest/setup.ts'],
   },
 })

--- a/test/vitest/setup.ts
+++ b/test/vitest/setup.ts
@@ -1,0 +1,17 @@
+// If these env vars exist in the environment, they can cause tests to behave unpredictably
+delete process.env.SANITY_ACTIVE_ENV
+delete process.env.SANITY_API_HOST
+delete process.env.SANITY_APP_BASEPATH
+delete process.env.SANITY_AUTH_TOKEN
+delete process.env.SANITY_BASE_PATH
+delete process.env.SANITY_CLI_CALLBACK_PORT
+delete process.env.SANITY_CLI_CONFIG_PATH
+delete process.env.SANITY_CLI_QUERY_API_VERSION
+delete process.env.SANITY_INTERNAL_IS_WORKBENCH_REMOTE
+delete process.env.SANITY_INTERNAL_WORKBENCH_REMOTE_URL
+delete process.env.SANITY_MODULES_HOST
+delete process.env.SANITY_STUDIO_BASEPATH
+delete process.env.SANITY_STUDIO_REACT_STRICT_MODE
+delete process.env.SANITY_TELEMETRY_PROJECT_ID
+
+process.env.SANITY_INTERNAL_ENV = 'production'


### PR DESCRIPTION
I noticed that tests for me would fail despite working fine in CI. Turns out it's because I have `SANITY_INTERNAL_ENV` set to `staging` in my shell, which was breaking a bunch of tests here.

This adds a setup script to all the Vitest configs to remove certain Sanity env vars that could be problematic and interfere with tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness changes with no production runtime impact; minor risk that tests relied on host env vars no longer being present.
> 
> **Overview**
> Adds a shared **`test/vitest/setup.ts`** that runs before tests: it **removes** a fixed list of Sanity-related `process.env` keys that can leak from a developer shell, then sets **`SANITY_INTERNAL_ENV`** to **`production`** so runs match CI.
> 
> That setup file is wired into **`setupFiles`** on Vitest configs across CLI-related packages (unit, integration, and e2e), including **`create-sanity`**. **`@sanity/cli`** keeps its local **`test/setup.ts`** but now loads the shared setup **first**.
> 
> The **`injectEnvVariables`** integration test clears **`SANITY_INTERNAL_ENV`** before asserting it is loaded from **`.env`**, so the new default does not mask the hook under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef27a9939c661eed0d75fa7ee520bfc390bd27d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->