### PR TITLE
feat: include source of auth token in `sanity debug`

### DIFF
--- a/.changeset/few-moose-draw.md
+++ b/.changeset/few-moose-draw.md
@@ -1,0 +1,6 @@
+---
+"@sanity/cli-core": minor
+"@sanity/cli": minor
+---
+
+feat: include source of auth token in `sanity debug`

--- a/packages/@sanity/cli-core/src/_exports/config.ts
+++ b/packages/@sanity/cli-core/src/_exports/config.ts
@@ -2,7 +2,9 @@
 
 export {
   clearCliTokenCache,
+  type CliTokenInfo,
   getCliToken,
+  getCliTokenInfo,
   getCliUserConfig,
   getUserConfig,
   setCliUserConfig,

--- a/packages/@sanity/cli-core/src/_exports/index.ts
+++ b/packages/@sanity/cli-core/src/_exports/index.ts
@@ -10,7 +10,9 @@ export {
 } from '../apiClient.js'
 export {
   clearCliTokenCache,
+  type CliTokenInfo,
   getCliToken,
+  getCliTokenInfo,
   getCliUserConfig,
   getUserConfig,
   setCliUserConfig,

--- a/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
+++ b/packages/@sanity/cli-core/src/config/cli/__tests__/cliUserConfig.test.ts
@@ -1,14 +1,17 @@
 import {mkdirSync} from 'node:fs'
+import path from 'node:path'
 
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {runWithCliExecutionContext} from '../../../executionContext.js'
+import {getSanityConfigDir} from '../../../util/getSanityConfigDir.js'
 import {readJsonFileSync} from '../../../util/readJsonFileSync'
 import {writeJsonFileSync} from '../../../util/writeJsonFileSync.js'
 import {clearCliTokenCache, getCachedToken, setCachedToken} from '../cliTokenCache.js'
 import {
   _internals,
   getCliToken,
+  getCliTokenInfo,
   getCliUserConfig,
   getUserConfig,
   setCliUserConfig,
@@ -69,7 +72,7 @@ describe('cliUserConfig', () => {
     })
 
     test('should return cached token if available', async () => {
-      vi.mocked(getCachedToken).mockReturnValue('cached-token')
+      vi.mocked(getCachedToken).mockReturnValue({source: 'cached-source', token: 'cached-token'})
       const token = await getCliToken()
       expect(token).toEqual('cached-token')
     })
@@ -80,7 +83,10 @@ describe('cliUserConfig', () => {
 
       const token = await getCliToken()
       expect(token).toEqual('cached-env-token')
-      expect(vi.mocked(setCachedToken)).toHaveBeenCalledWith('cached-env-token')
+      expect(vi.mocked(setCachedToken)).toHaveBeenCalledWith({
+        source: 'SANITY_AUTH_TOKEN environment variable',
+        token: 'cached-env-token',
+      })
       expect(mockGetCliUserConfig).not.toHaveBeenCalled()
     })
 
@@ -90,7 +96,10 @@ describe('cliUserConfig', () => {
 
       const token = await getCliToken()
       expect(token).toEqual('cached-config-token')
-      expect(vi.mocked(setCachedToken)).toHaveBeenCalledWith('cached-config-token')
+      expect(vi.mocked(setCachedToken)).toHaveBeenCalledWith({
+        source: expect.stringContaining('config.json'),
+        token: 'cached-config-token',
+      })
       expect(mockGetCliUserConfig).toHaveBeenCalledTimes(1)
     })
 
@@ -101,7 +110,7 @@ describe('cliUserConfig', () => {
     })
 
     test('should prefer execution context token over env, config and cache', async () => {
-      vi.mocked(getCachedToken).mockReturnValue('cached-token')
+      vi.mocked(getCachedToken).mockReturnValue({source: 'cached-source', token: 'cached-token'})
       vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
 
       const token = await runWithCliExecutionContext({token: 'context-token'}, () => getCliToken())
@@ -115,7 +124,7 @@ describe('cliUserConfig', () => {
     })
 
     test('execution context without token never falls back to host resolution', async () => {
-      vi.mocked(getCachedToken).mockReturnValue('cached-token')
+      vi.mocked(getCachedToken).mockReturnValue({source: 'cached-source', token: 'cached-token'})
       vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
 
       const token = await runWithCliExecutionContext({}, () => getCliToken())
@@ -138,6 +147,54 @@ describe('cliUserConfig', () => {
       const secondCall = await getCliToken()
       expect(secondCall).toBe('second-token')
       expect(mockGetCliUserConfig).toHaveBeenCalledTimes(2)
+    })
+
+    test('returns the execution context as the token source', async () => {
+      const tokenInfo = await runWithCliExecutionContext({token: 'context-token'}, () =>
+        getCliTokenInfo(),
+      )
+
+      expect(tokenInfo).toEqual({source: 'CLI execution context', token: 'context-token'})
+    })
+
+    test('returns the environment variable as the token source', async () => {
+      vi.stubEnv('SANITY_AUTH_TOKEN', 'env-token')
+
+      const tokenInfo = await getCliTokenInfo()
+
+      expect(tokenInfo).toEqual({
+        source: 'SANITY_AUTH_TOKEN environment variable',
+        token: 'env-token',
+      })
+    })
+
+    test('returns the custom config path as the token source', async () => {
+      vi.stubEnv('SANITY_CLI_CONFIG_PATH', '/test/custom-config.json')
+      mockGetCliUserConfig.mockReturnValue('config-token')
+
+      const tokenInfo = await getCliTokenInfo()
+
+      expect(tokenInfo).toEqual({source: '/test/custom-config.json', token: 'config-token'})
+    })
+
+    test('returns the default config path as the token source', async () => {
+      mockGetCliUserConfig.mockReturnValue('config-token')
+
+      const tokenInfo = await getCliTokenInfo()
+
+      expect(tokenInfo).toEqual({
+        source: path.join(getSanityConfigDir(), 'config.json'),
+        token: 'config-token',
+      })
+    })
+
+    test('returns the cached token and its original source', async () => {
+      const cachedTokenInfo = {source: 'cached-source', token: 'cached-token'}
+      vi.mocked(getCachedToken).mockReturnValue(cachedTokenInfo)
+
+      const tokenInfo = await getCliTokenInfo()
+
+      expect(tokenInfo).toBe(cachedTokenInfo)
     })
   })
 

--- a/packages/@sanity/cli-core/src/config/cli/cliTokenCache.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliTokenCache.ts
@@ -1,22 +1,27 @@
 /**
- * Module-level cache for the CLI auth token, shared between
- * `getCliToken` (reads/writes) and `setCliUserConfig` (invalidates).
+ * Module-level cache for the resolved CLI auth token, shared between
+ * `getCliTokenInfo` (reads/writes) and `setCliUserConfig` (invalidates).
  *
  * Extracted into its own module to avoid a circular dependency
  * between `cliUserConfig.ts` and `getCliToken.ts`.
  */
-let cachedToken: string | undefined
+export interface CliTokenInfo {
+  source: string
+  token: string
+}
 
-export function getCachedToken(): string | undefined {
+let cachedToken: CliTokenInfo | undefined
+
+export function getCachedToken(): CliTokenInfo | undefined {
   return cachedToken
 }
 
-export function setCachedToken(token: string | undefined): void {
+export function setCachedToken(token: CliTokenInfo | undefined): void {
   cachedToken = token
 }
 
 /**
- * Clear the in-process token cache so the next `getCliToken()` call
+ * Clear the in-process token cache so the next token resolution
  * re-reads from disk or the environment.
  *
  * Called automatically by `setCliUserConfig('authToken', ...)`.

--- a/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
+++ b/packages/@sanity/cli-core/src/config/cli/cliUserConfig.ts
@@ -8,11 +8,17 @@ import {getCliExecutionContext} from '../../executionContext.js'
 import {getSanityConfigDir} from '../../util/getSanityConfigDir.js'
 import {readJsonFileSync} from '../../util/readJsonFileSync.js'
 import {writeJsonFileSync} from '../../util/writeJsonFileSync.js'
-import {clearCliTokenCache, getCachedToken, setCachedToken} from './cliTokenCache.js'
+import {
+  clearCliTokenCache,
+  type CliTokenInfo,
+  getCachedToken,
+  setCachedToken,
+} from './cliTokenCache.js'
 import {type ConfigStore} from './types/cliConfig.js'
 
 // Re-export so existing consumers don't break
 export {clearCliTokenCache} from './cliTokenCache.js'
+export {type CliTokenInfo} from './cliTokenCache.js'
 
 // Only used for testing
 export const _internals = {
@@ -20,18 +26,32 @@ export const _internals = {
 }
 
 /**
- * Get the CLI authentication token from the environment or the config file
+ * Get the CLI authentication token selected for the current invocation.
  *
  * @returns A promise that resolves to a CLI token, or undefined if no token is found
  * @internal
  */
 export async function getCliToken(): Promise<string | undefined> {
+  return (await getCliTokenInfo())?.token
+}
+
+/**
+ * Get the CLI authentication token and where it was resolved from.
+ *
+ * @returns A promise that resolves to the token and its source, or undefined if no token is found
+ * @internal
+ */
+export async function getCliTokenInfo(): Promise<CliTokenInfo | undefined> {
   // A per-invocation execution context token (e.g. per-request from an MCP
   // server) takes precedence and must bypass the process-wide cache entirely:
   // reading the cache would leak another invocation's token, and writing it
   // would leak this one's.
   const context = getCliExecutionContext()
-  if (context) return context.token
+  if (context) {
+    return context.token === undefined
+      ? undefined
+      : {source: 'CLI execution context', token: context.token}
+  }
 
   const cached = getCachedToken()
   if (cached !== undefined) {
@@ -40,14 +60,19 @@ export async function getCliToken(): Promise<string | undefined> {
 
   const token = process.env.SANITY_AUTH_TOKEN
   if (token) {
-    const trimmed = token.trim()
-    setCachedToken(trimmed)
-    return trimmed
+    const tokenInfo = {
+      source: 'SANITY_AUTH_TOKEN environment variable',
+      token: token.trim(),
+    }
+    setCachedToken(tokenInfo)
+    return tokenInfo
   }
 
   const configToken = _internals.getCliUserConfig('authToken')
-  setCachedToken(configToken)
-  return configToken
+  const tokenInfo =
+    configToken === undefined ? undefined : {source: getCliUserConfigPath(), token: configToken}
+  setCachedToken(tokenInfo)
+  return tokenInfo
 }
 const cliUserConfigSchema = {
   authToken: z.optional(z.string()),

--- a/packages/@sanity/cli/src/actions/debug/gatherDebugInfo.ts
+++ b/packages/@sanity/cli/src/actions/debug/gatherDebugInfo.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import {
   getCliToken,
+  getCliTokenInfo,
   getStudioConfig,
   getUserConfig,
   tryFindStudioConfigPath,
@@ -42,13 +43,15 @@ export async function gatherUserInfo(projectId: string | undefined): Promise<Err
 }
 
 export async function gatherAuthInfo(includeSecrets: boolean): Promise<AuthInfo> {
-  const token = await getCliToken()
+  const tokenInfo = await getCliTokenInfo()
+  const token = tokenInfo?.token
   const hasToken = Boolean(token)
   const config = getUserConfig()
   const authType = config.get('authType')
 
   return {
     authToken: token ? (includeSecrets ? token : '<redacted>') : undefined,
+    authTokenSource: token ? tokenInfo.source : undefined,
     hasToken,
     userType: typeof authType === 'string' ? authType : 'normal',
   }

--- a/packages/@sanity/cli/src/actions/debug/types.ts
+++ b/packages/@sanity/cli/src/actions/debug/types.ts
@@ -8,6 +8,7 @@ export interface UserInfo {
 
 export interface AuthInfo {
   authToken: string | undefined
+  authTokenSource: string | undefined
   hasToken: boolean
   userType: string
 }

--- a/packages/@sanity/cli/src/commands/__tests__/debug.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/debug.test.ts
@@ -1,5 +1,6 @@
 import {
   getCliToken,
+  getCliTokenInfo,
   getStudioConfig,
   getUserConfig,
   ProjectRootNotFoundError,
@@ -7,8 +8,9 @@ import {
 } from '@sanity/cli-core'
 import {convertToSystemPath, mockApi, testCommand} from '@sanity/cli-test'
 import {cleanAll, pendingMocks} from 'nock'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
+import {gatherAuthInfo} from '../../actions/debug/gatherDebugInfo.js'
 import {PROJECTS_API_VERSION} from '../../services/projects.js'
 import {USERS_API_VERSION} from '../../services/user.js'
 import {Debug} from '../debug.js'
@@ -27,6 +29,7 @@ vi.mock('@sanity/cli-core', async () => {
   return {
     ...actual,
     getCliToken: vi.fn(),
+    getCliTokenInfo: vi.fn(),
     getStudioConfig: vi.fn(),
     getUserConfig: vi.fn().mockReturnValue({
       delete: vi.fn(),
@@ -73,8 +76,17 @@ const defaultMocks = {
   token: 'mock-auth-token',
 }
 
+beforeEach(() => {
+  vi.stubEnv('SANITY_INTERNAL_ENV', 'production')
+  vi.mocked(getCliTokenInfo).mockImplementation(async () => {
+    const token = await getCliToken()
+    return token ? {source: 'SANITY_AUTH_TOKEN environment variable', token} : undefined
+  })
+})
+
 afterEach(() => {
   vi.clearAllMocks()
+  vi.unstubAllEnvs()
   const pending = pendingMocks()
   cleanAll()
   expect(pending, 'pending mocks').toEqual([])
@@ -191,8 +203,31 @@ describe('#debug', () => {
       if (error) throw error
       expect(stdout).toContain('Authentication:')
       expect(stdout).toContain('<redacted>')
+      expect(stdout).toContain('Token source: SANITY_AUTH_TOKEN environment variable')
       expect(stdout).toContain('(run with --secrets to reveal token)')
       expect(stdout).not.toContain('mock-auth-token')
+    })
+
+    test('shows the config file containing the auth token', async () => {
+      vi.mocked(getCliTokenInfo).mockResolvedValue({
+        source: '/test/default-config.json',
+        token: 'mock-auth-token',
+      })
+
+      const auth = await gatherAuthInfo(false)
+
+      expect(auth.authTokenSource).toBe('/test/default-config.json')
+    })
+
+    test('shows a custom CLI config path as the auth token source', async () => {
+      vi.mocked(getCliTokenInfo).mockResolvedValue({
+        source: '/test/custom-config.json',
+        token: 'mock-auth-token',
+      })
+
+      const auth = await gatherAuthInfo(false)
+
+      expect(auth.authTokenSource).toBe('/test/custom-config.json')
     })
 
     test('shows actual auth token with --secrets flag', async () => {

--- a/packages/@sanity/cli/src/commands/debug.ts
+++ b/packages/@sanity/cli/src/commands/debug.ts
@@ -95,8 +95,9 @@ export class Debug extends SanityCommand<typeof Debug> {
     if (!auth.hasToken) return
 
     this.log(sectionHeader('Authentication'))
-    const padTo = 10 // "Auth token" is the longest key
+    const padTo = 12 // "Token source" is the longest key
     this.log(formatKeyValue('Auth token', auth.authToken, {padTo}))
+    this.log(formatKeyValue('Token source', auth.authTokenSource, {padTo}))
     this.log(formatKeyValue('User type', auth.userType, {padTo}))
 
     if (!includeSecrets) {


### PR DESCRIPTION
`sanity debug` now includes the source of the auth token (ex. env var, config file, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auth resolution behavior for `getCliToken()` is preserved; the change mainly adds metadata for debugging and extends the internal cache shape with matching test coverage.
> 
> **Overview**
> **`sanity debug`** now prints a **Token source** line in the Authentication section so you can see whether the active credential came from the execution context, `SANITY_AUTH_TOKEN`, or a config file path (including `SANITY_CLI_CONFIG_PATH`).
> 
> In **`@sanity/cli-core`**, token resolution is refactored around a new **`getCliTokenInfo()`** API and **`CliTokenInfo`** (`{ token, source }`). **`getCliToken()`** still returns only the string and now delegates to `getCliTokenInfo()`. The in-process token cache stores the full `CliTokenInfo` so repeated lookups keep the original source label.
> 
> Both symbols are exported from the public **`@sanity/cli-core`** entry points; tests cover source labeling and debug output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa5a032a4d80a56f82abc557e421a9f35f3091fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->