### PR TITLE
fix(dev): only add #token= to sanity dev URL for unclaimed projects

### DIFF
--- a/.changeset/studio-dev-token-url.md
+++ b/.changeset/studio-dev-token-url.md
@@ -1,0 +1,5 @@
+---
+'@sanity/cli': patch
+---
+
+fix(dev): announce the pre-claim Studio sign-in URL (`#token=`) only for locally unclaimed projects

--- a/packages/@sanity/cli/src/actions/dev/servers/__tests__/startStudioDevServer.test.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/__tests__/startStudioDevServer.test.ts
@@ -26,6 +26,7 @@ const mockGetPackageManagerChoice = vi.hoisted(() => vi.fn())
 const mockUpgradePackages = vi.hoisted(() => vi.fn())
 const mockIsInteractive = vi.hoisted(() => vi.fn())
 const mockConfirm = vi.hoisted(() => vi.fn())
+const mockHasLocalUnclaimedProject = vi.hoisted(() => vi.fn())
 
 vi.mock('../../../../server/devServer.js', () => ({
   startDevServer: mockStartDevServer,
@@ -55,6 +56,9 @@ vi.mock('../../../../util/packageManager/packageManagerChoice.js', () => ({
 }))
 vi.mock('../../../../util/packageManager/upgradePackages.js', () => ({
   upgradePackages: mockUpgradePackages,
+}))
+vi.mock('../../../../util/unclaimedProjects.js', () => ({
+  hasLocalUnclaimedProject: mockHasLocalUnclaimedProject,
 }))
 vi.mock('@sanity/cli-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/cli-core')>()
@@ -91,6 +95,7 @@ describe('startStudioDevServer', () => {
     mockGetAppId.mockReturnValue('app-id')
     mockIsInteractive.mockReturnValue(false)
     mockGetDashboardAppURL.mockResolvedValue('https://sanity.io/@org-x?dev=http://localhost:3333')
+    mockHasLocalUnclaimedProject.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -110,6 +115,56 @@ describe('startStudioDevServer', () => {
     if (!result.started) throw new Error('expected the server to start')
     expect(result.close).toBeDefined()
     expect(result.server).toBeDefined()
+  })
+
+  describe('unclaimed sign-in URL', () => {
+    const unclaimedOptions = createDevOptions({
+      cliConfig: {api: {projectId: 'abc123'}} as CliConfig,
+    })
+
+    afterEach(() => {
+      vi.unstubAllEnvs()
+    })
+
+    test('announces a token hash URL only when the project is locally unclaimed', async () => {
+      vi.stubEnv('SANITY_AUTH_TOKEN', 'sk-robot-token')
+      mockHasLocalUnclaimedProject.mockReturnValue(true)
+      const started = createMockDevServer()
+      mockStartDevServer.mockResolvedValueOnce(started)
+
+      await startStudioDevServer(unclaimedOptions)
+
+      expect(mockHasLocalUnclaimedProject).toHaveBeenCalledWith('abc123')
+      expect(started.server.config.logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('http://localhost:3333/#token=sk-robot-token'),
+      )
+    })
+
+    test('keeps the plain origin when SANITY_AUTH_TOKEN is set on a claimed project', async () => {
+      vi.stubEnv('SANITY_AUTH_TOKEN', 'sk-user-token')
+      mockHasLocalUnclaimedProject.mockReturnValue(false)
+      const started = createMockDevServer()
+      mockStartDevServer.mockResolvedValueOnce(started)
+
+      await startStudioDevServer(unclaimedOptions)
+
+      const announced = vi.mocked(started.server.config.logger.info).mock.calls[0]?.[0]
+      expect(announced).toContain('http://localhost:3333/')
+      expect(announced).not.toContain('#token=')
+    })
+
+    test('does not consult the unclaimed registry when SANITY_AUTH_TOKEN is unset', async () => {
+      vi.stubEnv('SANITY_AUTH_TOKEN', '')
+      const started = createMockDevServer()
+      mockStartDevServer.mockResolvedValueOnce(started)
+
+      await startStudioDevServer(unclaimedOptions)
+
+      expect(mockHasLocalUnclaimedProject).not.toHaveBeenCalled()
+      const announced = vi.mocked(started.server.config.logger.info).mock.calls[0]?.[0]
+      expect(announced).toContain('http://localhost:3333/')
+      expect(announced).not.toContain('#token=')
+    })
   })
 
   test('logs schema-extraction info line when enabled in cliConfig', async () => {

--- a/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
+++ b/packages/@sanity/cli/src/actions/dev/servers/startStudioDevServer.ts
@@ -16,6 +16,7 @@ import {getProjectById} from '../../../services/projects.js'
 import {getAppId} from '../../../util/appId.js'
 import {getPackageManagerChoice} from '../../../util/packageManager/packageManagerChoice.js'
 import {upgradePackages} from '../../../util/packageManager/upgradePackages.js'
+import {hasLocalUnclaimedProject} from '../../../util/unclaimedProjects.js'
 import {checkDependenciesEventListenerFactory} from '../../build/eventListenerFactory.js'
 import {shouldAutoUpdate} from '../../build/shouldAutoUpdate.js'
 import {devDebug} from '../devDebug.js'
@@ -152,7 +153,10 @@ export async function startStudioDevServer(
       )
     } else {
       const startupDuration = Date.now() - startTime
-      const url = `http://${httpHost || 'localhost'}:${port}${config.basePath}`
+      const url = withUnclaimedSignInHash(
+        `http://${httpHost || 'localhost'}:${port}${config.basePath}`,
+        projectId,
+      )
       const appType = 'Sanity Studio'
 
       const viteVersion = await getLocalPackageVersion('vite', import.meta.url)
@@ -171,4 +175,10 @@ export async function startStudioDevServer(
     devDebug('Error starting studio dev server', err)
     throw gracefulServerDeath('dev', config.httpHost, config.httpPort, err)
   }
+}
+
+function withUnclaimedSignInHash(url: string, projectId: string | undefined): string {
+  const token = process.env.SANITY_AUTH_TOKEN
+  if (!token || !projectId || !hasLocalUnclaimedProject(projectId)) return url
+  return `${url}#token=${encodeURIComponent(token)}`
 }

--- a/packages/@sanity/cli/src/commands/__tests__/new.test.ts
+++ b/packages/@sanity/cli/src/commands/__tests__/new.test.ts
@@ -153,6 +153,7 @@ describe('#new', () => {
       `│  SANITY_AUTH_TOKEN="${project.token}" sanity "command"`,
     ])
     expect(output).toContain(studioUrl)
+    expect(output).toContain('cd sanity && npx sanity@latest dev')
     const studioLinkIndex = lines.indexOf(`│  Then open this link: ${studioUrl}`)
     expect(lines.slice(studioLinkIndex, studioLinkIndex + 3)).toEqual([
       `│  Then open this link: ${studioUrl}`,

--- a/packages/@sanity/cli/src/commands/new.ts
+++ b/packages/@sanity/cli/src/commands/new.ts
@@ -302,7 +302,7 @@ export class NewCommand extends SanityCommand<typeof NewCommand> {
     const printStudioInstructions = () => {
       flow.highlight('Start your Studio:')
       flow.gap()
-      flow.command(`cd ${STUDIO_DIR} && npx sanity dev`)
+      flow.command(`cd ${STUDIO_DIR} && npx sanity@latest dev`)
       flow.gap()
       flow.link(studioUrl, {label: 'Then open this link:'})
       flow.gap()

--- a/packages/@sanity/cli/src/util/__tests__/unclaimedProjects.test.ts
+++ b/packages/@sanity/cli/src/util/__tests__/unclaimedProjects.test.ts
@@ -3,6 +3,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {type MintedProject} from '../../services/mintProject.js'
 import {
+  hasLocalUnclaimedProject,
   readUnclaimedProjects,
   recordUnclaimedProject,
   removeUnclaimedProject,
@@ -223,5 +224,37 @@ describe('removeUnclaimedProject', () => {
     })
 
     expect(removeUnclaimedProject(record.projectId, record.claimToken)).toBe(false)
+  })
+})
+
+describe('hasLocalUnclaimedProject', () => {
+  test('is true when the project ID is a key in the registry', () => {
+    mockGet.mockReturnValue({abc123: {projectId: 'abc123'}})
+
+    expect(hasLocalUnclaimedProject('abc123')).toBe(true)
+  })
+
+  test('is false when the registry has other projects only', () => {
+    mockGet.mockReturnValue({other: {projectId: 'other'}})
+
+    expect(hasLocalUnclaimedProject('abc123')).toBe(false)
+  })
+
+  test('is false when the registry is missing or unreadable', () => {
+    mockGet.mockReturnValue(undefined)
+    expect(hasLocalUnclaimedProject('abc123')).toBe(false)
+
+    mockGet.mockReturnValue([])
+    expect(hasLocalUnclaimedProject('abc123')).toBe(false)
+
+    mockGet.mockImplementationOnce(() => {
+      throw new Error('no config')
+    })
+    expect(hasLocalUnclaimedProject('abc123')).toBe(false)
+  })
+
+  test('is false for an empty project ID', () => {
+    expect(hasLocalUnclaimedProject('')).toBe(false)
+    expect(mockGet).not.toHaveBeenCalled()
   })
 })

--- a/packages/@sanity/cli/src/util/unclaimedProjects.ts
+++ b/packages/@sanity/cli/src/util/unclaimedProjects.ts
@@ -116,6 +116,17 @@ function parseRecord(projectId: string, value: unknown): UnclaimedProjectRecord 
   return parsed
 }
 
+export function hasLocalUnclaimedProject(projectId: string): boolean {
+  if (!projectId) return false
+  try {
+    const stored = getUserConfig().get(UNCLAIMED_PROJECTS_CONFIG_KEY)
+    if (!stored || typeof stored !== 'object' || Array.isArray(stored)) return false
+    return Object.hasOwn(stored, projectId)
+  } catch {
+    return false
+  }
+}
+
 /**
  * Read and validate the passive local recovery registry without changing it.
  */


### PR DESCRIPTION
### Description

For mint and claim, The URL in `sanity dev` prints without the token and hit a login wall. Pre-claim Studio only signs in via `#token=` in the hash. `sanity new` already prints that URL. `sanity dev` still announced the bare origin, which is the link people actually click.

This appends `#token=` only when `SANITY_AUTH_TOKEN` is set **and** this project ID is in the local unclaimed-projects config. That's a sync key lookup, not an API call. Claimed projects with a token (the common case) keep the plain origin.

Also switched the printed start command from `sanity new` to `npx sanity@latest dev` so agents don't pick up a stale global CLI.

Closes [AIGRO-5388](https://linear.app/sanity/issue/AIGRO-5388/sanity-dev-announces-a-login-url-that-does-not-work-pre-claim)

### What to review

The gate in `withUnclaimedSignInHash` / `hasLocalUnclaimedProject`. The claimed-project-plus-token path has to stay a plain origin. Don't add `&claim=` here. `sanity new` already prints that on first mint.

### Testing

1. Mint a project (`npx sanity@latest new ...`). Run `npx sanity@latest dev` in the Studio dir. The announced URL should include `#token=`. Opening it should land in Studio, not a login page.
2. In a claimed project with `SANITY_AUTH_TOKEN` set, `sanity dev` should still print `http://localhost:3333` with no hash.
3. Unit tests cover those two paths plus the missing-registry case.


Made with [Cursor](https://cursor.com)