### PR TITLE
docs: fix agent test guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,6 @@ jq '{total: .numTotalTests, passed: .numPassedTests, failed: .numFailedTests, fi
 ## Cursor Cloud specific instructions
 
 - The update script runs `pnpm install --frozen-lockfile` and `pnpm build:cli` on startup. Dependencies and build artifacts should already be up to date when a session begins.
-- The test results JSON file requires `CLAUDECODE=1` (or `CODEX_CI=1`). Set `export CLAUDECODE=1` before running tests so the `$TEST_RESULTS` / `jq` workflow described above works as expected.
 - The full test suite takes ~10 minutes. Prefer scoped runs (`--changed`, `--project`, or single files) during development. Before assuming a test failure is caused by your changes, check whether the same test also fails on `origin/main`.
 - CLI commands that hit the Sanity API (e.g. `documents query`, `login`) require authentication. Use fixture directories (e.g. `fixtures/basic-studio`) to run commands like `npx sanity debug`, `npx sanity doctor`, or `npx sanity versions` without authentication.
 - `pnpm install` may warn about ignored build scripts for `sharp` and `unrs-resolver`. These are safe to ignore; the `pnpm.onlyBuiltDependencies` allowlist in `package.json` already covers the required native modules (`@swc/core`, `esbuild`, `node-pty`).


### PR DESCRIPTION
Remove unneeded guidance for agents trying to run tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to agent guidance; no runtime, test, or build behavior changes.
> 
> **Overview**
> **Removes** a Cursor Cloud–only bullet from `AGENTS.md` that told agents to set `CLAUDECODE=1` or `CODEX_CI=1` so the `$TEST_RESULTS` / `jq` workflow would work.
> 
> The main **Testing Rules** section still documents computing `TEST_RESULTS` and reading failures with `jq`; this change only drops duplicate, environment-specific setup that is no longer needed for agents running tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96289d42e0204e45d4a0c0f29a5eaa5db488843f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->