### PR TITLE
feat(cli)!: unify the --json shape of deploy and undeploy

### DIFF
--- a/.changeset/pr-1691.md
+++ b/.changeset/pr-1691.md
@@ -1,0 +1,8 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': major
+'@sanity/cli': major
+'@sanity/workbench-cli': major
+---
+
+feat(cli)!: unify the --json shape of deploy and undeploy

--- a/packages/@sanity/cli-core/src/_exports/undeploy.ts
+++ b/packages/@sanity/cli-core/src/_exports/undeploy.ts
@@ -1,9 +1,7 @@
 /**
  * What an undeploy deletes, resolved once and read by every report — the
  * dry-run plan, the `--json` payloads, and the real run's confirmation prompt —
- * so the human and machine outputs can't drift. Adapters may extend the
- * variants with backend-specific fields; they serialize into `--json` as-is,
- * except the report-only `summary`.
+ * so the human and machine outputs can't drift.
  */
 export type UndeployTarget = UndeployApplicationTarget | UndeployConfigTarget
 
@@ -20,7 +18,6 @@ export interface UndeployConfigTarget extends UndeployTargetDetails {
 }
 
 interface UndeployTargetDetails {
-  /** Details of the deployment currently being served; `null` when none is live. */
   activeDeployment: {deployedAt: string; deployedBy: string} | null
   /** Hostname the application is served from; freed for anyone to claim after undeploy. */
   appHost: string | null
@@ -29,15 +26,24 @@ interface UndeployTargetDetails {
   projectId: string | null
   title: string | null
   type: 'coreApp' | 'studio'
-  /** Where the deployed studio/app is currently reachable. */
   url: string | null
 
-  /**
-   * Adapter-authored report lines about what gets deleted (interfaces, config
-   * snapshots, …), rendered under the target details. Built from the same data
-   * the adapter puts on its target, so the report can't drift from the payload.
-   */
+  application?: object
+  payload?: UndeployPayload
+  /** Human-report lines only; never serialized. */
   summary?: string[]
+}
+
+/** Collected locally, so a dry run reports it too. */
+export interface UndeployPayload {
+  /** The configured `deployment.appId`; `null` when none is set. */
+  appId: string | null
+  type: 'coreApp' | 'studio'
+
+  /** Media-library config summary. */
+  config?: string
+  services?: object[]
+  views?: object[]
 }
 
 export type UndeployTargetResolution<TTarget extends UndeployTarget = UndeployTarget> =

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployChecks.test.ts
@@ -73,13 +73,14 @@ describe('checkStudioTarget', () => {
     expect(reporter.results[0]?.message).toContain(
       'Deploys to existing studio https://my-studio.sanity.studio',
     )
-    // The URL the human report shows is the same one the JSON reporter reads
     expect(reporter.results[0]?.target).toEqual({
       action: 'update',
-      applicationId: 'app-1',
+      id: 'app-1',
       title: null,
+      type: 'studio',
       url: 'https://my-studio.sanity.studio',
     })
+    expect(reporter.results[0]?.application).toEqual(application())
   })
 
   test('would-create → pass check', async () => {
@@ -104,8 +105,9 @@ describe('checkStudioTarget', () => {
     // The JSON target echoes the requested title, matching the human message
     expect(reporter.results[0]?.target).toEqual({
       action: 'create',
-      applicationId: null,
+      id: null,
       title: 'My Studio',
+      type: 'studio',
       url: 'https://new-studio.sanity.studio',
     })
   })
@@ -219,7 +221,7 @@ describe('checkAppTarget', () => {
     expect(reporter.results[0]?.message).toContain('Deploys to existing application "My App"')
     expect(reporter.results[0]?.message).toContain('/@org-1/application/core-1')
     expect(reporter.results[0]?.target?.action).toBe('update')
-    expect(reporter.results[0]?.target?.applicationId).toBe('core-1')
+    expect(reporter.results[0]?.target?.id).toBe('core-1')
     expect(reporter.results[0]?.target?.url).toContain('/@org-1/application/core-1')
   })
 
@@ -246,8 +248,9 @@ describe('checkAppTarget', () => {
     // The JSON target carries the pending title; id and URL come on creation
     expect(reporter.results[0]?.target).toEqual({
       action: 'create',
-      applicationId: null,
+      id: null,
       title: 'My App',
+      type: 'coreApp',
       url: null,
     })
   })
@@ -349,9 +352,10 @@ describe('checkAppTarget (workbench backend)', () => {
     )
     expect(reporter.results[0]?.target).toEqual({
       action: 'create',
-      applicationId: null,
+      id: null,
       slug: 'drop-desk',
       title: 'New App',
+      type: 'coreApp',
       url: null,
     })
   })
@@ -363,6 +367,7 @@ describe('slug-taken', () => {
     id: 'existing-1',
     organizationId: 'org-1',
     title: 'Agent',
+    type: 'coreApp' as const,
     url: 'https://org-1.sanity.run/application/existing-1',
   }
 
@@ -376,8 +381,9 @@ describe('slug-taken', () => {
     // The resolved app id is machine-readable in the target too, for --json.
     expect(check.target).toEqual({
       action: 'update',
-      applicationId: 'existing-1',
+      id: 'existing-1',
       title: 'Agent',
+      type: 'coreApp',
       url: 'https://org-1.sanity.run/application/existing-1',
     })
     // A studio collides in the same namespace, so it gets the same diagnosis.
@@ -401,7 +407,8 @@ describe('a workbench would-create', () => {
     })
     const app = describeAppTarget(resolution, {title: 'My Thing'})
 
-    expect(studio.target).toEqual(app.target)
+    // Same pending target, only the type each command creates differs.
+    expect(studio.target).toEqual({...app.target, type: 'studio'})
     expect(studio.target?.slug).toBe('my-slug')
     expect(studio.message).toBe(
       'Would create a new studio "My Thing" with slug "my-slug" (name availability is checked on deploy)',
@@ -421,7 +428,7 @@ describe('checkStudioTarget (workbench backend)', () => {
     mockGetApplication.mockResolvedValue(workbenchApp({slug: 'my-studio', type: 'studio'}))
     const reporter = createCollectingReporter<DeployCheck>()
 
-    const target = await checkStudioTarget(reporter, {
+    const check = await checkStudioTarget(reporter, {
       appId: 'app-1',
       isWorkbenchApp: true,
       slug: 'my-studio',
@@ -431,8 +438,8 @@ describe('checkStudioTarget (workbench backend)', () => {
     expect(reporter.results[0]?.message).toContain(
       'Deploys to existing studio https://org-1.sanity.run/studio/app-1',
     )
-    expect(target?.action).toBe('update')
-    expect(target?.url).toBe('https://org-1.sanity.run/studio/app-1')
+    expect(check?.target?.action).toBe('update')
+    expect(check?.target?.url).toBe('https://org-1.sanity.run/studio/app-1')
   })
 
   test('no appId → pass check naming the slug the studio would be created at', async () => {
@@ -452,9 +459,10 @@ describe('checkStudioTarget (workbench backend)', () => {
     expect(reporter.results[0]?.message).not.toContain('hostname')
     expect(reporter.results[0]?.target).toEqual({
       action: 'create',
-      applicationId: null,
+      id: null,
       slug: 'my-studio',
       title: 'New Studio',
+      type: 'studio',
       url: null,
     })
     expect(mockGetApplication).not.toHaveBeenCalled()

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployRunner.test.ts
@@ -61,12 +61,14 @@ describe('runDeploy dry run', () => {
     expect(output.log).toHaveBeenCalledWith(expect.stringContaining('This studio can be deployed.'))
   })
 
-  test('the JSON plan reports the version the run resolved, not a separate lookup', async () => {
+  test('the JSON plan reports the payload the run collected', async () => {
     const output = mockOutput()
     const spec: DeploySpec = {
       listFiles: async () => [],
-      run: async (_options, reporter) =>
-        reporter.report({message: 'Using sanity 9.9.9', status: 'pass', version: '9.9.9'}),
+      run: async () => ({
+        application: null,
+        payload: {appId: null, isAutoUpdating: false, type: 'studio' as const, version: '9.9.9'},
+      }),
       type: 'studio',
     }
 
@@ -76,7 +78,7 @@ describe('runDeploy dry run', () => {
     )
 
     const payload = JSON.parse(vi.mocked(output.log).mock.calls.at(-1)![0] as string)
-    expect(payload.applicationVersion).toBe('9.9.9')
+    expect(payload.payload.version).toBe('9.9.9')
   })
 
   test('a blocked --json dry run prints the plan only, never a deploy envelope', async () => {
@@ -109,14 +111,16 @@ describe('runDeploy real deploy', () => {
   test('emits the deploy result as JSON, marked deployed', async () => {
     const output = mockOutput()
     const result = {
-      applicationType: 'studio' as const,
-      applicationVersion: '3.99.0',
-      target: {
-        action: 'update' as const,
-        applicationId: 'app-1',
+      action: 'update' as const,
+      application: {id: 'app-1', slug: 'my-studio'},
+      payload: {
+        appId: 'app-1',
+        isAutoUpdating: false,
         title: 'My Studio',
-        url: 'https://my-studio.sanity.studio',
+        type: 'studio' as const,
+        version: '3.99.0',
       },
+      url: 'https://my-studio.sanity.studio',
     }
     const spec: DeploySpec = {
       listFiles: async () => [],
@@ -127,7 +131,26 @@ describe('runDeploy real deploy', () => {
     await runDeploy({...dryRunOptions(output), flags: {json: true}} as DeployAppOptions, spec)
 
     const payload = JSON.parse(vi.mocked(output.log).mock.calls.at(-1)![0] as string)
-    expect(payload).toEqual({deployed: true, ...result})
+    expect(payload).toEqual({deployed: true, reason: null, ...result})
+  })
+
+  test('a plain deploy emits no workbench-only keys', async () => {
+    const output = mockOutput()
+    const spec: DeploySpec = {
+      listFiles: async () => [],
+      run: async () => ({
+        application: null,
+        payload: {appId: null, isAutoUpdating: false, type: 'studio' as const, version: '3.99.0'},
+      }),
+      type: 'studio',
+    }
+
+    await runDeploy({...dryRunOptions(output), flags: {json: true}} as DeployAppOptions, spec)
+
+    const payload = JSON.parse(vi.mocked(output.log).mock.calls.at(-1)![0] as string)
+    for (const key of ['views', 'services', 'config', 'isSingleton', 'installationId']) {
+      expect(payload.payload).not.toHaveProperty(key)
+    }
   })
 
   test('a failed deploy emits a {deployed: false} envelope and still errors on stderr', async () => {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deployStudio.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deployStudio.test.ts
@@ -1,6 +1,11 @@
 import {SchemaExtractionError} from '@sanity/cli-build/_internal/extract'
 import {type CliConfig, type Output} from '@sanity/cli-core'
-import {createStudio, deployWorkbenchApp, listApplications} from '@sanity/workbench-cli/deploy'
+import {
+  createStudio,
+  deployWorkbenchApp,
+  getApplication,
+  listApplications,
+} from '@sanity/workbench-cli/deploy'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {buildStudio} from '../../build/buildStudio.js'
@@ -14,6 +19,7 @@ vi.mock(import('@sanity/workbench-cli/deploy'), async (importOriginal) => ({
   checkBuiltOutput: vi.fn(),
   createStudio: vi.fn(),
   deployWorkbenchApp: vi.fn(),
+  getApplication: vi.fn(),
   listApplications: vi.fn(),
 }))
 vi.mock('@sanity/cli-core', async (importOriginal) => ({
@@ -30,6 +36,7 @@ vi.mock('../../../services/userApplications.js', () => ({createDeployment: vi.fn
 
 const mockCreateStudio = vi.mocked(createStudio)
 const mockDeployWorkbenchApp = vi.mocked(deployWorkbenchApp)
+const mockGetApplication = vi.mocked(getApplication)
 const mockListApplications = vi.mocked(listApplications)
 const mockBuildStudio = vi.mocked(buildStudio)
 
@@ -63,7 +70,16 @@ function deployedPayload(output: Output) {
 beforeEach(() => {
   vi.clearAllMocks()
   mockListApplications.mockResolvedValue([])
-  mockCreateStudio.mockResolvedValue({applicationId: 'studio-1', rollback: vi.fn()})
+  mockCreateStudio.mockResolvedValue({
+    application: {
+      id: 'studio-1',
+      organizationId: 'org-1',
+      slug: 'my-studio',
+      title: 'My Studio',
+      type: 'studio',
+    },
+    rollback: vi.fn(),
+  })
   vi.mocked(deployStudioSchemasAndManifests).mockResolvedValue({
     workspaces: [],
   } as unknown as Awaited<ReturnType<typeof deployStudioSchemasAndManifests>>)
@@ -114,25 +130,31 @@ describe('deployStudio (federated studio)', () => {
     await deployStudio(options)
 
     expect(deployedPayload(options.output)).toMatchObject({
+      action: 'create',
+      application: {id: 'studio-1', slug: 'my-studio'},
       deployed: true,
-      target: {
-        action: 'create',
-        applicationId: 'studio-1',
-        slug: 'my-studio',
-        url: 'https://org-1.sanity.run/studio/studio-1',
-      },
+      payload: {appId: null, slug: 'my-studio', type: 'studio'},
+      url: 'https://org-1.sanity.run/studio/studio-1',
     })
   })
 
-  test('a redeploy targets `deployment.appId` and omits the slug', async () => {
+  test('a redeploy targets `deployment.appId` and reports the resolved record', async () => {
+    mockGetApplication.mockResolvedValue({
+      id: 'studio-9',
+      organizationId: 'org-1',
+      slug: 'my-studio',
+      title: 'My Studio',
+      type: 'studio',
+    })
     const options = deployOptions({cliConfig: {deployment: {appId: 'studio-9'}}})
 
     await deployStudio(options)
 
     expect(mockCreateStudio).not.toHaveBeenCalled()
-    const {target} = deployedPayload(options.output)
-    expect(target).toMatchObject({action: 'update', applicationId: 'studio-9'})
-    expect(target).not.toHaveProperty('slug')
+    const {action, application, payload} = deployedPayload(options.output)
+    expect(action).toBe('update')
+    expect(payload.appId).toBe('studio-9')
+    expect(application).toMatchObject({id: 'studio-9', slug: 'my-studio'})
   })
 
   test('derives one deduped datasets access entry per unique workspace dataset', async () => {

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -8,12 +8,13 @@ import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {createCollectingReporter} from '../../../util/checks.js'
 import {type DeployCheck} from '../deployChecks.js'
 import {
+  declaredInterfaces,
   type DeploymentFile,
   type DeploymentPlan,
   deploymentPlanToJson,
   listDeploymentFiles,
   renderDeploymentPlan,
-  reportExposes,
+  reportInterfaces,
 } from '../deploymentPlan.js'
 
 vi.mock(import('node:fs/promises'), async (importOriginal) => ({
@@ -57,14 +58,14 @@ describe('listDeploymentFiles', () => {
   })
 })
 
+const payload = {appId: null, isAutoUpdating: false, type: 'studio' as const, version: '3.99.0'}
+
 const studioPlan = (checks: DeployCheck[], files: DeploymentFile[] = []): DeploymentPlan => ({
   checks,
-  config: null,
-  exposes: [],
   files,
+  payload: {...payload},
   target: null,
   type: 'studio',
-  version: '3.99.0',
 })
 
 describe('deploymentPlanToJson', () => {
@@ -80,97 +81,108 @@ describe('deploymentPlanToJson', () => {
       ),
     )
 
-    // No `exposes`/`config` keys — a plain (non-workbench) plan omits them.
     expect(json).toEqual({
-      applicationType: 'studio',
-      applicationVersion: '3.99.0',
+      action: null,
+      application: null,
+      canDeploy: false,
       errors: {'No studio hostname configured': 'Set `studioHost`'},
       files: [{path: 'dist/index.html', size: 1_048_576}],
-      isDeployable: false,
-      target: null,
+      payload,
+      reason: 'No studio hostname configured',
       totalBytes: 1_048_576,
+      url: null,
       warnings: ['The autoUpdates config has moved'],
     })
   })
 
-  test('passes the resolved target through to the JSON', () => {
-    const target = {
-      action: 'update' as const,
-      applicationId: 'app-1',
-      title: 'My Studio',
-      url: 'https://my-studio.sanity.studio',
-    }
+  test('reports the resolved action and url, never the backend record', () => {
     const json = deploymentPlanToJson({
       checks: [],
-      config: null,
-      exposes: [],
       files: [],
-      target,
+      payload: {...payload},
+      target: {
+        action: 'update',
+        id: 'app-1',
+        title: 'My Studio',
+        type: 'studio',
+        url: 'https://my-studio.sanity.studio',
+      },
       type: 'studio',
-      version: null,
     })
-    expect(json.target).toEqual(target)
+    expect(json.action).toBe('update')
+    expect(json.url).toBe('https://my-studio.sanity.studio')
+    expect(json.application).toBeNull()
+    expect(json.reason).toBeNull()
   })
 
   test('an error without a solution maps to null', () => {
     const json = deploymentPlanToJson(studioPlan([{message: 'boom', status: 'fail'}]))
     expect(json.errors).toEqual({boom: null})
-    expect(json.isDeployable).toBe(false)
+    expect(json.canDeploy).toBe(false)
   })
 
-  test('isDeployable is true when no check failed', () => {
-    expect(deploymentPlanToJson(studioPlan([{message: 'ok', status: 'pass'}])).isDeployable).toBe(
-      true,
-    )
+  test('canDeploy is true when no check failed', () => {
+    expect(deploymentPlanToJson(studioPlan([{message: 'ok', status: 'pass'}])).canDeploy).toBe(true)
   })
 
-  test('surfaces the registered exposes and config summary', () => {
+  test('passes the collected payload straight through', () => {
     const plan = studioPlan([{message: 'ok', status: 'pass'}])
-    plan.exposes = [{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}]
-    plan.config = 'Media Library fields:\n  Title (title)'
+    plan.payload = {
+      ...payload,
+      config: 'Media Library fields:\n  Title (title)',
+      isSingleton: false,
+      services: [],
+      views: [{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}],
+    }
 
-    const json = deploymentPlanToJson(plan)
-
-    expect(json.exposes).toEqual([{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}])
-    expect(json.config).toBe('Media Library fields:\n  Title (title)')
+    expect(deploymentPlanToJson(plan).payload).toEqual(plan.payload)
   })
 
-  test('surfaces isSingleton only when the app sets it explicitly', () => {
-    const unset = deploymentPlanToJson(studioPlan([]))
-    expect(unset).not.toHaveProperty('isSingleton')
-
-    const explicitFalse = studioPlan([])
-    explicitFalse.isSingleton = false
-    expect(deploymentPlanToJson(explicitFalse).isSingleton).toBe(false)
-
-    const explicitTrue = studioPlan([])
-    explicitTrue.isSingleton = true
-    expect(deploymentPlanToJson(explicitTrue).isSingleton).toBe(true)
+  test('omits every workbench-only key for a plain app', () => {
+    const json = deploymentPlanToJson(studioPlan([]))
+    for (const key of ['views', 'services', 'config', 'isSingleton']) {
+      expect(json.payload).not.toHaveProperty(key)
+    }
   })
 })
 
-describe('reportExposes', () => {
+describe('reportInterfaces', () => {
   test('reports views and services and returns them structured', () => {
     const reporter = createCollectingReporter<DeployCheck>()
 
-    const exposes = reportExposes(reporter, {
+    const interfaces = reportInterfaces(reporter, {
       services: [{name: 'sync', src: './sync.ts', title: 'sync', type: 'worker'}],
       views: [{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}],
     })
 
-    expect(exposes).toEqual([
-      {name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'},
-      {name: 'sync', src: './sync.ts', title: 'sync', type: 'worker'},
-    ])
+    expect(interfaces).toEqual({
+      services: [{name: 'sync', src: './sync.ts', title: 'sync', type: 'worker'}],
+      views: [{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}],
+    })
     expect(reporter.results.every((check) => check.status === 'pass')).toBe(true)
-    // The structured list rides on the first check so a dry run's collector reads it back.
-    expect(reporter.results[0].exposes).toEqual(exposes)
   })
 
   test('reports nothing and returns empty without views or services', () => {
     const reporter = createCollectingReporter<DeployCheck>()
-    expect(reportExposes(reporter, {})).toEqual([])
+    expect(reportInterfaces(reporter, {})).toEqual({services: [], views: []})
     expect(reporter.results).toEqual([])
+  })
+})
+
+describe('declaredInterfaces', () => {
+  const views = [{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}]
+
+  test('omits both keys for a plain app', () => {
+    expect(declaredInterfaces(null)).toEqual({})
+  })
+
+  // A real run and a dry run gate on the same rule, so the two modes can't drift.
+  test('omits both keys for a workbench app that declares neither', () => {
+    expect(declaredInterfaces({services: [], views: []})).toEqual({})
+  })
+
+  test('reports both keys when either kind is declared', () => {
+    expect(declaredInterfaces({services: [], views})).toEqual({services: [], views})
   })
 })
 
@@ -260,15 +272,7 @@ describe('renderDeploymentPlan', () => {
 
   test('labels a core app deploy as an application', () => {
     renderDeploymentPlan(
-      {
-        checks: [],
-        config: null,
-        exposes: [],
-        files: [],
-        target: null,
-        type: 'coreApp',
-        version: '1.0.0',
-      },
+      {checks: [], files: [], payload: null, target: null, type: 'coreApp'},
       output,
     )
 

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/resolveDeployTarget.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/resolveDeployTarget.test.ts
@@ -180,10 +180,11 @@ describe('resolveWorkbenchApp', () => {
     expect(result).toEqual({
       appHost: 'agent',
       existing: {
-        appHost: 'agent',
         id: 'app-1',
         organizationId: 'org-1',
+        slug: 'agent',
         title: 'Agent',
+        type: 'coreApp',
         url: 'https://org-1.sanity.run/application/app-1',
       },
       type: 'slug-taken',

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -43,8 +43,8 @@ import {
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
-import {listDeploymentFiles, reportExposes} from './deploymentPlan.js'
-import {type DeployResult, runDeploy} from './deployRunner.js'
+import {declaredInterfaces, listDeploymentFiles, reportInterfaces} from './deploymentPlan.js'
+import {type DeployPayload, type DeployResult, runDeploy} from './deployRunner.js'
 import {findUserApplication} from './findUserApplication.js'
 import {type DeployAppOptions} from './types.js'
 
@@ -119,6 +119,7 @@ async function runAppDeployment(
 
   let application: UserApplicationResolved | null = null
   let appCreated = false
+  let workbenchApp: object | undefined
   if (flags.external) {
     reporter.report({
       message: EXTERNAL_APP_NOT_SUPPORTED,
@@ -126,13 +127,15 @@ async function runAppDeployment(
       status: 'fail',
     })
   } else if (deployApplication && workbench) {
-    await checkAppTarget(reporter, {
-      appId,
-      isWorkbenchApp: true,
-      organizationId,
-      slug: workbench.slug,
-      title: appTitle,
-    })
+    workbenchApp = (
+      await checkAppTarget(reporter, {
+        appId,
+        isWorkbenchApp: true,
+        organizationId,
+        slug: workbench.slug,
+        title: appTitle,
+      })
+    )?.application
   } else if (deployApplication) {
     ;({application, created: appCreated} = await resolveAppApplication(options, {dryRun, reporter}))
   }
@@ -158,13 +161,16 @@ async function runAppDeployment(
   let applicationCreated = false
   let rollbackApp: (() => Promise<void>) | undefined
   if (!dryRun && deployApplication && workbench && organizationId && !applicationId) {
-    ;({applicationId, rollback: rollbackApp} = await createCoreApp({
+    const created = await createCoreApp({
       isSingleton: workbench.isSingleton,
       organizationId,
       slug: workbench.slug,
       title: appTitle,
       visibility: workbench.visibility,
-    }))
+    })
+    workbenchApp = created.application
+    applicationId = created.application.id
+    rollbackApp = created.rollback
     applicationCreated = true
   }
 
@@ -217,7 +223,7 @@ async function runAppDeployment(
       config = summarizeConfig(workbench.config)
       reporter.report(
         installationId
-          ? {config, message: config, status: 'pass'}
+          ? {message: config, status: 'pass'}
           : {
               exitCode: exitCodes.USAGE_ERROR,
               message: `No active "${configAppType}" installation for organization "${organizationId}"`,
@@ -228,16 +234,11 @@ async function runAppDeployment(
       )
     }
 
-    // Report the exposes deploying with the application, both modes.
-    const exposes = deployApplication && workbench ? reportExposes(reporter, workbench) : []
+    const interfaces = deployApplication && workbench ? reportInterfaces(reporter, workbench) : null
 
     // Surface the app's explicit singleton flag when set, both modes.
     if (deployApplication && workbench?.isSingleton !== undefined) {
-      reporter.report({
-        isSingleton: workbench.isSingleton,
-        message: `Singleton: ${workbench.isSingleton}`,
-        status: 'pass',
-      })
+      reporter.report({message: `Singleton: ${workbench.isSingleton}`, status: 'pass'})
     }
 
     // Applied after the app is live (see below) so a failed deploy never leaves
@@ -255,20 +256,27 @@ async function runAppDeployment(
       }
     }
 
+    const payload: DeployPayload = {
+      appId: appId ?? null,
+      ...(config ? {config} : {}),
+      ...declaredInterfaces(interfaces),
+      isAutoUpdating,
+      ...(workbench?.isSingleton === undefined ? {} : {isSingleton: workbench.isSingleton}),
+      ...(organizationId ? {organizationId} : {}),
+      ...(workbench ? {slug: workbench.slug, title: appTitle} : {}),
+      type: 'coreApp',
+      version,
+      ...(workbench?.visibility ? {visibility: workbench.visibility} : {}),
+    }
+
     // Dry run stops here — everything below mutates.
-    if (dryRun) return
+    if (dryRun) return {application: null, payload}
 
     // A config-only singleton ships no application, only its config.
     if (!deployApplication) {
       await deployApplicationConfig()
       if (installationId && version) {
-        return {
-          applicationType: 'coreApp',
-          applicationVersion: version,
-          ...(config ? {config} : {}),
-          installationId,
-          target: null,
-        }
+        return {application: null, installationId, payload}
       }
       return
     }
@@ -307,18 +315,10 @@ async function runAppDeployment(
         url,
       })
       return {
-        applicationType: 'coreApp',
-        applicationVersion: version,
-        ...(exposes.length > 0 ? {exposes} : {}),
-        ...(workbench.isSingleton === undefined ? {} : {isSingleton: workbench.isSingleton}),
-        target: {
-          action: applicationCreated ? 'create' : 'update',
-          applicationId,
-          // A redeploy targets an existing app; only a create reports the slug.
-          ...(applicationCreated ? {slug: workbench.slug} : {}),
-          title: appTitle,
-          url,
-        },
+        action: applicationCreated ? 'create' : 'update',
+        application: workbenchApp ?? null,
+        payload,
+        url,
       }
     }
 
@@ -342,14 +342,10 @@ async function runAppDeployment(
       title: application.title,
     })
     return {
-      applicationType: 'coreApp',
-      applicationVersion: version,
-      target: {
-        action: appCreated ? 'create' : 'update',
-        applicationId: application.id,
-        title: application.title ?? null,
-        url: getCoreAppUrl(application.organizationId, application.id),
-      },
+      action: appCreated ? 'create' : 'update',
+      application,
+      payload,
+      url: getCoreAppUrl(application.organizationId, application.id),
     }
   } catch (err) {
     await rollbackApp?.()

--- a/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployChecks.ts
@@ -2,7 +2,7 @@ import {type CliConfig, exitCodes, getLocalPackageVersion} from '@sanity/cli-cor
 import {getErrorMessage} from '@sanity/cli-core/errors'
 import {getCoreAppUrl} from '@sanity/cli-core/util'
 import {spinner} from '@sanity/cli-core/ux'
-import {checkBuiltOutput, type DeployedExpose} from '@sanity/workbench-cli/deploy'
+import {checkBuiltOutput} from '@sanity/workbench-cli/deploy'
 
 import {resolveAppIdIssue} from '../../util/appId.js'
 import {type Check, type CheckReporter, runStep} from '../../util/checks.js'
@@ -33,31 +33,21 @@ import {type DeployFlags} from './types.js'
 export interface DeployTarget {
   /** Whether the deploy creates a new application/studio or updates an existing one. */
   action: 'create' | 'update'
-  /** The application the deploy targets; `null` when a deploy would create one. */
-  applicationId: string | null
-  /** The application's title; `null` when it has none (or isn't created yet). */
+  /** `null` until the deploy creates the application. */
+  id: string | null
   title: string | null
-  /** Where the deployed studio/app is reachable; `null` when it can't be resolved yet. */
+  type: 'coreApp' | 'studio'
   url: string | null
 
-  /**
-   * Slug the deploy creates the application at. Omitted on redeploys, and in a
-   * dry run when no slug is configured (it's generated on deploy).
-   */
+  /** Absent on a plain app, whose backend reports `appHost` instead. */
   slug?: string
 }
 
 export interface DeployCheck extends Check {
-  /** Set on the config check with its summary both reporters read. */
-  config?: string
-  /** Set on the exposes check with the workbench exposes both reporters read. */
-  exposes?: DeployedExpose[]
-  /** Set on the singleton check when the app declares the flag explicitly. */
-  isSingleton?: boolean
+  /** The backend's record, verbatim; `--json` reports it once the deploy succeeds. */
+  application?: object
   /** Set on the deploy-target check with the resolved target both reporters read. */
   target?: DeployTarget
-  /** Set on the package-version check with the version both reporters read. */
-  version?: string
 }
 
 export type DeployCheckReporter = CheckReporter<DeployCheck>
@@ -69,7 +59,7 @@ export async function checkPackageVersion(
   const version = await getLocalPackageVersion(moduleName, workDir)
   reporter.report(
     version
-      ? {message: `Using ${moduleName} ${version}`, status: 'pass', version}
+      ? {message: `Using ${moduleName} ${version}`, status: 'pass'}
       : {
           message: `Failed to find installed ${moduleName} version`,
           solution: `Install ${moduleName} in this project`,
@@ -202,12 +192,14 @@ export function describeAppTarget(
       const title = application.title ?? application.appHost
       const url = application.url ?? getCoreAppUrl(application.organizationId, application.id)
       return {
+        application,
         message: `Deploys to existing application "${title}" at ${url}`,
         status: 'pass',
         target: {
           action: 'update',
-          applicationId: application.id,
-          title: application.title ?? null,
+          id: application.id,
+          title: application.title,
+          type: 'coreApp',
           url,
         },
       }
@@ -239,9 +231,10 @@ export function describeAppTarget(
           status: 'pass',
           target: {
             action: 'create',
-            applicationId: null,
+            id: null,
             ...(appHost ? {slug: appHost} : {}),
             title,
+            type: 'coreApp',
             url: null,
           },
         }
@@ -266,14 +259,16 @@ function describeSlugTaken({
   existing: DeployTargetApp
 }): DeployCheck {
   return {
+    application: existing,
     exitCode: exitCodes.USAGE_ERROR,
     message: `An application already exists at slug "${appHost}" in this organization (app ID ${existing.id})`,
     solution: `Add \`deployment: {appId: '${existing.id}'}\` to sanity.cli.ts to redeploy it`,
     status: 'fail',
     target: {
       action: 'update',
-      applicationId: existing.id,
+      id: existing.id,
       title: existing.title,
+      type: existing.type,
       url: existing.url ?? null,
     },
   }
@@ -306,7 +301,7 @@ export async function checkAppTarget(
         organizationId: string | undefined
         title?: string
       },
-): Promise<DeployTarget | null> {
+): Promise<DeployCheck | null> {
   const {title} = options
   if (options.isWorkbenchApp) {
     const {appId, organizationId, slug} = options
@@ -317,7 +312,7 @@ export async function checkAppTarget(
         const resolution = await resolveWorkbenchApp({appId, organizationId, slug})
         const check = describeAppTarget(resolution, {title})
         reporter.report(check)
-        return check.target ?? null
+        return check
       },
     })
   }
@@ -332,7 +327,7 @@ export async function checkAppTarget(
         title,
       })
       reporter.report(check)
-      return check.target ?? null
+      return check
     },
   })
 }
@@ -349,14 +344,17 @@ export function describeStudioTarget(
       return {message: `Deploy target not resolved — ${resolution.message}`, status: 'skip'}
     }
     case 'found': {
-      const url = resolution.application.url ?? studioUrl(resolution.application.appHost)
+      const {appHost} = resolution.application
+      const url = resolution.application.url ?? (appHost ? studioUrl(appHost) : null)
       return {
+        application: resolution.application,
         message: `Deploys to existing studio ${url}`,
         status: 'pass',
         target: {
           action: 'update',
-          applicationId: resolution.application.id,
-          title: resolution.application.title ?? null,
+          id: resolution.application.id,
+          title: resolution.application.title,
+          type: 'studio',
           url,
         },
       }
@@ -388,12 +386,7 @@ export function describeStudioTarget(
       const url = isWorkbench ? null : studioUrl(appHost)
       const result = {
         status: 'pass',
-        target: {
-          action: 'create',
-          applicationId: null,
-          title: title || null,
-          url,
-        },
+        target: {action: 'create', id: null, title: title || null, type: 'studio', url},
       } as const
       const titled = title ? ` titled "${title}"` : ''
 
@@ -444,7 +437,7 @@ export async function checkStudioTarget(
         slug: string
         title?: string
       },
-): Promise<DeployTarget | null> {
+): Promise<DeployCheck | null> {
   const {title} = options
   const resolve = options.isWorkbenchApp
     ? resolveWorkbenchStudio(options)
@@ -463,7 +456,7 @@ export async function checkStudioTarget(
         title,
       })
       reporter.report(check)
-      return check.target ?? null
+      return check
     },
   })
 }

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -1,7 +1,7 @@
 import {CLIError} from '@oclif/core/errors'
 import {type Output} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
-import {type DeployedExpose} from '@sanity/workbench-cli/deploy'
+import {type DeployedInterface} from '@sanity/workbench-cli/deploy'
 
 import {createCollectingReporter, createFailFastReporter} from '../../util/checks.js'
 import {toStderrOutput} from '../../util/toStderrOutput.js'
@@ -16,25 +16,34 @@ import {
 } from './deploymentPlan.js'
 import {type DeployAppOptions} from './types.js'
 
-/** What a real deploy produced — the payload `--json` reports. */
 export interface DeployResult {
-  applicationType: 'coreApp' | 'studio'
-  /** Installed framework version the deploy used (`sanity` or `@sanity/sdk-react`). */
-  applicationVersion: string
-  /**
-   * The deployed application/studio, in the same shape the dry-run plan reports
-   * so the two modes can't drift; `null` for a config-only singleton deploy.
-   */
-  target: DeployTarget | null
+  application: object | null
+  payload: DeployPayload
 
-  /** Media-library config summary, when a singleton config deployed. */
-  config?: string
-  /** Workbench views and services registered with the deploy. */
-  exposes?: DeployedExpose[]
-  /** Set when a media-library singleton deployed its config. */
+  action?: DeployTarget['action']
+  /** Resolved server-side, so it stays out of the local payload. */
   installationId?: string
-  /** The app's explicit `isSingleton` flag; omitted when the app doesn't set it. */
+  url?: string | null
+}
+
+/** Collected locally, so a dry run reports it too. */
+export interface DeployPayload {
+  /** The configured `deployment.appId`; `null` when the deploy would mint one. */
+  appId: string | null
+  isAutoUpdating: boolean
+  type: 'coreApp' | 'studio'
+  version: string | null
+
+  /** Media-library config summary. */
+  config?: string
   isSingleton?: boolean
+  organizationId?: string
+  projectId?: string
+  services?: DeployedInterface[]
+  slug?: string
+  title?: string
+  views?: DeployedInterface[]
+  visibility?: string
 }
 
 /**
@@ -74,13 +83,19 @@ export async function runDeploy(options: DeployAppOptions, spec: DeploySpec): Pr
     }
 
     const result = await spec.run(runOptions, createFailFastReporter(runOptions.output))
-    if (json && result) emitJson({deployed: true, ...result})
+    if (json && result) emitJson({deployed: true, reason: null, ...result})
   } catch (error) {
     const failure = normalizeFailure(error, spec.type)
     // A blocked dry run reaches this catch too (its exit throws) and already
     // printed its plan, so only a real deploy adds the {deployed: false} envelope.
     if (json && !options.flags['dry-run']) {
-      emitJson({deployed: false, error: {message: failure.message}})
+      emitJson({
+        application: null,
+        deployed: false,
+        error: {message: failure.message},
+        payload: null,
+        reason: failure.message,
+      })
     }
     output.error(failure.message, {exit: failure.exit})
   }
@@ -89,17 +104,14 @@ export async function runDeploy(options: DeployAppOptions, spec: DeploySpec): Pr
 /** Runs the step sequence read-only and gathers the plan a dry run reports. */
 async function collectPlan(options: DeployAppOptions, spec: DeploySpec): Promise<DeploymentPlan> {
   const reporter = createCollectingReporter<DeployCheck>()
-  await spec.run(options, reporter)
+  const result = await spec.run(options, reporter)
   const plan: DeploymentPlan = {
     checks: reporter.results,
-    config: reporter.results.find((check) => check.config)?.config ?? null,
-    exposes: reporter.results.find((check) => check.exposes)?.exposes ?? [],
     files: [],
-    isSingleton: reporter.results.find((check) => check.isSingleton !== undefined)?.isSingleton,
+    payload: result?.payload ?? null,
     target:
       reporter.results.find((check) => check.target && check.status !== 'fail')?.target ?? null,
     type: spec.type,
-    version: reporter.results.find((check) => check.version)?.version ?? null,
   }
   // A blocked deploy uploads nothing, so only enumerate files for a deployable plan.
   if (isDeployable(plan)) plan.files = await spec.listFiles(options)

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -31,8 +31,8 @@ import {
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
-import {listDeploymentFiles, reportExposes} from './deploymentPlan.js'
-import {type DeployResult, runDeploy} from './deployRunner.js'
+import {declaredInterfaces, listDeploymentFiles, reportInterfaces} from './deploymentPlan.js'
+import {type DeployPayload, type DeployResult, runDeploy} from './deployRunner.js'
 import {deployStudioSchemasAndManifests} from './deployStudioSchemasAndManifests.js'
 import {findUserApplicationForStudio} from './findUserApplication.js'
 import {type DeployAppOptions} from './types.js'
@@ -99,6 +99,7 @@ async function runStudioDeployment(
   // resolve/create on user-applications, unchanged.
   let application: UserApplication | null = null
   let studioCreated = false
+  let workbenchApp: object | undefined
   if (workbench && !isExternal) {
     reporter.report(
       organizationId
@@ -109,13 +110,15 @@ async function runStudioDeployment(
             status: 'fail',
           },
     )
-    await checkStudioTarget(reporter, {
-      appId,
-      isWorkbenchApp: true,
-      organizationId,
-      slug: workbench.slug,
-      title: appTitle,
-    })
+    workbenchApp = (
+      await checkStudioTarget(reporter, {
+        appId,
+        isWorkbenchApp: true,
+        organizationId,
+        slug: workbench.slug,
+        title: appTitle,
+      })
+    )?.application
   } else {
     ;({application, created: studioCreated} = await resolveStudioApplication(options, {
       dryRun,
@@ -146,13 +149,16 @@ async function runStudioDeployment(
   let applicationCreated = false
   let rollbackApp: (() => Promise<void>) | undefined
   if (!dryRun && workbench && !isExternal && organizationId && !applicationId) {
-    ;({applicationId, rollback: rollbackApp} = await createStudio({
+    const created = await createStudio({
       organizationId,
       projectId,
       slug: workbench.slug,
       title: appTitle,
       visibility: workbench.visibility,
-    }))
+    })
+    workbenchApp = created.application
+    applicationId = created.application.id
+    rollbackApp = created.rollback
     applicationCreated = true
   }
 
@@ -179,12 +185,23 @@ async function runStudioDeployment(
       await verifyOutputDir({isWorkbenchApp, reporter, sourceDir})
     }
 
-    // Report the exposes deploying with the studio, both modes. External studios
-    // host their own bundle, so nothing registers.
-    const exposes = workbench && !isExternal ? reportExposes(reporter, workbench) : []
+    // An external studio hosts its own bundle, so nothing registers.
+    const interfaces = workbench && !isExternal ? reportInterfaces(reporter, workbench) : null
+
+    const payload: DeployPayload = {
+      appId: appId ?? null,
+      ...declaredInterfaces(interfaces),
+      isAutoUpdating,
+      ...(organizationId ? {organizationId} : {}),
+      ...(projectId ? {projectId} : {}),
+      ...(workbench ? {slug: workbench.slug, title: appTitle} : {}),
+      type: 'studio',
+      version,
+      ...(workbench?.visibility ? {visibility: workbench.visibility} : {}),
+    }
 
     // Dry run stops here — everything below mutates.
-    if (dryRun) return
+    if (dryRun) return {application: null, payload}
 
     // A real deploy has already exited if anything failed; landing here without a
     // resolved version means the deploy target was never resolved.
@@ -216,16 +233,10 @@ async function runStudioDeployment(
       const url = getApplicationUrl({id: applicationId, organizationId, type: 'studio'})
       logWorkbenchStudioDeployed({applicationId, cliConfig, output, url})
       return {
-        applicationType: 'studio',
-        applicationVersion: version,
-        ...(exposes.length > 0 ? {exposes} : {}),
-        target: {
-          action: applicationCreated ? 'create' : 'update',
-          applicationId,
-          ...(applicationCreated ? {slug: workbench.slug} : {}),
-          title: appTitle,
-          url,
-        },
+        action: applicationCreated ? 'create' : 'update',
+        application: workbenchApp ?? null,
+        payload,
+        url,
       }
     }
 
@@ -240,14 +251,10 @@ async function runStudioDeployment(
     })
 
     return {
-      applicationType: 'studio',
-      applicationVersion: version,
-      target: {
-        action: studioCreated ? 'create' : 'update',
-        applicationId: application.id,
-        title: application.title ?? null,
-        url: location,
-      },
+      action: studioCreated ? 'create' : 'update',
+      application,
+      payload,
+      url: location,
     }
   } catch (err) {
     await rollbackApp?.()

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -3,11 +3,12 @@ import {join, relative, sep} from 'node:path'
 import {styleText} from 'node:util'
 
 import {type Output} from '@sanity/cli-core'
-import {type DeployedExpose, summarizeInterfaces} from '@sanity/workbench-cli/deploy'
+import {type DeployedInterface, summarizeInterfaces} from '@sanity/workbench-cli/deploy'
 
 import {checkStatusIcon, nestLines, renderIssues} from '../../util/checks.js'
 import {pluralize} from '../../util/pluralize.js'
 import {type DeployCheck, type DeployCheckReporter, type DeployTarget} from './deployChecks.js'
+import {type DeployPayload} from './deployRunner.js'
 
 export interface DeploymentFile {
   /** Path relative to the project root, POSIX-style. */
@@ -18,19 +19,12 @@ export interface DeploymentFile {
 /** What a `--dry-run` deploy would do: the real deploy sequence with every mutation gated off. */
 export interface DeploymentPlan {
   checks: DeployCheck[]
-  /** Media-library config summary; `null` unless a config deploys. */
-  config: string | null
-  /** Workbench views and services registered with the deploy. */
-  exposes: DeployedExpose[]
   files: DeploymentFile[]
+  /** `null` when the run bailed before collecting it. */
+  payload: DeployPayload | null
   /** The resolved deploy target; `null` when the checks can't determine one. */
   target: DeployTarget | null
   type: 'coreApp' | 'studio'
-  /** Installed framework version the deploy would use; `null` when not found. */
-  version: string | null
-
-  /** The app's explicit `isSingleton` flag; `undefined` when the app doesn't set it. */
-  isSingleton?: boolean
 }
 
 /**
@@ -82,16 +76,15 @@ function totalBytes(files: DeploymentFile[]): number {
  * human report renders (its pass/skip lines are informational and omitted here).
  */
 export function deploymentPlanToJson(plan: DeploymentPlan): {
-  applicationType: DeploymentPlan['type']
-  applicationVersion: string | null
-  config?: string
+  action: DeployTarget['action'] | null
+  application: null
+  canDeploy: boolean
   errors: Record<string, string | null>
-  exposes?: DeployedExpose[]
   files: DeploymentFile[]
-  isDeployable: boolean
-  isSingleton?: boolean
-  target: DeployTarget | null
+  payload: DeployPayload | null
+  reason: string | null
   totalBytes: number
+  url: string | null
   warnings: string[]
 } {
   const errors: Record<string, string | null> = {}
@@ -101,37 +94,37 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
     else if (check.status === 'warn') warnings.push(check.message)
   }
 
-  // `exposes`, `config` and `isSingleton` are workbench-only; plain
-  // apps (and apps that don't set the flag) omit them.
   return {
-    applicationType: plan.type,
-    applicationVersion: plan.version,
+    action: plan.target?.action ?? null,
+    // Only a successful deploy reports the backend's record.
+    application: null,
+    canDeploy: isDeployable(plan),
     errors,
-    ...(plan.exposes.length > 0 ? {exposes: plan.exposes} : {}),
     files: plan.files,
-    ...(plan.config ? {config: plan.config} : {}),
-    isDeployable: isDeployable(plan),
-    ...(plan.isSingleton === undefined ? {} : {isSingleton: plan.isSingleton}),
-    target: plan.target,
+    payload: plan.payload,
+    reason: plan.checks.find((check) => check.status === 'fail')?.message ?? null,
     totalBytes: totalBytes(plan.files),
+    url: plan.target?.url ?? null,
     warnings,
   }
 }
 
-/**
- * Reports an app's exposes as pass checks and returns them structured for the
- * `--json` payload. The structured list rides on the first check so a dry run's
- * collector can read it back.
- */
-export function reportExposes(
+/** Workbench-only, and both or neither. */
+export function declaredInterfaces(
+  declared: {services: DeployedInterface[]; views: DeployedInterface[]} | null,
+): {services?: DeployedInterface[]; views?: DeployedInterface[]} {
+  if (!declared) return {}
+  const {services, views} = declared
+  return services.length > 0 || views.length > 0 ? {services, views} : {}
+}
+
+export function reportInterfaces(
   reporter: DeployCheckReporter,
   app: Parameters<typeof summarizeInterfaces>[0],
-): DeployedExpose[] {
-  const {exposes, lines} = summarizeInterfaces(app)
-  for (const [index, message] of lines.entries()) {
-    reporter.report({exposes: index === 0 ? exposes : undefined, message, status: 'pass'})
-  }
-  return exposes
+): {services: DeployedInterface[]; views: DeployedInterface[]} {
+  const {lines, services, views} = summarizeInterfaces(app)
+  for (const message of lines) reporter.report({message, status: 'pass'})
+  return {services, views}
 }
 
 export function renderDeploymentPlan(plan: DeploymentPlan, output: Output): void {

--- a/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
+++ b/packages/@sanity/cli/src/actions/deploy/resolveDeployTarget.ts
@@ -11,10 +11,11 @@ import {normalizeUrl, validateUrl} from './urlUtils.js'
 
 /** The application fields a deploy-target verdict carries for reporting. */
 export interface DeployTargetApp {
-  appHost: string
   id: string
   title: string | null
+  type: 'coreApp' | 'studio'
 
+  appHost?: string
   url?: string
 }
 
@@ -185,13 +186,7 @@ export async function resolveWorkbenchApp({
     if (existing) {
       return {
         appHost: slug,
-        existing: {
-          appHost: slug,
-          id: existing.id,
-          organizationId: existing.organizationId,
-          title: existing.title,
-          url: getApplicationUrl(existing),
-        },
+        existing: {...existing, url: getApplicationUrl(existing)},
         type: 'slug-taken',
       }
     }
@@ -222,13 +217,7 @@ async function resolveAppById(
   const application = await getApplication(appId)
   return application
     ? {
-        application: {
-          appHost: application.slug ?? '',
-          id: application.id,
-          organizationId: application.organizationId,
-          title: application.title,
-          url: getApplicationUrl(application),
-        },
+        application: {...application, url: getApplicationUrl(application)},
         type: 'found',
       }
     : {message: APP_ID_NOT_FOUND_IN_ORGANIZATION, reason: 'app-not-found', type: 'invalid'}

--- a/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
@@ -1,6 +1,10 @@
 import {type Output} from '@sanity/cli-core'
 import {exitCodes} from '@sanity/cli-core/ExitCodes'
-import {type UndeployAdapter, type UndeployApplicationTarget} from '@sanity/cli-core/undeploy'
+import {
+  type UndeployAdapter,
+  type UndeployApplicationTarget,
+  type UndeployConfigTarget,
+} from '@sanity/cli-core/undeploy'
 import {confirm} from '@sanity/cli-test/mocks/cli-core/ux'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
@@ -32,12 +36,17 @@ function target(overrides: Partial<UndeployApplicationTarget> = {}): UndeployApp
     deletes: 'application',
     id: 'app-1',
     organizationId: null,
+    payload: {appId: 'app-1', type: 'studio'},
     projectId: 'project-1',
     title: null,
     type: 'studio',
     url: 'https://my-studio.sanity.studio',
     ...overrides,
   }
+}
+
+function configTarget(overrides: Partial<UndeployConfigTarget> = {}): UndeployConfigTarget {
+  return {...target(), deletes: 'config', id: null, ...overrides}
 }
 
 function adapter(overrides: Partial<UndeployAdapter> = {}): UndeployAdapter {
@@ -201,7 +210,7 @@ describe('runUndeploy real run', () => {
       options(output, {yes: true}),
       adapter({
         resolveTarget: async () => ({
-          target: {...target(), deletes: 'config' as const, id: null},
+          target: configTarget(),
           type: 'found',
         }),
         undeploy: async () => {
@@ -238,7 +247,7 @@ describe('runUndeploy --json', () => {
     expect(logged).toHaveLength(1)
     const payload = JSON.parse(logged[0]!)
     expect(payload.canUndeploy).toBe(true)
-    expect(payload.application.id).toBe('app-1')
+    expect(payload.payload.appId).toBe('app-1')
   })
 
   test('a real run emits an {undeployed: true} envelope with the target', async () => {
@@ -247,7 +256,7 @@ describe('runUndeploy --json', () => {
 
     const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
     expect(payload.undeployed).toBe(true)
-    expect(payload.application.id).toBe('app-1')
+    expect(payload.payload.appId).toBe('app-1')
   })
 
   test("without `yes` the runner still confirms — unattended consent is the command's job", async () => {
@@ -260,6 +269,28 @@ describe('runUndeploy --json', () => {
     expect(undeploy).not.toHaveBeenCalled()
   })
 
+  // `summary` is a report-only field on the target, so it must not be filtered
+  // out of the backend record, which reaches `--json` verbatim.
+  test('a backend field named summary survives into the reported record', async () => {
+    const output = mockOutput()
+    await runUndeploy(
+      options(output, {json: true, yes: true}),
+      adapter({
+        resolveTarget: async () => ({
+          target: {
+            ...target(),
+            application: {id: 'app-1', summary: 'from the server'},
+            summary: ['report only'],
+          },
+          type: 'found',
+        }),
+      }),
+    )
+
+    const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
+    expect(payload.application.summary).toBe('from the server')
+  })
+
   test('nothing to undeploy emits {undeployed: false} with the reason', async () => {
     const output = mockOutput()
     await runUndeploy(
@@ -268,7 +299,12 @@ describe('runUndeploy --json', () => {
     )
 
     const payload = JSON.parse(String(vi.mocked(output.log).mock.calls.at(-1)![0]))
-    expect(payload).toEqual({reason: 'No application ID provided', undeployed: false})
+    expect(payload).toEqual({
+      application: null,
+      payload: null,
+      reason: 'No application ID provided',
+      undeployed: false,
+    })
   })
 
   test('a failed deletion emits a {undeployed: false} error envelope and still errors on stderr', async () => {
@@ -364,10 +400,13 @@ describe('undeployPlanToJson', () => {
     })
 
     expect(json).toEqual({
-      application: target(),
+      application: null,
       canUndeploy: false,
+      deletes: 'application',
       errors: {boom: 'do X'},
-      reason: null,
+      payload: {appId: 'app-1', type: 'studio'},
+      reason: 'boom',
+      url: 'https://my-studio.sanity.studio',
       warnings: ['heads up'],
     })
   })
@@ -384,12 +423,19 @@ describe('undeployPlanToJson', () => {
     expect(json.errors).toEqual({})
     expect(json.reason).toBe('No application ID provided')
     expect(json.application).toBeNull()
+    expect(json.payload).toBeNull()
   })
 
-  test('an undeployable plan reports the full target', () => {
-    const json = undeployPlanToJson({checks: [], reason: null, target: target(), type: 'studio'})
+  test('reports the local payload, never the backend record', () => {
+    const json = undeployPlanToJson({
+      checks: [],
+      reason: null,
+      target: {...target(), application: {id: 'app-1', slug: 'my-studio'}},
+      type: 'studio',
+    })
     expect(json.canUndeploy).toBe(true)
-    expect(json.application).toEqual(target())
+    expect(json.payload).toEqual({appId: 'app-1', type: 'studio'})
+    expect(json.application).toBeNull()
   })
 })
 
@@ -481,11 +527,7 @@ describe('renderUndeployPlan', () => {
       {
         checks: [{message: 'boom', status: 'fail'}],
         reason: null,
-        target: {
-          ...target({title: 'media-library', type: 'coreApp'}),
-          deletes: 'config',
-          id: null,
-        },
+        target: configTarget({title: 'media-library', type: 'coreApp'}),
         type: 'coreApp',
       },
       output,
@@ -507,7 +549,7 @@ describe('renderUndeployPlan target summary', () => {
       {
         checks: [],
         reason: null,
-        target: target({summary: ['Views:\n  Insights (insights)', 'Singleton: true']}),
+        target: {...target(), summary: ['Views:\n  Insights (insights)', 'Singleton: true']},
         type: 'studio',
       },
       output,

--- a/packages/@sanity/cli/src/actions/undeploy/adapters.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/adapters.ts
@@ -1,9 +1,5 @@
 import {type CliConfig} from '@sanity/cli-core'
-import {
-  type UndeployAdapter,
-  type UndeployApplicationTarget,
-  type UndeployTarget,
-} from '@sanity/cli-core/undeploy'
+import {type UndeployAdapter, type UndeployApplicationTarget} from '@sanity/cli-core/undeploy'
 import {getCoreAppUrl} from '@sanity/cli-core/util'
 
 import {
@@ -81,22 +77,19 @@ export function createStudioUndeployAdapter(
 
 function toUndeployTarget(
   application: UserApplication,
-  type: UndeployTarget['type'],
+  type: UndeployApplicationTarget['type'],
 ): UndeployApplicationTarget {
   return {
-    activeDeployment: application.activeDeployment
-      ? {
-          deployedAt: application.activeDeployment.deployedAt,
-          deployedBy: application.activeDeployment.deployedBy,
-        }
-      : null,
-    appHost: application.appHost ?? null,
-    createdAt: application.createdAt ?? null,
+    activeDeployment: application.activeDeployment ?? null,
+    appHost: application.appHost,
+    application,
+    createdAt: application.createdAt,
     deletes: 'application',
     id: application.id,
-    organizationId: application.organizationId ?? null,
-    projectId: application.projectId ?? null,
-    title: application.title ?? null,
+    organizationId: application.organizationId,
+    payload: {appId: application.id, type},
+    projectId: application.projectId,
+    title: application.title,
     type,
     url: resolveTargetUrl(application, type),
   }
@@ -104,7 +97,7 @@ function toUndeployTarget(
 
 function resolveTargetUrl(
   application: UserApplication,
-  type: UndeployTarget['type'],
+  type: UndeployApplicationTarget['type'],
 ): string | null {
   if (type === 'coreApp') {
     return application.organizationId

--- a/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/runUndeploy.ts
@@ -37,8 +37,15 @@ export interface UndeployOptions {
 
 /** What a real undeploy produced — the payload `--json` reports. */
 type UndeployResult =
-  | {application: UndeployTarget; undeployed: true}
-  | {reason: string; undeployed: false}
+  | {application: null; payload: null; reason: string; undeployed: false}
+  | {
+      application: object | null
+      deletes: UndeployTarget['deletes']
+      payload: UndeployTarget['payload']
+      reason: null
+      undeployed: true
+      url: string | null
+    }
 
 /**
  * Runs an undeploy in the mode the flags select: a real undeploy fails fast,
@@ -52,9 +59,7 @@ export async function runUndeploy(
 ): Promise<void> {
   const {flags, output} = options
   const json = !!flags.json
-  // The report-only `summary` lines never enter the payload
-  const emitJson = (payload: unknown) =>
-    output.log(JSON.stringify(payload, (key, value) => (key === 'summary' ? undefined : value), 2))
+  const emitJson = (payload: unknown) => output.log(JSON.stringify(payload, null, 2))
 
   // The JSON payload owns stdout, so the run's progress logs go to stderr; only
   // the final JSON.stringify writes to stdout.
@@ -85,7 +90,13 @@ export async function runUndeploy(
     // A blocked dry run reaches this catch too (its exit throws) and already
     // printed its plan, so only a real undeploy adds the {undeployed: false} envelope.
     if (json && !flags['dry-run']) {
-      emitJson({error: {message: failure.message}, undeployed: false})
+      emitJson({
+        application: null,
+        error: {message: failure.message},
+        payload: null,
+        reason: failure.message,
+        undeployed: false,
+      })
     }
     output.error(failure.message, {exit: failure.exit})
   }
@@ -105,7 +116,7 @@ async function undeployApp(
     output.log(`${resolution.message}.`)
     if (resolution.solution) output.log(`${resolution.solution}.`)
     output.log('Nothing to undeploy.')
-    return {reason: resolution.message, undeployed: false}
+    return {application: null, payload: null, reason: resolution.message, undeployed: false}
   }
 
   const {target} = resolution
@@ -138,7 +149,14 @@ async function undeployApp(
   spin.succeed()
 
   printUndeployed(target, output)
-  return {application: target, undeployed: true}
+  return {
+    application: target.application ?? null,
+    deletes: target.deletes,
+    payload: target.payload,
+    reason: null,
+    undeployed: true,
+    url: target.url,
+  }
 }
 
 /**

--- a/packages/@sanity/cli/src/actions/undeploy/undeployPlan.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/undeployPlan.ts
@@ -32,13 +32,7 @@ export function undeployLabel(target: UndeployTarget | null, type: 'coreApp' | '
  * fix, warnings as messages. Derived from the same checks and target the human
  * report renders, so the two can't drift.
  */
-export function undeployPlanToJson(plan: UndeployPlan): {
-  application: UndeployTarget | null
-  canUndeploy: boolean
-  errors: Record<string, string | null>
-  reason: string | null
-  warnings: string[]
-} {
+export function undeployPlanToJson(plan: UndeployPlan): UndeployPlanJson {
   const errors: Record<string, string | null> = {}
   const warnings: string[] = []
   for (const check of plan.checks) {
@@ -47,12 +41,27 @@ export function undeployPlanToJson(plan: UndeployPlan): {
   }
 
   return {
-    application: plan.target,
+    // Only a successful undeploy reports the backend's record.
+    application: null,
     canUndeploy: canUndeploy(plan),
+    deletes: plan.target?.deletes ?? null,
     errors,
-    reason: plan.reason,
+    payload: plan.target?.payload ?? null,
+    reason: plan.reason ?? plan.checks.find((check) => check.status === 'fail')?.message ?? null,
+    url: plan.target?.url ?? null,
     warnings,
   }
+}
+
+interface UndeployPlanJson {
+  application: null
+  canUndeploy: boolean
+  deletes: UndeployTarget['deletes'] | null
+  errors: Record<string, string | null>
+  payload: UndeployTarget['payload'] | null
+  reason: string | null
+  url: string | null
+  warnings: string[]
 }
 
 /**

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -519,10 +519,8 @@ describe('#undeploy', () => {
 
     const payload = JSON.parse(stdout)
     expect(payload.canUndeploy).toBe(true)
-    expect(payload.application).toMatchObject({
-      id: 'app-id',
-      url: 'https://my-host.sanity.studio',
-    })
+    expect(payload.payload).toEqual({appId: 'app-id', type: 'studio'})
+    expect(payload.url).toBe('https://my-host.sanity.studio')
   })
 
   test('--json with --yes undeploys and emits the result envelope', async () => {
@@ -554,7 +552,7 @@ describe('#undeploy', () => {
 
     const payload = JSON.parse(stdout)
     expect(payload.undeployed).toBe(true)
-    expect(payload.application.id).toBe('app-id')
+    expect(payload.payload.appId).toBe('app-id')
   })
 
   test('--json without --yes reports the required confirmation as JSON', async () => {
@@ -580,9 +578,12 @@ describe('#undeploy', () => {
     expect(confirm).not.toHaveBeenCalled()
     const payload = JSON.parse(stdout)
     expect(payload).toEqual({
+      application: null,
       error: {
         message: 'Undeploy requires confirmation. Pass --yes to continue.',
       },
+      payload: null,
+      reason: 'Undeploy requires confirmation. Pass --yes to continue.',
       undeployed: false,
     })
     expect(error?.oclif?.exit).toBe(exitCodes.USAGE_ERROR)
@@ -653,11 +654,10 @@ describe('#undeploy', () => {
 
     const payload = JSON.parse(stdout)
     expect(payload.undeployed).toBe(true)
-    expect(payload.application).toMatchObject({
-      deletes: 'application',
-      id: 'wb-app-1',
-      url: 'https://org-1.sanity.run/application/wb-app-1',
-    })
+    expect(payload.deletes).toBe('application')
+    expect(payload.payload).toMatchObject({appId: 'wb-app-1'})
+    expect(payload.url).toBe('https://org-1.sanity.run/application/wb-app-1')
+    expect(payload.application).toMatchObject({id: 'wb-app-1', slug: 'my-app-x1'})
   })
 
   test('media library dry run reports the installation config', async () => {
@@ -698,7 +698,7 @@ describe('#undeploy', () => {
     })
 
     expect(stdout).toContain('Undeploys the installation config')
-    expect(stdout).toContain('at 2024-01-01T00:00:00Z by gustav@sanity.io')
+    expect(stdout).toContain('Served since 2024-01-01T00:00:00Z by gustav@sanity.io')
     expect(stdout).not.toContain('1.0.0')
     expect(stdout).toContain('Alt text (alt): ./src/alt.ts')
     expect(stdout).not.toContain('Config snapshots')
@@ -743,21 +743,11 @@ describe('#undeploy', () => {
 
     const payload = JSON.parse(stdout)
     expect(payload.canUndeploy).toBe(true)
-    expect(payload.application).toMatchObject({
-      activeDeployment: {
-        deployedAt: '2024-01-01T00:00:00Z',
-        deployedBy: 'gustav@sanity.io',
-      },
-      configs: [expect.objectContaining({id: 'cfg-1'})],
-      deletes: 'config',
-    })
-    expect(payload.application.summary).toBeUndefined()
-    // Workbench internals and versions never reach the machine payload
-    expect(payload.application.fields).toBeUndefined()
-    expect(payload.application.installationId).toBeUndefined()
-    expect(payload.application.isSingleton).toBeUndefined()
-    expect(payload.application.activeDeployment.version).toBeUndefined()
-    expect(payload.application.configs[0].version).toBeUndefined()
+    expect(payload.deletes).toBe('config')
+    expect(payload.payload.config).toContain('Media library fields')
+    expect(payload.payload.fields).toBeUndefined()
+    expect(payload.payload.installationId).toBeUndefined()
+    expect(payload.payload.isSingleton).toBeUndefined()
   })
 
   test('handles error when deployment.appId does not exist for the org', async () => {

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -335,7 +335,15 @@ describe('#deploy app', () => {
     const cwd = await testFixture('basic-app')
     process.cwd = () => cwd
 
-    mockCreateCoreApp.mockResolvedValue({applicationId: 'app_new'})
+    mockCreateCoreApp.mockResolvedValue({
+      application: {
+        id: 'app_new',
+        organizationId,
+        slug: 'drop-desk-host',
+        title: 'Workbench App',
+        type: 'coreApp',
+      },
+    })
 
     const app = unstable_defineApp({
       entry: './src/App.tsx',
@@ -360,11 +368,10 @@ describe('#deploy app', () => {
     )
     const result = JSON.parse(stdout)
     expect(result.deployed).toBe(true)
-    expect(result.target).toMatchObject({
-      applicationId: 'app_new',
-      slug: 'drop-desk-host',
-      url: `https://${organizationId}.sanity.run/application/app_new`,
-    })
+    expect(result.action).toBe('create')
+    expect(result.url).toBe(`https://${organizationId}.sanity.run/application/app_new`)
+    expect(result.payload).toMatchObject({appId: null, slug: 'drop-desk-host', type: 'coreApp'})
+    expect(result.application).toMatchObject({id: 'app_new', slug: 'drop-desk-host'})
   })
 
   test('rolls back a freshly created app when the build fails, so its slug is free to retry', async () => {
@@ -372,7 +379,16 @@ describe('#deploy app', () => {
     process.cwd = () => cwd
 
     const rollback = vi.fn()
-    mockCreateCoreApp.mockResolvedValue({applicationId: 'app_new', rollback})
+    mockCreateCoreApp.mockResolvedValue({
+      application: {
+        id: 'app_new',
+        organizationId,
+        slug: 'drop-desk-host',
+        title: 'Workbench App',
+        type: 'coreApp',
+      },
+      rollback,
+    })
     mockBuildApp.mockRejectedValueOnce(new Error('build blew up'))
 
     const app = unstable_defineApp({
@@ -432,14 +448,15 @@ describe('#deploy app', () => {
 
     if (error) throw error
     const plan = JSON.parse(stdout)
-    expect(plan.isDeployable).toBe(true)
-    expect(plan.target).toEqual({
-      action: 'create',
-      applicationId: null,
+    expect(plan.canDeploy).toBe(true)
+    expect(plan.action).toBe('create')
+    expect(plan.payload).toMatchObject({
+      appId: null,
       slug: 'drop-desk-host',
       title: 'Workbench App',
-      url: null,
+      type: 'coreApp',
     })
+    expect(plan.application).toBeNull()
     expect(mockCreateCoreApp).not.toHaveBeenCalled()
     expect(mockDeployWorkbenchApp).not.toHaveBeenCalled()
   })
@@ -481,7 +498,15 @@ describe('#deploy app', () => {
     process.cwd = () => cwd
     await writeFile(join(cwd, 'icon.svg'), '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>')
 
-    mockCreateCoreApp.mockResolvedValue({applicationId: 'app_new'})
+    mockCreateCoreApp.mockResolvedValue({
+      application: {
+        id: 'app_new',
+        organizationId,
+        slug: 'drop-desk-host',
+        title: 'Workbench App',
+        type: 'coreApp',
+      },
+    })
 
     const app = unstable_defineApp({
       entry: './src/App.tsx',

--- a/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.studio.test.ts
@@ -275,6 +275,46 @@ describe('#deploy studio', () => {
     expect(stdout).not.toContain('Success! Studio deployed')
   })
 
+  test('a plain studio collects no workbench data into the --json payload', async () => {
+    const cwd = await testFixture('basic-studio')
+    process.cwd = () => cwd
+
+    const projectId = 'test-project-id'
+    const studioHost = 'existing-studio'
+    await mkdir(join(cwd, 'dist'), {recursive: true})
+    await writeFile(join(cwd, 'dist', 'index.html'), '<html></html>')
+
+    mockApi({
+      apiVersion: USER_APPLICATIONS_API_VERSION,
+      query: {appHost: studioHost, appType: 'studio'},
+      uri: `/projects/${projectId}/user-applications`,
+    }).reply(200, {
+      appHost: studioHost,
+      createdAt: '2024-01-01T00:00:00Z',
+      id: 'studio-app-id',
+      projectId,
+      title: 'Existing Studio',
+      type: 'studio',
+      updatedAt: '2024-01-01T00:00:00Z',
+      urlType: 'internal',
+    })
+
+    const {error, stdout} = await testCommand(DeployCommand, ['--dry-run', '--json'], {
+      config: {root: cwd},
+      mocks: {cliConfig: {api: {projectId}, studioHost}},
+    })
+
+    if (error) throw error
+    const {payload} = JSON.parse(stdout)
+    expect(Object.keys(payload).toSorted()).toEqual([
+      'appId',
+      'isAutoUpdating',
+      'projectId',
+      'type',
+      'version',
+    ])
+  })
+
   test('runs the dry-run build unattended so it cannot prompt', async () => {
     const cwd = await testFixture('basic-studio')
     process.cwd = () => cwd

--- a/packages/@sanity/workbench-cli/src/_exports/deploy.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/deploy.ts
@@ -11,7 +11,7 @@ export {
   deployWorkbenchApp,
 } from '../actions/deploy/deployWorkbenchApp.js'
 export {getWorkbench} from '../actions/deploy/getWorkbench.js'
-export {type DeployedExpose, summarizeInterfaces} from '../actions/deploy/summarizeInterfaces.js'
+export {type DeployedInterface, summarizeInterfaces} from '../actions/deploy/summarizeInterfaces.js'
 export {
   type Application,
   type BrettAccess,

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployWorkbenchApp.test.ts
@@ -62,7 +62,7 @@ describe('createCoreApp', () => {
 
     expect(
       await createCoreApp({organizationId: 'org-1', slug: 'abc123', title: 'Drop Desk'}),
-    ).toMatchObject({applicationId: 'app_new'})
+    ).toMatchObject({application: {id: 'app_new'}})
     // A record-only create is a plain JSON POST (no multipart, no tarball).
     expect(mockClient.request).toHaveBeenCalledWith({
       body: {organizationId: 'org-1', slug: 'abc123', title: 'Drop Desk', type: 'coreApp'},
@@ -110,7 +110,7 @@ describe('createCoreApp', () => {
 })
 
 describe('createStudio', () => {
-  test('creates a studio at the given slug and returns the id', async () => {
+  test('creates a studio at the given slug and returns the record', async () => {
     mockClient.request.mockResolvedValueOnce({id: 'studio_new'})
 
     expect(
@@ -120,7 +120,7 @@ describe('createStudio', () => {
         slug: 'my-studio',
         title: 'My Studio',
       }),
-    ).toMatchObject({applicationId: 'studio_new'})
+    ).toMatchObject({application: {id: 'studio_new'}})
     expect(mockClient.request).toHaveBeenCalledWith({
       body: {
         config: {studio: {projectId: 'proj-1'}},

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/summarizeInterfaces.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/summarizeInterfaces.test.ts
@@ -3,23 +3,21 @@ import {describe, expect, test} from 'vitest'
 import {summarizeInterfaces} from '../summarizeInterfaces.js'
 
 describe('summarizeInterfaces', () => {
-  test('returns views-then-services records with a report line per group', () => {
-    const {exposes, lines} = summarizeInterfaces({
+  test('returns the records per kind with a report line per group', () => {
+    const {lines, services, views} = summarizeInterfaces({
       services: [{name: 'sync', src: './src/sync.ts', title: 'sync', type: 'worker'}],
       views: [{name: 'feed', src: './src/feed.tsx', title: 'Feed', type: 'panel'}],
     })
 
-    expect(exposes).toEqual([
-      {name: 'feed', src: './src/feed.tsx', title: 'Feed', type: 'panel'},
-      {name: 'sync', src: './src/sync.ts', title: 'sync', type: 'worker'},
-    ])
+    expect(views).toEqual([{name: 'feed', src: './src/feed.tsx', title: 'Feed', type: 'panel'}])
+    expect(services).toEqual([{name: 'sync', src: './src/sync.ts', title: 'sync', type: 'worker'}])
     expect(lines).toEqual([
       'Views:\n  Feed (feed): ./src/feed.tsx',
       'Services:\n  sync: ./src/sync.ts',
     ])
   })
 
-  test('is empty when nothing is exposed', () => {
-    expect(summarizeInterfaces({})).toEqual({exposes: [], lines: []})
+  test('is empty when nothing is declared', () => {
+    expect(summarizeInterfaces({})).toEqual({lines: [], services: [], views: []})
   })
 })

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployConfig.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployConfig.ts
@@ -7,7 +7,7 @@ import {pack} from 'tar-fs'
 
 import {getWorkbenchUrl} from '../../services/applications.js'
 import {createConfig, resolveSingletonInstallationId} from '../../services/installations.js'
-import {summarizeExposeGroup} from './summarizeInterfaces.js'
+import {summarizeGroup} from './summarizeInterfaces.js'
 
 const debug = subdebug('deploy')
 
@@ -41,7 +41,7 @@ export function summarizeConfig(config: {
 }): string {
   switch (config.appType) {
     case 'media-library': {
-      return summarizeExposeGroup('Media library fields', config.fields)
+      return summarizeGroup('Media library fields', config.fields)
     }
     default: {
       throw new Error(`Cannot create config for unknown app type: ${config.appType}`)

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployWorkbenchApp.ts
@@ -7,6 +7,7 @@ import {pack} from 'tar-fs'
 
 import {deriveInterfaces} from '../../deriveInterfaces.js'
 import {
+  type Application,
   type BrettAccess,
   type BrettInterface,
   type BrettWorkspace,
@@ -17,13 +18,11 @@ import {
 } from '../../services/applications.js'
 
 /**
- * A freshly created application record: its id, plus a way to undo the creation.
- * The caller builds and deploys with the id, and calls `rollback` if a later
- * step fails so the record isn't stranded at its slug.
+ * `rollback` undoes the creation, so a later failure leaves no record stranded at the slug.
  * @internal
  */
 export interface CreatedApplication {
-  applicationId: string
+  application: Application
   rollback: () => Promise<void>
 }
 
@@ -41,9 +40,9 @@ export async function createCoreApp(options: {
 }): Promise<CreatedApplication> {
   const spin = spinner('Creating application...').start()
   try {
-    const {id} = await createApplication({...options, type: 'coreApp'})
+    const application = await createApplication({...options, type: 'coreApp'})
     spin.succeed()
-    return {applicationId: id, rollback: () => deleteApplication(id)}
+    return {application, rollback: () => deleteApplication(application.id)}
   } catch (error) {
     spin.fail()
     throw error
@@ -63,9 +62,9 @@ export async function createStudio(options: {
 }): Promise<CreatedApplication> {
   const spin = spinner('Creating studio...').start()
   try {
-    const {id} = await createApplication({...options, type: 'studio'})
+    const application = await createApplication({...options, type: 'studio'})
     spin.succeed()
-    return {applicationId: id, rollback: () => deleteApplication(id)}
+    return {application, rollback: () => deleteApplication(application.id)}
   } catch (error) {
     spin.fail()
     throw error

--- a/packages/@sanity/workbench-cli/src/actions/deploy/summarizeInterfaces.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/summarizeInterfaces.ts
@@ -1,7 +1,7 @@
 import {type WorkbenchExposes} from '../../resolveWorkbenchApp.js'
 
 /** A view or service as the deploy report and `--json` output surface it. */
-export interface DeployedExpose {
+export interface DeployedInterface {
   name: string
   src: string
   title: string
@@ -15,7 +15,7 @@ const label = (item: {name: string; title: string}) =>
  * One `Title (name): src` report line per declared entry point.
  * @internal
  */
-export function summarizeExposeGroup(
+export function summarizeGroup(
   heading: string,
   items: readonly {name: string; src: string; title: string}[],
 ): string {
@@ -23,25 +23,25 @@ export function summarizeExposeGroup(
 }
 
 /**
- * The deploy summary of an app's exposes: the structured records (for `--json`)
- * and one report line per non-empty group (for the human report).
+ * One report line per non-empty group, alongside the records `--json` reports.
  * @internal
  */
 export function summarizeInterfaces({services, views}: WorkbenchExposes): {
-  exposes: DeployedExpose[]
   lines: string[]
+  services: DeployedInterface[]
+  views: DeployedInterface[]
 } {
-  const toExpose = (decl: DeployedExpose): DeployedExpose => ({
+  const toInterface = (decl: DeployedInterface): DeployedInterface => ({
     name: decl.name,
     src: decl.src,
     title: decl.title,
     type: decl.type,
   })
-  const viewExposes = (views ?? []).map((view) => toExpose(view))
-  const serviceExposes = (services ?? []).map((service) => toExpose(service))
+  const deployedViews = (views ?? []).map((view) => toInterface(view))
+  const deployedServices = (services ?? []).map((service) => toInterface(service))
 
   const lines: string[] = []
-  if (viewExposes.length > 0) lines.push(summarizeExposeGroup('Views', viewExposes))
-  if (serviceExposes.length > 0) lines.push(summarizeExposeGroup('Services', serviceExposes))
-  return {exposes: [...viewExposes, ...serviceExposes], lines}
+  if (deployedViews.length > 0) lines.push(summarizeGroup('Views', deployedViews))
+  if (deployedServices.length > 0) lines.push(summarizeGroup('Services', deployedServices))
+  return {lines, services: deployedServices, views: deployedViews}
 }

--- a/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
@@ -106,13 +106,16 @@ describe('createWorkbenchUndeployAdapter — application', () => {
       expect.objectContaining({uri: '/applications/wb-app-1'}),
     )
     expect(resolution.type === 'found' && resolution.target).toMatchObject({
+      appHost: 'my-app-x1',
+      application: {id: 'wb-app-1', slug: 'my-app-x1', title: 'My App', type: 'coreApp'},
       deletes: 'application',
       id: 'wb-app-1',
-      interfaces: [{name: 'insights', title: 'Insights', type: 'panel'}],
       organizationId: 'org-1',
+      services: [],
       title: 'My App',
       type: 'coreApp',
       url: 'https://org-1.sanity.run/application/wb-app-1',
+      views: [{name: 'insights', title: 'Insights', type: 'panel'}],
     })
   })
 
@@ -210,22 +213,19 @@ describe('createWorkbenchUndeployAdapter — config-only singleton', () => {
     const resolution = await configAdapter().resolveTarget()
 
     expect(resolution.type === 'found' && resolution.target).toMatchObject({
-      // The active snapshot is the config being served
-      activeDeployment: {
-        deployedAt: '2024-02-01T00:00:00Z',
-        deployedBy: 'gustav@sanity.io',
-      },
       configs: [expect.objectContaining({id: 'cfg-2'}), expect.objectContaining({id: 'cfg-1'})],
-      createdAt: '2024-01-01T00:00:00Z',
       deletes: 'config',
       id: null,
       organizationId: 'org-1',
+      summary: expect.arrayContaining([
+        expect.stringContaining('Served since 2024-02-01T00:00:00Z'),
+      ]),
       title: 'media-library',
       url: 'https://org-1.sanity.run',
     })
   })
 
-  test('workbench internals and versions stay off the target', async () => {
+  test('local workbench internals stay off the target', async () => {
     stubInstallations([
       {
         createdAt: '2024-01-01T00:00:00Z',
@@ -244,8 +244,7 @@ describe('createWorkbenchUndeployAdapter — config-only singleton', () => {
     expect(resolution.target).not.toHaveProperty('fields')
     expect(resolution.target).not.toHaveProperty('installationId')
     expect(resolution.target).not.toHaveProperty('isSingleton')
-    expect(resolution.target.activeDeployment).not.toHaveProperty('version')
-    expect(resolution.target.configs[0]).not.toHaveProperty('version')
+    expect(resolution.target.configs[0]).toMatchObject({id: 'cfg-1', version: '1.0.0'})
   })
 
   test('a media library without local fields still undeploys its config', async () => {

--- a/packages/@sanity/workbench-cli/src/actions/undeploy/workbenchUndeployAdapter.ts
+++ b/packages/@sanity/workbench-cli/src/actions/undeploy/workbenchUndeployAdapter.ts
@@ -11,24 +11,19 @@ import {
   getApplicationUrl,
   getWorkbenchUrl,
 } from '../../services/applications.js'
-import {deleteConfig, listConfigs} from '../../services/installations.js'
+import {type ConfigSnapshot, deleteConfig, listConfigs} from '../../services/installations.js'
 import {resolveInstallationId, summarizeConfig} from '../deploy/deployConfig.js'
 import {type DeployableWorkbenchApp} from '../deploy/getWorkbench.js'
-import {type DeployedExpose, summarizeInterfaces} from '../deploy/summarizeInterfaces.js'
+import {type DeployedInterface, summarizeInterfaces} from '../deploy/summarizeInterfaces.js'
 
 /** The workbench extension of the shared target; serializes into `--json` as-is. */
 export type WorkbenchUndeployTarget =
   | (UndeployApplicationTarget & {
-      /** Interfaces (views and services) registered by the application. */
-      interfaces: DeployedExpose[]
+      services: DeployedInterface[]
+      views: DeployedInterface[]
     })
   | (UndeployConfigTarget & {
-      /** The deployed config snapshots an undeploy deletes. */
-      configs: {
-        createdAt: string | null
-        deployedBy: string | null
-        id: string
-      }[]
+      configs: ConfigSnapshot[]
     })
 
 /**
@@ -95,17 +90,19 @@ async function resolveApplicationTarget({
     return {message: 'Application with the given ID does not exist', type: 'none'}
   }
 
-  const {exposes, lines} = summarizeInterfaces(workbench)
+  const {lines, services, views} = summarizeInterfaces(workbench)
   return {
     target: {
       activeDeployment: null,
       appHost: application.slug,
+      application,
       createdAt: null,
       deletes: 'application',
       id: application.id,
-      interfaces: exposes,
       organizationId: application.organizationId,
+      payload: {appId: application.id, services, type, views},
       projectId: null,
+      services,
       summary: [
         ...lines,
         ...(workbench.isSingleton === undefined ? [] : [`Singleton: ${workbench.isSingleton}`]),
@@ -113,6 +110,7 @@ async function resolveApplicationTarget({
       title: application.title,
       type,
       url: getApplicationUrl({...application, type}),
+      views,
     },
     type: 'found',
   }
@@ -158,27 +156,28 @@ async function resolveConfigTarget({
     }
   }
 
-  // At most one snapshot is active (served); the rest are deactivated history.
   const active = configs.find((snapshot) => snapshot.isActive)
   return {
     installationId,
     resolution: {
       target: {
-        activeDeployment: active
-          ? {deployedAt: active.createdAt ?? '', deployedBy: active.deployedBy ?? ''}
-          : null,
+        activeDeployment: null,
         appHost: null,
-        configs: configs.map((snapshot) => ({
-          createdAt: snapshot.createdAt ?? null,
-          deployedBy: snapshot.deployedBy ?? null,
-          id: snapshot.id,
-        })),
-        createdAt: configs.at(-1)?.createdAt ?? null,
+        configs,
+        createdAt: null,
         deletes: 'config',
         id: null,
         organizationId,
+        payload: {
+          appId: null,
+          ...(config ? {config: summarizeConfig(config)} : {}),
+          type: 'coreApp',
+        },
         projectId: null,
-        summary: config ? [summarizeConfig(config)] : undefined,
+        summary: [
+          ...(active ? [`Served since ${active.createdAt} by ${active.deployedBy}`] : []),
+          ...(config ? [summarizeConfig(config)] : []),
+        ],
         title: workbench.slug,
         type: 'coreApp',
         url: getWorkbenchUrl(organizationId),


### PR DESCRIPTION
### Description

`sanity deploy --json` and `sanity undeploy --json` exposed different shapes for the same application data. This is a breaking change to the machine-readable output, landing ahead of the pending major.

Both commands now split their output three ways:

- `payload` is what the CLI collected from `sanity.cli.ts` and the app definition. It's small, it's local, and a dry run reports it in full
- `application` is the backend's record verbatim, nothing aliased or merged in. Only a successful run has one
- the envelope carries the verdict, `action` or `deletes`, `url`, `reason`, and the dry-run diagnostics

Brett reports `slug`, the user-applications backend reports `appHost`, and each reaches `--json` as the backend sent it.

`reason` is present in every payload of both commands: `null` on success, the blocking check on a blocked dry run, the error message on failure. Deploy renames `isDeployable` to `canDeploy`, matching `canUndeploy`.

Deploy reported its interface list as `exposes`, undeploy as `interfaces`. Both now report `views` and `services`, the words you already write in `sanity.cli.ts`. Those, plus `config` and `isSingleton`, only ever appear for workbench apps, and one rule gates them in both modes.

### What to review

The payload shapes, side by side.

#### `sanity deploy --json`

<table>
<tr><th width="50%">Before</th><th width="50%">After</th></tr>

<tr><td colspan="2"><b>Real run</b>, workbench app with one view</td></tr>
<tr>
<td>

```json
{
  "deployed": true,
  "applicationType": "coreApp",
  "applicationVersion": "4.12.0",
  "target": {
    "action": "update",
    "applicationId": "abc",
    "title": "My app",
    "url": "https://...",
    "slug": "my-app"
  },
  "exposes": [],
  "config": "...",
  "installationId": "...",
  "isSingleton": false
}
```

</td>
<td>

```json
{
  "deployed": true,
  "action": "update",
  "url": "https://oXyZ.sanity.run/application/abc",
  "reason": null,
  "application": {
    "id": "abc",
    "organizationId": "oXyZ",
    "slug": "my-app",
    "title": "My app",
    "type": "coreApp"
  },
  "payload": {
    "appId": "abc",
    "organizationId": "oXyZ",
    "slug": "my-app",
    "title": "My app",
    "type": "coreApp",
    "version": "4.12.0",
    "isAutoUpdating": false,
    "views": [
      {"name": "feed", "src": "./src/feed.tsx",
       "title": "Feed", "type": "panel"}
    ],
    "services": []
  }
}
```

</td>
</tr>

<tr><td colspan="2"><b>Dry run</b>, plain studio</td></tr>
<tr>
<td>

```json
{
  "applicationType": "studio",
  "applicationVersion": "4.12.0",
  "target": { "...": "as above" },
  "isDeployable": true,
  "errors": {},
  "warnings": [],
  "exposes": [],
  "files": [],
  "totalBytes": 0
}
```

</td>
<td>

```json
{
  "action": "update",
  "url": "https://my-studio.sanity.studio",
  "application": null,
  "canDeploy": true,
  "errors": {},
  "warnings": [],
  "files": [],
  "totalBytes": 0,
  "reason": null,
  "payload": {
    "appId": "abc",
    "projectId": "p1",
    "type": "studio",
    "version": "4.12.0",
    "isAutoUpdating": true
  }
}
```

</td>
</tr>

<tr><td colspan="2"><b>Failure</b></td></tr>
<tr>
<td>

```json
{
  "deployed": false,
  "error": {"message": "..."}
}
```

</td>
<td>

```json
{
  "deployed": false,
  "application": null,
  "payload": null,
  "reason": "...",
  "error": {"message": "..."}
}
```

</td>
</tr>
</table>

A plain (non-workbench) app has no `slug`, `title`, `views`, `services`, `config` or `isSingleton` to collect, so its `payload` is just the four fields above.

#### `sanity undeploy --json`

<table>
<tr><th width="50%">Before</th><th width="50%">After</th></tr>

<tr><td colspan="2"><b>Real run</b></td></tr>
<tr>
<td>

```json
{
  "application": {
    "deletes": "application",
    "id": "abc",
    "type": "coreApp",
    "title": "My app",
    "url": "https://...",
    "appHost": "my-app",
    "createdAt": "...",
    "organizationId": "oXyZ",
    "projectId": null,
    "activeDeployment": {"deployedAt": "..."},
    "interfaces": []
  },
  "undeployed": true
}
```

</td>
<td>

```json
{
  "undeployed": true,
  "deletes": "application",
  "url": "https://oXyZ.sanity.run/application/abc",
  "reason": null,
  "application": {
    "id": "abc",
    "organizationId": "oXyZ",
    "slug": "my-app",
    "title": "My app",
    "type": "coreApp"
  },
  "payload": {
    "appId": "abc",
    "type": "coreApp",
    "views": [],
    "services": []
  }
}
```

</td>
</tr>

<tr><td colspan="2"><b>Dry run</b></td></tr>
<tr>
<td>

```json
{
  "application": { "...": "as above" },
  "canUndeploy": true,
  "errors": {},
  "reason": null,
  "warnings": []
}
```

</td>
<td>

```json
{
  "deletes": "application",
  "url": "https://oXyZ.sanity.run/application/abc",
  "application": null,
  "canUndeploy": true,
  "errors": {},
  "warnings": [],
  "reason": null,
  "payload": {
    "appId": "abc",
    "type": "coreApp",
    "views": [],
    "services": []
  }
}
```

</td>
</tr>

<tr><td colspan="2"><b>Nothing to undeploy</b></td></tr>
<tr>
<td>

```json
{
  "reason": "...",
  "undeployed": false
}
```

</td>
<td>

```json
{
  "undeployed": false,
  "application": null,
  "payload": null,
  "reason": "..."
}
```

</td>
</tr>

<tr><td colspan="2"><b>Failure</b></td></tr>
<tr>
<td>

```json
{
  "error": {"message": "..."},
  "undeployed": false
}
```

</td>
<td>

```json
{
  "undeployed": false,
  "application": null,
  "payload": null,
  "reason": "...",
  "error": {"message": "..."}
}
```

</td>
</tr>
</table>

An undeploy of a media-library config reports `{"appId": null, "type": "coreApp", "config": "..."}` instead, since that's the local thing being removed.

Two behaviour changes worth a look. A config-only undeploy no longer reports `activeDeployment`: a config snapshot isn't a deployment, and presenting one meant aliasing its `createdAt`. The human report gains a `Served since ... by ...` line instead.

And `--json` no longer strips keys named `summary`. That filter existed to keep report-only lines out of the payload; now that the target isn't serialized wholesale it only risked deleting a `summary` field out of the backend's own record.

### Testing

Unit tests cover the new payload shapes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major breaking change to CLI `--json` contracts for deploy/undeploy; any automation parsing old field names or shapes will fail until updated.
> 
> **Overview**
> **Breaking change** to `sanity deploy --json` and `sanity undeploy --json` (major bumps in `@sanity/cli`, `@sanity/cli-core`, `@sanity/workbench-cli`).
> 
> Both commands now use the same mental model: **`payload`** is what the CLI collected locally (full on dry run); **`application`** is the API record verbatim and only appears after a successful run; the envelope carries **`action`/`deletes`**, **`url`**, **`reason`**, and dry-run gates (**`canDeploy`** / **`canUndeploy`**). Deploy drops `applicationType`/`applicationVersion`, nested `target.applicationId`, and **`isDeployable`** in favor of **`canDeploy`**, top-level **`action`/`url`**, and **`payload.version`**.
> 
> Workbench interface reporting is renamed from **`exposes`/`interfaces`** to **`views`** and **`services`**, included only when at least one is declared (same rule for deploy dry run and real run). **`DeployTarget`** uses **`id`** and **`type`** instead of **`applicationId`**. Workbench **`createCoreApp`/`createStudio`** return a full **`application`** object, not just an id.
> 
> Undeploy dry-run JSON no longer dumps the whole resolved target as **`application`**; it exposes **`payload`**, **`deletes`**, and **`url`** with **`application: null`**. Success/failure/nothing-to-undeploy envelopes add **`reason`** and null **`application`/`payload`** where appropriate. Config-only undeploy drops **`activeDeployment`** from machine output; the human plan uses **"Served since …"** instead. **`summary`** is report-only and is no longer stripped from backend records in JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b25be2405cc8750eb75fa5fb66aefdb488e023ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->