### PR TITLE
chore: add lint rules for project conventions

### DIFF
--- a/packages/@sanity/cli/eslint.config.mjs
+++ b/packages/@sanity/cli/eslint.config.mjs
@@ -60,6 +60,34 @@ export default [
     },
   },
   {
+    files: ['src/commands/**/*.ts'],
+    ignores: ['src/commands/**/*.test.ts', 'src/commands/**/__tests__/**'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          message:
+            'Dynamic imports are not allowed. Use `doImport` function from @sanity/cli-core instead.',
+          selector: 'ImportExpression',
+        },
+        {
+          message: 'Use `this.resolveIsInteractive()` instead of `process.stderr.isTTY`.',
+          selector:
+            "MemberExpression[property.name='isTTY'][object.type='MemberExpression'][object.object.name='process'][object.property.name='stderr']",
+        },
+        {
+          message: 'Use a named value from `exitCodes` instead of a raw exit code number.',
+          selector: "Property[key.name='exit'][value.type='Literal'][value.raw=/^[0-9]+$/]",
+        },
+        {
+          message: 'Use a named value from `exitCodes` instead of a raw exit code number.',
+          selector:
+            "CallExpression[callee.type='MemberExpression'][callee.property.name='exit'][arguments.0.type='Literal'][arguments.0.raw=/^[0-9]+$/]",
+        },
+      ],
+    },
+  },
+  {
     files: ['test/__fixtures__/**/*.ts'],
     rules: {
       'import-x/no-extraneous-dependencies': 'off',

--- a/packages/@sanity/cli/src/commands/docs/__tests__/search.test.ts
+++ b/packages/@sanity/cli/src/commands/docs/__tests__/search.test.ts
@@ -1,7 +1,7 @@
 import {select} from '@sanity/cli-core/ux'
 import {testCommand} from '@sanity/cli-test'
 import nock, {cleanAll, pendingMocks} from 'nock'
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {DocsSearchCommand} from '../search.js'
 
@@ -15,12 +15,10 @@ vi.mock('@sanity/cli-core/ux', async () => {
 
 const mockedIsInteractive = vi.hoisted(() => vi.fn())
 
-vi.mock('@sanity/cli-core', async () => {
-  const actual = await vi.importActual<typeof import('@sanity/cli-core')>('@sanity/cli-core')
-  return {
-    ...actual,
-    isInteractive: mockedIsInteractive,
-  }
+beforeEach(() => {
+  vi.spyOn(DocsSearchCommand.prototype, 'resolveIsInteractive').mockImplementation(
+    mockedIsInteractive,
+  )
 })
 
 const mockedSelect = vi.mocked(select)

--- a/packages/@sanity/cli/src/commands/docs/search.ts
+++ b/packages/@sanity/cli/src/commands/docs/search.ts
@@ -1,7 +1,7 @@
 import {styleText} from 'node:util'
 
 import {Args, Flags} from '@oclif/core'
-import {exitCodes, isInteractive, SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {select} from '@sanity/cli-core/ux'
 
 import {readDoc, searchDocs, type SearchResult} from '../../services/docs.js'
@@ -82,7 +82,7 @@ export class DocsSearchCommand extends SanityCommand<typeof DocsSearchCommand> {
     }
 
     // Show usage hint in non-interactive mode
-    if (!isInteractive()) {
+    if (!this.resolveIsInteractive()) {
       this.log('Use `sanity docs read <url>` to read an article in terminal.')
       this.log('Use `sanity docs read <path>` to follow links found within articles.')
       this.log('')

--- a/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
+++ b/packages/@sanity/cli/src/commands/mcp/__tests__/configure.test.ts
@@ -23,14 +23,6 @@ vi.mock('../../../actions/auth/ensureAuthenticated.js', async (importOriginal) =
   }
 })
 
-vi.mock('@sanity/cli-core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@sanity/cli-core')>()
-  return {
-    ...actual,
-    isInteractive: mockIsInteractive,
-  }
-})
-
 vi.mock('../../../services/mcp.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../services/mcp.js')>()
   return {
@@ -419,6 +411,9 @@ const mcporterTestCases: Array<{
 
 describe.sequential('#mcp:configure', () => {
   beforeEach(async () => {
+    vi.spyOn(ConfigureMcpCommand.prototype, 'resolveIsInteractive').mockImplementation(
+      mockIsInteractive,
+    )
     mockEnsureAuthenticated.mockResolvedValue({
       email: 'test@example.com',
       id: 'user-123',

--- a/packages/@sanity/cli/src/commands/mcp/configure.ts
+++ b/packages/@sanity/cli/src/commands/mcp/configure.ts
@@ -1,4 +1,4 @@
-import {exitCodes, isInteractive, SanityCommand, subdebug} from '@sanity/cli-core'
+import {exitCodes, SanityCommand, subdebug} from '@sanity/cli-core'
 import {getErrorMessage, toError} from '@sanity/cli-core/errors'
 
 import {ensureAuthenticated} from '../../actions/auth/ensureAuthenticated.js'
@@ -43,7 +43,7 @@ export class ConfigureMcpCommand extends SanityCommand<typeof ConfigureMcpComman
     try {
       const mcpResult = await setupMCP({
         explicit: true,
-        mode: isInteractive() ? 'prompt' : 'auto',
+        mode: this.resolveIsInteractive() ? 'prompt' : 'auto',
         output: this.output,
         skillsMode: 'skip',
       })

--- a/packages/@sanity/cli/src/commands/typegen/generate.ts
+++ b/packages/@sanity/cli/src/commands/typegen/generate.ts
@@ -3,7 +3,7 @@ import {styleText} from 'node:util'
 
 import {Flags} from '@oclif/core'
 import {CLIError} from '@oclif/core/errors'
-import {SanityCommand} from '@sanity/cli-core'
+import {exitCodes, SanityCommand} from '@sanity/cli-core'
 import {spinner, type SpinnerInstance} from '@sanity/cli-core/ux'
 import {
   configDefinition,
@@ -97,13 +97,15 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
       } catch (err) {
         if (err instanceof Error && 'code' in err && err.code === 'ENOENT' && configPath) {
           spin.fail()
-          this.error(`Typegen config file not found: ${configPath}`, {exit: 1})
+          this.error(`Typegen config file not found: ${configPath}`, {
+            exit: exitCodes.RUNTIME_ERROR,
+          })
         }
 
         if (err instanceof Error && 'code' in err && err.code !== 'ENOENT') {
           spin.fail()
           this.error(`Error when checking if typegen config file exists: ${legacyConfigPath}`, {
-            exit: 1,
+            exit: exitCodes.RUNTIME_ERROR,
           })
         }
       }
@@ -158,7 +160,9 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
       // wrapping them a second time and failing the spinner twice.
       if (err instanceof CLIError) throw err
       spin.fail()
-      this.error(`An error occurred during config loading: ${err}`, {exit: 1})
+      this.error(`An error occurred during config loading: ${err}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 
@@ -194,7 +198,9 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
         spin.fail()
       }
       trace.error(error instanceof Error ? error : new Error(String(error)))
-      this.error(`${error instanceof Error ? error.message : 'Unknown error'}`, {exit: 1})
+      this.error(`${error instanceof Error ? error.message : 'Unknown error'}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 
@@ -265,7 +271,9 @@ export class TypegenGenerateCommand extends SanityCommand<typeof TypegenGenerate
         spin.fail()
       }
       trace.error(error instanceof Error ? error : new Error(String(error)))
-      this.error(`${error instanceof Error ? error.message : 'Unknown error'}`, {exit: 1})
+      this.error(`${error instanceof Error ? error.message : 'Unknown error'}`, {
+        exit: exitCodes.RUNTIME_ERROR,
+      })
     }
   }
 }


### PR DESCRIPTION
Add ESLint rules that check syntax to enforce project conventions automatically

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only enforcement plus small, behavior-preserving refactors (same interactive checks and exit code 1); no auth or data-path changes.
> 
> **Overview**
> Adds **ESLint `no-restricted-syntax` rules** on `src/commands/**/*.ts` (excluding tests) so new command code must use `doImport` instead of dynamic `import()`, `this.resolveIsInteractive()` instead of `process.stderr.isTTY`, and `exitCodes` instead of numeric exit values.
> 
> **Command updates** bring existing code in line with those rules: `docs search` and `mcp configure` switch from the `isInteractive()` helper to `this.resolveIsInteractive()`, and `typegen generate` replaces raw `{exit: 1}` with `exitCodes.RUNTIME_ERROR`.
> 
> **Tests** stop mocking `@sanity/cli-core`’s `isInteractive` and instead stub `resolveIsInteractive` on the command prototype in `beforeEach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a979ed86e2f1bb32671be30791a273aa440eeeca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->