### PR TITLE
fix(cli): add command-owned telemetry redaction

### DIFF
--- a/.changeset/pr-1694.md
+++ b/.changeset/pr-1694.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/cli': patch
+---
+
+fix(cli): redact file paths from telemetry

--- a/.changeset/pr-1694.md
+++ b/.changeset/pr-1694.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-Add command-owned configuration for redacting CLI flag values from telemetry.
+fix(cli): add command-owned telemetry redaction

--- a/.changeset/pr-1694.md
+++ b/.changeset/pr-1694.md
@@ -3,4 +3,4 @@
 '@sanity/cli': patch
 ---
 
-fix(cli): redact file paths from telemetry
+Add command-owned configuration for redacting CLI flag values from telemetry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,38 +31,24 @@ All commands are run from the root of the repo.
 
 `packages/@sanity/cli-core/src/ux/flowOutput.ts` is reserved for the `new.ts` command. Before reusing its [`@clack/prompts`-style output](https://www.npmjs.com/package/@clack/prompts) in another CLI feature, clearly articulate the compelling use case to the end user or harness.
 
-# Telemetry input classification
+# Telemetry redaction
 
-Raw command inputs are redacted by default. A normal flag declaration records only the flag name:
-
-```ts
-static flags = {
-  output: Flags.string({description: 'Output path'}),
-}
-// telemetry: ["--output"]
-```
-
-To retain a value, add a typed command-level opt-in. Only use this for a closed enum, validated API version, operational number, or resolved project ID:
+Flag telemetry keeps its existing value unless the command opts into redaction with `defineCommandTelemetry`:
 
 ```ts
 const flags = {
-  format: Flags.string({options: ['json', 'ndjson', 'pretty']}),
+  file: Flags.string({description: 'Input file'}),
+  format: Flags.string({options: ['json', 'ndjson']}),
 }
-
 static flags = flags
 static telemetry = defineCommandTelemetry(flags, {
-  flags: {
-    format: telemetry.enum(['json', 'ndjson', 'pretty']),
-  },
+  redact: ['file'],
 })
-// telemetry: ["--format=json"]
+// --file=private.ndjson --format=json
+// telemetry: ["--file", "--format=json"]
 ```
 
-Never add a general string opt-in. Do not collect paths, filenames, free text, opaque IDs, URLs, headers, tokens, request bodies, or forwarded arguments.
-
-Oclif rejects unregistered flags even when a command sets `static strict = false`; that setting only permits additional positional arguments. Telemetry records registered flag presence for these commands under the same redaction policy as every other command. It continues to omit positional and `--`-forwarded inputs.
-
-Before opting in, state the debugging or support question the value answers and why command ID, flag presence, runtime data, and error category are insufficient. Then weigh the value's PII, customer-data, and security implications against that concrete triage benefit. Add focused coverage for spaced, inline, and short option forms, and update the telemetry input inventory when command inputs or their telemetry category changes.
+The helper type-checks names against the command's option flags and applies the declaration to registered aliases. When configuring a command, consider whether an input can contain PII, customer data, credentials, local paths, or other unbounded user content, and weigh that risk against any concrete support or debugging need for the value. Add focused coverage for the flag forms the command supports.
 
 # Testing Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,39 @@ All commands are run from the root of the repo.
 
 `packages/@sanity/cli-core/src/ux/flowOutput.ts` is reserved for the `new.ts` command. Before reusing its [`@clack/prompts`-style output](https://www.npmjs.com/package/@clack/prompts) in another CLI feature, clearly articulate the compelling use case to the end user or harness.
 
+# Telemetry input classification
+
+Raw command inputs are redacted by default. A normal flag declaration records only the flag name:
+
+```ts
+static flags = {
+  output: Flags.string({description: 'Output path'}),
+}
+// telemetry: ["--output"]
+```
+
+To retain a value, add a typed command-level opt-in. Only use this for a closed enum, validated API version, operational number, or resolved project ID:
+
+```ts
+const flags = {
+  format: Flags.string({options: ['json', 'ndjson', 'pretty']}),
+}
+
+static flags = flags
+static telemetry = defineCommandTelemetry(flags, {
+  flags: {
+    format: telemetry.enum(['json', 'ndjson', 'pretty']),
+  },
+})
+// telemetry: ["--format=json"]
+```
+
+Never add a general string opt-in. Do not collect paths, filenames, free text, opaque IDs, URLs, headers, tokens, request bodies, or forwarded arguments.
+
+Oclif rejects unregistered flags even when a command sets `static strict = false`; that setting only permits additional positional arguments. Telemetry records registered flag presence for these commands under the same redaction policy as every other command. It continues to omit positional and `--`-forwarded inputs.
+
+Before opting in, state the debugging or support question the value answers and why command ID, flag presence, runtime data, and error category are insufficient. Then weigh the value's PII, customer-data, and security implications against that concrete triage benefit. Add focused coverage for spaced, inline, and short option forms, and update the telemetry input inventory when command inputs or their telemetry category changes.
+
 # Testing Rules
 
 Follow all instructions and guidance laid out in the Testing Requirements section in `CONTRIBUTING.md`.

--- a/packages/@sanity/cli/src/commands/mcp/configure.ts
+++ b/packages/@sanity/cli/src/commands/mcp/configure.ts
@@ -5,10 +5,8 @@ import {ensureAuthenticated} from '../../actions/auth/ensureAuthenticated.js'
 import {setupMCP} from '../../actions/mcp/setupMCP.js'
 import {LoginError} from '../../errors/LoginError.js'
 import {MCPConfigureTrace} from '../../telemetry/mcp.telemetry.js'
-import {defineCommandTelemetry} from '../../util/telemetry/commandTelemetry.js'
 
 const debug = subdebug('mcp:configure')
-const flags = {}
 
 export class ConfigureMcpCommand extends SanityCommand<typeof ConfigureMcpCommand> {
   static override description =
@@ -19,10 +17,6 @@ export class ConfigureMcpCommand extends SanityCommand<typeof ConfigureMcpComman
       description: 'Configure Sanity MCP server for detected AI editors',
     },
   ]
-
-  static override flags = flags
-
-  static telemetry = defineCommandTelemetry(flags, {})
 
   public async run(): Promise<void> {
     const trace = this.telemetry.trace(MCPConfigureTrace)

--- a/packages/@sanity/cli/src/commands/mcp/configure.ts
+++ b/packages/@sanity/cli/src/commands/mcp/configure.ts
@@ -5,19 +5,24 @@ import {ensureAuthenticated} from '../../actions/auth/ensureAuthenticated.js'
 import {setupMCP} from '../../actions/mcp/setupMCP.js'
 import {LoginError} from '../../errors/LoginError.js'
 import {MCPConfigureTrace} from '../../telemetry/mcp.telemetry.js'
+import {defineCommandTelemetry} from '../../util/telemetry/commandTelemetry.js'
 
 const debug = subdebug('mcp:configure')
+const flags = {}
 
 export class ConfigureMcpCommand extends SanityCommand<typeof ConfigureMcpCommand> {
   static override description =
     'Configure Sanity MCP server for AI editors (Antigravity, Claude Code, Cline, Cline CLI, Codex CLI, Cursor, Gemini CLI, GitHub Copilot CLI, MCPorter, OpenCode, VS Code, VS Code Insiders, Zed)'
-
   static override examples = [
     {
       command: '<%= config.bin %> <%= command.id %>',
       description: 'Configure Sanity MCP server for detected AI editors',
     },
   ]
+
+  static override flags = flags
+
+  static telemetry = defineCommandTelemetry(flags, {})
 
   public async run(): Promise<void> {
     const trace = this.telemetry.trace(MCPConfigureTrace)

--- a/packages/@sanity/cli/src/exports/_internal.ts
+++ b/packages/@sanity/cli/src/exports/_internal.ts
@@ -1,5 +1,11 @@
 export {extractManifestSchemaTypes} from '../actions/manifest/extractWorkspaceManifest.js'
 export {
+  type CommandTelemetry,
+  defineCommandTelemetry,
+  telemetry,
+  type TelemetryValue,
+} from '../util/telemetry/commandTelemetry.js'
+export {
   getStudioEnvironmentVariables,
   type StudioEnvVariablesOptions,
 } from '@sanity/cli-build/_internal/env'

--- a/packages/@sanity/cli/src/exports/_internal.ts
+++ b/packages/@sanity/cli/src/exports/_internal.ts
@@ -1,10 +1,5 @@
 export {extractManifestSchemaTypes} from '../actions/manifest/extractWorkspaceManifest.js'
-export {
-  type CommandTelemetry,
-  defineCommandTelemetry,
-  telemetry,
-  type TelemetryValue,
-} from '../util/telemetry/commandTelemetry.js'
+export {type CommandTelemetry, defineCommandTelemetry} from '../util/telemetry/commandTelemetry.js'
 export {
   getStudioEnvironmentVariables,
   type StudioEnvVariablesOptions,

--- a/packages/@sanity/cli/src/hooks/prerun/setupTelemetry.ts
+++ b/packages/@sanity/cli/src/hooks/prerun/setupTelemetry.ts
@@ -1,7 +1,7 @@
 import {spawn} from 'node:child_process'
 import {fileURLToPath} from 'node:url'
 
-import {type Hook} from '@oclif/core'
+import {Flags, type Hook} from '@oclif/core'
 import {
   type CliConfig,
   debug,
@@ -16,10 +16,11 @@ import {telemetryDebug} from '../../actions/telemetry/telemetryDebug.js'
 import {telemetryDisclosure} from '../../actions/telemetry/telemetryDisclosure.js'
 import {CliCommandTelemetry, type CLITraceData} from '../../telemetry/cli.telemetry.js'
 import {detectRuntime} from '../../util/detectRuntime.js'
-import {parseArguments} from '../../util/parseArguments.js'
+import {parseCommandArguments} from '../../util/parseArguments.js'
+import {type CommandTelemetry} from '../../util/telemetry/commandTelemetry.js'
 import {createTelemetryStore} from '../../util/telemetry/createTelemetryStore.js'
 
-export const setupTelemetry: Hook.Prerun = async function ({config}) {
+export const setupTelemetry: Hook.Prerun = async function ({argv, Command, config}) {
   // Show telemetry disclosure
   telemetryDisclosure({logToStderr: (message) => process.stderr.write(`${message}\n`)})
 
@@ -47,17 +48,28 @@ export const setupTelemetry: Hook.Prerun = async function ({config}) {
     runtimeVersion: process.version,
   })
 
-  const args = parseArguments()
+  const commandId = Command?.id ?? 'unknown'
+  const commandTelemetry = (
+    Command as (typeof Command & {telemetry?: CommandTelemetry}) | undefined
+  )?.telemetry
+  const commandFlags = {
+    ...(Command?.enableJsonFlag ? {json: Flags.boolean()} : {}),
+    ...Command?.baseFlags,
+    ...Command?.flags,
+  }
+  const args = await parseCommandArguments(argv, commandFlags, commandTelemetry, {
+    isHelpCommand: commandId === 'help',
+  })
 
   const traceOptions: CLITraceData = {
-    commandArguments: args.argsWithoutOptions,
+    commandArguments: [],
     coreOptions: {
       debug: args.coreOptions.debug ?? undefined,
       help: args.coreOptions.help ?? undefined,
       version: args.coreOptions.version ?? undefined,
     },
     extraArguments: args.extraArguments,
-    groupOrCommand: args.groupOrCommand,
+    groupOrCommand: commandId,
   }
 
   telemetryDebug('Starting command trace', traceOptions)
@@ -66,7 +78,7 @@ export const setupTelemetry: Hook.Prerun = async function ({config}) {
   cliCommandTrace.start()
 
   // Set the global telemetry store and trace error reporter
-  setCliTelemetry(cliCommandTrace.newContext(args.groupOrCommand), {
+  setCliTelemetry(cliCommandTrace.newContext(commandId), {
     reportTraceError: (error) => cliCommandTrace.error(error),
   })
 

--- a/packages/@sanity/cli/src/hooks/prerun/setupTelemetry.ts
+++ b/packages/@sanity/cli/src/hooks/prerun/setupTelemetry.ts
@@ -1,7 +1,7 @@
 import {spawn} from 'node:child_process'
 import {fileURLToPath} from 'node:url'
 
-import {Flags, type Hook} from '@oclif/core'
+import {type Hook} from '@oclif/core'
 import {
   type CliConfig,
   debug,
@@ -16,11 +16,11 @@ import {telemetryDebug} from '../../actions/telemetry/telemetryDebug.js'
 import {telemetryDisclosure} from '../../actions/telemetry/telemetryDisclosure.js'
 import {CliCommandTelemetry, type CLITraceData} from '../../telemetry/cli.telemetry.js'
 import {detectRuntime} from '../../util/detectRuntime.js'
-import {parseCommandArguments} from '../../util/parseArguments.js'
+import {parseArguments} from '../../util/parseArguments.js'
 import {type CommandTelemetry} from '../../util/telemetry/commandTelemetry.js'
 import {createTelemetryStore} from '../../util/telemetry/createTelemetryStore.js'
 
-export const setupTelemetry: Hook.Prerun = async function ({argv, Command, config}) {
+export const setupTelemetry: Hook.Prerun = async function ({Command, config}) {
   // Show telemetry disclosure
   telemetryDisclosure({logToStderr: (message) => process.stderr.write(`${message}\n`)})
 
@@ -48,28 +48,20 @@ export const setupTelemetry: Hook.Prerun = async function ({argv, Command, confi
     runtimeVersion: process.version,
   })
 
-  const commandId = Command?.id ?? 'unknown'
   const commandTelemetry = (
     Command as (typeof Command & {telemetry?: CommandTelemetry}) | undefined
   )?.telemetry
-  const commandFlags = {
-    ...(Command?.enableJsonFlag ? {json: Flags.boolean()} : {}),
-    ...Command?.baseFlags,
-    ...Command?.flags,
-  }
-  const args = await parseCommandArguments(argv, commandFlags, commandTelemetry, {
-    isHelpCommand: commandId === 'help',
-  })
+  const args = parseArguments(process.argv, commandTelemetry)
 
   const traceOptions: CLITraceData = {
-    commandArguments: [],
+    commandArguments: args.argsWithoutOptions,
     coreOptions: {
       debug: args.coreOptions.debug ?? undefined,
       help: args.coreOptions.help ?? undefined,
       version: args.coreOptions.version ?? undefined,
     },
     extraArguments: args.extraArguments,
-    groupOrCommand: commandId,
+    groupOrCommand: args.groupOrCommand,
   }
 
   telemetryDebug('Starting command trace', traceOptions)
@@ -78,7 +70,7 @@ export const setupTelemetry: Hook.Prerun = async function ({argv, Command, confi
   cliCommandTrace.start()
 
   // Set the global telemetry store and trace error reporter
-  setCliTelemetry(cliCommandTrace.newContext(commandId), {
+  setCliTelemetry(cliCommandTrace.newContext(args.groupOrCommand), {
     reportTraceError: (error) => cliCommandTrace.error(error),
   })
 

--- a/packages/@sanity/cli/src/util/__tests__/parseArguments.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/parseArguments.test.ts
@@ -1,54 +1,131 @@
+import {Flags} from '@oclif/core'
 import {describe, expect, test} from 'vitest'
 
-import {parseArguments} from '../parseArguments.js'
+import {parseArguments, parseCommandArguments} from '../parseArguments.js'
+import {defineCommandTelemetry, telemetry} from '../telemetry/commandTelemetry.js'
 
 describe('parseArguments', () => {
-  test('omits spaced file and filename values from telemetry arguments', () => {
-    const result = parseArguments([
-      'node',
-      'sanity',
-      'assets',
-      'upload',
-      '--file',
-      '-private/path.png',
-      '--filename',
-      '-private.png',
-      '--type',
-      'image',
-    ])
+  const flags = {
+    dataset: Flags.string(),
+    format: Flags.string({
+      aliases: ['output-format'],
+      char: 'f',
+    }),
+    header: Flags.string({multiple: true}),
+    mcp: Flags.boolean({allowNo: true}),
+    token: Flags.string({char: 't'}),
+    type: Flags.string(),
+  }
 
-    expect(result.extraArguments).toEqual(['--file', '--filename', '--type'])
-    expect(result.extraArguments.join(' ')).not.toContain('private')
+  const commandTelemetry = defineCommandTelemetry(flags, {
+    flags: {
+      format: telemetry.enum(['json', 'ndjson', 'pretty']),
+    },
   })
 
-  test('omits inline file and filename values from telemetry arguments', () => {
-    const result = parseArguments([
-      'node',
-      'sanity',
-      'assets',
-      'upload',
-      '--file=/Users/test/private/path.png',
-      '--filename=-private.png',
-      '--type=image',
-    ])
+  test('preserves the full process argv contract', async () => {
+    const result = await parseArguments(
+      ['/path/to/node', '/path/to/sanity', '--dataset=production'],
+      flags,
+    )
 
-    expect(result.extraArguments).toEqual(['--file', '--filename', '--type=image'])
-    expect(result.extraArguments.join(' ')).not.toContain('private')
+    expect(result.argv).toEqual(['--dataset=production'])
+    expect(result.extraArguments).toEqual(['--dataset'])
   })
 
-  test('redacts sensitive values forwarded after the argument separator', () => {
-    const result = parseArguments([
-      'node',
-      'sanity',
-      'assets',
-      'upload',
-      '--',
-      '--file=/Users/test/private/path.png',
-      '--filename',
-      '-private.png',
-    ])
+  test('detects help from full process argv', async () => {
+    const result = await parseArguments(['/path/to/node', '/path/to/sanity', 'help', 'dataset'])
 
-    expect(result.extraArguments).toEqual(['--file', '--filename'])
-    expect(result.extraArguments.join(' ')).not.toContain('private')
+    expect(result.coreOptions.help).toBe(true)
+  })
+
+  test('uses resolved command metadata for help with command-scoped argv', async () => {
+    const positionalHelp = await parseCommandArguments(['help'])
+    const helpCommand = await parseCommandArguments(['dataset'], {}, {}, {isHelpCommand: true})
+
+    expect(positionalHelp.coreOptions.help).toBe(false)
+    expect(helpCommand.coreOptions.help).toBe(true)
+  })
+
+  test('records option names without user-supplied values', async () => {
+    const result = await parseCommandArguments(
+      [
+        'private.ndjson',
+        '--token=secret-token',
+        '--dataset',
+        'production',
+        '--type=image',
+        '--header=Authorization: Bearer secret-token',
+      ],
+      flags,
+    )
+
+    expect(result.extraArguments).toEqual(['--token', '--dataset', '--type', '--header'])
+    expect(result.extraArguments.join(' ')).not.toContain('secret-token')
+    expect(result.extraArguments.join(' ')).not.toContain('image')
+  })
+
+  test('records registered flags alongside additional positional arguments', async () => {
+    const result = await parseCommandArguments(
+      ['script.ts', 'additional.ts', '--token=secret-token'],
+      flags,
+      commandTelemetry,
+    )
+
+    expect(result.extraArguments).toEqual(['--token'])
+  })
+
+  test('rejects unregistered flags while allowing additional positional arguments', async () => {
+    await expect(
+      parseCommandArguments(['script.ts', 'additional.ts', '--api-key=secret-key'], flags),
+    ).rejects.toThrow('Nonexistent flag: --api-key')
+  })
+
+  test('uses command flag registration to normalize concatenated short options', async () => {
+    const result = await parseCommandArguments(['-tsecret-token'], flags)
+
+    expect(result.extraArguments).toEqual(['--token'])
+  })
+
+  test('records boolean presence using the canonical flag name', async () => {
+    const result = await parseCommandArguments(['--mcp', '--no-mcp'], flags)
+
+    expect(result.extraArguments).toEqual(['--mcp', '--mcp'])
+  })
+
+  test('retains declared enum values across spaced and inline forms', async () => {
+    const result = await parseCommandArguments(
+      ['--format', 'json', '--format=pretty'],
+      flags,
+      commandTelemetry,
+    )
+
+    expect(result.extraArguments).toEqual(['--format=json', '--format=pretty'])
+  })
+
+  test('uses the canonical flag name for declared aliases', async () => {
+    const result = await parseCommandArguments(
+      ['--output-format=json', '-f', 'ndjson'],
+      flags,
+      commandTelemetry,
+    )
+
+    expect(result.extraArguments).toEqual(['--format=json', '--format=ndjson'])
+  })
+
+  test('redacts values outside a declared enum', async () => {
+    const result = await parseCommandArguments(['--format=private-format'], flags, commandTelemetry)
+
+    expect(result.extraArguments).toEqual(['--format'])
+  })
+
+  test('does not record arguments forwarded after the argument separator', async () => {
+    const result = await parseCommandArguments(
+      ['script.ts', '--', '--format=json', '--api-key=secret-key', 'private-value'],
+      flags,
+      commandTelemetry,
+    )
+
+    expect(result.extraArguments).toEqual([])
   })
 })

--- a/packages/@sanity/cli/src/util/__tests__/parseArguments.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/parseArguments.test.ts
@@ -1,131 +1,146 @@
 import {Flags} from '@oclif/core'
 import {describe, expect, test} from 'vitest'
 
-import {parseArguments, parseCommandArguments} from '../parseArguments.js'
-import {defineCommandTelemetry, telemetry} from '../telemetry/commandTelemetry.js'
+import {parseArguments} from '../parseArguments.js'
+import {defineCommandTelemetry} from '../telemetry/commandTelemetry.js'
 
 describe('parseArguments', () => {
   const flags = {
     dataset: Flags.string(),
+    file: Flags.string(),
     format: Flags.string({
-      aliases: ['output-format'],
+      aliases: ['output-format', 'p'],
       char: 'f',
+      charAliases: ['o'],
     }),
-    header: Flags.string({multiple: true}),
-    mcp: Flags.boolean({allowNo: true}),
+    header: Flags.string({char: 'H', multiple: true}),
     token: Flags.string({char: 't'}),
-    type: Flags.string(),
   }
 
   const commandTelemetry = defineCommandTelemetry(flags, {
-    flags: {
-      format: telemetry.enum(['json', 'ndjson', 'pretty']),
-    },
+    redact: ['file', 'format', 'header', 'token'],
   })
 
-  test('preserves the full process argv contract', async () => {
-    const result = await parseArguments(
-      ['/path/to/node', '/path/to/sanity', '--dataset=production'],
-      flags,
+  test('reads process argv by default', () => {
+    const originalArgv = process.argv
+    process.argv = ['node', 'sanity', 'documents', 'validate']
+
+    try {
+      expect(parseArguments().groupOrCommand).toBe('documents')
+    } finally {
+      process.argv = originalArgv
+    }
+  })
+
+  test('preserves the full process argv contract', () => {
+    const argv = ['/path/to/node', '/path/to/sanity', 'documents', 'validate']
+    const result = parseArguments(argv)
+
+    expect(result.argv).toBe(argv)
+    expect(result.groupOrCommand).toBe('documents')
+    expect(result.argsWithoutOptions).toEqual(['validate'])
+  })
+
+  test('preserves option telemetry by default', () => {
+    const result = parseArguments([
+      'node',
+      'sanity',
+      'documents',
+      'validate',
+      '--dataset=production',
+      '--file=/Users/jane/private.ndjson',
+      '-tsecret-token',
+    ])
+
+    expect(result.extraArguments).toEqual([
+      '--dataset=production',
+      '--file=/Users/jane/private.ndjson',
+      '-tsecret-token',
+    ])
+  })
+
+  test('redacts declared inline and concatenated option values', () => {
+    const result = parseArguments(
+      [
+        'node',
+        'sanity',
+        'documents',
+        'validate',
+        '--file=/Users/jane/private.ndjson',
+        '--header=Authorization: Bearer secret-token',
+        '-tsecret-token',
+      ],
+      commandTelemetry,
     )
 
-    expect(result.argv).toEqual(['--dataset=production'])
-    expect(result.extraArguments).toEqual(['--dataset'])
+    expect(result.extraArguments).toEqual(['--file', '--header', '--token'])
+    expect(result.extraArguments.join(' ')).not.toContain('jane')
+    expect(result.extraArguments.join(' ')).not.toContain('secret-token')
   })
 
-  test('detects help from full process argv', async () => {
-    const result = await parseArguments(['/path/to/node', '/path/to/sanity', 'help', 'dataset'])
+  test('uses the canonical name when redacting aliases', () => {
+    const result = parseArguments(
+      [
+        'node',
+        'sanity',
+        'documents',
+        'validate',
+        '--output-format=private-format',
+        '-fprivate-format',
+        '-oprivate-format',
+        '-pprivate-format',
+      ],
+      commandTelemetry,
+    )
+
+    expect(result.extraArguments).toEqual(['--format', '--format', '--format', '--format'])
+  })
+
+  test('redacts the canonical syntax when the flag definition is missing', () => {
+    const result = parseArguments(
+      ['node', 'sanity', 'documents', 'validate', '--missing=private-value'],
+      defineCommandTelemetry(flags as Record<string, (typeof flags)[keyof typeof flags]>, {
+        redact: ['missing'],
+      }),
+    )
+
+    expect(result.extraArguments).toEqual(['--missing'])
+  })
+
+  test('does not match long options against short flag syntax', () => {
+    const result = parseArguments(
+      ['node', 'sanity', 'documents', 'validate', '--file=public', '--tokenize=public'],
+      defineCommandTelemetry(flags, {redact: ['format', 'token']}),
+    )
+
+    expect(result.extraArguments).toEqual(['--file=public', '--tokenize=public'])
+  })
+
+  test('keeps the existing name-only telemetry for spaced option values', () => {
+    const result = parseArguments(
+      ['node', 'sanity', 'documents', 'validate', '--file', 'private.ndjson', '-t', 'secret'],
+      commandTelemetry,
+    )
+
+    expect(result.extraArguments).toEqual(['--file', '--token'])
+  })
+
+  test('preserves forwarded argument telemetry', () => {
+    const result = parseArguments(
+      ['node', 'sanity', 'exec', 'script.ts', '--', '--token=forwarded-secret'],
+      commandTelemetry,
+    )
+
+    expect(result.extraArguments).toEqual([
+      '--token=forwarded-secret',
+      '--',
+      '--token=forwarded-secret',
+    ])
+  })
+
+  test('detects help from full process argv', () => {
+    const result = parseArguments(['/path/to/node', '/path/to/sanity', 'help', 'dataset'])
 
     expect(result.coreOptions.help).toBe(true)
-  })
-
-  test('uses resolved command metadata for help with command-scoped argv', async () => {
-    const positionalHelp = await parseCommandArguments(['help'])
-    const helpCommand = await parseCommandArguments(['dataset'], {}, {}, {isHelpCommand: true})
-
-    expect(positionalHelp.coreOptions.help).toBe(false)
-    expect(helpCommand.coreOptions.help).toBe(true)
-  })
-
-  test('records option names without user-supplied values', async () => {
-    const result = await parseCommandArguments(
-      [
-        'private.ndjson',
-        '--token=secret-token',
-        '--dataset',
-        'production',
-        '--type=image',
-        '--header=Authorization: Bearer secret-token',
-      ],
-      flags,
-    )
-
-    expect(result.extraArguments).toEqual(['--token', '--dataset', '--type', '--header'])
-    expect(result.extraArguments.join(' ')).not.toContain('secret-token')
-    expect(result.extraArguments.join(' ')).not.toContain('image')
-  })
-
-  test('records registered flags alongside additional positional arguments', async () => {
-    const result = await parseCommandArguments(
-      ['script.ts', 'additional.ts', '--token=secret-token'],
-      flags,
-      commandTelemetry,
-    )
-
-    expect(result.extraArguments).toEqual(['--token'])
-  })
-
-  test('rejects unregistered flags while allowing additional positional arguments', async () => {
-    await expect(
-      parseCommandArguments(['script.ts', 'additional.ts', '--api-key=secret-key'], flags),
-    ).rejects.toThrow('Nonexistent flag: --api-key')
-  })
-
-  test('uses command flag registration to normalize concatenated short options', async () => {
-    const result = await parseCommandArguments(['-tsecret-token'], flags)
-
-    expect(result.extraArguments).toEqual(['--token'])
-  })
-
-  test('records boolean presence using the canonical flag name', async () => {
-    const result = await parseCommandArguments(['--mcp', '--no-mcp'], flags)
-
-    expect(result.extraArguments).toEqual(['--mcp', '--mcp'])
-  })
-
-  test('retains declared enum values across spaced and inline forms', async () => {
-    const result = await parseCommandArguments(
-      ['--format', 'json', '--format=pretty'],
-      flags,
-      commandTelemetry,
-    )
-
-    expect(result.extraArguments).toEqual(['--format=json', '--format=pretty'])
-  })
-
-  test('uses the canonical flag name for declared aliases', async () => {
-    const result = await parseCommandArguments(
-      ['--output-format=json', '-f', 'ndjson'],
-      flags,
-      commandTelemetry,
-    )
-
-    expect(result.extraArguments).toEqual(['--format=json', '--format=ndjson'])
-  })
-
-  test('redacts values outside a declared enum', async () => {
-    const result = await parseCommandArguments(['--format=private-format'], flags, commandTelemetry)
-
-    expect(result.extraArguments).toEqual(['--format'])
-  })
-
-  test('does not record arguments forwarded after the argument separator', async () => {
-    const result = await parseCommandArguments(
-      ['script.ts', '--', '--format=json', '--api-key=secret-key', 'private-value'],
-      flags,
-      commandTelemetry,
-    )
-
-    expect(result.extraArguments).toEqual([])
   })
 })

--- a/packages/@sanity/cli/src/util/__tests__/parseArguments.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/parseArguments.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, test} from 'vitest'
+
+import {parseArguments} from '../parseArguments.js'
+
+describe('parseArguments', () => {
+  test('omits spaced file and filename values from telemetry arguments', () => {
+    const result = parseArguments([
+      'node',
+      'sanity',
+      'assets',
+      'upload',
+      '--file',
+      '-private/path.png',
+      '--filename',
+      '-private.png',
+      '--type',
+      'image',
+    ])
+
+    expect(result.extraArguments).toEqual(['--file', '--filename', '--type'])
+    expect(result.extraArguments.join(' ')).not.toContain('private')
+  })
+
+  test('omits inline file and filename values from telemetry arguments', () => {
+    const result = parseArguments([
+      'node',
+      'sanity',
+      'assets',
+      'upload',
+      '--file=/Users/test/private/path.png',
+      '--filename=-private.png',
+      '--type=image',
+    ])
+
+    expect(result.extraArguments).toEqual(['--file', '--filename', '--type=image'])
+    expect(result.extraArguments.join(' ')).not.toContain('private')
+  })
+
+  test('redacts sensitive values forwarded after the argument separator', () => {
+    const result = parseArguments([
+      'node',
+      'sanity',
+      'assets',
+      'upload',
+      '--',
+      '--file=/Users/test/private/path.png',
+      '--filename',
+      '-private.png',
+    ])
+
+    expect(result.extraArguments).toEqual(['--file', '--filename'])
+    expect(result.extraArguments.join(' ')).not.toContain('private')
+  })
+})

--- a/packages/@sanity/cli/src/util/parseArguments.ts
+++ b/packages/@sanity/cli/src/util/parseArguments.ts
@@ -36,6 +36,52 @@ interface ParsedArguments<F = Record<string, string>> {
   groupOrCommand: string
 }
 
+const SENSITIVE_TELEMETRY_OPTIONS = ['--file', '--filename'] as const
+
+function getSensitiveTelemetryOption(argument: string): string | undefined {
+  return SENSITIVE_TELEMETRY_OPTIONS.find(
+    (option) => argument === option || argument.startsWith(`${option}=`),
+  )
+}
+
+function redactSensitiveTelemetryValues(arguments_: string[]): string[] {
+  const redactedArguments: string[] = []
+
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index]
+    const sensitiveOption = getSensitiveTelemetryOption(argument)
+
+    if (!sensitiveOption) {
+      redactedArguments.push(argument)
+      continue
+    }
+
+    redactedArguments.push(sensitiveOption)
+    if (argument === sensitiveOption) index += 1
+  }
+
+  return redactedArguments
+}
+
+function collectOptionArguments(arguments_: string[]): string[] {
+  const optionArguments: string[] = []
+
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index]
+    const sensitiveOption = getSensitiveTelemetryOption(argument)
+
+    if (sensitiveOption) {
+      optionArguments.push(sensitiveOption)
+      if (argument === sensitiveOption) index += 1
+      continue
+    }
+
+    if (argument.startsWith('-')) optionArguments.push(argument)
+  }
+
+  return optionArguments
+}
+
 /**
  * Parse the arguments from the command line
  *
@@ -58,9 +104,12 @@ export function parseArguments(argv = process.argv): ParsedArguments {
 
   const [groupOrCommand, ...argsWithoutOptions] = _
 
+  const argumentSeparatorIndex = args.indexOf('--')
+  const argumentsBeforeSeparator =
+    argumentSeparatorIndex === -1 ? args : args.slice(0, argumentSeparatorIndex)
   const finalExtraArguments = [
-    ...(extraArguments || []),
-    ...argv.filter((arg) => arg.startsWith('-')),
+    ...redactSensitiveTelemetryValues(extraArguments || []),
+    ...collectOptionArguments(argumentsBeforeSeparator),
   ]
 
   // oclif allows to run `sanity help` or `sanity help <command>`

--- a/packages/@sanity/cli/src/util/parseArguments.ts
+++ b/packages/@sanity/cli/src/util/parseArguments.ts
@@ -1,7 +1,6 @@
-import {type Interfaces, Parser} from '@oclif/core'
 import minimist from 'minimist'
 
-import {type CommandTelemetry} from './telemetry/commandTelemetry.js'
+import {type CommandTelemetry, redactTelemetryArguments} from './telemetry/commandTelemetry.js'
 
 interface ParsedArguments<F = Record<string, string>> {
   /**
@@ -39,90 +38,24 @@ interface ParsedArguments<F = Record<string, string>> {
   groupOrCommand: string
 }
 
-function createTelemetryParserFlags(flags: Interfaces.FlagInput): Interfaces.FlagInput {
-  return Object.fromEntries(
-    Object.entries(flags).map(([name, flag]) => {
-      const aliases = {
-        aliases: flag.aliases,
-        char: flag.char,
-        charAliases: flag.charAliases,
-      }
-
-      if (flag.type === 'boolean') {
-        return [
-          name,
-          {
-            ...aliases,
-            allowNo: flag.allowNo,
-            parse: async (input: boolean) => input,
-            type: 'boolean' as const,
-          },
-        ]
-      }
-
-      return [
-        name,
-        {
-          ...aliases,
-          input: [],
-          multiple: true,
-          multipleNonGreedy: true,
-          parse: async (input: string) => input,
-          type: 'option' as const,
-        },
-      ]
-    }),
-  ) as Interfaces.FlagInput
-}
-
-async function collectOptionArguments(
-  arguments_: string[],
-  flags: Interfaces.FlagInput,
-  commandTelemetry: CommandTelemetry,
-): Promise<string[]> {
-  const parserFlags = createTelemetryParserFlags(flags)
-  const {raw} = await Parser.parse(arguments_, {
-    '--': true,
-    args: {},
-    flags: parserFlags,
-    strict: false,
-  })
-
-  return raw.flatMap((token) => {
-    if (token.type !== 'flag') return []
-
-    const optionName = `--${token.flag}`
-    if (parserFlags[token.flag].type === 'boolean') return optionName
-
-    const normalizedValue = commandTelemetry.flags?.[token.flag]?.normalize(token.input)
-
-    return normalizedValue === undefined ? optionName : `${optionName}=${normalizedValue}`
-  })
+function collectOptionArguments(argv: string[], commandTelemetry?: CommandTelemetry): string[] {
+  return redactTelemetryArguments(argv, commandTelemetry).filter((argument) =>
+    argument.startsWith('-'),
+  )
 }
 
 /**
  * Parse the arguments from the command line
  *
  * @param argv - The arguments from the command line
+ * @param commandTelemetry - Resolved telemetry behavior for the command
  * @returns The parsed arguments
  */
 export function parseArguments(
   argv = process.argv,
-  flags: Interfaces.FlagInput = {},
-  commandTelemetry: CommandTelemetry = {},
-): Promise<ParsedArguments> {
+  commandTelemetry?: CommandTelemetry,
+): ParsedArguments {
   const args = argv.slice(2)
-  return parseCommandArguments(args, flags, commandTelemetry, {
-    isHelpCommand: args.includes('help'),
-  })
-}
-
-export async function parseCommandArguments(
-  args: string[],
-  flags: Interfaces.FlagInput = {},
-  commandTelemetry: CommandTelemetry = {},
-  options: {isHelpCommand?: boolean} = {},
-): Promise<ParsedArguments> {
   const {
     '--': extraArguments,
     _,
@@ -136,7 +69,14 @@ export async function parseCommandArguments(
 
   const [groupOrCommand, ...argsWithoutOptions] = _
 
-  const finalExtraArguments = await collectOptionArguments(args, flags, commandTelemetry)
+  const finalExtraArguments = [
+    ...(extraArguments || []),
+    ...collectOptionArguments(argv, commandTelemetry),
+  ]
+
+  // oclif allows to run `sanity help` or `sanity help <command>`
+  // It does not fire the hooks on `--help` so this is okay to track
+  const hasHelp = args.includes('help')
 
   // We only have global debug via env var
   const hasDebug = !!process.env.DEBUG
@@ -145,13 +85,13 @@ export async function parseCommandArguments(
     groupOrCommand,
 
     argsWithoutOptions,
-    argv: args,
+    argv,
     extOptions,
     extraArguments: finalExtraArguments,
 
     coreOptions: {
       debug: hasDebug,
-      help: options.isHelpCommand ?? false,
+      help: hasHelp,
       version,
     },
   }

--- a/packages/@sanity/cli/src/util/parseArguments.ts
+++ b/packages/@sanity/cli/src/util/parseArguments.ts
@@ -1,4 +1,7 @@
+import {type Interfaces, Parser} from '@oclif/core'
 import minimist from 'minimist'
+
+import {type CommandTelemetry} from './telemetry/commandTelemetry.js'
 
 interface ParsedArguments<F = Record<string, string>> {
   /**
@@ -36,50 +39,65 @@ interface ParsedArguments<F = Record<string, string>> {
   groupOrCommand: string
 }
 
-const SENSITIVE_TELEMETRY_OPTIONS = ['--file', '--filename'] as const
+function createTelemetryParserFlags(flags: Interfaces.FlagInput): Interfaces.FlagInput {
+  return Object.fromEntries(
+    Object.entries(flags).map(([name, flag]) => {
+      const aliases = {
+        aliases: flag.aliases,
+        char: flag.char,
+        charAliases: flag.charAliases,
+      }
 
-function getSensitiveTelemetryOption(argument: string): string | undefined {
-  return SENSITIVE_TELEMETRY_OPTIONS.find(
-    (option) => argument === option || argument.startsWith(`${option}=`),
-  )
+      if (flag.type === 'boolean') {
+        return [
+          name,
+          {
+            ...aliases,
+            allowNo: flag.allowNo,
+            parse: async (input: boolean) => input,
+            type: 'boolean' as const,
+          },
+        ]
+      }
+
+      return [
+        name,
+        {
+          ...aliases,
+          input: [],
+          multiple: true,
+          multipleNonGreedy: true,
+          parse: async (input: string) => input,
+          type: 'option' as const,
+        },
+      ]
+    }),
+  ) as Interfaces.FlagInput
 }
 
-function redactSensitiveTelemetryValues(arguments_: string[]): string[] {
-  const redactedArguments: string[] = []
+async function collectOptionArguments(
+  arguments_: string[],
+  flags: Interfaces.FlagInput,
+  commandTelemetry: CommandTelemetry,
+): Promise<string[]> {
+  const parserFlags = createTelemetryParserFlags(flags)
+  const {raw} = await Parser.parse(arguments_, {
+    '--': true,
+    args: {},
+    flags: parserFlags,
+    strict: false,
+  })
 
-  for (let index = 0; index < arguments_.length; index += 1) {
-    const argument = arguments_[index]
-    const sensitiveOption = getSensitiveTelemetryOption(argument)
+  return raw.flatMap((token) => {
+    if (token.type !== 'flag') return []
 
-    if (!sensitiveOption) {
-      redactedArguments.push(argument)
-      continue
-    }
+    const optionName = `--${token.flag}`
+    if (parserFlags[token.flag].type === 'boolean') return optionName
 
-    redactedArguments.push(sensitiveOption)
-    if (argument === sensitiveOption) index += 1
-  }
+    const normalizedValue = commandTelemetry.flags?.[token.flag]?.normalize(token.input)
 
-  return redactedArguments
-}
-
-function collectOptionArguments(arguments_: string[]): string[] {
-  const optionArguments: string[] = []
-
-  for (let index = 0; index < arguments_.length; index += 1) {
-    const argument = arguments_[index]
-    const sensitiveOption = getSensitiveTelemetryOption(argument)
-
-    if (sensitiveOption) {
-      optionArguments.push(sensitiveOption)
-      if (argument === sensitiveOption) index += 1
-      continue
-    }
-
-    if (argument.startsWith('-')) optionArguments.push(argument)
-  }
-
-  return optionArguments
+    return normalizedValue === undefined ? optionName : `${optionName}=${normalizedValue}`
+  })
 }
 
 /**
@@ -88,9 +106,23 @@ function collectOptionArguments(arguments_: string[]): string[] {
  * @param argv - The arguments from the command line
  * @returns The parsed arguments
  */
-export function parseArguments(argv = process.argv): ParsedArguments {
+export function parseArguments(
+  argv = process.argv,
+  flags: Interfaces.FlagInput = {},
+  commandTelemetry: CommandTelemetry = {},
+): Promise<ParsedArguments> {
   const args = argv.slice(2)
+  return parseCommandArguments(args, flags, commandTelemetry, {
+    isHelpCommand: args.includes('help'),
+  })
+}
 
+export async function parseCommandArguments(
+  args: string[],
+  flags: Interfaces.FlagInput = {},
+  commandTelemetry: CommandTelemetry = {},
+  options: {isHelpCommand?: boolean} = {},
+): Promise<ParsedArguments> {
   const {
     '--': extraArguments,
     _,
@@ -104,17 +136,7 @@ export function parseArguments(argv = process.argv): ParsedArguments {
 
   const [groupOrCommand, ...argsWithoutOptions] = _
 
-  const argumentSeparatorIndex = args.indexOf('--')
-  const argumentsBeforeSeparator =
-    argumentSeparatorIndex === -1 ? args : args.slice(0, argumentSeparatorIndex)
-  const finalExtraArguments = [
-    ...redactSensitiveTelemetryValues(extraArguments || []),
-    ...collectOptionArguments(argumentsBeforeSeparator),
-  ]
-
-  // oclif allows to run `sanity help` or `sanity help <command>`
-  // It does not fire the hooks on `--help` so this is okay to track
-  const hasHelp = args.includes('help')
+  const finalExtraArguments = await collectOptionArguments(args, flags, commandTelemetry)
 
   // We only have global debug via env var
   const hasDebug = !!process.env.DEBUG
@@ -123,13 +145,13 @@ export function parseArguments(argv = process.argv): ParsedArguments {
     groupOrCommand,
 
     argsWithoutOptions,
-    argv,
+    argv: args,
     extOptions,
     extraArguments: finalExtraArguments,
 
     coreOptions: {
       debug: hasDebug,
-      help: hasHelp,
+      help: options.isHelpCommand ?? false,
       version,
     },
   }

--- a/packages/@sanity/cli/src/util/telemetry/commandTelemetry.ts
+++ b/packages/@sanity/cli/src/util/telemetry/commandTelemetry.ts
@@ -1,51 +1,72 @@
 import {type Interfaces} from '@oclif/core'
 
+interface RedactedFlag {
+  canonical: string
+  long: readonly string[]
+  short: readonly string[]
+}
+
 /** @internal */
 export interface CommandTelemetry {
-  flags?: Partial<Record<string, TelemetryValue>>
+  redactedFlags: readonly RedactedFlag[]
 }
 
 type OptionFlagName<Flags extends Interfaces.FlagInput> = string &
   {
-    [Name in keyof Flags]: Flags[Name] extends Interfaces.OptionFlag<unknown> ? Name : never
+    [Name in keyof Flags]: Flags[Name] extends {type: 'option'} ? Name : never
   }[keyof Flags]
 
 type CommandTelemetryConfig<Flags extends Interfaces.FlagInput> = {
-  flags?: Partial<Record<OptionFlagName<Flags>, TelemetryValue>>
-}
-
-/** @internal */
-export interface TelemetryValue {
-  normalize(value: string): string | undefined
+  redact?: readonly OptionFlagName<Flags>[]
 }
 
 /** @internal */
 export function defineCommandTelemetry<const Flags extends Interfaces.FlagInput>(
-  _flags: Flags,
+  flags: Flags,
   config: CommandTelemetryConfig<Flags>,
 ): CommandTelemetry {
-  return config
+  return {
+    redactedFlags: (config.redact ?? []).map((name) => {
+      const flag = flags[name]
+      const aliases = flag?.aliases ?? []
+
+      return {
+        canonical: `--${name}`,
+        long: [name, ...aliases.filter((alias) => alias.length > 1)].map((alias) => `--${alias}`),
+        short: [
+          flag?.char,
+          ...(flag?.charAliases ?? []),
+          ...aliases.filter((alias) => alias.length === 1),
+        ]
+          .filter(Boolean)
+          .map((alias) => `-${alias}`),
+      }
+    }),
+  }
 }
 
-/** @internal */
-export const telemetry = {
-  apiVersion(): TelemetryValue {
-    return {
-      normalize: (value) => (/^v\d{4}-\d{2}-\d{2}$/.test(value) ? value : undefined),
-    }
-  },
+export function redactTelemetryArguments(
+  arguments_: string[],
+  commandTelemetry?: CommandTelemetry,
+): string[] {
+  let forwarding = false
 
-  enum<const Values extends readonly string[]>(values: Values): TelemetryValue {
-    const allowedValues = new Set(values)
-
-    return {
-      normalize: (value) => (allowedValues.has(value as Values[number]) ? value : undefined),
+  return arguments_.map((argument) => {
+    if (argument === '--') {
+      forwarding = true
+      return argument
     }
-  },
 
-  number(): TelemetryValue {
-    return {
-      normalize: (value) => (Number.isFinite(Number(value)) ? value : undefined),
-    }
-  },
+    if (forwarding) return argument
+
+    const isShortOption = argument.startsWith('-') && !argument.startsWith('--')
+    const redactedFlag = commandTelemetry?.redactedFlags.find(
+      ({long, short}) =>
+        long.some((syntax) => argument === syntax || argument.startsWith(`${syntax}=`)) ||
+        (isShortOption &&
+          short.some((syntax) => argument === syntax || argument.startsWith(syntax))),
+    )
+
+    return redactedFlag?.canonical ?? argument
+  })
 }

--- a/packages/@sanity/cli/src/util/telemetry/commandTelemetry.ts
+++ b/packages/@sanity/cli/src/util/telemetry/commandTelemetry.ts
@@ -2,8 +2,7 @@ import {type Interfaces} from '@oclif/core'
 
 interface RedactedFlag {
   canonical: string
-  long: readonly string[]
-  short: readonly string[]
+  flags: readonly string[]
 }
 
 /** @internal */
@@ -32,14 +31,12 @@ export function defineCommandTelemetry<const Flags extends Interfaces.FlagInput>
 
       return {
         canonical: `--${name}`,
-        long: [name, ...aliases.filter((alias) => alias.length > 1)].map((alias) => `--${alias}`),
-        short: [
-          flag?.char,
-          ...(flag?.charAliases ?? []),
-          ...aliases.filter((alias) => alias.length === 1),
-        ]
-          .filter(Boolean)
-          .map((alias) => `-${alias}`),
+        flags: [
+          `--${name}`,
+          ...aliases.map((alias) => `${alias.length === 1 ? '-' : '--'}${alias}`),
+          ...(flag?.char ? [`-${flag.char}`] : []),
+          ...(flag?.charAliases ?? []).map((alias) => `-${alias}`),
+        ],
       }
     }),
   }
@@ -60,11 +57,12 @@ export function redactTelemetryArguments(
     if (forwarding) return argument
 
     const isShortOption = argument.startsWith('-') && !argument.startsWith('--')
-    const redactedFlag = commandTelemetry?.redactedFlags.find(
-      ({long, short}) =>
-        long.some((syntax) => argument === syntax || argument.startsWith(`${syntax}=`)) ||
-        (isShortOption &&
-          short.some((syntax) => argument === syntax || argument.startsWith(syntax))),
+    const redactedFlag = commandTelemetry?.redactedFlags.find(({flags}) =>
+      flags.some((syntax) =>
+        syntax.startsWith('--')
+          ? argument === syntax || argument.startsWith(`${syntax}=`)
+          : isShortOption && argument.startsWith(syntax),
+      ),
     )
 
     return redactedFlag?.canonical ?? argument

--- a/packages/@sanity/cli/src/util/telemetry/commandTelemetry.ts
+++ b/packages/@sanity/cli/src/util/telemetry/commandTelemetry.ts
@@ -1,0 +1,51 @@
+import {type Interfaces} from '@oclif/core'
+
+/** @internal */
+export interface CommandTelemetry {
+  flags?: Partial<Record<string, TelemetryValue>>
+}
+
+type OptionFlagName<Flags extends Interfaces.FlagInput> = string &
+  {
+    [Name in keyof Flags]: Flags[Name] extends Interfaces.OptionFlag<unknown> ? Name : never
+  }[keyof Flags]
+
+type CommandTelemetryConfig<Flags extends Interfaces.FlagInput> = {
+  flags?: Partial<Record<OptionFlagName<Flags>, TelemetryValue>>
+}
+
+/** @internal */
+export interface TelemetryValue {
+  normalize(value: string): string | undefined
+}
+
+/** @internal */
+export function defineCommandTelemetry<const Flags extends Interfaces.FlagInput>(
+  _flags: Flags,
+  config: CommandTelemetryConfig<Flags>,
+): CommandTelemetry {
+  return config
+}
+
+/** @internal */
+export const telemetry = {
+  apiVersion(): TelemetryValue {
+    return {
+      normalize: (value) => (/^v\d{4}-\d{2}-\d{2}$/.test(value) ? value : undefined),
+    }
+  },
+
+  enum<const Values extends readonly string[]>(values: Values): TelemetryValue {
+    const allowedValues = new Set(values)
+
+    return {
+      normalize: (value) => (allowedValues.has(value as Values[number]) ? value : undefined),
+    }
+  },
+
+  number(): TelemetryValue {
+    return {
+      normalize: (value) => (Number.isFinite(Number(value)) ? value : undefined),
+    }
+  },
+}

--- a/packages/@sanity/cli/test/integration/hooks/prerun/setupTelemetry.test.ts
+++ b/packages/@sanity/cli/test/integration/hooks/prerun/setupTelemetry.test.ts
@@ -3,6 +3,7 @@ import {mkdir} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
+import {Flags} from '@oclif/core'
 import {
   clearCliTelemetry,
   CLI_TELEMETRY_SYMBOL,
@@ -21,6 +22,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {setupTelemetry} from '../../../../src/hooks/prerun/setupTelemetry.js'
 import {TELEMETRY_API_VERSION} from '../../../../src/services/telemetry.js'
+import {defineCommandTelemetry} from '../../../../src/util/telemetry/commandTelemetry.js'
 import {flushTelemetryFiles} from '../../../../src/util/telemetry/flushTelemetryFiles.js'
 import {readNDJSON} from '../../../../src/util/telemetry/readNDJSON.js'
 import {getCommandAndConfig} from '../../../helpers/getCommandAndConfig.js'
@@ -58,6 +60,12 @@ const mockGetUserConfig = vi.mocked(getUserConfig)
 const mockIsCi = vi.mocked(isCi)
 
 const {Command, config} = await getCommandAndConfig('help')
+const {Command: validateCommand} = await getCommandAndConfig('documents:validate')
+const validateCommandTelemetry = defineCommandTelemetry({file: Flags.string()}, {redact: ['file']})
+const redactedValidateCommand = new Proxy(validateCommand, {
+  get: (target, property, receiver) =>
+    property === 'telemetry' ? validateCommandTelemetry : Reflect.get(target, property, receiver),
+})
 
 // Create mock functions for getUserConfig get/set methods
 const mockGet = vi.fn()
@@ -231,14 +239,71 @@ describe('setupTelemetry integration test', () => {
     expect(timestamp).toBeLessThanOrEqual(afterTime)
   })
 
-  test('records help from the resolved command', async () => {
-    await testHook<'prerun'>(setupTelemetry, {Command, config})
+  test('records help from the process arguments', async () => {
+    const originalArgv = process.argv
+    process.argv = ['node', 'sanity', 'help', 'documents', 'validate']
+
+    try {
+      await testHook<'prerun'>(setupTelemetry, {Command, config})
+    } finally {
+      process.argv = originalArgv
+    }
 
     expect(mockTelemetryDebug).toHaveBeenCalledWith(
       'Starting command trace',
       expect.objectContaining({
         coreOptions: expect.objectContaining({help: true}),
         groupOrCommand: 'help',
+      }),
+    )
+  })
+
+  test('preserves flag values when the command does not opt into redaction', async () => {
+    const originalArgv = process.argv
+    process.argv = [
+      'node',
+      'sanity',
+      'documents',
+      'validate',
+      '--file=/Users/jane/private.ndjson',
+      '--format=json',
+    ]
+
+    try {
+      await testHook<'prerun'>(setupTelemetry, {Command: validateCommand, config})
+    } finally {
+      process.argv = originalArgv
+    }
+
+    expect(mockTelemetryDebug).toHaveBeenCalledWith(
+      'Starting command trace',
+      expect.objectContaining({
+        extraArguments: ['--file=/Users/jane/private.ndjson', '--format=json'],
+      }),
+    )
+  })
+
+  test('applies command-owned flag redaction without changing other values', async () => {
+    const originalArgv = process.argv
+    process.argv = [
+      'node',
+      'sanity',
+      'documents',
+      'validate',
+      '--file=/Users/jane/private.ndjson',
+      '--format=json',
+    ]
+
+    try {
+      await testHook<'prerun'>(setupTelemetry, {Command: redactedValidateCommand, config})
+    } finally {
+      process.argv = originalArgv
+    }
+
+    expect(mockTelemetryDebug).toHaveBeenCalledWith(
+      'Starting command trace',
+      expect.objectContaining({
+        extraArguments: ['--file', '--format=json'],
       }),
     )
   })

--- a/packages/@sanity/cli/test/integration/hooks/prerun/setupTelemetry.test.ts
+++ b/packages/@sanity/cli/test/integration/hooks/prerun/setupTelemetry.test.ts
@@ -25,6 +25,11 @@ import {flushTelemetryFiles} from '../../../../src/util/telemetry/flushTelemetry
 import {readNDJSON} from '../../../../src/util/telemetry/readNDJSON.js'
 import {getCommandAndConfig} from '../../../helpers/getCommandAndConfig.js'
 
+const mockTelemetryDebug = vi.hoisted(() => {
+  const debug = vi.fn()
+  return Object.assign(debug, {enabled: false, extend: () => debug})
+})
+
 // Mock external dependencies
 vi.mock('node:os', () => ({tmpdir: vi.fn()}))
 vi.mock('node:child_process', async () => {
@@ -41,6 +46,9 @@ vi.mock('@sanity/cli-core', async () => ({
   getUserConfig: vi.fn(),
   isCi: vi.fn(() => false),
 }))
+vi.mock('../../../../src/actions/telemetry/telemetryDebug.js', () => ({
+  telemetryDebug: mockTelemetryDebug,
+}))
 
 const mockTmpdir = vi.mocked(tmpdir)
 const mockSpawn = vi.mocked(spawn)
@@ -49,7 +57,7 @@ const mockGetCliConfig = vi.mocked(getCliConfig)
 const mockGetUserConfig = vi.mocked(getUserConfig)
 const mockIsCi = vi.mocked(isCi)
 
-const {config} = await getCommandAndConfig('help')
+const {Command, config} = await getCommandAndConfig('help')
 
 // Create mock functions for getUserConfig get/set methods
 const mockGet = vi.fn()
@@ -221,6 +229,18 @@ describe('setupTelemetry integration test', () => {
     const timestamp = mockSet.mock.calls[0][1]
     expect(timestamp).toBeGreaterThanOrEqual(beforeTime)
     expect(timestamp).toBeLessThanOrEqual(afterTime)
+  })
+
+  test('records help from the resolved command', async () => {
+    await testHook<'prerun'>(setupTelemetry, {Command, config})
+
+    expect(mockTelemetryDebug).toHaveBeenCalledWith(
+      'Starting command trace',
+      expect.objectContaining({
+        coreOptions: expect.objectContaining({help: true}),
+        groupOrCommand: 'help',
+      }),
+    )
   })
 
   test('should handle complete telemetry lifecycle from initialization to flush', async () => {


### PR DESCRIPTION
### Description

Add an opt-in, command-owned way to redact selected flag values from CLI telemetry. No existing command opts in, so current telemetry remains unchanged.

This prepares for assets upload: that command can redact its own local-file inputs without changing telemetry for unrelated commands that use the same flag name.

Issue: [AIGRO-5379](https://linear.app/sanity/issue/AIGRO-5379/redact-file-paths-and-filenames-from-cli-telemetry)  
Related: [CLI #1684](https://github.com/sanity-io/cli/pull/1684), [Mellon #669](https://github.com/sanity-io/mellon/pull/669)

### Examples

In a future assets upload command, we might define a `--filename` flag like:

```ts
const flags = {
  file: Flags.string({
    aliases: ['filename'],
    char: 'f',
    description: 'Path to the asset',
  }),
  format: Flags.string({
    options: ['json', 'text'],
  }),
}
```

When we create the command's `telemetry` recorder, we'd supply the `redact` option with a list of in-scope flags:

```ts
export class AssetsUploadCommand extends SanityCommand {
  static flags = flags

  static telemetry = defineCommandTelemetry(flags, {
    redact: ['file'],
  })
}
```

When we run:

```sh
sanity assets upload \
  --file=/Users/jane/Clients/Acme/private.png \
  --format=json
```

Without `redact`, we'd see this telemetry output:

```json
{
  "extraArguments": [
    "--file=/Users/jane/Clients/Acme/private.png",
    "--format=json"
  ]
}
```

After supplying `{ redact: ['file'] }`, we'd see this output instead:

```json
{
  "extraArguments": ["--file", "--format=json"]
}
```

Redaction is command-specific. Other commands that use the same flag name aren't affected:

```sh
sanity documents validate --file=/Users/jane/private.ndjson
```

Unless `documents validate` independently opts in, its telemetry remains:

```json
{
  "extraArguments": ["--file=/Users/jane/private.ndjson"]
}
```

### What to review

- `defineCommandTelemetry` type-checks redacted names and resolves canonical names, long aliases, and short forms from the owning command's flag definitions.
- `parseArguments` consumes the resolved telemetry contract rather than reconciling flag definitions and redaction names independently.
- Commands without a redaction declaration preserve the existing telemetry payload.

### Testing

- Unit tests cover unchanged defaults, canonical names, long aliases, `char`, `charAliases`, single-character aliases, short/long option boundaries, and forwarded arguments.
- Telemetry integration tests cover unchanged defaults and explicit command-owned redaction.
- Format, types, lint, dependency checks, and CLI build pass.

### Notes for release

Add command-owned configuration for redacting CLI flag values from telemetry.
