### PR TITLE
ci: smoke test sanity new in scheduled e2e

### DIFF
--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -55,7 +55,7 @@ jobs:
           "$INSTALL_DIR/node_modules/.bin/create-sanity" --help > /dev/null
 
       - name: Smoke test sanity new
-        if: matrix.node-version == 24
+        if: matrix.node-version == 22
         run: |
           SANITY_NEW_RESULT="$RUNNER_TEMP/sanity-new.json"
           trap 'rm -f "$SANITY_NEW_RESULT"' EXIT

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -54,6 +54,19 @@ jobs:
           "$INSTALL_DIR/node_modules/.bin/sanity" --version
           "$INSTALL_DIR/node_modules/.bin/create-sanity" --help > /dev/null
 
+      - name: Smoke test sanity new
+        if: matrix.node-version == 24
+        run: |
+          SANITY_NEW_RESULT="$RUNNER_TEMP/sanity-new.json"
+          trap 'rm -f "$SANITY_NEW_RESULT"' EXIT
+          "$E2E_BINARY_PATH" new "Scheduled E2E ${GITHUB_RUN_ID}" --json > "$SANITY_NEW_RESULT"
+          jq -e '
+            (.projectId | type == "string" and length > 0) and
+            (.dataset | type == "string" and length > 0) and
+            (.claimUrl | type == "string" and startswith("https://")) and
+            (.expiresAt | type == "string" and length > 0)
+          ' "$SANITY_NEW_RESULT" > /dev/null
+
       - name: Build test infrastructure
         run: pnpm --filter @sanity/cli-test build
 

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -55,7 +55,6 @@ jobs:
           "$INSTALL_DIR/node_modules/.bin/create-sanity" --help > /dev/null
 
       - name: Smoke test sanity new
-        if: matrix.node-version == 22
         run: |
           SANITY_NEW_RESULT="$RUNNER_TEMP/sanity-new.json"
           trap 'rm -f "$SANITY_NEW_RESULT"' EXIT


### PR DESCRIPTION
### Description

Adds `sanity new` to the hourly published-CLI smoke tests on every supported Node.js shard (22, 24, and 26). Each shard mints one project with `--json`, validates the non-secret response shape, keeps credentials out of logs, and removes the temporary output.

> [!IMPORTANT]
> Do not merge or ship this change until [AIGRO-5368](https://linear.app/sanity/issue/AIGRO-5368/ensure-internal-claims-not-included-in-data) lands and confirms that internal claims are excluded from metrics

Resolves [AIGRO-5369](https://linear.app/sanity/issue/AIGRO-5369/include-sanity-new-in-hourly-cli-smoketests)

### What to review

Review the new smoke step in `.github/workflows/e2e-scheduled.yml`, especially its execution across all Node.js shards, response validation, and credential handling.

### Testing

- `pnpm check:format -- .github/workflows/e2e-scheduled.yml`
- `git diff --check`
- [E2E Tests (Scheduled)](https://github.com/sanity-io/cli/actions/runs/31715677646) previously passed on Node.js 22, 24, and 26, including the `sanity new` smoke step on its original single shard.
- The all-shard follow-up only removes the matrix guard. Do not run or ship it until AIGRO-5368 lands.
