### PR TITLE
fix(cli): resolve command topic aliases in programmatic CLI invocations

### DIFF
--- a/.changeset/tame-phones-find.md
+++ b/.changeset/tame-phones-find.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cli": patch
+---
+
+fix(cli): resolve command topic aliases in programmatic CLI invocations

--- a/packages/@sanity/cli/src/SanityHelp.ts
+++ b/packages/@sanity/cli/src/SanityHelp.ts
@@ -1,15 +1,7 @@
 import {Command, CommandHelp, Help, Interfaces} from '@oclif/core'
 import {getBinCommand, getRunningPackageManager} from '@sanity/cli-core/package-manager'
 
-import {topicAliases} from './topicAliases.js'
-
-// Reverse map: alias name → canonical topic name
-const aliasToCanonical = new Map<string, string>()
-for (const [canonical, aliases] of Object.entries(topicAliases)) {
-  for (const alias of aliases) {
-    aliasToCanonical.set(alias, canonical)
-  }
-}
+import {resolveTopicAliasInArgv} from './topicAliases.js'
 
 // Running `oclif readme`, we don't want to apply the `prefixBinName` transformation,
 // as it will include whatever pm was used to spawn the script in the generated readme.
@@ -106,32 +98,4 @@ function guessCreateCommand() {
 function needsFlagSeparator() {
   const pm = getRunningPackageManager()
   return pm === 'npm' || !pm
-}
-
-/**
- * Replace the first positional argument in argv with the canonical topic name
- * if it is a known topic alias. This ensures that `sanity dataset --help`
- * resolves to the same help output as `sanity datasets --help`.
- *
- * Without this, `--help` bypasses the command_not_found hook (which normally
- * handles alias resolution) and the help system fails to find the topic.
- *
- * @internal
- */
-export function resolveTopicAliasInArgv(argv: string[]): string[] {
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]
-    if (arg === '--') break
-    if (arg.startsWith('-')) continue
-
-    // First positional argument is the topic/command name
-    const canonical = aliasToCanonical.get(arg)
-    if (canonical) {
-      const resolved = [...argv]
-      resolved[i] = canonical
-      return resolved
-    }
-    break
-  }
-  return argv
 }

--- a/packages/@sanity/cli/src/__tests__/SanityHelp.test.ts
+++ b/packages/@sanity/cli/src/__tests__/SanityHelp.test.ts
@@ -1,11 +1,7 @@
 import {type Command, type Interfaces} from '@oclif/core'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import SanityHelp, {
-  prefixBinName,
-  replaceInitWithCreateCommand,
-  resolveTopicAliasInArgv,
-} from '../SanityHelp.js'
+import SanityHelp, {prefixBinName, replaceInitWithCreateCommand} from '../SanityHelp.js'
 
 class TestSanityHelp extends SanityHelp {
   getFlagSortOrder(commandId: string) {
@@ -307,53 +303,5 @@ describe('replaceInitWithCreateCommand + prefixBinName interaction', () => {
 
     // With unknown PM, getBinCommand returns "sanity" so prefixBinName is a no-op
     expect(result).toBe(afterCreate)
-  })
-})
-
-describe('resolveTopicAliasInArgv', () => {
-  test('resolves singular topic alias to canonical plural form', () => {
-    expect(resolveTopicAliasInArgv(['dataset', '--help'])).toEqual(['datasets', '--help'])
-  })
-
-  test('resolves other singular aliases', () => {
-    expect(resolveTopicAliasInArgv(['document', '--help'])).toEqual(['documents', '--help'])
-    expect(resolveTopicAliasInArgv(['user', '--help'])).toEqual(['users', '--help'])
-    expect(resolveTopicAliasInArgv(['token', '--help'])).toEqual(['tokens', '--help'])
-    expect(resolveTopicAliasInArgv(['project', '--help'])).toEqual(['projects', '--help'])
-    expect(resolveTopicAliasInArgv(['hook', '--help'])).toEqual(['hooks', '--help'])
-    expect(resolveTopicAliasInArgv(['backup', '--help'])).toEqual(['backups', '--help'])
-    expect(resolveTopicAliasInArgv(['schema', '--help'])).toEqual(['schemas', '--help'])
-  })
-
-  test('does not modify argv for canonical topic names', () => {
-    expect(resolveTopicAliasInArgv(['datasets', '--help'])).toEqual(['datasets', '--help'])
-  })
-
-  test('does not modify argv for unknown topics', () => {
-    expect(resolveTopicAliasInArgv(['unknown', '--help'])).toEqual(['unknown', '--help'])
-  })
-
-  test('resolves alias with subcommand in argv', () => {
-    expect(resolveTopicAliasInArgv(['dataset', 'list', '--help'])).toEqual([
-      'datasets',
-      'list',
-      '--help',
-    ])
-  })
-
-  test('returns original argv when no positional argument found', () => {
-    expect(resolveTopicAliasInArgv(['--help'])).toEqual(['--help'])
-  })
-
-  test('returns original argv for empty input', () => {
-    expect(resolveTopicAliasInArgv([])).toEqual([])
-  })
-
-  test('stops processing at -- separator', () => {
-    expect(resolveTopicAliasInArgv(['--', 'dataset', '--help'])).toEqual([
-      '--',
-      'dataset',
-      '--help',
-    ])
   })
 })

--- a/packages/@sanity/cli/src/__tests__/topicAliases.test.ts
+++ b/packages/@sanity/cli/src/__tests__/topicAliases.test.ts
@@ -1,0 +1,70 @@
+import {describe, expect, test} from 'vitest'
+
+import {resolveTopicAlias, resolveTopicAliasInArgv} from '../topicAliases.js'
+
+describe('resolveTopicAlias', () => {
+  test('resolves a bare topic alias', () => {
+    expect(resolveTopicAlias('hook')).toBe('hooks')
+  })
+
+  test('resolves an alias in a colon-separated command ID', () => {
+    expect(resolveTopicAlias('hook:list')).toBe('hooks:list')
+  })
+
+  test('does not resolve canonical or unknown topics', () => {
+    expect(resolveTopicAlias('hooks:list')).toBeUndefined()
+    expect(resolveTopicAlias('unknown:list')).toBeUndefined()
+  })
+})
+
+describe('resolveTopicAliasInArgv', () => {
+  test('resolves singular topic alias to canonical plural form', () => {
+    expect(resolveTopicAliasInArgv(['dataset', '--help'])).toEqual(['datasets', '--help'])
+  })
+
+  test('resolves other singular aliases', () => {
+    expect(resolveTopicAliasInArgv(['document', '--help'])).toEqual(['documents', '--help'])
+    expect(resolveTopicAliasInArgv(['user', '--help'])).toEqual(['users', '--help'])
+    expect(resolveTopicAliasInArgv(['token', '--help'])).toEqual(['tokens', '--help'])
+    expect(resolveTopicAliasInArgv(['project', '--help'])).toEqual(['projects', '--help'])
+    expect(resolveTopicAliasInArgv(['hook', '--help'])).toEqual(['hooks', '--help'])
+    expect(resolveTopicAliasInArgv(['backup', '--help'])).toEqual(['backups', '--help'])
+    expect(resolveTopicAliasInArgv(['schema', '--help'])).toEqual(['schemas', '--help'])
+  })
+
+  test('does not modify argv for canonical topic names', () => {
+    expect(resolveTopicAliasInArgv(['datasets', '--help'])).toEqual(['datasets', '--help'])
+  })
+
+  test('does not modify argv for unknown topics', () => {
+    expect(resolveTopicAliasInArgv(['unknown', '--help'])).toEqual(['unknown', '--help'])
+  })
+
+  test('resolves alias with subcommand in argv', () => {
+    expect(resolveTopicAliasInArgv(['dataset', 'list', '--help'])).toEqual([
+      'datasets',
+      'list',
+      '--help',
+    ])
+  })
+
+  test('resolves a colon-separated alias', () => {
+    expect(resolveTopicAliasInArgv(['hook:list', '--help'])).toEqual(['hooks:list', '--help'])
+  })
+
+  test('returns original argv when no positional argument found', () => {
+    expect(resolveTopicAliasInArgv(['--help'])).toEqual(['--help'])
+  })
+
+  test('returns original argv for empty input', () => {
+    expect(resolveTopicAliasInArgv([])).toEqual([])
+  })
+
+  test('stops processing at -- separator', () => {
+    expect(resolveTopicAliasInArgv(['--', 'dataset', '--help'])).toEqual([
+      '--',
+      'dataset',
+      '--help',
+    ])
+  })
+})

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -653,18 +653,24 @@ describe('invokeSanityCli', () => {
     },
   )
 
-  test('resolves topic aliases for help', async () => {
-    const result = await invokeSanityCli({
-      args: 'hook list --help',
-      config,
-      source: 'mcp',
-      token: 'user-token',
-    })
+  test.each(['hook --help', 'help hook'])('`%s` resolves topic aliases for help', async (args) => {
+    const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
 
     expect(result.exitCode).toBe(0)
-    expect(result.commandId).toBe('hooks:list')
-    expect(result.output).toContain('List webhooks for the project')
+    expect(result.commandId).toBeUndefined()
+    expect(result.output).toContain('hooks list')
   })
+
+  test.each(['hook list --help', 'help hook list'])(
+    '`%s` resolves topic aliases for command help',
+    async (args) => {
+      const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+
+      expect(result.exitCode).toBe(0)
+      expect(result.commandId).toBe('hooks:list')
+      expect(result.output).toContain('List webhooks for the project')
+    },
+  )
 
   test('`-h` is not a help flag, matching the regular CLI dispatch', async () => {
     const result = await invokeSanityCli({

--- a/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
+++ b/packages/@sanity/cli/src/exports/__tests__/commands.test.ts
@@ -380,6 +380,18 @@ describe('invokeSanityCli', () => {
     expect(result.output).toContain('Nonexistent flag')
   })
 
+  test.each(['hook list --no-such-flag', 'hook:list --no-such-flag'])(
+    'resolves the topic alias in `%s` before applying the MCP policy',
+    async (args) => {
+      const result = await invokeSanityCli({args, config, source: 'mcp', token: 'user-token'})
+
+      expect(result.exitCode).toBe(2)
+      expect(result.commandId).toBe('hooks:list')
+      expect(result.output).toContain('Nonexistent flag')
+      expect(result.output).not.toContain('Unknown or unsupported command')
+    },
+  )
+
   test('never resolves project context from the host filesystem', async () => {
     // Run from inside a fixture that has a resolvable sanity.cli.ts. Without
     // the execution-context guard, the command would walk up from cwd, find
@@ -640,6 +652,19 @@ describe('invokeSanityCli', () => {
       expect(result.output).toContain('cors list')
     },
   )
+
+  test('resolves topic aliases for help', async () => {
+    const result = await invokeSanityCli({
+      args: 'hook list --help',
+      config,
+      source: 'mcp',
+      token: 'user-token',
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.commandId).toBe('hooks:list')
+    expect(result.output).toContain('List webhooks for the project')
+  })
 
   test('`-h` is not a help flag, matching the regular CLI dispatch', async () => {
     const result = await invokeSanityCli({

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/help.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/help.ts
@@ -1,6 +1,7 @@
 import {type Command, type Config, Help, type Interfaces} from '@oclif/core'
 import {getHelpFlagAdditions} from '@oclif/core/help'
 
+import {resolveTopicAliasInArgv} from '../../topicAliases.js'
 import {
   type CommandPolicy,
   type CommandPolicySet,
@@ -118,6 +119,10 @@ class InvokableHelp extends Help {
     if (!this.commandIds.has(command.id)) throw new NotInvokableError(command.id)
     this.commandId = command.id
     return super.showCommandHelp(withoutDeniedFlags(command, this.policySet[command.id]))
+  }
+
+  public override async showHelp(argv: string[]): Promise<void> {
+    return super.showHelp(resolveTopicAliasInArgv(argv))
   }
 
   protected override async showTopicHelp(topic: Interfaces.Topic): Promise<void> {

--- a/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
+++ b/packages/@sanity/cli/src/exports/invokeSanityCli/index.ts
@@ -27,6 +27,7 @@ import {runWithCliExecutionContext, type SanityEnvironment} from '@sanity/cli-co
 import {type SanityCommand} from '@sanity/cli-core/SanityCommand'
 import {parseArgsStringToArgv} from 'string-argv'
 
+import {resolveTopicAliasInArgv} from '../../topicAliases.js'
 import {commandPolicies} from './commandPolicies/index.js'
 import {
   type CommandPolicySet,
@@ -201,6 +202,7 @@ async function invokeSanityCliInContext(
       ? parseArgsStringToArgv(args).map((t) => stripFlagQuotes(t))
       : [...args]
   if (argv[0] === 'sanity') argv = argv.slice(1)
+  argv = resolveTopicAliasInArgv(argv)
 
   // Help requests are routed through oclif's help system, scoped to the
   // source's policy: root help for a bare request, topic/command help when a

--- a/packages/@sanity/cli/src/hooks/commandNotFound/topicAliases.ts
+++ b/packages/@sanity/cli/src/hooks/commandNotFound/topicAliases.ts
@@ -26,16 +26,16 @@ const hook: Hook.CommandNotFound = async function (opts) {
   // Standardize the ID (handles topic separator differences)
   const standardId = toStandardizedId(id, config)
   const parts = standardId.split(':')
+  const hasTopic = parts.length === 1
   const rewrittenId = resolveTopicAlias(standardId)
 
   const aliasExists =
-    rewrittenId &&
-    (parts.length === 1 ? config.findTopic(rewrittenId) : config.findCommand(rewrittenId))
+    rewrittenId && (hasTopic ? config.findTopic(rewrittenId) : config.findCommand(rewrittenId))
   if (aliasExists) {
     debug('Rewriting topic: %s -> %s', parts[0], rewrittenId.split(':')[0])
 
     // Bare topic (eg "sanity dataset" with no subcommand) -> show topic help
-    if (parts.length === 1) {
+    if (hasTopic) {
       return config.runCommand('help', [rewrittenId])
     }
 

--- a/packages/@sanity/cli/src/hooks/commandNotFound/topicAliases.ts
+++ b/packages/@sanity/cli/src/hooks/commandNotFound/topicAliases.ts
@@ -16,25 +16,9 @@
 import {type Hook, toStandardizedId} from '@oclif/core'
 import {subdebug} from '@sanity/cli-core'
 
-import {topicAliases} from '../../topicAliases.js'
+import {resolveTopicAlias} from '../../topicAliases.js'
 
 const debug = subdebug('hooks:topicAliases')
-
-// Build a lookup from alias names to candidate topics.
-// This hook only fires for names oclif doesn't recognize. Since canonical
-// topics (eg "datasets") are registered and resolved by oclif directly,
-// only aliases (eg "dataset") reach here. We still map both directions
-// so the hook is resilient to future renames or plugin-provided topics
-// where the canonical name may not be a registered topic.
-const topicMappings = new Map<string, string[]>()
-for (const [canonical, aliases] of Object.entries(topicAliases)) {
-  // canonical -> all aliases
-  topicMappings.set(canonical, aliases)
-  // each alias -> [canonical]
-  for (const alias of aliases) {
-    topicMappings.set(alias, [canonical])
-  }
-}
 
 const hook: Hook.CommandNotFound = async function (opts) {
   const {config, id} = opts
@@ -42,29 +26,21 @@ const hook: Hook.CommandNotFound = async function (opts) {
   // Standardize the ID (handles topic separator differences)
   const standardId = toStandardizedId(id, config)
   const parts = standardId.split(':')
-  const topic = parts[0]
+  const rewrittenId = resolveTopicAlias(standardId)
 
-  const candidates = topicMappings.get(topic)
-  if (candidates) {
-    // Find which candidate topic actually has commands registered
-    const resolvedTopic = candidates.find((candidate) =>
-      parts.length === 1
-        ? config.findTopic(candidate)
-        : config.findCommand([candidate, ...parts.slice(1)].join(':')),
-    )
+  const aliasExists =
+    rewrittenId &&
+    (parts.length === 1 ? config.findTopic(rewrittenId) : config.findCommand(rewrittenId))
+  if (aliasExists) {
+    debug('Rewriting topic: %s -> %s', parts[0], rewrittenId.split(':')[0])
 
-    if (resolvedTopic) {
-      debug('Rewriting topic: %s -> %s', topic, resolvedTopic)
-
-      // Bare topic (eg "sanity dataset" with no subcommand) -> show topic help
-      if (parts.length === 1) {
-        return config.runCommand('help', [resolvedTopic])
-      }
-
-      // Full command (eg "sanity dataset create") -> run the resolved command
-      const rewrittenId = [resolvedTopic, ...parts.slice(1)].join(':')
-      return config.runCommand(rewrittenId, opts.argv ?? [])
+    // Bare topic (eg "sanity dataset" with no subcommand) -> show topic help
+    if (parts.length === 1) {
+      return config.runCommand('help', [rewrittenId])
     }
+
+    // Full command (eg "sanity dataset create") -> run the resolved command
+    return config.runCommand(rewrittenId, opts.argv ?? [])
   }
 
   // No alias match - fall back to oclif plugin-not-found's "did you mean?" behavior

--- a/packages/@sanity/cli/src/topicAliases.ts
+++ b/packages/@sanity/cli/src/topicAliases.ts
@@ -3,6 +3,8 @@
  *
  * Maps canonical topic names to their aliases. Used by:
  * - The command_not_found hook (runtime alias resolution)
+ * - Programmatic CLI invocation
+ * - Help rendering
  * - The check-topic-aliases script (build-time validation)
  *
  * Every topic with aliases must be listed here. The key is the canonical
@@ -29,4 +31,48 @@ export const topicAliases: Record<string, string[]> = {
   schemas: ['schema'],
   tokens: ['token'],
   users: ['user'],
+}
+
+const canonicalTopicByAlias = new Map(
+  Object.entries(topicAliases).flatMap(([canonical, aliases]) =>
+    aliases.map((alias) => [alias, canonical]),
+  ),
+)
+
+/**
+ * Resolve the topic portion of a command ID from an alias to its canonical name.
+ * Handles both bare topics (`hook`) and colon-separated command IDs (`hook:list`).
+ *
+ * @internal
+ */
+export function resolveTopicAlias(id: string): string | undefined {
+  const separatorIndex = id.indexOf(':')
+  const topic = separatorIndex === -1 ? id : id.slice(0, separatorIndex)
+  const canonical = canonicalTopicByAlias.get(topic)
+  if (!canonical) return undefined
+
+  const suffix = separatorIndex === -1 ? '' : id.slice(separatorIndex)
+  return `${canonical}${suffix}`
+}
+
+/**
+ * Resolve the first positional topic in argv, preserving flags and arguments.
+ *
+ * @internal
+ */
+export function resolveTopicAliasInArgv(argv: string[]): string[] {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--') break
+    if (arg.startsWith('-')) continue
+
+    const resolvedTopic = resolveTopicAlias(arg)
+    if (resolvedTopic) {
+      const resolved = [...argv]
+      resolved[i] = resolvedTopic
+      return resolved
+    }
+    break
+  }
+  return argv
 }


### PR DESCRIPTION
`invokeSanityCLI` (used by `run_sanity_cli`) was not using the same command topic alias resolution as the regular CLI. This meant commands that would work locally were failing when called via `run_sanity_cli`

This change:
- Centralizes alias resolution to a single file
- Resolves topic aliases in `invokeSanityCli`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI argument normalization with broad test coverage; no changes to auth, data handling, or command execution semantics beyond correct routing for aliases.
> 
> **Overview**
> **Programmatic CLI** (`invokeSanityCli` / MCP) now rewrites singular topic aliases (e.g. `hook`, `hook:list`) to canonical names before command dispatch and help, matching the interactive CLI behavior that previously only ran through the `command_not_found` hook.
> 
> Alias logic is **centralized** in `topicAliases.ts`: new `resolveTopicAlias` handles bare topics and colon-separated command IDs; `resolveTopicAliasInArgv` moves there from `SanityHelp`. The `command_not_found` hook drops its local alias map and calls `resolveTopicAlias` instead. Policy-scoped help (`InvokableHelp.showHelp`) applies the same argv rewrite.
> 
> Tests move to `topicAliases.test.ts` (including colon-form argv) and integration cases cover alias resolution for MCP policy and help.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8e54f7910f897e5c465d85b5bd6e3f6c5a47d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->