### PR TITLE
fix(migrations): preserve progress counts and transaction log URLs on failure

### DIFF
--- a/.changeset/pr-1688.md
+++ b/.changeset/pr-1688.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(migrations): preserve progress counts and transaction log URLs on failure

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -95,7 +95,7 @@
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/id-utils": "^1.0.0",
     "@sanity/import": "^6.0.3",
-    "@sanity/migrate": "^8.0.1",
+    "@sanity/migrate": "^8.0.2",
     "@sanity/runtime-cli": "^17.4.0",
     "@sanity/schema": "catalog:",
     "@sanity/telemetry": "catalog:",

--- a/packages/@sanity/cli/src/commands/migrations/__tests__/run.test.ts
+++ b/packages/@sanity/cli/src/commands/migrations/__tests__/run.test.ts
@@ -1,7 +1,7 @@
 import {readdir} from 'node:fs/promises'
 
 import {testCommand} from '@sanity/cli-test'
-import {type Migration} from '@sanity/migrate'
+import {type Migration, UnknownTransactionOutcomeError} from '@sanity/migrate'
 import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {RunMigrationCommand} from '../run.js'
@@ -708,5 +708,165 @@ describe('#migration:run', () => {
     // The spinner must be stopped even when run() rejects, so it does not keep
     // animating after the command has failed.
     expect(mockSpinner.stop).toHaveBeenCalled()
+  })
+
+  test('persists the progress summary when the migration run throws partway', async () => {
+    mockConfirm.mockResolvedValueOnce(true)
+    mockRun.mockImplementation(async (config) => {
+      config.onProgress?.({
+        completedTransactions: [
+          {id: 'tx-1', mutations: []},
+          {id: 'tx-2', mutations: []},
+        ],
+        currentTransactions: [],
+        documents: 42,
+        done: false,
+        mutations: 21,
+        pending: 3,
+      })
+      throw new Error('migration failed')
+    })
+
+    const {error} = await testCommand(RunMigrationCommand, ['my-migration', '--no-dry-run'], {
+      mocks: {
+        ...defaultMocks,
+        cliConfig: {api: {dataset: 'production', projectId: 'test-project'}},
+      },
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    // `stop()` clears the spinner region, so the counters are only visible if the
+    // failure path persists them first.
+    expect(mockSpinner.stopAndPersist).toHaveBeenCalledTimes(1)
+    expect(mockSpinner.text).toContain('Migration "my-migration" failed.')
+    expect(mockSpinner.text).toContain('42 documents processed')
+    expect(mockSpinner.text).toContain('21 mutations generated')
+    expect(mockSpinner.text).toContain('2 transactions committed')
+  })
+
+  test('does not persist a progress summary on failure when --no-progress is passed', async () => {
+    mockConfirm.mockResolvedValueOnce(true)
+    mockRun.mockImplementation(async (config) => {
+      config.onProgress?.({
+        completedTransactions: [],
+        currentTransactions: [],
+        documents: 1,
+        done: false,
+        mutations: 1,
+        pending: 0,
+      })
+      throw new Error('migration failed')
+    })
+
+    const {error} = await testCommand(
+      RunMigrationCommand,
+      ['my-migration', '--no-dry-run', '--no-progress'],
+      {
+        mocks: {
+          ...defaultMocks,
+          cliConfig: {api: {dataset: 'production', projectId: 'test-project'}},
+        },
+      },
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(mockSpinner.stopAndPersist).not.toHaveBeenCalled()
+  })
+
+  test('prints unknown transaction outcome recovery details without oclif wrapping them', async () => {
+    mockConfirm.mockResolvedValueOnce(true)
+
+    const transactionId = '1ca5a8d8-15d7-4db4-84fa-02a25aaea5ef'
+    const cause = Object.assign(new Error('Headers Timeout Error'), {
+      code: 'UND_ERR_HEADERS_TIMEOUT',
+      name: 'HeadersTimeoutError',
+    })
+    const unknownOutcome = new UnknownTransactionOutcomeError([transactionId], {
+      api: {
+        apiHost: 'https://api.sanity.io',
+        apiVersion: 'v2024-01-29',
+        dataset: 'production',
+        projectId: 'test-project',
+        token: 'mock-token',
+      },
+      cause: new Error('fetch failed', {cause}),
+    })
+
+    mockRun.mockRejectedValueOnce(unknownOutcome)
+
+    const {error, stderr} = await testCommand(
+      RunMigrationCommand,
+      ['my-migration', '--no-dry-run'],
+      {
+        mocks: {
+          ...defaultMocks,
+          cliConfig: {api: {dataset: 'production', projectId: 'test-project'}},
+        },
+      },
+    )
+
+    // The transaction log URL is the most actionable line in the message, so it
+    // has to reach stderr in one piece rather than through oclif's hard wrap.
+    const transactionLogUrl = `https://test-project.api.sanity.io/v2024-01-29/data/history/production/transactions?excludeContent=true&fromTransaction=${transactionId}&limit=1`
+    expect(stderr).toContain(transactionLogUrl)
+    expect(stderr).toContain(transactionId)
+    expect(stderr).toContain('https://www.sanity.io/docs/history-api')
+
+    // The transport failure that caused the unknown outcome is still reported.
+    expect(stderr).toContain('Caused by: Error: fetch failed')
+    expect(stderr).toContain('Caused by: HeadersTimeoutError: Headers Timeout Error')
+    expect(stderr).toContain('Code: UND_ERR_HEADERS_TIMEOUT')
+
+    // The rethrown error only carries the exit code, and stays short enough that
+    // oclif's wrapping cannot mangle anything that matters.
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toBe(
+      'Migration "my-migration" failed: the outcome of 1 transaction is unknown. See the transaction log details above.',
+    )
+    expect(error?.oclif?.exit).toBe(1)
+  })
+
+  test('lists every unknown transaction and pluralizes the summary', async () => {
+    mockConfirm.mockResolvedValueOnce(true)
+
+    const transactionIds = [
+      '1ca5a8d8-15d7-4db4-84fa-02a25aaea5ef',
+      '2db6b9e9-26e8-5ec5-95fb-13b36bbfb6f0',
+    ]
+    mockRun.mockRejectedValueOnce(
+      new UnknownTransactionOutcomeError(transactionIds, {
+        api: {
+          apiVersion: 'v2024-01-29',
+          dataset: 'production',
+          projectId: 'test-project',
+          token: 'mock-token',
+        },
+        // A non-Error cause must not break the cause chain formatting.
+        cause: 'connection reset',
+      }),
+    )
+
+    const {error, stderr} = await testCommand(
+      RunMigrationCommand,
+      ['my-migration', '--no-dry-run'],
+      {
+        mocks: {
+          ...defaultMocks,
+          cliConfig: {api: {dataset: 'production', projectId: 'test-project'}},
+        },
+      },
+    )
+
+    for (const transactionId of transactionIds) {
+      expect(stderr).toContain(
+        `https://test-project.api.sanity.io/v2024-01-29/data/history/production/transactions?excludeContent=true&fromTransaction=${transactionId}&limit=1`,
+      )
+    }
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toBe(
+      'Migration "my-migration" failed: the outcome of 2 transactions are unknown. See the transaction log details above.',
+    )
+    expect(error?.oclif?.exit).toBe(1)
   })
 })

--- a/packages/@sanity/cli/src/commands/migrations/__tests__/run.test.ts
+++ b/packages/@sanity/cli/src/commands/migrations/__tests__/run.test.ts
@@ -865,7 +865,7 @@ describe('#migration:run', () => {
 
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toBe(
-      'Migration "my-migration" failed: the outcome of 2 transactions are unknown. See the transaction log details above.',
+      'Migration "my-migration" failed: the outcomes of 2 transactions are unknown. See the transaction log details above.',
     )
     expect(error?.oclif?.exit).toBe(1)
   })

--- a/packages/@sanity/cli/src/commands/migrations/run.ts
+++ b/packages/@sanity/cli/src/commands/migrations/run.ts
@@ -12,6 +12,7 @@ import {
   type Migration,
   type MigrationProgress,
   run,
+  UnknownTransactionOutcomeError,
 } from '@sanity/migrate'
 
 import {DEFAULT_API_VERSION, MIGRATIONS_DIRECTORY} from '../../actions/migration/constants.js'
@@ -25,6 +26,29 @@ import {
 import {Table} from '../../util/responsiveTable.js'
 
 const runMigrationDebug = subdebug('migration:run')
+
+/**
+ * Renders the `cause` chain of an error the way oclif's own error printer would.
+ *
+ * Used when printing an error ourselves to bypass oclif's hard word wrapping:
+ * the underlying transport error (a timeout, a dropped connection) is the part
+ * that explains _why_ the outcome is unknown, so it should not be dropped just
+ * because the top-level message is printed separately.
+ */
+function formatCauseChain(error: unknown): string[] {
+  const lines: string[] = []
+  let cause: unknown = error instanceof Error ? error.cause : undefined
+
+  while (cause instanceof Error) {
+    lines.push(`Caused by: ${cause.name}: ${cause.message}`)
+    if ('code' in cause && typeof cause.code === 'string') {
+      lines.push(`Code: ${cause.code}`)
+    }
+    cause = cause.cause
+  }
+
+  return lines
+}
 
 export type RunMigrationFlags = RunMigrationCommand['flags']
 
@@ -267,15 +291,46 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
     }
 
     const spin = spinner(`Running migration "${id}"`).start()
+    const onProgress = this.createProgress(spin, flags, id, dry, apiConfig, migration)
+    let lastProgress: MigrationProgress | undefined
+
     try {
       await run(
         {
           api: apiConfig,
           concurrency,
-          onProgress: this.createProgress(spin, flags, id, dry, apiConfig, migration),
+          onProgress: (progress) => {
+            lastProgress = progress
+            onProgress(progress)
+          },
         },
         migration,
       )
+    } catch (err) {
+      // ora's `stop()` clears the spinner region, taking the multi-line progress
+      // block with it. Persist a failure summary first, so the transaction counts
+      // (the only record of what was committed before the failure) survive.
+      this.persistFailureSummary(spin, flags, id, apiConfig, lastProgress)
+
+      if (err instanceof UnknownTransactionOutcomeError) {
+        // oclif hard-wraps error messages, which splits the transaction log URLs
+        // across lines and makes them impossible to copy. Print the recovery
+        // instructions ourselves and rethrow something short for the exit code.
+        this.logToStderr(err.message)
+        for (const line of formatCauseChain(err)) {
+          this.logToStderr(line)
+        }
+
+        const count = err.transactionIds.length
+        this.error(
+          `Migration "${id}" failed: the outcome of ${count} ${
+            count === 1 ? 'transaction is' : 'transactions are'
+          } unknown. See the transaction log details above.`,
+          {exit: exitCodes.RUNTIME_ERROR},
+        )
+      }
+
+      throw err
     } finally {
       spin.stop()
     }
@@ -354,6 +409,34 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
         }),
       )
     }
+  }
+
+  /**
+   * Persist the last reported progress with a failure marker.
+   *
+   * Only the `progress.done` path finalizes the spinner on its own, so without
+   * this the entire progress block is wiped when the migration fails partway.
+   */
+  private persistFailureSummary(
+    progressSpinner: ReturnType<typeof spinner>,
+    flags: RunMigrationFlags,
+    id: string,
+    apiConfig: APIConfig,
+    progress: MigrationProgress | undefined,
+  ) {
+    // With `--no-progress` the spinner was already stopped and nothing was ever
+    // rendered; a `done` progress event has already persisted its own summary.
+    if (!flags.progress || !progress || progress.done) return
+
+    progressSpinner.text = `Migration "${id}" failed.
+
+  Project id:  ${styleText('bold', apiConfig.projectId)}
+  Dataset:     ${styleText('bold', apiConfig.dataset)}
+
+  ${progress.documents} documents processed.
+  ${progress.mutations} mutations generated.
+  ${styleText('green', String(progress.completedTransactions.length))} transactions committed.`
+    progressSpinner.stopAndPersist({symbol: styleText('red', '✖')})
   }
 
   private async promptConfirmMigrate(apiConfig: APIConfig) {

--- a/packages/@sanity/cli/src/commands/migrations/run.ts
+++ b/packages/@sanity/cli/src/commands/migrations/run.ts
@@ -323,9 +323,9 @@ export class RunMigrationCommand extends SanityCommand<typeof RunMigrationComman
 
         const count = err.transactionIds.length
         this.error(
-          `Migration "${id}" failed: the outcome of ${count} ${
-            count === 1 ? 'transaction is' : 'transactions are'
-          } unknown. See the transaction log details above.`,
+          `Migration "${id}" failed: the ${count === 1 ? 'outcome' : 'outcomes'} of ${count} ${
+            count === 1 ? 'transaction' : 'transactions'
+          } ${count === 1 ? 'is' : 'are'} unknown. See the transaction log details above.`,
           {exit: exitCodes.RUNTIME_ERROR},
         )
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,8 +583,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)
       '@sanity/migrate':
-        specifier: ^8.0.1
-        version: 8.0.1(@types/react@19.2.17)(xstate@5.32.5)
+        specifier: ^8.0.2
+        version: 8.0.2(@types/react@19.2.17)(xstate@5.32.5)
       '@sanity/runtime-cli':
         specifier: ^17.4.0
         version: 17.4.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@22.20.0)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(rolldown@1.2.0)(terser@5.48.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
@@ -4588,8 +4588,8 @@ packages:
     resolution: {integrity: sha512-F/MwFVc3fN8uVvCIGuTxHN5EVo148wLhjL7h/u6wbShWJGMKgcGx0n6MwfCPyi6ftpdvRXsPZVDgZ1GMeeBf2Q==}
     engines: {node: '>=20.0.0'}
 
-  '@sanity/migrate@8.0.1':
-    resolution: {integrity: sha512-a0soNMIiSBdYgHoRp/Xf02uqmx5DL4Y2qwio4ux43fhxJCfmGkrbevoBt2J1Vf7risT+Gn9n7cL450J1P5j94w==}
+  '@sanity/migrate@8.0.2':
+    resolution: {integrity: sha512-XeDbtq/YmpXwLd01wJU/mrNqXxPEKRZiPugt/ukXJoDdetjgBNmcIPkic6RnXpzHyLNf/Pi6+d5ktlrUvMYI2Q==}
     engines: {node: '>=22.12'}
 
   '@sanity/mutate@0.18.1':
@@ -13263,7 +13263,7 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
 
-  '@sanity/migrate@8.0.1(@types/react@19.2.17)(xstate@5.32.5)':
+  '@sanity/migrate@8.0.2(@types/react@19.2.17)(xstate@5.32.5)':
     dependencies:
       '@sanity/client': 7.25.0
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
@@ -14428,7 +14428,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.4
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@22.20.0)(@vitest/coverage-istanbul@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -17784,7 +17784,7 @@ snapshots:
       '@sanity/logos': 2.2.5(react@19.2.7)
       '@sanity/media-library-types': 1.6.0
       '@sanity/message-protocol': 0.24.0
-      '@sanity/migrate': 8.0.1(@types/react@19.2.17)(xstate@5.32.5)
+      '@sanity/migrate': 8.0.2(@types/react@19.2.17)(xstate@5.32.5)
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/mutator': 6.7.0(@types/react@19.2.17)
       '@sanity/presentation-comlink': 2.2.0(@sanity/client@7.25.0)(@sanity/types@6.7.0(@types/react@19.2.17))


### PR DESCRIPTION
### Description

Upgrades `@sanity/migrate` to `^8.0.2` and fixes two ways a failed `sanity migration run` threw away the information you need to recover from it.

**The progress block was erased on failure.** `progress.done` was the only path that called `stopAndPersist`, so any mid-run failure fell through to `finally { spin.stop() }`. ora's `stop()` calls `clear()` when enabled, which wipes the spinner region and takes the whole multi-line progress block with it. In a TTY you got the error and nothing else, even though the transaction counts are the only record of what was actually committed before the failure. The error path now persists a `Migration "<id>" failed.` summary carrying the same document, mutation, and committed-transaction counts, marked with a red `✖`, before rethrowing. It stays quiet under `--no-progress`, when no progress was ever reported, and when `done` already persisted its own summary.

**The recovery URL got hard-wrapped.** `@sanity/migrate@8.0.2` introduces `UnknownTransactionOutcomeError`, whose message includes a transaction log URL per affected transaction. `SanityCommand.catch` falls through to `super.catch(err)`, reaching oclif's `prettyPrint`, which wraps with `{hard: true}` at `errtermwidth - 6`. `hard: true` breaks long words, and a UUID in a query string cannot fit in 74 columns, so the most actionable line in the message was split across three lines with indentation injected and could not be copy-pasted. The error is now caught, its message printed via `logToStderr` so it bypasses the wrapper entirely, and a short one-line error carries the exit code. The `cause` chain is printed alongside it, since the short rethrown error would otherwise drop the underlying transport failure (`HeadersTimeoutError`, `UND_ERR_HEADERS_TIMEOUT`) that explains why the outcome is unknown.

Reported from a customer transcript where a headers timeout left a transaction in an unknown state.

### What to review

Only `packages/@sanity/cli/src/commands/migrations/run.ts` changes behavior. Worth a look at:

- `persistFailureSummary()` and its three no-op guards. Double-persisting or persisting an empty block would be worse than the current behavior.
- The `catch` block ordering: spinner summary first, then the recovery details, then the short throw. Both write to stderr, so ordering is what makes the output readable.
- Whether printing the cause chain ourselves is the right call versus letting the short error carry a `cause` for oclif to render. Rendering it ourselves keeps it out of the hard wrap, at the cost of duplicating a little of oclif's formatting.
- The failure summary reuses the green transaction count from the success path for consistency. Reasonable people may want that in a different color when the run failed.

To see it by hand, run a migration with `--no-dry-run` against a dataset and kill connectivity partway.

### Testing

Four new unit tests in `packages/@sanity/cli/src/commands/migrations/__tests__/run.test.ts`:

- the progress summary is persisted, with correct counts, when `run()` throws partway
- nothing is persisted on failure under `--no-progress`
- `UnknownTransactionOutcomeError` puts the full transaction log URL on stderr unbroken, along with the docs link and the full cause chain, and the rethrown error message is short and exits 1
- multiple unknown transactions are all listed and the summary pluralizes

`run.ts` is at 97.6% statements and 90.6% branches; the two uncovered lines predate this change. Full suite: 3690 unit tests passing, 0 failures. `build:cli`, `check:types`, `check:lint`, `check:deps`, and `check:format` are all clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches failure handling for live dataset migrations, where incorrect recovery output could mislead operators about what was committed. Does not change the migration execution path itself.
> 
> **Overview**
> Improves recovery info when `sanity migration run` fails mid-flight, after bumping `@sanity/migrate` to `^8.0.2`.
> 
> **Progress is no longer wiped on failure.** Mid-run errors previously hit `spin.stop()`, which cleared the multi-line progress block. The catch path now persists a failure summary with document, mutation, and committed-transaction counts before rethrowing (skipped under `--no-progress` or when `done` already finalized).
> 
> **Unknown transaction outcomes stay copyable.** For the new `UnknownTransactionOutcomeError`, recovery details (transaction log URLs and cause chain) are printed via `logToStderr` to bypass oclif's hard wrap, then a short exit-code error is thrown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5da9629db9acefafed91b415e50eb411a8f069c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->