### PR TITLE
fix(cli): trim deploy payload and undeploy dry-run output

### DIFF
--- a/.changeset/pr-1696.md
+++ b/.changeset/pr-1696.md
@@ -1,0 +1,8 @@
+<!-- auto-generated -->
+---
+'@sanity/cli-core': patch
+'@sanity/cli': patch
+'@sanity/workbench-cli': patch
+---
+
+fix(cli): trim deploy payload and undeploy dry-run output

--- a/packages/@sanity/cli-core/src/_exports/undeploy.ts
+++ b/packages/@sanity/cli-core/src/_exports/undeploy.ts
@@ -18,12 +18,6 @@ export interface UndeployConfigTarget extends UndeployTargetDetails {
 }
 
 interface UndeployTargetDetails {
-  activeDeployment: {deployedAt: string; deployedBy: string} | null
-  /** Hostname the application is served from; freed for anyone to claim after undeploy. */
-  appHost: string | null
-  createdAt: string | null
-  organizationId: string | null
-  projectId: string | null
   title: string | null
   type: 'coreApp' | 'studio'
   url: string | null

--- a/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
+++ b/packages/@sanity/cli/src/actions/deploy/__tests__/deploymentPlan.test.ts
@@ -8,7 +8,6 @@ import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {createCollectingReporter} from '../../../util/checks.js'
 import {type DeployCheck} from '../deployChecks.js'
 import {
-  declaredInterfaces,
   type DeploymentFile,
   type DeploymentPlan,
   deploymentPlanToJson,
@@ -166,23 +165,6 @@ describe('reportInterfaces', () => {
     const reporter = createCollectingReporter<DeployCheck>()
     expect(reportInterfaces(reporter, {})).toEqual({services: [], views: []})
     expect(reporter.results).toEqual([])
-  })
-})
-
-describe('declaredInterfaces', () => {
-  const views = [{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}]
-
-  test('omits both keys for a plain app', () => {
-    expect(declaredInterfaces(null)).toEqual({})
-  })
-
-  // A real run and a dry run gate on the same rule, so the two modes can't drift.
-  test('omits both keys for a workbench app that declares neither', () => {
-    expect(declaredInterfaces({services: [], views: []})).toEqual({})
-  })
-
-  test('reports both keys when either kind is declared', () => {
-    expect(declaredInterfaces({services: [], views})).toEqual({services: [], views})
   })
 })
 

--- a/packages/@sanity/cli/src/actions/deploy/deployApp.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployApp.ts
@@ -14,6 +14,7 @@ import {
   getWorkbench,
   resolveInstallationId,
   summarizeConfig,
+  toWorkbenchPayload,
 } from '@sanity/workbench-cli/deploy'
 import {pack} from 'tar-fs'
 
@@ -43,7 +44,7 @@ import {
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
-import {declaredInterfaces, listDeploymentFiles, reportInterfaces} from './deploymentPlan.js'
+import {listDeploymentFiles, reportInterfaces} from './deploymentPlan.js'
 import {type DeployPayload, type DeployResult, runDeploy} from './deployRunner.js'
 import {findUserApplication} from './findUserApplication.js'
 import {type DeployAppOptions} from './types.js'
@@ -258,15 +259,11 @@ async function runAppDeployment(
 
     const payload: DeployPayload = {
       appId: appId ?? null,
-      ...(config ? {config} : {}),
-      ...declaredInterfaces(interfaces),
       isAutoUpdating,
-      ...(workbench?.isSingleton === undefined ? {} : {isSingleton: workbench.isSingleton}),
       ...(organizationId ? {organizationId} : {}),
-      ...(workbench ? {slug: workbench.slug, title: appTitle} : {}),
       type: 'coreApp',
       version,
-      ...(workbench?.visibility ? {visibility: workbench.visibility} : {}),
+      ...toWorkbenchPayload(workbench, {config, interfaces, title: appTitle}),
     }
 
     // Dry run stops here — everything below mutates.

--- a/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployRunner.ts
@@ -1,7 +1,7 @@
 import {CLIError} from '@oclif/core/errors'
 import {type Output} from '@sanity/cli-core'
 import {getErrorMessage} from '@sanity/cli-core/errors'
-import {type DeployedInterface} from '@sanity/workbench-cli/deploy'
+import {type WorkbenchDeployPayload} from '@sanity/workbench-cli/deploy'
 
 import {createCollectingReporter, createFailFastReporter} from '../../util/checks.js'
 import {toStderrOutput} from '../../util/toStderrOutput.js'
@@ -27,23 +27,15 @@ export interface DeployResult {
 }
 
 /** Collected locally, so a dry run reports it too. */
-export interface DeployPayload {
+export interface DeployPayload extends Partial<WorkbenchDeployPayload> {
   /** The configured `deployment.appId`; `null` when the deploy would mint one. */
   appId: string | null
   isAutoUpdating: boolean
   type: 'coreApp' | 'studio'
   version: string | null
 
-  /** Media-library config summary. */
-  config?: string
-  isSingleton?: boolean
   organizationId?: string
   projectId?: string
-  services?: DeployedInterface[]
-  slug?: string
-  title?: string
-  views?: DeployedInterface[]
-  visibility?: string
 }
 
 /**

--- a/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deployStudio.ts
@@ -12,6 +12,7 @@ import {
   deployWorkbenchApp,
   getApplicationUrl,
   getWorkbench,
+  toWorkbenchPayload,
 } from '@sanity/workbench-cli/deploy'
 import {type StudioManifest} from 'sanity'
 import {pack} from 'tar-fs'
@@ -31,7 +32,7 @@ import {
   verifyOutputDir,
 } from './deployChecks.js'
 import {deployDebug} from './deployDebug.js'
-import {declaredInterfaces, listDeploymentFiles, reportInterfaces} from './deploymentPlan.js'
+import {listDeploymentFiles, reportInterfaces} from './deploymentPlan.js'
 import {type DeployPayload, type DeployResult, runDeploy} from './deployRunner.js'
 import {deployStudioSchemasAndManifests} from './deployStudioSchemasAndManifests.js'
 import {findUserApplicationForStudio} from './findUserApplication.js'
@@ -190,14 +191,12 @@ async function runStudioDeployment(
 
     const payload: DeployPayload = {
       appId: appId ?? null,
-      ...declaredInterfaces(interfaces),
       isAutoUpdating,
       ...(organizationId ? {organizationId} : {}),
       ...(projectId ? {projectId} : {}),
-      ...(workbench ? {slug: workbench.slug, title: appTitle} : {}),
       type: 'studio',
       version,
-      ...(workbench?.visibility ? {visibility: workbench.visibility} : {}),
+      ...toWorkbenchPayload(workbench, {interfaces, title: appTitle}),
     }
 
     // Dry run stops here — everything below mutates.

--- a/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
+++ b/packages/@sanity/cli/src/actions/deploy/deploymentPlan.ts
@@ -109,15 +109,6 @@ export function deploymentPlanToJson(plan: DeploymentPlan): {
   }
 }
 
-/** Workbench-only, and both or neither. */
-export function declaredInterfaces(
-  declared: {services: DeployedInterface[]; views: DeployedInterface[]} | null,
-): {services?: DeployedInterface[]; views?: DeployedInterface[]} {
-  if (!declared) return {}
-  const {services, views} = declared
-  return services.length > 0 || views.length > 0 ? {services, views} : {}
-}
-
 export function reportInterfaces(
   reporter: DeployCheckReporter,
   app: Parameters<typeof summarizeInterfaces>[0],

--- a/packages/@sanity/cli/src/actions/undeploy/__tests__/adapters.test.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/__tests__/adapters.test.ts
@@ -77,12 +77,10 @@ describe('createAppUndeployAdapter', () => {
 
     expect(resolution.type).toBe('found')
     expect(resolution.type === 'found' && resolution.target).toMatchObject({
-      activeDeployment: {
-        deployedAt: '2024-01-02T00:00:00Z',
-        deployedBy: 'gustav@sanity.io',
-      },
+      application: expect.objectContaining({
+        activeDeployment: expect.objectContaining({deployedAt: '2024-01-02T00:00:00Z'}),
+      }),
       id: 'core-1',
-      organizationId: 'org-1',
       title: 'My App',
       type: 'coreApp',
       url: expect.stringContaining('/@org-1/application/core-1'),
@@ -150,7 +148,6 @@ describe('createStudioUndeployAdapter', () => {
     } as CliConfig).resolveTarget()
 
     expect(resolution.type === 'found' && resolution.target).toMatchObject({
-      appHost: 'my-studio',
       id: 'app-1',
       type: 'studio',
       url: 'https://my-studio.sanity.studio',

--- a/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/__tests__/runUndeploy.test.ts
@@ -30,14 +30,9 @@ const options = (output: Output, flags: Partial<UndeployOptions['flags']> = {}):
 
 function target(overrides: Partial<UndeployApplicationTarget> = {}): UndeployApplicationTarget {
   return {
-    activeDeployment: null,
-    appHost: 'my-studio',
-    createdAt: null,
     deletes: 'application',
     id: 'app-1',
-    organizationId: null,
     payload: {appId: 'app-1', type: 'studio'},
-    projectId: 'project-1',
     title: null,
     type: 'studio',
     url: 'https://my-studio.sanity.studio',
@@ -464,13 +459,7 @@ describe('renderUndeployPlan', () => {
       {
         checks: [],
         reason: null,
-        target: target({
-          activeDeployment: {
-            deployedAt: '2024-01-02T00:00:00Z',
-            deployedBy: 'gustav@sanity.io',
-          },
-          title: 'My Studio',
-        }),
+        target: target({title: 'My Studio'}),
         type: 'studio',
       },
       output,
@@ -483,7 +472,6 @@ describe('renderUndeployPlan', () => {
     expect(logged).toContain('My Studio')
     expect(logged).toContain('app-1')
     expect(logged).toContain('https://my-studio.sanity.studio')
-    expect(logged).toContain('at 2024-01-02T00:00:00Z by gustav@sanity.io')
   })
 
   test('no target renders "Nothing to undeploy." without a verdict', () => {

--- a/packages/@sanity/cli/src/actions/undeploy/adapters.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/adapters.ts
@@ -80,15 +80,10 @@ function toUndeployTarget(
   type: UndeployApplicationTarget['type'],
 ): UndeployApplicationTarget {
   return {
-    activeDeployment: application.activeDeployment ?? null,
-    appHost: application.appHost,
     application,
-    createdAt: application.createdAt,
     deletes: 'application',
     id: application.id,
-    organizationId: application.organizationId,
     payload: {appId: application.id, type},
-    projectId: application.projectId,
     title: application.title,
     type,
     url: resolveTargetUrl(application, type),

--- a/packages/@sanity/cli/src/actions/undeploy/undeployPlan.ts
+++ b/packages/@sanity/cli/src/actions/undeploy/undeployPlan.ts
@@ -130,7 +130,6 @@ function renderTarget(target: UndeployTarget, output: Output): void {
     ['Title', target.title],
     ['ID', target.id],
     ['URL', target.url],
-    ['Deployed', formatDeployment(target.activeDeployment)],
   ]
 
   output.log('')
@@ -142,13 +141,4 @@ function renderTarget(target: UndeployTarget, output: Output): void {
   for (const entry of target.summary ?? []) {
     for (const line of entry.split('\n')) output.log(`    ${line}`)
   }
-}
-
-function formatDeployment(deployment: UndeployTarget['activeDeployment']): string | null {
-  if (!deployment) return null
-  const parts = [
-    deployment.deployedAt ? `at ${deployment.deployedAt}` : null,
-    deployment.deployedBy ? `by ${deployment.deployedBy}` : null,
-  ].filter(Boolean)
-  return parts.length > 0 ? parts.join(' ') : null
 }

--- a/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/undeploy.test.ts
@@ -430,7 +430,6 @@ describe('#undeploy', () => {
     expect(confirm).not.toHaveBeenCalled()
     expect(stdout).toContain('Dry run — no changes made.')
     expect(stdout).toContain('Undeploys studio https://my-host.sanity.studio')
-    expect(stdout).toContain('at 2024-01-02T00:00:00Z by gustav@sanity.io')
     expect(stdout).not.toContain('3.99.0')
   })
 
@@ -521,6 +520,17 @@ describe('#undeploy', () => {
     expect(payload.canUndeploy).toBe(true)
     expect(payload.payload).toEqual({appId: 'app-id', type: 'studio'})
     expect(payload.url).toBe('https://my-host.sanity.studio')
+    // A plain studio has no workbench data, at either level of the output
+    expect(Object.keys(payload).toSorted()).toEqual([
+      'application',
+      'canUndeploy',
+      'deletes',
+      'errors',
+      'payload',
+      'reason',
+      'url',
+      'warnings',
+    ])
   })
 
   test('--json with --yes undeploys and emits the result envelope', async () => {
@@ -698,7 +708,6 @@ describe('#undeploy', () => {
     })
 
     expect(stdout).toContain('Undeploys the installation config')
-    expect(stdout).toContain('Served since 2024-01-01T00:00:00Z by gustav@sanity.io')
     expect(stdout).not.toContain('1.0.0')
     expect(stdout).toContain('Alt text (alt): ./src/alt.ts')
     expect(stdout).not.toContain('Config snapshots')

--- a/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
+++ b/packages/@sanity/cli/test/integration/commands/deploy.app.test.ts
@@ -248,6 +248,42 @@ describe('#deploy app', () => {
     expect(stdout).toContain('— "Existing App"')
   })
 
+  test('a plain core app collects no workbench data into the --json payload', async () => {
+    const cwd = await testFixture('basic-app')
+    process.cwd = () => cwd
+
+    mockApi({
+      apiVersion: USER_APPLICATIONS_API_VERSION,
+      query: {appType: 'coreApp'},
+      uri: `/user-applications/${appId}`,
+    }).reply(200, {
+      appHost: 'existing-host',
+      createdAt: '2024-01-01T00:00:00Z',
+      id: appId,
+      organizationId: 'org-id',
+      projectId: null,
+      title: 'Existing App',
+      type: 'coreApp',
+      updatedAt: '2024-01-01T00:00:00Z',
+      urlType: 'internal',
+    })
+
+    const {error, stdout} = await testCommand(DeployCommand, ['--dry-run', '--json'], {
+      config: {root: cwd},
+      mocks: defaultMocks,
+    })
+
+    if (error) throw error
+    const {payload} = JSON.parse(stdout)
+    expect(Object.keys(payload).toSorted()).toEqual([
+      'appId',
+      'isAutoUpdating',
+      'organizationId',
+      'type',
+      'version',
+    ])
+  })
+
   test('should report the target and files in a dry run without deploying', async () => {
     const cwd = await testFixture('basic-app')
     process.cwd = () => cwd

--- a/packages/@sanity/workbench-cli/src/_exports/deploy.ts
+++ b/packages/@sanity/workbench-cli/src/_exports/deploy.ts
@@ -4,6 +4,7 @@ export {
   resolveInstallationId,
   summarizeConfig,
 } from '../actions/deploy/deployConfig.js'
+export {toWorkbenchPayload, type WorkbenchDeployPayload} from '../actions/deploy/deployPayload.js'
 export {
   createCoreApp,
   type CreatedApplication,

--- a/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployPayload.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/__tests__/deployPayload.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, test} from 'vitest'
+
+import {toWorkbenchPayload} from '../deployPayload.js'
+import {type DeployableWorkbenchApp} from '../getWorkbench.js'
+
+const views = [{name: 'edit', src: './edit.ts', title: 'Edit', type: 'panel'}]
+const app = (overrides: Record<string, unknown> = {}) =>
+  ({slug: 'my-app', ...overrides}) as unknown as DeployableWorkbenchApp
+const none = {interfaces: null, title: 'My app'}
+
+describe('toWorkbenchPayload', () => {
+  test('contributes nothing for a plain app', () => {
+    expect(toWorkbenchPayload(null, none)).toEqual({})
+  })
+
+  test('always carries the locally declared slug and title', () => {
+    expect(toWorkbenchPayload(app(), none)).toEqual({slug: 'my-app', title: 'My app'})
+  })
+
+  test('omits both interface lists when the app declares neither', () => {
+    const payload = toWorkbenchPayload(app(), {...none, interfaces: {services: [], views: []}})
+    expect(payload).not.toHaveProperty('views')
+    expect(payload).not.toHaveProperty('services')
+  })
+
+  test('reports both interface lists when either kind is declared', () => {
+    expect(toWorkbenchPayload(app(), {...none, interfaces: {services: [], views}})).toMatchObject({
+      services: [],
+      views,
+    })
+  })
+
+  test('carries the optional workbench fields only when set', () => {
+    expect(
+      toWorkbenchPayload(app({isSingleton: false, visibility: 'unlisted'}), {
+        ...none,
+        config: 'Media library fields:\n  Title (title)',
+      }),
+    ).toMatchObject({
+      config: 'Media library fields:\n  Title (title)',
+      isSingleton: false,
+      visibility: 'unlisted',
+    })
+  })
+})

--- a/packages/@sanity/workbench-cli/src/actions/deploy/deployPayload.ts
+++ b/packages/@sanity/workbench-cli/src/actions/deploy/deployPayload.ts
@@ -1,0 +1,43 @@
+import {type DeployableWorkbenchApp} from './getWorkbench.js'
+import {type DeployedInterface} from './summarizeInterfaces.js'
+
+/** What a workbench app contributes to a deploy payload. */
+export interface WorkbenchDeployPayload {
+  slug: string
+  title: string
+
+  /** Media-library config summary. */
+  config?: string
+  isSingleton?: boolean
+  services?: DeployedInterface[]
+  views?: DeployedInterface[]
+  visibility?: string
+}
+
+/**
+ * Gated once so a plain app can't pick up a stray key: without a workbench
+ * there is nothing to contribute. `views` and `services` travel together.
+ */
+export function toWorkbenchPayload(
+  workbench: DeployableWorkbenchApp | null,
+  {
+    config,
+    interfaces,
+    title,
+  }: {
+    config?: string
+    interfaces: {services: DeployedInterface[]; views: DeployedInterface[]} | null
+    title: string
+  },
+): Partial<WorkbenchDeployPayload> {
+  if (!workbench) return {}
+  const {services, views} = interfaces ?? {services: [], views: []}
+  return {
+    ...(config ? {config} : {}),
+    ...(workbench.isSingleton === undefined ? {} : {isSingleton: workbench.isSingleton}),
+    ...(services.length > 0 || views.length > 0 ? {services, views} : {}),
+    slug: workbench.slug,
+    title,
+    ...(workbench.visibility ? {visibility: workbench.visibility} : {}),
+  }
+}

--- a/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
+++ b/packages/@sanity/workbench-cli/src/actions/undeploy/__tests__/workbenchUndeployAdapter.test.ts
@@ -106,11 +106,9 @@ describe('createWorkbenchUndeployAdapter — application', () => {
       expect.objectContaining({uri: '/applications/wb-app-1'}),
     )
     expect(resolution.type === 'found' && resolution.target).toMatchObject({
-      appHost: 'my-app-x1',
       application: {id: 'wb-app-1', slug: 'my-app-x1', title: 'My App', type: 'coreApp'},
       deletes: 'application',
       id: 'wb-app-1',
-      organizationId: 'org-1',
       services: [],
       title: 'My App',
       type: 'coreApp',
@@ -216,10 +214,6 @@ describe('createWorkbenchUndeployAdapter — config-only singleton', () => {
       configs: [expect.objectContaining({id: 'cfg-2'}), expect.objectContaining({id: 'cfg-1'})],
       deletes: 'config',
       id: null,
-      organizationId: 'org-1',
-      summary: expect.arrayContaining([
-        expect.stringContaining('Served since 2024-02-01T00:00:00Z'),
-      ]),
       title: 'media-library',
       url: 'https://org-1.sanity.run',
     })
@@ -261,15 +255,6 @@ describe('createWorkbenchUndeployAdapter — config-only singleton', () => {
       configs: [expect.objectContaining({id: 'cfg-1'})],
       deletes: 'config',
     })
-  })
-
-  test('history without an active snapshot reports no active deployment', async () => {
-    stubInstallations([{createdAt: '2024-01-01T00:00:00Z', id: 'cfg-1', version: '1.0.0'}])
-
-    const resolution = await configAdapter().resolveTarget()
-    if (resolution.type !== 'found') throw new Error('expected found')
-
-    expect(resolution.target.activeDeployment).toBeNull()
   })
 
   test('no active installation → nothing to undeploy', async () => {

--- a/packages/@sanity/workbench-cli/src/actions/undeploy/workbenchUndeployAdapter.ts
+++ b/packages/@sanity/workbench-cli/src/actions/undeploy/workbenchUndeployAdapter.ts
@@ -93,15 +93,10 @@ async function resolveApplicationTarget({
   const {lines, services, views} = summarizeInterfaces(workbench)
   return {
     target: {
-      activeDeployment: null,
-      appHost: application.slug,
       application,
-      createdAt: null,
       deletes: 'application',
       id: application.id,
-      organizationId: application.organizationId,
       payload: {appId: application.id, services, type, views},
-      projectId: null,
       services,
       summary: [
         ...lines,
@@ -156,28 +151,19 @@ async function resolveConfigTarget({
     }
   }
 
-  const active = configs.find((snapshot) => snapshot.isActive)
   return {
     installationId,
     resolution: {
       target: {
-        activeDeployment: null,
-        appHost: null,
         configs,
-        createdAt: null,
         deletes: 'config',
         id: null,
-        organizationId,
         payload: {
           appId: null,
           ...(config ? {config: summarizeConfig(config)} : {}),
           type: 'coreApp',
         },
-        projectId: null,
-        summary: [
-          ...(active ? [`Served since ${active.createdAt} by ${active.deployedBy}`] : []),
-          ...(config ? [summarizeConfig(config)] : []),
-        ],
+        summary: config ? [summarizeConfig(config)] : [],
         title: workbench.slug,
         type: 'coreApp',
         url: getWorkbenchUrl(organizationId),


### PR DESCRIPTION
### Description

Review comments after #1691 exposed two leftovers: deploy still knew workbench-only fields, and undeploy carried four target fields nothing reads. Dry runs could print "Served since undefined by undefined" and a misleading "Deployed" row.

Workbench now owns its payload contribution, keeping the JSON contract in one place.

### What to review

- Workbench fields are gated once, so plain apps omit them
- Undeploy targets keep only data used by the command and report
- Config undeploys no longer translate a snapshot timestamp into deployment output
- the payload contract is unchanged; only the code behind it moved

### Testing

Unit tests cover the moved helper and the trimmed target, and the integration test asserting a plain studio's exact payload keys is untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and dry-run output cleanup with an unchanged deploy payload contract; no auth, mutation, or API behavior changes.
> 
> **Overview**
> **Centralizes workbench deploy fields** into a new `toWorkbenchPayload` helper in `@sanity/workbench-cli`, so plain apps omit workbench-only keys and the JSON contract lives in one place. `deployApp` / `deployStudio` now spread that helper instead of assembling slug, title, interfaces, and related fields locally; `declaredInterfaces` is removed from the CLI.
> 
> **Trims undeploy targets** by dropping unused fields (`activeDeployment`, `appHost`, `createdAt`, `organizationId`, `projectId`) and the dry-run "Deployed" / "Served since …" lines that could print `undefined`. Config undeploys now summarize only the local config, not snapshot timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1836204d119bfec056a64908b9d0892f3b05963b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->